### PR TITLE
fix(storefront): Smartedit contract should not be rendered for static slots

### DIFF
--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
@@ -1,11 +1,10 @@
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CmsService, ContentSlotData } from '@spartacus/core';
-import { of, Observable } from 'rxjs';
-
-import { PageSlotComponent } from './page-slot.component';
-import { ComponentWrapperDirective } from '../component/component-wrapper.directive';
-import { OutletDirective } from '../../../lib/outlet';
 import { CmsMappingService } from '@spartacus/storefront';
+import { Observable, of } from 'rxjs';
+import { OutletDirective } from '../../../lib/outlet';
+import { ComponentWrapperDirective } from '../component/component-wrapper.directive';
+import { PageSlotComponent } from './page-slot.component';
 
 class MockCmsService {
   getContentSlot(): Observable<ContentSlotData> {
@@ -80,6 +79,22 @@ describe('PageSlotComponent', () => {
 
   it('should not add smart edit slot contract if app not launch in smart edit', () => {
     spyOn(cmsService, 'isLaunchInSmartEdit').and.returnValue(false);
+
+    fixture = TestBed.createComponent(PageSlotComponent);
+    pageSlotComponent = fixture.componentInstance;
+    pageSlotComponent.position = 'left';
+    fixture.detectChanges();
+
+    const native = fixture.debugElement.nativeElement;
+    expect(native.classList.contains('smartEditComponent')).toBeFalsy();
+    expect(native.getAttribute('data-smartedit-component-id')).toEqual(null);
+  });
+
+  it('should not add smart edit slot contract if the slot is statically added', () => {
+    spyOn(cmsService, 'isLaunchInSmartEdit').and.returnValue(true);
+    spyOn(cmsService, 'getContentSlot').and.returnValue(
+      of({ uid: 'slot_uid' })
+    );
 
     fixture = TestBed.createComponent(PageSlotComponent);
     pageSlotComponent = fixture.componentInstance;

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.ts
@@ -1,19 +1,18 @@
 import {
-  Component,
-  OnInit,
-  Input,
   ChangeDetectionStrategy,
-  Renderer2,
+  Component,
   ElementRef,
+  Input,
+  OnInit,
+  Renderer2,
 } from '@angular/core';
-
 import {
   CmsService,
-  ContentSlotData,
   ContentSlotComponentData,
+  ContentSlotData,
 } from '@spartacus/core';
 import { Observable } from 'rxjs';
-import { tap, map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 import { CmsMappingService } from '../../../lib/cms/services/cms-mapping.service';
 
 @Component({
@@ -31,7 +30,7 @@ export class PageSlotComponent implements OnInit {
     protected cmsMapping: CmsMappingService
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     // add the position name as a css class so that
     // layout can be applied to it, using the position based class.
     this.renderer.addClass(this.hostElement.nativeElement, this.position);
@@ -58,42 +57,44 @@ export class PageSlotComponent implements OnInit {
   }
 
   // add a class to indicate whether the class is empty or not
-  private addComponentClass(components) {
+  private addComponentClass(components): void {
     if (components && components.length > 0) {
       this.renderer.addClass(this.hostElement.nativeElement, 'has-components');
     }
   }
 
-  private addSmartEditSlotClass(slot) {
+  private addSmartEditSlotClass(slot): void {
     if (this.cmsService.isLaunchInSmartEdit()) {
       this.addSmartEditContract(slot);
     }
   }
 
   private addSmartEditContract(slot: ContentSlotData): void {
-    this.renderer.addClass(
-      this.hostElement.nativeElement,
-      'smartEditComponent'
-    );
-    this.renderer.setAttribute(
-      this.hostElement.nativeElement,
-      'data-smartedit-component-type',
-      'ContentSlot'
-    );
-    this.renderer.setAttribute(
-      this.hostElement.nativeElement,
-      'data-smartedit-component-id',
-      slot.uid
-    );
-    this.renderer.setAttribute(
-      this.hostElement.nativeElement,
-      'data-smartedit-catalog-version-uuid',
-      slot.catalogUuid
-    );
-    this.renderer.setAttribute(
-      this.hostElement.nativeElement,
-      'data-smartedit-component-uuid',
-      slot.uuid
-    );
+    if (slot.catalogUuid && slot.uuid) {
+      this.renderer.addClass(
+        this.hostElement.nativeElement,
+        'smartEditComponent'
+      );
+      this.renderer.setAttribute(
+        this.hostElement.nativeElement,
+        'data-smartedit-component-type',
+        'ContentSlot'
+      );
+      this.renderer.setAttribute(
+        this.hostElement.nativeElement,
+        'data-smartedit-component-id',
+        slot.uid
+      );
+      this.renderer.setAttribute(
+        this.hostElement.nativeElement,
+        'data-smartedit-catalog-version-uuid',
+        slot.catalogUuid
+      );
+      this.renderer.setAttribute(
+        this.hostElement.nativeElement,
+        'data-smartedit-component-uuid',
+        slot.uuid
+      );
+    }
   }
 }


### PR DESCRIPTION
Whenever page slots are added based on static configuration (#1706), the slot should not fulfil the SmartEdit contract; there's nothing to manage.

fixes #1818 