### PR TITLE
fix: Login page: 'Don’t have an account' link should be closer to Register (GH-3130)

### DIFF
--- a/projects/assets/src/translations/en/user.ts
+++ b/projects/assets/src/translations/en/user.ts
@@ -16,7 +16,7 @@ export const user = {
     forgotPassword: 'Forgot password?',
     signIn: 'Sign In',
     register: 'Register',
-    dontHaveAccount: 'Don’t have an account',
+    dontHaveAccount: 'Don’t have an account?',
     emailAddress: {
       label: 'Email address',
       placeholder: 'Enter email',

--- a/projects/storefrontlib/src/cms-components/user/login-form/login-form.component.html
+++ b/projects/storefrontlib/src/cms-components/user/login-form/login-form.component.html
@@ -57,7 +57,7 @@
 </form>
 
 <div class="register">
-  <h3 class="cx-section-title cx-section-title-alt">
+  <h3 class="cx-section-title cx-section-title-close">
     {{ 'loginForm.dontHaveAccount' | cxTranslate }}
   </h3>
   <a

--- a/projects/storefrontstyles/scss/cxbase/layout/section.scss
+++ b/projects/storefrontstyles/scss/cxbase/layout/section.scss
@@ -17,3 +17,8 @@
 .cx-section-title-alt {
   text-transform: var(--cx-text-transform, none);
 }
+
+.cx-section-title-close {
+  margin-top: var(--cx-margin-bottom, 25px);
+  margin-bottom: var(--cx-margin-bottom, 0px);
+}


### PR DESCRIPTION

Fixes https://github.com/SAP/cloud-commerce-spartacus-storefront/issues/3130