### PR TITLE
Update product-image-normalizer.ts to allow external product images

### DIFF
--- a/projects/core/src/occ/adapters/product/converters/product-image-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/product-image-normalizer.ts
@@ -54,10 +54,13 @@ export class ProductImageNormalizer implements Converter<Occ.Product, Product> {
          * `backend.media.baseUrl` by default, but fallback to `backend.occ.baseUrl`
          * if none provided.
          */
-        image.url =
-          (this.config.backend.media.baseUrl ||
-            this.config.backend.occ.baseUrl ||
-            '') + image.url;
+        image.url = image.url.startsWith('http')
+          ? image.url
+          : (
+            (this.config.backend.media.baseUrl ||
+              this.config.backend.occ.baseUrl ||
+              '') + image.url
+          );
 
         imageContainer[image.format] = image;
       }

--- a/projects/core/src/occ/adapters/product/converters/product-image-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/product-image-normalizer.ts
@@ -56,11 +56,9 @@ export class ProductImageNormalizer implements Converter<Occ.Product, Product> {
          */
         image.url = image.url.startsWith('http')
           ? image.url
-          : (
-            (this.config.backend.media.baseUrl ||
+          : (this.config.backend.media.baseUrl ||
               this.config.backend.occ.baseUrl ||
-              '') + image.url
-          );
+              '') + image.url;
 
         imageContainer[image.format] = image;
       }


### PR DESCRIPTION
As per the media service, it would be good to allow externally hosted product images

fixes #5559 