### PR TITLE
feat: allow to get multiple cms components data in one request

### DIFF
--- a/projects/core/src/cms/facade/cms.service.ts
+++ b/projects/core/src/cms/facade/cms.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
-import { asyncScheduler, combineLatest, Observable, of } from 'rxjs';
+import { combineLatest, Observable, of } from 'rxjs';
 import {
   catchError,
+  debounceTime,
   filter,
   map,
-  observeOn,
   pluck,
   shareReplay,
   switchMap,
@@ -114,7 +114,7 @@ export class CmsService {
             select(CmsSelectors.componentStateSelectorFactory(uid))
           )
         )
-      ).pipe(observeOn(asyncScheduler)); // prevent consuming partial updates from combineLatest
+      ).pipe(debounceTime(0)); // prevent consuming partial updates from combineLatest
 
       this.componentsLists[uidsSerialized] = combineLatest([
         this.routingService.isNavigating(),

--- a/projects/core/src/cms/facade/cms.service.ts
+++ b/projects/core/src/cms/facade/cms.service.ts
@@ -139,7 +139,7 @@ export class CmsService {
             const uidsToLoad = indexesToLoad.map(index => uids[index]);
 
             if (uidsToLoad.length) {
-              this.store.dispatch(new CmsActions.LoadCmsComponents(uidsToLoad));
+              this.store.dispatch(new CmsActions.LoadCmsComponent(uidsToLoad));
             }
           }
         }),
@@ -148,8 +148,9 @@ export class CmsService {
           componentsState =>
             componentsState && componentsState.every(state => state.success)
         ),
-        map(componentsState =>
-          componentsState.map(state => state.value).filter(x => !!x)
+        map(
+          componentsState =>
+            componentsState.map(state => state.value).filter(x => !!x) // filter out undefined components
         ),
         shareReplay({ bufferSize: 1, refCount: true })
       );

--- a/projects/core/src/cms/facade/cms.service.ts
+++ b/projects/core/src/cms/facade/cms.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
-import { combineLatest, Observable, of } from 'rxjs';
+import { asyncScheduler, combineLatest, Observable, of } from 'rxjs';
 import {
   catchError,
-  debounceTime,
   filter,
   map,
+  observeOn,
   pluck,
   shareReplay,
   switchMap,
@@ -114,7 +114,7 @@ export class CmsService {
             select(CmsSelectors.componentStateSelectorFactory(uid))
           )
         )
-      ).pipe(debounceTime(0));
+      ).pipe(observeOn(asyncScheduler)); // prevent consuming partial updates from combineLatest
 
       this.componentsLists[uidsSerialized] = combineLatest([
         this.routingService.isNavigating(),

--- a/projects/core/src/cms/store/actions/component.action.ts
+++ b/projects/core/src/cms/store/actions/component.action.ts
@@ -5,6 +5,11 @@ import { COMPONENT_ENTITY } from '../cms-state';
 export const LOAD_CMS_COMPONENT = '[Cms] Load Component';
 export const LOAD_CMS_COMPONENT_FAIL = '[Cms] Load Component Fail';
 export const LOAD_CMS_COMPONENT_SUCCESS = '[Cms] Load Component Success';
+
+export const LOAD_CMS_COMPONENTS = '[Cms] Load Components';
+export const LOAD_CMS_COMPONENTS_FAIL = '[Cms] Load Components Fail';
+export const LOAD_CMS_COMPONENTS_SUCCESS = '[Cms] Load Components Success';
+
 export const CMS_GET_COMPONENET_FROM_PAGE = '[Cms] Get Component from Page';
 
 export class LoadCmsComponent extends StateEntityLoaderActions.EntityLoadAction {
@@ -27,6 +32,29 @@ export class LoadCmsComponentSuccess<
   readonly type = LOAD_CMS_COMPONENT_SUCCESS;
   constructor(public payload: T, uid?: string) {
     super(COMPONENT_ENTITY, uid || payload.uid || '');
+  }
+}
+
+export class LoadCmsComponents extends StateEntityLoaderActions.EntityLoadAction {
+  readonly type = LOAD_CMS_COMPONENTS;
+  constructor(public payload: string[]) {
+    super(COMPONENT_ENTITY, payload);
+  }
+}
+
+export class LoadCmsComponentsSuccess<
+  T extends CmsComponent
+> extends StateEntityLoaderActions.EntitySuccessAction {
+  readonly type = LOAD_CMS_COMPONENTS_SUCCESS;
+  constructor(public payload: T[], uids?: string[]) {
+    super(COMPONENT_ENTITY, uids);
+  }
+}
+
+export class LoadCmsComponentsFail extends StateEntityLoaderActions.EntityFailAction {
+  readonly type = LOAD_CMS_COMPONENTS_FAIL;
+  constructor(uids: string[], public payload: any) {
+    super(COMPONENT_ENTITY, uids, payload);
   }
 }
 

--- a/projects/core/src/cms/store/actions/component.action.ts
+++ b/projects/core/src/cms/store/actions/component.action.ts
@@ -6,22 +6,18 @@ export const LOAD_CMS_COMPONENT = '[Cms] Load Component';
 export const LOAD_CMS_COMPONENT_FAIL = '[Cms] Load Component Fail';
 export const LOAD_CMS_COMPONENT_SUCCESS = '[Cms] Load Component Success';
 
-export const LOAD_CMS_COMPONENTS = '[Cms] Load Components';
-export const LOAD_CMS_COMPONENTS_FAIL = '[Cms] Load Components Fail';
-export const LOAD_CMS_COMPONENTS_SUCCESS = '[Cms] Load Components Success';
-
 export const CMS_GET_COMPONENET_FROM_PAGE = '[Cms] Get Component from Page';
 
 export class LoadCmsComponent extends StateEntityLoaderActions.EntityLoadAction {
   readonly type = LOAD_CMS_COMPONENT;
-  constructor(public payload: string) {
+  constructor(public payload: string | string[]) {
     super(COMPONENT_ENTITY, payload);
   }
 }
 
 export class LoadCmsComponentFail extends StateEntityLoaderActions.EntityFailAction {
   readonly type = LOAD_CMS_COMPONENT_FAIL;
-  constructor(uid: string, public payload: any) {
+  constructor(uid: string | string[], public payload: any) {
     super(COMPONENT_ENTITY, uid, payload);
   }
 }
@@ -30,31 +26,11 @@ export class LoadCmsComponentSuccess<
   T extends CmsComponent
 > extends StateEntityLoaderActions.EntitySuccessAction {
   readonly type = LOAD_CMS_COMPONENT_SUCCESS;
-  constructor(public payload: T, uid?: string) {
-    super(COMPONENT_ENTITY, uid || payload.uid || '');
-  }
-}
-
-export class LoadCmsComponents extends StateEntityLoaderActions.EntityLoadAction {
-  readonly type = LOAD_CMS_COMPONENTS;
-  constructor(public payload: string[]) {
-    super(COMPONENT_ENTITY, payload);
-  }
-}
-
-export class LoadCmsComponentsSuccess<
-  T extends CmsComponent
-> extends StateEntityLoaderActions.EntitySuccessAction {
-  readonly type = LOAD_CMS_COMPONENTS_SUCCESS;
-  constructor(public payload: T[], uids?: string[]) {
-    super(COMPONENT_ENTITY, uids);
-  }
-}
-
-export class LoadCmsComponentsFail extends StateEntityLoaderActions.EntityFailAction {
-  readonly type = LOAD_CMS_COMPONENTS_FAIL;
-  constructor(uids: string[], public payload: any) {
-    super(COMPONENT_ENTITY, uids, payload);
+  constructor(public payload: T | T[], uid?: string | string[]) {
+    super(
+      COMPONENT_ENTITY,
+      uid || (!Array.isArray(payload) && payload.uid) || ''
+    );
   }
 }
 

--- a/projects/storefrontlib/src/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.ts
+++ b/projects/storefrontlib/src/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CmsService, CMSTabParagraphContainer } from '@spartacus/core';
-import { combineLatest, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { CmsComponentData } from '../../../cms-structure/page/model/index';
 
@@ -19,24 +19,21 @@ export class TabParagraphContainerComponent {
 
   components$: Observable<any[]> = this.componentData.data$.pipe(
     switchMap(data =>
-      combineLatest(
-        data.components.split(' ').map(component =>
-          this.cmsService.getComponentData<any>(component).pipe(
-            map(tab => {
-              if (!tab.flexType) {
-                tab = {
-                  ...tab,
-                  flexType: tab.typeCode,
-                };
-              }
-              return {
-                ...tab,
-                title: `CMSTabParagraphContainer.tabs.${tab.uid}`,
-              };
-            })
-          )
-        )
-      )
+      this.cmsService.getComponentsData(data.components.split(' '))
+    ),
+    map(componentsData =>
+      componentsData.map((tab: any) => {
+        if (!tab.flexType) {
+          tab = {
+            ...tab,
+            flexType: tab.typeCode,
+          };
+        }
+        return {
+          ...tab,
+          title: `CMSTabParagraphContainer.tabs.${tab.uid}`,
+        };
+      })
     )
   );
 


### PR DESCRIPTION
For now in `CmsService.getComponentData` we can get one component's data via its uid. This method prepares request to OCC and saves response as component data in the store and returns an observable with such chain.

Now we add also a similar method `CmsService.getComponentsData` to load multiple CMS components in one OCC call.

**TODO: remove usage of the new method from the `TabParagraphComponent`, because it's a breaking change**

TODO: add unit tests

close GH-3769