### PR TITLE
e2e tests failing in nightly builds related to anonymous consents (GH-5219)

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -107,7 +107,9 @@ export function verifyDeliveryMethod() {
     '/checkout/payment-details',
     'getPaymentPage'
   );
-  cy.get('button.btn-primary').click();
+  cy.get('button.btn-primary')
+    .contains('Continue')
+    .click();
   cy.wait(`@${paymentPage}`);
 }
 

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -5,5 +5,5 @@
 
 export const environment = {
   production: false,
-  occBaseUrl: 'https://dev-com-17.accdemo.b2c.ydev.hybris.com:9002',
+  occBaseUrl: '',
 };


### PR DESCRIPTION
Fixes e2e tests related to anonymous consents dialog causing cypress to match two different DOM button elements.

Closes GH-5219