### PR TITLE
feat: Add ghost loading effect when cart is loading (#5009)

### DIFF
--- a/projects/storefrontlib/src/cms-components/cart/cart-shared/cart-item-list/cart-item-list.component.html
+++ b/projects/storefrontlib/src/cms-components/cart/cart-shared/cart-item-list/cart-item-list.component.html
@@ -16,7 +16,8 @@
 </div>
 
 <div [formGroup]="form">
-  <div class="cx-item-list-row" *ngFor="let item of items">
+  <div class="cx-item-list-row position-relative" *ngFor="let item of items" >
+    <div class="cx-ghost-overlay-loader" *ngIf="cartIsLoading"></div>
     <div class="cx-item-list-items">
       <cx-cart-item
         [parent]="form.controls[item.product.code]"

--- a/projects/storefrontlib/src/cms-components/cart/cart-shared/cart-item-list/cart-item-list.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/cart/cart-shared/cart-item-list/cart-item-list.component.spec.ts
@@ -138,4 +138,21 @@ describe('CartItemListComponent', () => {
       component.form.controls[multipleMockItems[1].product.code]
     ).toBeDefined();
   });
+
+  it('should display ghost loader when cart is loading', () => {
+    component.cartIsLoading = true;
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.nativeElement.querySelector('.cx-ghost-overlay-loader')
+    ).toBeTruthy();
+  });
+
+  it('should  not display ghost loader when cart is loading', () => {
+    component.cartIsLoading = false;
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.nativeElement.querySelector('.cx-ghost-overlay-loader')
+    ).not.toBeTruthy();
+  });
+
 });

--- a/projects/storefrontstyles/scss/components/misc/_index.scss
+++ b/projects/storefrontstyles/scss/components/misc/_index.scss
@@ -1,6 +1,7 @@
 @import './card/index';
 @import './paging/index';
 @import './spinner/index';
+@import './ghost_overlay_loader/index';
 @import './icons';
 
 $misc-components-whitelist: cx-icon, cx-spinner, cx-card, cx-pagination !default;

--- a/projects/storefrontstyles/scss/components/misc/ghost_overlay_loader/_ghost_overlay_loader.scss
+++ b/projects/storefrontstyles/scss/components/misc/ghost_overlay_loader/_ghost_overlay_loader.scss
@@ -1,0 +1,35 @@
+$base-color: rgba(221, 221, 221, 0.863);
+$ghost-color: #ecebebf1;
+$animation-duration: 1000ms; 
+$gradient-offset: 52 + 16; 
+ 
+
+@mixin background-gradient { 
+  background-image: linear-gradient(90deg, $base-color 0px, $ghost-color 40px, $base-color 80px);
+  background-size: 80vw;
+}
+
+@keyframes ghost-lines { 
+  0%   { background-position: -100px;  }
+  40%  { background-position: 40vw;    }
+  100% { background-position: 60vw;    }
+}
+
+@mixin animate-ghost-line {
+  animation: ghost-lines $animation-duration infinite linear;
+}
+
+@mixin backdrop {
+  opacity: 0.5;
+  z-index: 2;
+  width: 100.5%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+}
+
+.cx-ghost-overlay-loader {
+    @include backdrop;
+    @include background-gradient;
+    @include animate-ghost-line;
+}

--- a/projects/storefrontstyles/scss/components/misc/ghost_overlay_loader/_index.scss
+++ b/projects/storefrontstyles/scss/components/misc/ghost_overlay_loader/_index.scss
@@ -1,0 +1,1 @@
+@import './ghost_overlay_loader';


### PR DESCRIPTION
Display ghost overlay loading effect when the cart is loading. This effect could be re-used in different places. 

closes (#5009)