### PR TITLE
refactor: drop default context config for languages ang currencies

### DIFF
--- a/docs/migration/2_0.md
+++ b/docs/migration/2_0.md
@@ -7,6 +7,17 @@
 Storage synchronization mechanism previously used to persist active cart id had some limitations that caused bugs on multi site stores (issue: [https://github.com/SAP/cloud-commerce-spartacus-storefront/issues/6215](https://github.com/SAP/cloud-commerce-spartacus-storefront/issues/6215)).
 Default storage sync configuration was removed from `MultiCartStoreModule`. Instead state persistence mechanism have been added for multi cart to provide the same behavior and to support multi site stores. It is build on top of `StatePersistenceService`. This is a new and recommended way to synchronize state to browser storage. Head to docs (TODO: add link to state persistence doc when it will be published) for more information.
 
+**Required config of the site context - languages and currencies**
+
+The default config for `context.language` and `context.currency` was dropped in favour of [the automatic site context configuration (multi-site)](https://sap.github.io/cloud-commerce-spartacus-storefront-docs/automatic-context-configuration/). This was the previous default config:
+```typescript
+context: {
+  language: ['en', 'de', 'ja', 'zh', 'ru', 'fr', 'tr', 'it', 'es', 'uk', 'pl', 'nl', 'hi', 'ar', 'pt', 'bn', 'pa'],
+  currency: ['USD', 'EUR', 'JPY', 'GBP', 'AUD', 'CAD', 'CHF', 'CNY', 'SEK', 'NZD', 'MXN', 'SGD', 'HKD', 'NOK', 'KRW', 'TRY', 'RUB', 'INR', 'BRL', 'ZAR'],
+}
+```
+To use static config of `context`, define it using `ConfigModule`.
+
 ### Deprecated since 1.2
 
 |  API  | Replacement |  Notes  |

--- a/projects/core/src/occ/adapters/site-context/site-context.interceptor.ts
+++ b/projects/core/src/occ/adapters/site-context/site-context.interceptor.ts
@@ -1,21 +1,20 @@
-import { Injectable } from '@angular/core';
 import {
   HttpEvent,
   HttpHandler,
   HttpInterceptor,
   HttpRequest,
 } from '@angular/common/http';
-
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { getContextParameterDefault } from '../../../site-context/config/context-config-utils';
+import { SiteContextConfig } from '../../../site-context/config/site-context-config';
 import { CurrencyService } from '../../../site-context/facade/currency.service';
 import { LanguageService } from '../../../site-context/facade/language.service';
-import { OccEndpointsService } from '../../services/occ-endpoints.service';
-import { SiteContextConfig } from '../../../site-context/config/site-context-config';
-import { getContextParameterDefault } from '../../../site-context/config/context-config-utils';
 import {
   CURRENCY_CONTEXT_ID,
   LANGUAGE_CONTEXT_ID,
 } from '../../../site-context/providers/context-ids';
+import { OccEndpointsService } from '../../services/occ-endpoints.service';
 
 @Injectable({ providedIn: 'root' })
 export class SiteContextInterceptor implements HttpInterceptor {
@@ -53,8 +52,8 @@ export class SiteContextInterceptor implements HttpInterceptor {
     if (request.url.includes(this.occEndpoints.getBaseEndpoint())) {
       request = request.clone({
         setParams: {
-          lang: this.activeLang,
-          curr: this.activeCurr,
+          lang: this.activeLang ?? '',
+          curr: this.activeCurr ?? '',
         },
       });
     }

--- a/projects/core/src/site-context/config/default-site-context-config.ts
+++ b/projects/core/src/site-context/config/default-site-context-config.ts
@@ -1,53 +1,5 @@
 import { SiteContextConfig } from './site-context-config';
-import {
-  CURRENCY_CONTEXT_ID,
-  LANGUAGE_CONTEXT_ID,
-} from '../providers/context-ids';
 
-export function defaultSiteContextConfigFactory(): SiteContextConfig {
-  return {
-    context: {
-      [LANGUAGE_CONTEXT_ID]: [
-        'en',
-        'de',
-        'ja',
-        'zh',
-        'ru',
-        'fr',
-        'tr',
-        'it',
-        'es',
-        'uk',
-        'pl',
-        'nl',
-        'hi',
-        'ar',
-        'pt',
-        'bn',
-        'pa',
-      ],
-      [CURRENCY_CONTEXT_ID]: [
-        'USD',
-        'EUR',
-        'JPY',
-        'GBP',
-        'AUD',
-        'CAD',
-        'CHF',
-        'CNY',
-        'SEK',
-        'NZD',
-        'MXN',
-        'SGD',
-        'HKD',
-        'NOK',
-        'KRW',
-        'TRY',
-        'RUB',
-        'INR',
-        'BRL',
-        'ZAR',
-      ],
-    },
-  };
-}
+export const defaultSiteContextConfig: SiteContextConfig = {
+  context: {},
+};

--- a/projects/core/src/site-context/site-context.module.ts
+++ b/projects/core/src/site-context/site-context.module.ts
@@ -1,9 +1,9 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { Config, ConfigModule } from '../config/config.module';
 import { provideConfigValidator } from '../config/config-validator/config-validator';
+import { Config, ConfigModule } from '../config/config.module';
 import { StateModule } from '../state/index';
 import { baseSiteConfigValidator } from './config/base-site-config-validator';
-import { defaultSiteContextConfigFactory } from './config/default-site-context-config';
+import { defaultSiteContextConfig } from './config/default-site-context-config';
 import { SiteContextConfig } from './config/site-context-config';
 import { contextServiceMapProvider } from './providers/context-service-map';
 import { contextServiceProviders } from './providers/context-service-providers';
@@ -13,7 +13,7 @@ import { SiteContextStoreModule } from './store/site-context-store.module';
 // @dynamic
 @NgModule({
   imports: [
-    ConfigModule.withConfigFactory(defaultSiteContextConfigFactory),
+    ConfigModule.withConfig(defaultSiteContextConfig),
     StateModule,
     SiteContextStoreModule,
   ],

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -48,6 +48,8 @@ if (!environment.production) {
           'apparel-uk',
           'apparel-uk-spa',
         ],
+        language: ['en', 'de', 'ja', 'zh'],
+        currency: ['USD', 'EUR', 'JPY', 'GBP'],
       },
 
       // custom routing configuration for e2e testing


### PR DESCRIPTION
Unless the auto multi-site config is used, the config `context.language` and `context.currency` must be now defined by a customer.

Now stackblitz examples will require at least:
```typescript
context: {
   language: ['en'],
   currency: ['USD']
}
```

Our internal instalation (deployment) scripts should also use the explicit config.

Schematics should now support options `language` and `currency` with many possible values.

Our installation docs should be also updated.

closes GH-5241