### PR TITLE
Checkout as persistent user test failing (GH-6696)

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -212,6 +212,7 @@ export function selectDeliveryMethod() {
 
 export function selectPaymentMethod() {
   cy.get('cx-breadcrumb h1').should('contain', 'Checkout');
+  cy.get('cx-payment-method').should('exist');
   cy.get('cx-payment-method h3.cx-checkout-title').should('contain', 'Payment');
   cy.get('p.cx-checkout-text').should('contain', 'Choose a payment method');
 
@@ -363,19 +364,19 @@ export function checkoutAsPersistentUserTest() {
     selectPaymentMethod();
   });
 
-  xit('should review and place order', () => {
+  it('should review and place order', () => {
     verifyAndPlaceOrder();
   });
 
-  xit('should display summary page', () => {
+  it('should display summary page', () => {
     displaySummaryPage();
   });
 
-  xit('should delete shipping address', () => {
+  it('should delete shipping address', () => {
     deleteShippingAddress();
   });
 
-  xit('should delete payment card', () => {
+  it('should delete payment card', () => {
     deletePaymentCard();
   });
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -215,6 +215,9 @@ export function selectDeliveryMethod() {
     'GET',
     '/rest/v2/electronics-spa/cms/pages?*/checkout/payment-details*'
   ).as('getPaymentPage');
+
+  cy.get('cx-checkout-progress').should('exist');
+
   cy.get('cx-checkout-progress a.is-active').should(
     'contain',
     '2. Delivery mode'

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -156,6 +156,15 @@ export function addPaymentMethod() {
 export function selectShippingAddress() {
   cy.server();
 
+  cy.route('GET', '/rest/v2/electronics-spa//users/current/carts/*').as(
+    'cartLoaded'
+  );
+
+  cy.route(
+    'GET',
+    '/rest/v2/electronics-spa/users/current/carts/*/deliverymodes?*'
+  ).as('loadDeliveryModes');
+
   cy.route(
     'GET',
     '/rest/v2/electronics-spa/cms/pages?*/checkout/shipping-address*'
@@ -188,6 +197,14 @@ export function selectShippingAddress() {
     .should('contain', 'Continue')
     .click();
   cy.wait('@getDeliveryPage')
+    .its('status')
+    .should('eq', 200);
+
+  cy.wait('@cartLoaded')
+    .its('status')
+    .should('eq', 200);
+
+  cy.wait('@loadDeliveryModes')
     .its('status')
     .should('eq', 200);
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -211,7 +211,13 @@ export function selectDeliveryMethod() {
 }
 
 export function selectPaymentMethod() {
-  cy.get('.cx-checkout-title').should('contain', 'Payment');
+  cy.get('cx-breadcrumb h1').should('contain', 'Checkout');
+  cy.get('cx-payment-method > h3.cx-checkout-title').should(
+    'contain',
+    'Payment'
+  );
+  cy.get('p.cx-checkout-text').should('contain', 'Choose a payment method');
+
   cy.get('cx-order-summary .cx-summary-partials .cx-summary-total')
     .find('.cx-summary-amount')
     .should('not.be.empty');

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -228,6 +228,13 @@ export function selectDeliveryMethod() {
 }
 
 export function selectPaymentMethod() {
+  cy.server();
+
+  cy.route(
+    'PUT',
+    '/rest/v2/electronics-spa/users/current/carts/*/paymentdetails*'
+  ).as('sendOrderData');
+
   cy.get('cx-breadcrumb h1').should('contain', 'Checkout');
   cy.get('cx-payment-method').should('exist');
   cy.get('cx-payment-method h3.cx-checkout-title').should('contain', 'Payment');
@@ -238,7 +245,10 @@ export function selectPaymentMethod() {
     .should('not.be.empty');
   cy.get('.cx-card-title').should('contain', 'Default Payment Method');
   cy.get('.card-header').should('contain', 'Selected');
+
   cy.get('button.btn-primary').click({ force: true });
+
+  cy.wait('@sendOrderData');
 }
 
 export function verifyAndPlaceOrder() {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -190,7 +190,6 @@ export function selectShippingAddress() {
   cy.wait('@getDeliveryPage')
     .its('status')
     .should('eq', 200);
-  cy.visit(`${Cypress.config('baseUrl')}/checkout/delivery-mode`);
 }
 
 export function selectDeliveryMethod() {
@@ -361,19 +360,19 @@ export function checkoutAsPersistentUserTest() {
     selectPaymentMethod();
   });
 
-  it('should review and place order', () => {
+  xit('should review and place order', () => {
     verifyAndPlaceOrder();
   });
 
-  it('should display summary page', () => {
+  xit('should display summary page', () => {
     displaySummaryPage();
   });
 
-  it('should delete shipping address', () => {
+  xit('should delete shipping address', () => {
     deleteShippingAddress();
   });
 
-  it('should delete payment card', () => {
+  xit('should delete payment card', () => {
     deletePaymentCard();
   });
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -190,6 +190,7 @@ export function selectShippingAddress() {
   cy.wait('@getDeliveryPage')
     .its('status')
     .should('eq', 200);
+  cy.visit(`${Cypress.config('baseUrl')}/checkout/delivery-mode`);
 }
 
 export function selectDeliveryMethod() {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -160,14 +160,23 @@ export function selectShippingAddress() {
     'GET',
     '/rest/v2/electronics-spa/cms/pages?*/checkout/shipping-address*'
   ).as('getShippingPage');
-  cy.getByText(/proceed to checkout/i).click();
+  cy.get('button.btn-primary')
+    .getByText(/proceed to checkout/i)
+    .click();
   cy.wait('@getShippingPage');
 
   cy.get('.cx-checkout-title').should('contain', 'Shipping Address');
+
+  cy.get('p.cx-checkout-text').should(
+    'contain',
+    'Select your Shipping Address'
+  );
+
   cy.get('cx-order-summary .cx-summary-partials .cx-summary-row')
     .first()
     .find('.cx-summary-amount')
     .should('not.be.empty');
+
   cy.get('.cx-card-title').should('contain', 'Default Shipping Address');
   cy.get('.card-header').should('contain', 'Selected');
 
@@ -175,7 +184,9 @@ export function selectShippingAddress() {
     'GET',
     '/rest/v2/electronics-spa/cms/pages?*/checkout/delivery-mode*'
   ).as('getDeliveryPage');
-  cy.get('button.btn-primary').click({ force: true });
+  cy.get('button.cx-btn.btn-primary')
+    .should('contain', 'Continue')
+    .click();
   cy.wait('@getDeliveryPage')
     .its('status')
     .should('eq', 200);
@@ -187,7 +198,6 @@ export function selectDeliveryMethod() {
     'GET',
     '/rest/v2/electronics-spa/cms/pages?*/checkout/payment-details*'
   ).as('getPaymentPage');
-  cy.get('cx-searchbox input[placeholder="Search here..."]');
   cy.get('cx-checkout-progress a.is-active').should(
     'contain',
     '2. Delivery mode'

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -216,12 +216,15 @@ export function selectDeliveryMethod() {
     '/rest/v2/electronics-spa/cms/pages?*/checkout/payment-details*'
   ).as('getPaymentPage');
 
-  cy.get('cx-checkout-progress').should('exist');
+  cy.get('cx-checkout-progress')
+    .should('exist')
+    .then(() => {
+      cy.get('cx-checkout-progress a.is-active').should(
+        'contain',
+        '2. Delivery mode'
+      );
+    });
 
-  cy.get('cx-checkout-progress a.is-active').should(
-    'contain',
-    '2. Delivery mode'
-  );
   cy.get('h3.cx-checkout-title').should('contain', 'Shipping Method');
   cy.get('#deliveryMode-standard-net').should('be.checked');
   cy.get('button.btn-primary').click({ force: true });

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -1,5 +1,6 @@
 import { product } from '../sample-data/checkout-flow';
 import { config, login, setSessionData } from '../support/utils/login';
+import { waitForPage } from './checkout-flow';
 
 export const username = 'test-user-cypress@ydev.hybris.com';
 export const password = 'Password123.';
@@ -162,7 +163,7 @@ export function selectShippingAddress() {
   ).as('cartLoaded');
 
   cy.route('GET', '/rest/v2/electronics-spa/users/current/addresses?*').as(
-    'getAdresses'
+    'getAddresses'
   );
 
   cy.route(
@@ -179,6 +180,7 @@ export function selectShippingAddress() {
     'GET',
     '/rest/v2/electronics-spa/cms/pages?*&pageType=ContentPage&pageLabelOrId=/checkout*'
   ).as('checkoutPageContent');
+
   cy.get('button.btn-primary')
     .getByText(/proceed to checkout/i)
     .click();
@@ -191,33 +193,41 @@ export function selectShippingAddress() {
     .its('status')
     .should('eq', 200);
 
-  cy.wait('@getAdresses')
+  cy.wait('@getAddresses')
     .its('status')
     .should('eq', 200);
 
-  cy.get('.cx-checkout-title').should('contain', 'Shipping Address');
+  cy.get('.cx-checkout-title')
+    .should('contain', 'Shipping Address')
+    .click({ force: true });
 
-  cy.get('p.cx-checkout-text').should(
-    'contain',
-    'Select your Shipping Address'
-  );
+  cy.get('p.cx-checkout-text')
+    .should('contain', 'Select your Shipping Address')
+    .click({ force: true });
 
   cy.get('cx-order-summary .cx-summary-partials .cx-summary-row')
     .first()
     .find('.cx-summary-amount')
     .should('not.be.empty');
 
-  cy.get('.cx-card-title').should('contain', 'Default Shipping Address');
-  cy.get('.card-header').should('contain', 'Selected');
+  cy.get('.cx-card-title')
+    .should('contain', 'Default Shipping Address')
+    .click({ force: true });
+  cy.get('.card-header')
+    .should('contain', 'Selected')
+    .click({ force: true });
 
-  cy.route(
-    'GET',
-    '/rest/v2/electronics-spa/cms/pages?*/checkout/delivery-mode*'
-  ).as('getDeliveryPage');
+  cy.get('button.btn-action').should('contain', 'Add New Address');
+
+  const deliveryPage = waitForPage(
+    '/checkout/delivery-mode',
+    'getDeliveryPage'
+  );
   cy.get('button.cx-btn.btn-primary')
     .should('contain', 'Continue')
-    .click();
-  cy.wait('@getDeliveryPage')
+    .click({ force: true });
+
+  cy.wait(`@${deliveryPage}`)
     .its('status')
     .should('eq', 200);
 
@@ -244,7 +254,7 @@ export function selectDeliveryMethod() {
   cy.get('cx-checkout-progress')
     .should('exist')
     .then(() => {
-      cy.get('cx-checkout-progress a.is-active').should(
+      cy.get('cx-checkout-progress a.cx-link').should(
         'contain',
         '2. Delivery mode'
       );

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -175,7 +175,7 @@ export function selectShippingAddress() {
     'GET',
     '/rest/v2/electronics-spa/cms/pages?*/checkout/delivery-mode*'
   ).as('getDeliveryPage');
-  cy.get('button.btn-primary').click();
+  cy.get('button.btn-primary').click({ force: true });
   cy.wait('@getDeliveryPage')
     .its('status')
     .should('eq', 200);
@@ -187,9 +187,14 @@ export function selectDeliveryMethod() {
     'GET',
     '/rest/v2/electronics-spa/cms/pages?*/checkout/payment-details*'
   ).as('getPaymentPage');
-  cy.get('.cx-checkout-title').should('contain', 'Shipping Method');
+  cy.get('cx-searchbox input[placeholder="Search here..."]');
+  cy.get('cx-checkout-progress a.is-active').should(
+    'contain',
+    '2. Delivery mode'
+  );
+  cy.get('h3.cx-checkout-title').should('contain', 'Shipping Method');
   cy.get('#deliveryMode-standard-net').should('be.checked');
-  cy.get('button.btn-primary').click();
+  cy.get('button.btn-primary').click({ force: true });
   cy.wait('@getPaymentPage')
     .its('status')
     .should('eq', 200);
@@ -202,7 +207,7 @@ export function selectPaymentMethod() {
     .should('not.be.empty');
   cy.get('.cx-card-title').should('contain', 'Default Payment Method');
   cy.get('.card-header').should('contain', 'Selected');
-  cy.get('button.btn-primary').click();
+  cy.get('button.btn-primary').click({ force: true });
 }
 
 export function verifyAndPlaceOrder() {
@@ -220,7 +225,7 @@ export function verifyAndPlaceOrder() {
   );
 
   cy.get('.form-check-input').check();
-  cy.get('button.btn-primary').click();
+  cy.get('button.btn-primary').click({ force: true });
 }
 
 export function displaySummaryPage() {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -212,10 +212,7 @@ export function selectDeliveryMethod() {
 
 export function selectPaymentMethod() {
   cy.get('cx-breadcrumb h1').should('contain', 'Checkout');
-  cy.get('cx-payment-method > h3.cx-checkout-title').should(
-    'contain',
-    'Payment'
-  );
+  cy.get('cx-payment-method h3.cx-checkout-title').should('contain', 'Payment');
   cy.get('p.cx-checkout-text').should('contain', 'Choose a payment method');
 
   cy.get('cx-order-summary .cx-summary-partials .cx-summary-total')


### PR DESCRIPTION
Closes GH-6696

Should also fix the flaky wishlist e2e tests on 1.5 branch as they use the same helper methods for checkout