### PR TITLE
chore: Add more schematics for classes with multiple constructors

### DIFF
--- a/projects/schematics/src/migrations/2_0/constructor-deprecations/constructor-deprecation-data.ts
+++ b/projects/schematics/src/migrations/2_0/constructor-deprecations/constructor-deprecation-data.ts
@@ -1,8 +1,8 @@
 import { ConstructorDeprecation } from '../../../shared/utils/file-utils';
 import { ADD_TO_CART_COMPONENT_MIGRATION } from './data/add-to-cart.component.migration';
-import { ADDRESS_BOOK_COMPONENT_SERVICE_MIGRATION } from './data/address-book.component.service.migration';
+import { ADDRESS_BOOK_COMPONENT_SERVICE_MIGRATIONS } from './data/address-book.component.service.migration';
 import { CART_NOT_EMPTY_GUARD_MIGRATION } from './data/cart-not-empty.guard.migration';
-import { CART_PAGE_LAYOUT_HANDLER_MIGRATION } from './data/cart-page-layout-handler.migration';
+import { CART_PAGE_LAYOUT_HANDLER_MIGRATIONS } from './data/cart-page-layout-handler.migration';
 import { CART_TOTALS_COMPONENT_MIGRATION } from './data/cart-totals.component.migration';
 import { CHECKOUT_AUTH_GUARD_MIGRATION } from './data/checkout-auth.guard.migration';
 import { CHECKOUT_DELIVERY_SERVICE_MIGRATION } from './data/checkout-delivery.service.migration';
@@ -12,12 +12,12 @@ import { CHECKOUT_ORDER_SUMMARY_COMPONENT_MIGRATION } from './data/checkout-orde
 import { CHECKOUT_PAGE_META_RESOLVER_MIGRATION } from './data/checkout-page-meta.resolver.migration';
 import { CHECKOUT_PAYMENT_SERVICE_MIGRATION } from './data/checkout-payment.service.migration';
 import { CHECKOUT_PROGRESS_MOBILE_TOP_COMPONENT_MIGRATION } from './data/checkout-progress-mobile-top.migration';
-import { CHECKOUT_GUARD_MIGRATION } from './data/checkout.guard.migration';
+import { CHECKOUT_GUARD_MIGRATIONS } from './data/checkout.guard.migration';
 import { CHECKOUT_SERVICE_MIGRATION } from './data/checkout.service.migration';
 import { MINI_CART_COMPONENT_MIGRATION } from './data/mini-cart.component.migration';
 import { NOT_CHECKOUT_AUTH_GUARD_MIGRATION } from './data/not-checkout-auth-guard.migration';
 import { PAGE_META_SERVICE_MIGRATION } from './data/page-meta.service.migration';
-import { PAYMENT_METHOD_COMPONENT_MIGRATION } from './data/payment-method.component.migration';
+import { PAYMENT_METHOD_COMPONENT_MIGRATIONS } from './data/payment-method.component.migration';
 import { PROMOTION_SERVICE_MIGRATION } from './data/promotion.service.migration';
 import { SHIPPING_ADDRESS_COMPONENT_MIGRATION } from './data/shipping-address.component.migration';
 import { CDS_SPARTACUS_EVENT_SERVICE_MIGRATION } from './data/spartacus-event.service.migration';
@@ -39,12 +39,12 @@ export const CONSTRUCTOR_DEPRECATION_DATA: ConstructorDeprecation[] = [
   CART_NOT_EMPTY_GUARD_MIGRATION,
   CART_TOTALS_COMPONENT_MIGRATION,
   MINI_CART_COMPONENT_MIGRATION,
-  ADDRESS_BOOK_COMPONENT_SERVICE_MIGRATION,
-  CHECKOUT_GUARD_MIGRATION,
+  ...ADDRESS_BOOK_COMPONENT_SERVICE_MIGRATIONS,
+  ...CHECKOUT_GUARD_MIGRATIONS,
   CHECKOUT_ORDER_SUMMARY_COMPONENT_MIGRATION,
   CHECKOUT_PROGRESS_MOBILE_TOP_COMPONENT_MIGRATION,
-  PAYMENT_METHOD_COMPONENT_MIGRATION,
+  ...PAYMENT_METHOD_COMPONENT_MIGRATIONS,
   CHECKOUT_AUTH_GUARD_MIGRATION,
-  CART_PAGE_LAYOUT_HANDLER_MIGRATION,
+  ...CART_PAGE_LAYOUT_HANDLER_MIGRATIONS,
   CDS_SPARTACUS_EVENT_SERVICE_MIGRATION,
 ];

--- a/projects/schematics/src/migrations/2_0/constructor-deprecations/data/add-to-cart.component.migration.ts
+++ b/projects/schematics/src/migrations/2_0/constructor-deprecations/data/add-to-cart.component.migration.ts
@@ -21,11 +21,11 @@ export const ADD_TO_CART_COMPONENT_MIGRATION: ConstructorDeprecation = {
       importPath: SPARTACUS_CORE,
     },
     {
-      className: CURRENT_PRODUCT_SERVICE,
+      className: MODAL_SERVICE,
       importPath: SPARTACUS_STOREFRONTLIB,
     },
     {
-      className: MODAL_SERVICE,
+      className: CURRENT_PRODUCT_SERVICE,
       importPath: SPARTACUS_STOREFRONTLIB,
     },
     {

--- a/projects/schematics/src/migrations/2_0/constructor-deprecations/data/address-book.component.service.migration.ts
+++ b/projects/schematics/src/migrations/2_0/constructor-deprecations/data/address-book.component.service.migration.ts
@@ -1,26 +1,53 @@
 import {
   ADDRESS_BOOK_COMPONENT_SERVICE,
   CHECKOUT_DELIVERY_SERVICE,
+  FEATURE_CONFIG_SERVICE,
   SPARTACUS_CORE,
   SPARTACUS_STOREFRONTLIB,
   USER_ADDRESS_SERVICE,
 } from '../../../../shared/constants';
 import { ConstructorDeprecation } from '../../../../shared/utils/file-utils';
 
-export const ADDRESS_BOOK_COMPONENT_SERVICE_MIGRATION: ConstructorDeprecation = {
+export const ADDRESS_BOOK_COMPONENT_SERVICE_MIGRATIONS: ConstructorDeprecation[] = [
   // projects/storefrontlib/src/cms-components/myaccount/address-book/address-book.component.service.ts
-  class: ADDRESS_BOOK_COMPONENT_SERVICE,
-  importPath: SPARTACUS_STOREFRONTLIB,
-  deprecatedParams: [
-    {
-      className: USER_ADDRESS_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-  ],
-  addParams: [
-    {
-      className: CHECKOUT_DELIVERY_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-  ],
-};
+  {
+    class: ADDRESS_BOOK_COMPONENT_SERVICE,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedParams: [
+      {
+        className: USER_ADDRESS_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    addParams: [
+      {
+        className: CHECKOUT_DELIVERY_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+  },
+  {
+    class: ADDRESS_BOOK_COMPONENT_SERVICE,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedParams: [
+      {
+        className: USER_ADDRESS_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_DELIVERY_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: FEATURE_CONFIG_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    removeParams: [
+      {
+        className: FEATURE_CONFIG_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+  },
+];

--- a/projects/schematics/src/migrations/2_0/constructor-deprecations/data/cart-page-layout-handler.migration.ts
+++ b/projects/schematics/src/migrations/2_0/constructor-deprecations/data/cart-page-layout-handler.migration.ts
@@ -2,36 +2,81 @@ import {
   ACTIVE_CART_SERVICE,
   CART_PAGE_LAYOUT_HANDLER,
   CART_SERVICE,
+  FEATURE_CONFIG_SERVICE,
   SELECTIVE_CART_SERVICE,
   SPARTACUS_CORE,
   SPARTACUS_STOREFRONTLIB,
 } from '../../../../shared/constants';
 import { ConstructorDeprecation } from '../../../../shared/utils/file-utils';
 
-export const CART_PAGE_LAYOUT_HANDLER_MIGRATION: ConstructorDeprecation = {
+export const CART_PAGE_LAYOUT_HANDLER_MIGRATIONS: ConstructorDeprecation[] = [
   // projects/storefrontlib/cms-components/cart/cart-page-layout-handler.ts
-  class: CART_PAGE_LAYOUT_HANDLER,
-  importPath: SPARTACUS_STOREFRONTLIB,
-  deprecatedParams: [
-    {
-      className: CART_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-  ],
-  removeParams: [
-    {
-      className: CART_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-  ],
-  addParams: [
-    {
-      className: ACTIVE_CART_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-    {
-      className: SELECTIVE_CART_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-  ],
-};
+  {
+    class: CART_PAGE_LAYOUT_HANDLER,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedParams: [
+      {
+        className: CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    removeParams: [
+      {
+        className: CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    addParams: [
+      {
+        className: ACTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: SELECTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+  },
+  {
+    class: CART_PAGE_LAYOUT_HANDLER,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedParams: [
+      {
+        className: CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: SELECTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: FEATURE_CONFIG_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    removeParams: [
+      {
+        className: CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: SELECTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: FEATURE_CONFIG_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    addParams: [
+      {
+        className: ACTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: SELECTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+  },
+];

--- a/projects/schematics/src/migrations/2_0/constructor-deprecations/data/checkout.guard.migration.ts
+++ b/projects/schematics/src/migrations/2_0/constructor-deprecations/data/checkout.guard.migration.ts
@@ -1,6 +1,7 @@
 import {
   ACTIVE_CART_SERVICE,
   ANGULAR_ROUTER,
+  CART_SERVICE,
   CHECKOUT_CONFIG,
   CHECKOUT_CONFIG_SERVICE,
   CHECKOUT_GUARD,
@@ -12,43 +13,90 @@ import {
 } from '../../../../shared/constants';
 import { ConstructorDeprecation } from '../../../../shared/utils/file-utils';
 
-export const CHECKOUT_GUARD_MIGRATION: ConstructorDeprecation = {
+export const CHECKOUT_GUARD_MIGRATIONS: ConstructorDeprecation[] = [
   // projects/storefrontlib/src/cms-components/checkout/guards/checkout.guard.ts
-
-  class: CHECKOUT_GUARD,
-  importPath: SPARTACUS_STOREFRONTLIB,
-  deprecatedParams: [
-    {
-      className: ROUTER,
-      importPath: ANGULAR_ROUTER,
-    },
-    {
-      className: CHECKOUT_CONFIG,
-      importPath: SPARTACUS_STOREFRONTLIB,
-    },
-    {
-      className: ROUTING_CONFIG_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-  ],
-  removeParams: [
-    {
-      className: CHECKOUT_CONFIG,
-      importPath: SPARTACUS_STOREFRONTLIB,
-    },
-  ],
-  addParams: [
-    {
-      className: CHECKOUT_CONFIG_SERVICE,
-      importPath: SPARTACUS_STOREFRONTLIB,
-    },
-    {
-      className: EXPRESS_CHECKOUT_SERVICE,
-      importPath: SPARTACUS_STOREFRONTLIB,
-    },
-    {
-      className: ACTIVE_CART_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-  ],
-};
+  {
+    class: CHECKOUT_GUARD,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedParams: [
+      {
+        className: ROUTER,
+        importPath: ANGULAR_ROUTER,
+      },
+      {
+        className: CHECKOUT_CONFIG,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+      {
+        className: ROUTING_CONFIG_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    removeParams: [
+      {
+        className: CHECKOUT_CONFIG,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+    ],
+    addParams: [
+      {
+        className: CHECKOUT_CONFIG_SERVICE,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+      {
+        className: EXPRESS_CHECKOUT_SERVICE,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+      {
+        className: ACTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+  },
+  {
+    class: CHECKOUT_GUARD,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedParams: [
+      {
+        className: ROUTER,
+        importPath: ANGULAR_ROUTER,
+      },
+      {
+        className: CHECKOUT_CONFIG,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+      {
+        className: ROUTING_CONFIG_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_CONFIG_SERVICE,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+      {
+        className: EXPRESS_CHECKOUT_SERVICE,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+      {
+        className: CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    removeParams: [
+      {
+        className: CHECKOUT_CONFIG,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+      {
+        className: CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    addParams: [
+      {
+        className: ACTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+  },
+];

--- a/projects/schematics/src/migrations/2_0/constructor-deprecations/data/payment-method.component.migration.ts
+++ b/projects/schematics/src/migrations/2_0/constructor-deprecations/data/payment-method.component.migration.ts
@@ -2,6 +2,7 @@ import {
   ACTIVATED_ROUTE,
   ACTIVE_CART_SERVICE,
   ANGULAR_ROUTER,
+  CART_SERVICE,
   CHECKOUT_CONFIG_SERVICE,
   CHECKOUT_DELIVERY_SERVICE,
   CHECKOUT_PAYMENT_SERVICE,
@@ -16,52 +17,112 @@ import {
 } from '../../../../shared/constants';
 import { ConstructorDeprecation } from '../../../../shared/utils/file-utils';
 
-export const PAYMENT_METHOD_COMPONENT_MIGRATION: ConstructorDeprecation = {
+export const PAYMENT_METHOD_COMPONENT_MIGRATIONS: ConstructorDeprecation[] = [
   // projects/storefrontlib/src/cms-components/checkout/components/payment-method/payment-method.component.ts
-  class: PAYMENT_METHOD_COMPONENT,
-  importPath: SPARTACUS_STOREFRONTLIB,
-  deprecatedParams: [
-    {
-      className: USER_PAYMENT_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-    {
-      className: CHECKOUT_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-    {
-      className: CHECKOUT_DELIVERY_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-    {
-      className: CHECKOUT_PAYMENT_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-    {
-      className: GLOBAL_MESSAGE_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-    {
-      className: ROUTING_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-    {
-      className: CHECKOUT_CONFIG_SERVICE,
-      importPath: SPARTACUS_STOREFRONTLIB,
-    },
-    {
-      className: ACTIVATED_ROUTE,
-      importPath: ANGULAR_ROUTER,
-    },
-    {
-      className: TRANSLATION_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-  ],
-  addParams: [
-    {
-      className: ACTIVE_CART_SERVICE,
-      importPath: SPARTACUS_CORE,
-    },
-  ],
-};
+  {
+    class: PAYMENT_METHOD_COMPONENT,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedParams: [
+      {
+        className: USER_PAYMENT_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_DELIVERY_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_PAYMENT_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: GLOBAL_MESSAGE_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: ROUTING_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_CONFIG_SERVICE,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+      {
+        className: ACTIVATED_ROUTE,
+        importPath: ANGULAR_ROUTER,
+      },
+      {
+        className: TRANSLATION_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    addParams: [
+      {
+        className: ACTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+  },
+  {
+    class: PAYMENT_METHOD_COMPONENT,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedParams: [
+      {
+        className: USER_PAYMENT_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_DELIVERY_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_PAYMENT_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: GLOBAL_MESSAGE_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: ROUTING_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CHECKOUT_CONFIG_SERVICE,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+      {
+        className: ACTIVATED_ROUTE,
+        importPath: ANGULAR_ROUTER,
+      },
+      {
+        className: TRANSLATION_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    removeParams: [
+      {
+        className: CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+    addParams: [
+      {
+        className: ACTIVE_CART_SERVICE,
+        importPath: SPARTACUS_CORE,
+      },
+    ],
+  },
+];


### PR DESCRIPTION
Use case:
Customer might have already provided some classes and in that case we might to do another change (like removing featureConfigService).

Additionally found one bad config with switched constrcutor parameters.