### PR TITLE
feat: Remove deprecated behavior in component-wrapper directive

### DIFF
--- a/docs/migration/2_0.md
+++ b/docs/migration/2_0.md
@@ -21,7 +21,7 @@ To avoid one type of bugs (missing parameters) when dispatching ngrx actions we 
 
 List of actions with changed payload type: `CartAddEntry`, `CartAddEntrySuccess`, `CartRemoveEntry`, `CartRemoveEntrySuccess`, `CartUpdateEntry`, `CartUpdateEntrySuccess`, `AddEmailToCartSuccess`, `MergeCartSuccess`.
 
-### Deprecated since 1.0
+### Deprecated since 1.1
 
 |  API  | Replacement |  Notes  |
 |-------|-------------|---------|

--- a/docs/migration/2_0.md
+++ b/docs/migration/2_0.md
@@ -21,6 +21,12 @@ To avoid one type of bugs (missing parameters) when dispatching ngrx actions we 
 
 List of actions with changed payload type: `CartAddEntry`, `CartAddEntrySuccess`, `CartRemoveEntry`, `CartRemoveEntrySuccess`, `CartUpdateEntry`, `CartUpdateEntrySuccess`, `AddEmailToCartSuccess`, `MergeCartSuccess`.
 
+### Deprecated since 1.0
+
+|  API  | Replacement |  Notes  |
+|-------|-------------|---------|
+| cxApi.CmsComponentData | cxApi.cmsComponentData | - |
+
 ### Deprecated since 1.2
 
 |  API  | Replacement |  Notes  |

--- a/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.spec.ts
@@ -262,7 +262,7 @@ describe('ComponentWrapperDirective', () => {
             'cms-component'
           );
           expect(cmsComponentElement).toBeTruthy();
-          const componentData = cmsComponentElement.cxApi.CmsComponentData;
+          const componentData = cmsComponentElement.cxApi.cmsComponentData;
           expect(componentData.uid).toEqual('test_uid');
           done();
         });

--- a/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
@@ -92,7 +92,6 @@ export class ComponentWrapperDirective implements OnInit, OnDestroy {
 
       this.webElement.cxApi = {
         ...this.injector.get(CxApiService),
-        CmsComponentData: cmsComponentData, // TODO: remove / deprecated since 1.0.x
         cmsComponentData,
       };
 


### PR DESCRIPTION
Closes #6971

cxApi.CmsComponentData was removed. cxApi.cmsComponentData should be used instead.