### PR TITLE
fix: carousel slides container take size of active slide (GH-6980)

### DIFF
--- a/projects/storefrontlib/src/shared/components/carousel/carousel.component.html
+++ b/projects/storefrontlib/src/shared/components/carousel/carousel.component.html
@@ -13,7 +13,7 @@
 
     <div class="slides">
       <ng-container *ngFor="let _ of items; let i = index">
-        <div class="slide" *ngIf="i % size === 0">
+        <div class="slide" *ngIf="i % size === 0" [class.active]="i === activeSlide">
           <ng-container
             *ngFor="let item of items | slice: i:i + size; let j = index"
           >

--- a/projects/storefrontlib/src/shared/components/carousel/carousel.component.html
+++ b/projects/storefrontlib/src/shared/components/carousel/carousel.component.html
@@ -13,7 +13,11 @@
 
     <div class="slides">
       <ng-container *ngFor="let _ of items; let i = index">
-        <div class="slide" *ngIf="i % size === 0" [class.active]="i === activeSlide">
+        <div
+          class="slide"
+          *ngIf="i % size === 0"
+          [class.active]="i === activeSlide"
+        >
           <ng-container
             *ngFor="let item of items | slice: i:i + size; let j = index"
           >

--- a/projects/storefrontstyles/scss/components/product/carousel/_carousel.scss
+++ b/projects/storefrontstyles/scss/components/product/carousel/_carousel.scss
@@ -39,10 +39,11 @@
         flex-wrap: nowrap;
         justify-content: flex-start;
 
-        &:not(:last-child) {
-          // we keep the last slide non-absolute, so the height
-          //  of the parent size is based on contetn
+        &:not(.active) {
+          // we keep the active slide non-absolute, so the height
+          // of the parent is based on the displayed slide
           position: absolute;
+          top: 0;
         }
 
         .item {


### PR DESCRIPTION
Carousel takes the height of the last slide. Active class is given to the active slide so it will set the height of the container.

Closes GH-6980