### PR TITLE
Breaking changes since 1.1 - Client Authentication Token Service constructor deprecation (GH-7012)

### DIFF
--- a/docs/migration/2_0.md
+++ b/docs/migration/2_0.md
@@ -128,7 +128,8 @@ Support for functions dropped:
 - `StarRatingComponent` now requires new parameter `Renderer2`. This service needs to be provided for `StarRatingComponent`.
 - `ProductService` now requires `ProductLoadingService`
 - `ProductCarouselComponent` no longer requires `FeatureConfigService`
-- `CurrentProductService` no longer requires `FeatureConfigService` 
+- `CurrentProductService` no longer requires `FeatureConfigService`
+- `ClientAuthenticationTokenService` now requires parameter `occEndpointsService`. This parameter is no longer optional and is required instead.
 
 # Larger refactoring for 2.0
 

--- a/projects/core/src/auth/services/client-authentication/client-authentication-token.service.ts
+++ b/projects/core/src/auth/services/client-authentication/client-authentication-token.service.ts
@@ -8,21 +8,9 @@ import { ClientToken } from '../../models/token-types.model';
 @Injectable()
 export class ClientAuthenticationTokenService {
   constructor(
-    config: AuthConfig,
-    http: HttpClient,
-    // tslint:disable-next-line:unified-signatures
-    occEndpointsService: OccEndpointsService
-  );
-
-  /**
-   * @deprecated since version 1.1
-   * Use constructor(http: HttpClient, config: AuthConfig, occEndpointsService: OccEndpointsService) instead
-   */
-  constructor(config: AuthConfig, http: HttpClient);
-  constructor(
     protected config: AuthConfig,
     protected http: HttpClient,
-    protected occEndpointsService?: OccEndpointsService
+    protected occEndpointsService: OccEndpointsService
   ) {}
 
   loadClientAuthenticationToken(): Observable<ClientToken> {


### PR DESCRIPTION
Closes GH-7012