### PR TITLE
fix: provide Session affinity with the withCredentials=true flag on http requests

### DIFF
--- a/projects/core/src/occ/index.ts
+++ b/projects/core/src/occ/index.ts
@@ -6,6 +6,7 @@ export * from './config/config-from-meta-tag-factory';
 export * from './config/default-occ-config';
 export * from './config/occ-config';
 export * from './config/occ-config-validator';
+export * from './interceptor/index';
 export * from './occ-models/index';
 export * from './occ.module';
 export * from './services/index';

--- a/projects/core/src/occ/interceptor/index.ts
+++ b/projects/core/src/occ/interceptor/index.ts
@@ -10,7 +10,7 @@ export * from './with-credentials.interceptor';
  * In version 2.0 this provider will be removed, as you no longer need to
  * manually provide this interceptor as it will be provided in the `OccModule`.
  */
-export const WithCredentialsInterceptorProvider: Provider = {
+export const withCredentialsInterceptorProvider: Provider = {
   provide: HTTP_INTERCEPTORS,
   useExisting: WithCredentialsInterceptor,
   multi: true,

--- a/projects/core/src/occ/interceptor/index.ts
+++ b/projects/core/src/occ/interceptor/index.ts
@@ -1,0 +1,17 @@
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { Provider } from '@angular/core';
+import { WithCredentialsInterceptor } from './with-credentials.interceptor';
+
+export * from './with-credentials.interceptor';
+
+/**
+ * @deprecated since 1.4.0
+ *
+ * In version 2.0 this provider will be removed, as you no longer need to
+ * manually provide this interceptor as it will be provided in the `OccModule`.
+ */
+export const WithCredentialsInterceptorProvider: Provider = {
+  provide: HTTP_INTERCEPTORS,
+  useExisting: WithCredentialsInterceptor,
+  multi: true,
+};

--- a/projects/core/src/occ/interceptor/with-credentials.interceptor.spec.ts
+++ b/projects/core/src/occ/interceptor/with-credentials.interceptor.spec.ts
@@ -12,7 +12,7 @@ import { WithCredentialsInterceptor } from './with-credentials.interceptor';
 const OccUrl = `https://localhost:9002${defaultOccConfig.backend.occ.prefix}/electronics/test`;
 const NonOccUrl = 'https://other.com/endpoint';
 
-fdescribe('WithCredentialsInterceptor', () => {
+describe('WithCredentialsInterceptor', () => {
   describe('useWithCredentials: true', () => {
     const MockAuthModuleConfig: OccConfig = {
       backend: {

--- a/projects/core/src/occ/interceptor/with-credentials.interceptor.spec.ts
+++ b/projects/core/src/occ/interceptor/with-credentials.interceptor.spec.ts
@@ -1,0 +1,125 @@
+import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+  TestRequest,
+} from '@angular/common/http/testing';
+import { inject, TestBed } from '@angular/core/testing';
+import { defaultOccConfig } from '../config/default-occ-config';
+import { OccConfig } from '../config/occ-config';
+import { WithCredentialsInterceptor } from './with-credentials.interceptor';
+
+const OccUrl = `https://localhost:9002${defaultOccConfig.backend.occ.prefix}/electronics/test`;
+const NonOccUrl = 'https://other.com/endpoint';
+
+fdescribe('WithCredentialsInterceptor', () => {
+  describe('useWithCredentials: true', () => {
+    const MockAuthModuleConfig: OccConfig = {
+      backend: {
+        occ: {
+          baseUrl: 'https://localhost:9002',
+          prefix: defaultOccConfig.backend.occ.prefix,
+        },
+      },
+    };
+
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [
+          { provide: OccConfig, useValue: MockAuthModuleConfig },
+          {
+            provide: HTTP_INTERCEPTORS,
+            useClass: WithCredentialsInterceptor,
+            multi: true,
+          },
+        ],
+      });
+      httpMock = TestBed.get(HttpTestingController);
+    });
+
+    it('should add the `withCredentials` flag to an OCC request', inject(
+      [HttpClient],
+      (http: HttpClient) => {
+        http
+          .get(OccUrl)
+          .subscribe()
+          .unsubscribe();
+
+        const mockReq: TestRequest = httpMock.expectOne(OccUrl);
+
+        expect(mockReq.request.withCredentials).toBe(true);
+      }
+    ));
+
+    it('should not add the `withCredentials` flag to other request', inject(
+      [HttpClient],
+      (http: HttpClient) => {
+        http
+          .get(NonOccUrl)
+          .subscribe()
+          .unsubscribe();
+
+        const mockReq: TestRequest = httpMock.expectOne(NonOccUrl);
+
+        expect(mockReq.request.withCredentials).toBe(false);
+      }
+    ));
+  });
+
+  describe('custom prefix', () => {
+    const MockAuthModuleConfig: OccConfig = {
+      backend: {
+        occ: {
+          baseUrl: 'https://localhost:9002',
+          prefix: '/my/prefix/',
+        },
+      },
+    };
+
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [
+          { provide: OccConfig, useValue: MockAuthModuleConfig },
+          {
+            provide: HTTP_INTERCEPTORS,
+            useClass: WithCredentialsInterceptor,
+            multi: true,
+          },
+        ],
+      });
+      httpMock = TestBed.get(HttpTestingController);
+    });
+
+    it('should not add the `withCredentials` flag to request with wrong prefix', inject(
+      [HttpClient],
+      (http: HttpClient) => {
+        http
+          .get(OccUrl)
+          .subscribe()
+          .unsubscribe();
+        const mockReq: TestRequest = httpMock.expectOne(OccUrl);
+        expect(mockReq.request.withCredentials).toBe(false);
+      }
+    ));
+
+    it('should add the `withCredentials` flag to request with configured prefix', inject(
+      [HttpClient],
+      (http: HttpClient) => {
+        http
+          .get('thirdparty.com/my/prefix/xyz')
+          .subscribe()
+          .unsubscribe();
+        const mockReq: TestRequest = httpMock.expectOne(
+          'thirdparty.com/my/prefix/xyz'
+        );
+        expect(mockReq.request.withCredentials).toBe(true);
+      }
+    ));
+  });
+});

--- a/projects/core/src/occ/interceptor/with-credentials.interceptor.ts
+++ b/projects/core/src/occ/interceptor/with-credentials.interceptor.ts
@@ -1,0 +1,54 @@
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { OccConfig } from '../config/occ-config';
+
+/**
+ * Http interceptor to add cookies to all cross-site requests.
+ */
+@Injectable({ providedIn: 'root' })
+export class WithCredentialsInterceptor implements HttpInterceptor {
+  constructor(protected config: OccConfig) {}
+
+  /**
+   * Intercepts each request and adds the `withCredential` flag to it
+   * if it hasn't been added already.
+   */
+  intercept(
+    request: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    if (this.requiresWithCredentials(request)) {
+      request = request.clone({
+        withCredentials: true,
+      });
+    }
+    return next.handle(request);
+  }
+
+  /**
+   * Indicates whether this is an OCC request.
+   */
+  protected requiresWithCredentials(request: HttpRequest<any>): boolean {
+    return (
+      /**
+       * This `occConfig?.useWithCredentials` flag has only been introduced in
+       * version 2.0. Customers must provide this interceptors manually in their
+       * app to opt-in to use this feature, as we don't backport the configuration.
+       */
+      // this.occConfig?.useWithCredentials &&
+      request.url.indexOf(this.occConfig.prefix) > -1
+    );
+  }
+
+  private get occConfig() {
+    return this.config && this.config.backend && this.config.backend.occ
+      ? this.config.backend.occ
+      : {};
+  }
+}


### PR DESCRIPTION
closes #7104

This could be considered a feature as well. It's been introduced in 2.0, but a backport was required for customers who scale out their API. In order to configure this behaviour (which is turned of by default), you must provide the interceptor in a module (i.e. in the `AppModule`)

```
providers: [withCredentialsInterceptorProvider],
```

Additionally, a CORS configuration is required in the backend to pass requests from another domain. The following configuration must be installed:

`corsfilter.ycommercewebservices.allowCredentials=true`

This can be done either in the backoffice or by using project.properties. 