### PR TITLE
fix: remove anonymous consents feature flag from cds app

### DIFF
--- a/projects/storefrontapp-cds-integration/src/app/app.module.ts
+++ b/projects/storefrontapp-cds-integration/src/app/app.module.ts
@@ -67,7 +67,6 @@ if (!environment.production) {
       },
       features: {
         level: '1.5',
-        anonymousConsents: true,
       },
     }),
     JsonLdBuilderModule,


### PR DESCRIPTION
This fix removes the anonymous consents flag from the CDS shell app.