### PR TITLE
feat: Improve scoped loader reducer and state

### DIFF
--- a/docs/migration/2_0.md
+++ b/docs/migration/2_0.md
@@ -10,7 +10,11 @@ Before 2.0 some dependencies of the `CmsPageGuard` were not public, so the guard
 
 Previously config validator logic was part of `ConfigModule`. If you are not using `StorefrontFoundationModule` or any of its descendants, it's required to import `ConfigValidatorModule.forRoot()` in order to make config validators run.
 
-### Factories removed from storefrontlib public API
+### Selectors removed from @spartacus/core
+
+`getSelectedProductsFactory` was removed as it was outdated.
+
+### Factories removed from @spartacus/storefront public API
 
 `pwaConfigurationFactory`, `pwaFactory`, `getStructuredDataFactory` and `skipLinkFactory` were removed from storefront library public API.
 

--- a/docs/migration/2_0.md
+++ b/docs/migration/2_0.md
@@ -12,7 +12,7 @@ Previously config validator logic was part of `ConfigModule`. If you are not usi
 
 ### Selectors removed from @spartacus/core
 
-`getSelectedProductsFactory` was removed as it was outdated.
+`ProductSelectors.getSelectedProductsFactory` was removed as it was outdated.
 
 ### Factories removed from @spartacus/storefront public API
 

--- a/projects/core/src/product/store/selectors/product.selectors.spec.ts
+++ b/projects/core/src/product/store/selectors/product.selectors.spec.ts
@@ -7,7 +7,7 @@ import * as fromReducers from '../reducers/index';
 import { ProductSelectors } from '../selectors/index';
 import { Subscription } from 'rxjs';
 
-describe('Cms Component Selectors', () => {
+describe('Product Selectors', () => {
   let store: Store<StateWithProduct>;
 
   const code = 'testCode';
@@ -36,19 +36,6 @@ describe('Cms Component Selectors', () => {
       subscription.unsubscribe();
       subscription = undefined;
     }
-  });
-
-  describe('getSelectedProductsFactory', () => {
-    it('should return product by code', () => {
-      let result: Product[];
-      subscription = store
-        .pipe(select(ProductSelectors.getSelectedProductsFactory(['testCode'])))
-        .subscribe((value) => (result = value));
-
-      store.dispatch(new ProductActions.LoadProductSuccess(product));
-
-      expect(result).toEqual([product]);
-    });
   });
 
   describe('getAllProductCodes', () => {

--- a/projects/core/src/product/store/selectors/product.selectors.ts
+++ b/projects/core/src/product/store/selectors/product.selectors.ts
@@ -15,36 +15,21 @@ export const getProductState: MemoizedSelector<
   EntityLoaderState<Product>
 > = createSelector(getProductsState, (state: ProductsState) => state.details);
 
-export const getSelectedProductsFactory = (
-  codes: string[]
-): MemoizedSelector<StateWithProduct, Product[]> => {
-  return createSelector(
-    getProductState,
-    (details: EntityLoaderState<Product>) => {
-      return codes
-        .map((code) =>
-          details.entities[code] ? details.entities[code].value : undefined
-        )
-        .filter((product) => product !== undefined);
-    }
-  );
-};
-
 export const getSelectedProductStateFactory = (
   code: string,
-  scope?: string
+  scope = ''
 ): MemoizedSelector<StateWithProduct, LoaderState<Product>> => {
-  return createSelector(getProductState, (details) =>
-    scope
-      ? StateEntityLoaderSelectors.entityStateSelector(details, code)[scope] ||
-        initialLoaderState
-      : StateEntityLoaderSelectors.entityStateSelector(details, code)
+  return createSelector(
+    getProductState,
+    (details) =>
+      StateEntityLoaderSelectors.entityStateSelector(details, code)[scope] ||
+      initialLoaderState
   );
 };
 
 export const getSelectedProductFactory = (
   code: string,
-  scope?: string
+  scope = ''
 ): MemoizedSelector<StateWithProduct, Product> => {
   return createSelector(
     getSelectedProductStateFactory(code, scope),
@@ -54,7 +39,7 @@ export const getSelectedProductFactory = (
 
 export const getSelectedProductLoadingFactory = (
   code: string,
-  scope?: string
+  scope = ''
 ): MemoizedSelector<StateWithProduct, boolean> => {
   return createSelector(
     getSelectedProductStateFactory(code, scope),
@@ -64,7 +49,7 @@ export const getSelectedProductLoadingFactory = (
 
 export const getSelectedProductSuccessFactory = (
   code: string,
-  scope?: string
+  scope = ''
 ): MemoizedSelector<StateWithProduct, boolean> => {
   return createSelector(
     getSelectedProductStateFactory(code, scope),
@@ -74,7 +59,7 @@ export const getSelectedProductSuccessFactory = (
 
 export const getSelectedProductErrorFactory = (
   code: string,
-  scope?: string
+  scope = ''
 ): MemoizedSelector<StateWithProduct, boolean> => {
   return createSelector(
     getSelectedProductStateFactory(code, scope),

--- a/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.spec.ts
+++ b/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.spec.ts
@@ -19,6 +19,72 @@ describe('entityScopedLoaderReducer', () => {
     });
   });
 
+  describe('without scope', () => {
+    const TEST_ENTITY_ID = 'testId';
+
+    describe('single entity', () => {
+      it('LOAD ACTION should set load state', () => {
+        const action = new EntityScopedLoaderActions.EntityScopedLoadAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITY_ID
+        );
+        const state = entityScopedLoaderReducer(TEST_ENTITY_TYPE)(
+          undefined,
+          action
+        );
+        const expectedState = {
+          entities: {
+            [TEST_ENTITY_ID]: {
+              '': {
+                loading: true,
+                error: false,
+                success: false,
+                value: undefined,
+              },
+            },
+          },
+        };
+        expect(state).toEqual(expectedState);
+      });
+    });
+
+    describe('multiple entities', () => {
+      const TEST_ENTITIES_ID = ['test1', 'test2'];
+
+      it('LOAD ACTION should set load state', () => {
+        const action = new EntityScopedLoaderActions.EntityScopedLoadAction(
+          TEST_ENTITY_TYPE,
+          TEST_ENTITIES_ID
+        );
+        const state = entityScopedLoaderReducer(TEST_ENTITY_TYPE)(
+          undefined,
+          action
+        );
+        const expectedState = {
+          entities: {
+            [TEST_ENTITIES_ID[0]]: {
+              '': {
+                loading: true,
+                error: false,
+                success: false,
+                value: undefined,
+              },
+            },
+            [TEST_ENTITIES_ID[1]]: {
+              '': {
+                loading: true,
+                error: false,
+                success: false,
+                value: undefined,
+              },
+            },
+          },
+        };
+        expect(state).toEqual(expectedState);
+      });
+    });
+  });
+
   describe('with scope', () => {
     const SCOPE = 'testScope';
     const TEST_ENTITY_ID = 'testId';

--- a/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.spec.ts
+++ b/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.spec.ts
@@ -19,66 +19,6 @@ describe('entityScopedLoaderReducer', () => {
     });
   });
 
-  describe('without scope', () => {
-    const TEST_ENTITY_ID = 'testId';
-
-    describe('single entity', () => {
-      it('LOAD ACTION should set load state', () => {
-        const action = new EntityScopedLoaderActions.EntityScopedLoadAction(
-          TEST_ENTITY_TYPE,
-          TEST_ENTITY_ID
-        );
-        const state = entityScopedLoaderReducer(TEST_ENTITY_TYPE)(
-          undefined,
-          action
-        );
-        const expectedState = {
-          entities: {
-            [TEST_ENTITY_ID]: {
-              loading: true,
-              error: false,
-              success: false,
-              value: undefined,
-            },
-          },
-        };
-        expect(state).toEqual(expectedState);
-      });
-    });
-
-    describe('multiple entities', () => {
-      const TEST_ENTITIES_ID = ['test1', 'test2'];
-
-      it('LOAD ACTION should set load state', () => {
-        const action = new EntityScopedLoaderActions.EntityScopedLoadAction(
-          TEST_ENTITY_TYPE,
-          TEST_ENTITIES_ID
-        );
-        const state = entityScopedLoaderReducer(TEST_ENTITY_TYPE)(
-          undefined,
-          action
-        );
-        const expectedState = {
-          entities: {
-            [TEST_ENTITIES_ID[0]]: {
-              loading: true,
-              error: false,
-              success: false,
-              value: undefined,
-            },
-            [TEST_ENTITIES_ID[1]]: {
-              loading: true,
-              error: false,
-              success: false,
-              value: undefined,
-            },
-          },
-        };
-        expect(state).toEqual(expectedState);
-      });
-    });
-  });
-
   describe('with scope', () => {
     const SCOPE = 'testScope';
     const TEST_ENTITY_ID = 'testId';
@@ -97,10 +37,6 @@ describe('entityScopedLoaderReducer', () => {
         const expectedState: any = {
           entities: {
             [TEST_ENTITY_ID]: {
-              loading: false,
-              error: false,
-              success: false,
-              value: undefined,
               [SCOPE]: {
                 loading: true,
                 error: false,
@@ -130,10 +66,6 @@ describe('entityScopedLoaderReducer', () => {
         const expectedState = {
           entities: {
             [TEST_ENTITIES_ID[0]]: {
-              loading: false,
-              error: false,
-              success: false,
-              value: undefined,
               [SCOPE]: {
                 loading: true,
                 error: false,
@@ -142,10 +74,6 @@ describe('entityScopedLoaderReducer', () => {
               },
             },
             [TEST_ENTITIES_ID[1]]: {
-              loading: false,
-              error: false,
-              success: false,
-              value: undefined,
               [SCOPE]: {
                 loading: true,
                 error: false,

--- a/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.ts
+++ b/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.ts
@@ -7,7 +7,6 @@ import { scopedLoaderReducer } from './scoped-loader.reducer';
 import { entityReducer } from '../entity/entity.reducer';
 import { LoaderAction } from '../loader/loader.action';
 import { EntityScopedLoaderActions } from './entity-scoped-loader.actions';
-import EntityScopedLoaderAction = EntityScopedLoaderActions.EntityScopedLoaderAction;
 
 /**
  * Higher order reducer that wraps scopedLoaderReducer and EntityReducer enhancing
@@ -18,7 +17,7 @@ export function entityScopedLoaderReducer<T>(
   reducer?: (state: T, action: LoaderAction) => T
 ): (
   state: EntityScopedLoaderState<T>,
-  action: EntityScopedLoaderAction
+  action: EntityScopedLoaderActions.EntityScopedLoaderAction
 ) => EntityScopedLoaderState<T> {
   return entityReducer<ScopedLoaderState<T>>(
     entityType,

--- a/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.ts
+++ b/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.ts
@@ -1,11 +1,13 @@
-import { ScopedLoaderState } from './scoped-loader.state';
+import {
+  EntityScopedLoaderState,
+  ScopedLoaderState,
+} from './scoped-loader.state';
 import { scopedLoaderReducer } from './scoped-loader.reducer';
 
 import { entityReducer } from '../entity/entity.reducer';
 import { LoaderAction } from '../loader/loader.action';
-import { EntityLoaderState } from '../entity-loader/entity-loader-state';
-import { EntityLoaderAction } from '../entity-loader/entity-loader.action';
-import { LoaderState } from '../loader/loader-state';
+import { EntityScopedLoaderActions } from './entity-scoped-loader.actions';
+import EntityScopedLoaderAction = EntityScopedLoaderActions.EntityScopedLoaderAction;
 
 /**
  * Higher order reducer that wraps scopedLoaderReducer and EntityReducer enhancing
@@ -15,10 +17,10 @@ export function entityScopedLoaderReducer<T>(
   entityType: string,
   reducer?: (state: T, action: LoaderAction) => T
 ): (
-  state: EntityLoaderState<T>,
-  action: EntityLoaderAction
-) => EntityLoaderState<T> {
-  return entityReducer<ScopedLoaderState<T> | LoaderState<T>>(
+  state: EntityScopedLoaderState<T>,
+  action: EntityScopedLoaderAction
+) => EntityScopedLoaderState<T> {
+  return entityReducer<ScopedLoaderState<T>>(
     entityType,
     scopedLoaderReducer<T>(entityType, reducer)
   );

--- a/projects/core/src/state/utils/scoped-loader/scoped-loader.reducer.spec.ts
+++ b/projects/core/src/state/utils/scoped-loader/scoped-loader.reducer.spec.ts
@@ -1,40 +1,9 @@
 import { scopedLoaderReducer } from './scoped-loader.reducer';
 import { loaderReducer } from '../loader/loader.reducer';
-import { Action } from '@ngrx/store';
 import { LoaderLoadAction } from '../loader/loader.action';
 
 describe('scopedLoaderReducer', () => {
   const TEST_ENTITY_TYPE = 'test';
-
-  describe('without scope should proxy to loader reducer', () => {
-    it('undefined action', () => {
-      const action = {} as Action;
-      const state = scopedLoaderReducer(TEST_ENTITY_TYPE)(undefined, action);
-      const expected = loaderReducer(TEST_ENTITY_TYPE)(undefined, action);
-      expect(state).toEqual(expected);
-    });
-
-    it('undefined action with subReducer', () => {
-      const subReducer = (s = 'default', _action: Action) => s;
-      const action = {} as Action;
-      const state = scopedLoaderReducer(TEST_ENTITY_TYPE, subReducer)(
-        undefined,
-        action
-      );
-      const expected = loaderReducer(TEST_ENTITY_TYPE, subReducer)(
-        undefined,
-        action
-      );
-      expect(state).toEqual(expected);
-    });
-
-    it('loader action', () => {
-      const action: any = new LoaderLoadAction(TEST_ENTITY_TYPE);
-      const state = scopedLoaderReducer(TEST_ENTITY_TYPE)(undefined, action);
-      const expected = loaderReducer(TEST_ENTITY_TYPE)(undefined, action);
-      expect(state).toEqual(expected);
-    });
-  });
 
   describe('with scope should target sub state', () => {
     it('loader action', () => {

--- a/projects/core/src/state/utils/scoped-loader/scoped-loader.reducer.spec.ts
+++ b/projects/core/src/state/utils/scoped-loader/scoped-loader.reducer.spec.ts
@@ -14,5 +14,12 @@ describe('scopedLoaderReducer', () => {
       const expected = loaderReducer(TEST_ENTITY_TYPE)(undefined, action);
       expect(state[scope]).toEqual(expected);
     });
+
+    it('should use empty scope if no scope is provided', () => {
+      const action: any = new LoaderLoadAction(TEST_ENTITY_TYPE);
+      const state = scopedLoaderReducer(TEST_ENTITY_TYPE)(undefined, action);
+      const expected = loaderReducer(TEST_ENTITY_TYPE)(undefined, action);
+      expect(state['']).toEqual(expected);
+    });
   });
 });

--- a/projects/core/src/state/utils/scoped-loader/scoped-loader.reducer.ts
+++ b/projects/core/src/state/utils/scoped-loader/scoped-loader.reducer.ts
@@ -1,17 +1,12 @@
-import { initialLoaderState, loaderReducer } from '../loader/loader.reducer';
+import { loaderReducer } from '../loader/loader.reducer';
 import { EntityScopedLoaderAction } from '../../../product/store/actions/product.action';
-import { LoaderState } from '../loader/loader-state';
 import { ScopedLoaderState } from './scoped-loader.state';
 import { Action } from '@ngrx/store';
 
+export const initialScopedLoaderState: ScopedLoaderState<any> = {};
+
 /**
  * Higher order reducer designed to add scope support for loader reducer
- *
- * For backward compatibility, we accommodate scopes alongside current
- * loading/error/success/value flags, thus those names can't be used as scope
- * names.
- *
- * TODO: Improve, issue #5445
  *
  * @param entityType
  * @param reducer
@@ -20,27 +15,21 @@ export function scopedLoaderReducer<T>(
   entityType: string,
   reducer?: (state: T, action: Action) => T
 ): (
-  state: ScopedLoaderState<T> | LoaderState<T>,
+  state: ScopedLoaderState<T>,
   action: EntityScopedLoaderAction
-) => ScopedLoaderState<T> | LoaderState<T> {
+) => ScopedLoaderState<T> {
   const loader = loaderReducer<T>(entityType, reducer);
 
   return (
-    state: ScopedLoaderState<T> | LoaderState<T> = initialLoaderState,
+    state: ScopedLoaderState<T> = initialScopedLoaderState,
     action: EntityScopedLoaderAction
-  ): ScopedLoaderState<T> | LoaderState<T> => {
-    if (
-      action &&
-      action.meta &&
-      action.meta.entityType === entityType &&
-      action.meta.scope
-    ) {
+  ): ScopedLoaderState<T> => {
+    if (action && action.meta && action.meta.entityType === entityType) {
       return {
         ...state,
-        [action.meta.scope]: loader(state[action.meta.scope], action),
+        [action.meta.scope ?? '']: loader(state[action.meta.scope], action),
       };
-    } else {
-      return loader(state, action);
     }
+    return state;
   };
 }

--- a/projects/core/src/state/utils/scoped-loader/scoped-loader.state.ts
+++ b/projects/core/src/state/utils/scoped-loader/scoped-loader.state.ts
@@ -5,8 +5,4 @@ export interface ScopedLoaderState<T> {
   [scope: string]: LoaderState<T>;
 }
 
-export type EntityScopedLoaderState<T> = EntityState<
-  | ScopedLoaderState<T>
-  /** TODO: deprecated since 1.4, remove, issue #5445 */
-  | LoaderState<T>
->;
+export type EntityScopedLoaderState<T> = EntityState<ScopedLoaderState<T>>;


### PR DESCRIPTION
For backward compatibility, we accommodate scopes alongside current
loading/error/success/value flags, thus those names can't be used as scope names.

We should consider improving this mechanism, i..e. keep default scope '' as any other scope (on the same level).

Closes #5445