### PR TITLE
feat: schematics - introduce occ prefix option

### DIFF
--- a/projects/core/src/occ/config/default-occ-config.ts
+++ b/projects/core/src/occ/config/default-occ-config.ts
@@ -4,7 +4,6 @@ export const defaultOccConfig: OccConfig = {
   backend: {
     occ: {
       prefix: '/occ/v2/',
-      legacy: false,
     },
     media: {},
   },

--- a/projects/core/src/occ/config/default-occ-config.ts
+++ b/projects/core/src/occ/config/default-occ-config.ts
@@ -3,7 +3,8 @@ import { OccConfig } from './occ-config';
 export const defaultOccConfig: OccConfig = {
   backend: {
     occ: {
-      prefix: '/rest/v2/',
+      prefix: '/occ/v2/',
+      legacy: false,
     },
     media: {},
   },

--- a/projects/schematics/README.md
+++ b/projects/schematics/README.md
@@ -12,9 +12,10 @@ Run the following command from your project root:
 
 - `baseUrl`: Base url of your CX OCC backend
 - `baseSite`: Name of your base site
+- `occPrefix`: The OCC API prefix. E.g.: /occ/v2/
 - `useMetaTags`: Whether or not to configure baseUrl and mediaUrl in the meta tags from `index.html`
-- `featureLevel`: Application feature level. (default: _1.3_)
-- `overwriteAppComponent`: Overwrite content of app.component.html file. (default: false)
+- `featureLevel`: Application feature level. (default: _2.0_)
+- `overwriteAppComponent`: Overwrite content of app.component.html file. (default: true)
 - `pwa`: Include PWA features while constructing application.
 - `ssr`: Include Server-side Rendering configuration.
 

--- a/projects/schematics/src/add-cms-component/index_spec.ts
+++ b/projects/schematics/src/add-cms-component/index_spec.ts
@@ -6,6 +6,7 @@ import { Style } from '@angular/cli/lib/config/schema';
 import { Schema as ApplicationOptions } from '@schematics/angular/application/schema';
 import { addSymbolToNgModuleMetadata } from '@schematics/angular/utility/ast-utils';
 import * as path from 'path';
+import { Schema as SpartacusOptions } from '../add-spartacus/schema';
 import {
   ANGULAR_SCHEMATICS,
   CMS_CONFIG,
@@ -93,10 +94,8 @@ describe('add-cms-component', () => {
     projectRoot: '',
   };
 
-  const defaultOptions = {
+  const defaultOptions: SpartacusOptions = {
     project: 'schematics-test',
-    target: 'build',
-    configuration: 'production',
     baseSite: 'electronics',
     baseUrl: 'https://localhost:9002',
   };

--- a/projects/schematics/src/add-pwa/index_spec.ts
+++ b/projects/schematics/src/add-pwa/index_spec.ts
@@ -1,8 +1,9 @@
-import * as path from 'path';
 import {
   SchematicTestRunner,
   UnitTestTree,
 } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { Schema as SpartacusOptions } from '../add-spartacus/schema';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
@@ -27,10 +28,8 @@ describe('Spartacus Schematics: add-pwa', () => {
     skipTests: false,
   };
 
-  const defaultOptions = {
+  const defaultOptions: SpartacusOptions = {
     project: 'schematics-test',
-    target: 'build',
-    configuration: 'production',
   };
 
   beforeEach(async () => {

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -155,7 +155,7 @@ function getStorefrontConfig(options: SpartacusOptions): string {
   return `{
       backend: {
         occ: {${options.useMetaTags ? '' : baseUrlPart}
-          prefix: '/rest/v2/'
+          prefix: '${options.occPrefix}'
         }
       },${contextContent}
       i18n: {

--- a/projects/schematics/src/add-spartacus/index_spec.ts
+++ b/projects/schematics/src/add-spartacus/index_spec.ts
@@ -3,6 +3,7 @@ import {
   UnitTestTree,
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
+import { Schema as SpartacusOptions } from './schema';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
@@ -26,10 +27,9 @@ describe('add-spartacus', () => {
     skipTests: false,
   };
 
-  const defaultOptions = {
+  const defaultOptions: SpartacusOptions = {
     project: 'schematics-test',
-    target: 'build',
-    configuration: 'production',
+    occPrefix: 'xxx',
     baseSite: 'electronics',
     baseUrl: 'https://localhost:9002',
   };
@@ -94,6 +94,20 @@ describe('add-spartacus', () => {
         '/projects/schematics-test/src/app/app.module.ts'
       );
       expect(appModule.includes(`baseUrl: 'test-url'`)).toBe(true);
+    });
+
+    it('should set occPrefix', async () => {
+      const tree = await schematicRunner
+        .runSchematicAsync(
+          'add-spartacus',
+          { ...defaultOptions, occPrefix: '/occ/v2/' },
+          appTree
+        )
+        .toPromise();
+      const appModule = tree.readContent(
+        '/projects/schematics-test/src/app/app.module.ts'
+      );
+      expect(appModule.includes(`prefix: '/occ/v2/'`)).toBe(true);
     });
 
     it('should set baseSite', async () => {

--- a/projects/schematics/src/add-spartacus/schema.json
+++ b/projects/schematics/src/add-spartacus/schema.json
@@ -16,6 +16,11 @@
       "description": "The url of the OCC backend",
       "default": "https://localhost:9002"
     },
+    "occPrefix": {
+      "type": "string",
+      "description": "The OCC API prefix. E.g.: /occ/v2/",
+      "default": "/rest/v2/"
+    },
     "baseSite": {
       "type": "string",
       "description": "The base site to use with spartacus"

--- a/projects/schematics/src/add-spartacus/schema.ts
+++ b/projects/schematics/src/add-spartacus/schema.ts
@@ -1,6 +1,7 @@
 export interface Schema {
   project: string;
   baseUrl?: string;
+  occPrefix?: string;
   baseSite?: string;
   useMetaTags?: boolean;
   featureLevel?: string;

--- a/projects/schematics/src/add-ssr/index_spec.ts
+++ b/projects/schematics/src/add-ssr/index_spec.ts
@@ -5,6 +5,7 @@ import {
 import { Style } from '@angular/cli/lib/config/schema';
 import { Schema as ApplicationOptions } from '@schematics/angular/application/schema';
 import * as path from 'path';
+import { Schema as SpartacusOptions } from '../add-spartacus/schema';
 import { UTF_8 } from '../shared/constants';
 import { getPathResultsForFile } from '../shared/utils/file-utils';
 
@@ -30,10 +31,8 @@ describe('add-ssr', () => {
     projectRoot: '',
   };
 
-  const defaultOptions = {
+  const defaultOptions: SpartacusOptions = {
     project: 'schematics-test',
-    target: 'build',
-    configuration: 'production',
     baseSite: 'electronics',
     baseUrl: 'https://localhost:9002',
   };

--- a/projects/schematics/src/ng-add/index_spec.ts
+++ b/projects/schematics/src/ng-add/index_spec.ts
@@ -3,6 +3,7 @@ import {
   UnitTestTree,
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
+import { Schema as SpartacusOptions } from '../add-spartacus/schema';
 import { UTF_8 } from '../shared/constants';
 import { getPathResultsForFile } from '../shared/utils/file-utils';
 
@@ -29,10 +30,8 @@ describe('Spartacus Schematics: ng-add', () => {
     projectRoot: '',
   };
 
-  const defaultOptions = {
+  const defaultOptions: SpartacusOptions = {
     project: 'schematics-test',
-    target: 'build',
-    configuration: 'production',
   };
 
   beforeEach(async () => {

--- a/projects/storefrontapp-cds-integration/src/app/app.module.ts
+++ b/projects/storefrontapp-cds-integration/src/app/app.module.ts
@@ -37,7 +37,7 @@ if (!environment.production) {
       backend: {
         occ: {
           baseUrl: environment.occBaseUrl,
-          legacy: false,
+          prefix: '/rest/v2/',
         },
       },
       context: {

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -36,7 +36,7 @@ if (!environment.production) {
       backend: {
         occ: {
           baseUrl: environment.occBaseUrl,
-          legacy: false,
+          prefix: '/rest/v2/',
         },
       },
       context: {


### PR DESCRIPTION
This PR adds `--occ-prefix` option to the add Spartacus schematics. This enables customers to override the default `/rest/v2/` or `/occ/v2/` prefix.