### PR TITLE
fix facet overflow on desktop version

### DIFF
--- a/projects/storefrontstyles/scss/components/product/list/_facet-list.scss
+++ b/projects/storefrontstyles/scss/components/product/list/_facet-list.scss
@@ -51,8 +51,10 @@ body.modal-open {
 
 %cx-facet-list {
   .inner {
-    overflow: scroll;
-    max-height: 100vh;
+    @include media-breakpoint-down(md) {
+      max-height: 100vh;
+      overflow: scroll;
+    }
 
     padding: 0 10px 10px 10px;
 


### PR DESCRIPTION
very small glitch on the desktop version, where the max height is set to 100vh