### PR TITLE
feat: Traverse parent nodes rather than parent elements in outlet directive

### DIFF
--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
@@ -130,15 +130,19 @@ export class OutletDirective implements OnDestroy, OnChanges {
 
   /**
    * Returns the closest `HtmlElement`, by iterating over the
-   * parent elements of the given element.
+   * parent nodes of the given element.
+   *
+   * We avoid traversing the parent _elements_, as this is blocking
+   * ie11 implementations. One of the spare exclusions we make to not
+   * supporting ie11.
    *
    * @param element
    */
-  private getHostElement(element: Element): HTMLElement {
+  private getHostElement(element: Node): HTMLElement {
     if (element instanceof HTMLElement) {
       return element;
     }
-    return this.getHostElement(element.parentElement);
+    return this.getHostElement(element.parentNode);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
The outlet directive uses the host element to render the original template or any additional UI. The host element is read by traversing the DOM until there's an HtmlElement is found. The API to use is `parentElement`, but this is blocking projects who need to support ie11 (which Spartacus doesn't). To make life easier, we make an exception in the code base and find the `parentNode` instead. 

closes #7220