### PR TITLE
fix: remove doubled cart detail entry in migration doc

### DIFF
--- a/docs/migration/2_0.md
+++ b/docs/migration/2_0.md
@@ -200,8 +200,7 @@ Support for functions dropped:
 - `UserNotificationPreferenceService` now requires new parameter `AuthService`. This service needs to be provided for `UserNotificationPreferenceService`.
 - `ProductReviewsComponent` now requires new parameter `ChangeDetectorRef`. This service needs to be provided for `ProductReviewsComponent`.
 - `SearchBoxComponent` now requires new parameter `WindowRef`. This service needs to be provided for `SearchBoxComponent`.
-- `AddressBookComponent` now requires new parameters `TranslationService`, `UserAddressService` and `CheckoutDeliveryService`. These services need to be provided for `AddressBookComponent`.
-- `CartDetailsComponent` no longer requires `FeatureConfigService` and  `CartService`. `CartService` was replaced with corresponding methods from `ActiveCartService`. The deprecated method `isSaveForLaterEnabled()` was removed.
+- `AddressBookComponent` now requires new parameters `TranslationService`, `UserAddressService` and `CheckoutDeliveryService`. These services need to be provided for `AddressBookComponent`
 - `CartItemListComponent` no longer requires `FormBuilder`, `FeatureConfigService` and  `CartService`. `CartService` was replaced with corresponding methods from `ActiveCartService`. The deprecated method `isSaveForLaterEnabled()` was removed.
 - `CartItemComponent` no longer uses `FeatureConfigService`. The deprecated method `isSaveForLaterEnabled()` was removed.
 - `PaymentFormComponent` requires new parameter now: `UserAddressService`.


### PR DESCRIPTION
Closes: #6909 