### PR TITLE
add missing focus key

### DIFF
--- a/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/facet/facet.component.html
+++ b/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/facet/facet.component.html
@@ -52,6 +52,7 @@
       *ngIf="state.maxVisible > 0 && state.maxVisible < facet.values.length"
       (click)="increaseVisibleValues()"
       class="cx-action-link"
+      cxFocus="moreorless"
     >
       {{ 'productList.showMore' | cxTranslate }}
     </button>


### PR DESCRIPTION
We forgot a tiny focus key on the more button in the facet navigation, which result in loosing focus.