### PR TITLE
fix: [SAFARI/IOS] all ngbootstrap modal with small height/width (viewport) not scrollable (GH-6546) - maintenance

### DIFF
--- a/projects/storefrontstyles/scss/components/layout/_storefront.scss
+++ b/projects/storefrontstyles/scss/components/layout/_storefront.scss
@@ -17,6 +17,12 @@
 
   > footer {
     margin-top: auto;
+
+    cx-paragraph {
+      p {
+        margin-bottom: 0;
+      }
+    }
   }
 
   // prevents visible focus when the UI is not used by keyboard.

--- a/projects/storefrontstyles/scss/cxbase/blocks/modal.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/modal.scss
@@ -62,4 +62,8 @@ $modal-min-width-sm: 100% !important;
     align-items: unset !important;
     overflow-y: auto;
   }
+
+  .modal-dialog {
+    overflow-y: initial;
+  }
 }


### PR DESCRIPTION
closes GH-6546

note:

- issue said it was only for mobile and anon consent modal, but I was able to reproduce it in safari and other modals in our app (desktop) by changing the width and height of the screen to a mobile version. I did not try with an iphone as I don't have one, but I believe it works :) (can anyone verify this with an iphone or so please) ---> this is a solution for all modal that takes full screen
- while debugging the safari problem, I noticed the footer had an extra white line of space due to a margin-bottom applying to it when it shouldn't, so I included it.