### PR TITLE
fix: ExpressionChangedAfterItHasBeenCheckedError occurs on breadcrumb (GH-7413)

### DIFF
--- a/projects/storefrontlib/src/cms-components/navigation/breadcrumb/breadcrumb.component.ts
+++ b/projects/storefrontlib/src/cms-components/navigation/breadcrumb/breadcrumb.component.ts
@@ -5,8 +5,8 @@ import {
   PageMetaService,
   TranslationService,
 } from '@spartacus/core';
-import { asyncScheduler, combineLatest, Observable } from 'rxjs';
-import { filter, map, observeOn } from 'rxjs/operators';
+import { combineLatest, Observable } from 'rxjs';
+import { delay, filter, map } from 'rxjs/operators';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 
 @Component({
@@ -39,8 +39,9 @@ export class BreadcrumbComponent implements OnInit {
   private setCrumbs(): void {
     this.crumbs$ = combineLatest([
       this.pageMetaService.getMeta(),
-      this.translation.translate('common.home').pipe(observeOn(asyncScheduler)),
+      this.translation.translate('common.home'),
     ]).pipe(
+      delay(0),
       map(([meta, textHome]) =>
         meta?.breadcrumbs ? meta.breadcrumbs : [{ label: textHome, link: '/' }]
       )


### PR DESCRIPTION
closes GH-7413

Solution:
- make the change happen at the end of the tasks using the delay(0) as callback of setTimeout (under the hood)

EDIT:
- no problems in e2e https://jkmaster.test.c3po.b2c.ydev.hybris.com/job/spartacus-regression-tests-for-branch/383/