### PR TITLE
docs: 2.0 migration docs for setting initial context #6900 - for 2.0.x

### DIFF
--- a/docs/migration/2_0.md
+++ b/docs/migration/2_0.md
@@ -109,6 +109,19 @@ Methods `ngOnInit`, `isSaveForLaterEnabled`, `updateEntry` and `getPotentialProd
 
 Skip link default configuration was simplified. Previously by default there were skip links for top header, bottom header, facets, product list and footer. Now it's only header, main content and footer.
 
+### Context change action not dispatched on the initial setting the value
+Before 2.0, the `LanguageChange` ngrx action was dispatched on setting the initial value (same for `CurrencyChange`). Moreover, the language (and currency) sometimes was initialized multiple times by the competing sources of truth (i.e. routing, session storage, default config), which caused fake multiple language change actions in some circumstances (combinations of configuration and user journey).
+
+Now the language change action is not dispatched on application start (same for currency). The language is initialized only once, using one source of truth (the first matched condition wins):
+
+1. If SSR transferred state is present, take value from there. OR
+1. If param was configured to be persisted from URL, take value from there. (When the value is not present in the  current URL, the URL is updated using default configured value and then we use this value.) OR
+1. If value can be retrieved from session storage, take value from there OR
+1. Otherwise take the static default value from config
+
+The same priorities hold for currency. However, for base site have only 1, 2 and 4 apply (there is no session storage as source).
+
+
 ### Deprecated since 1.1
 
 |  API  | Replacement |  Notes  |


### PR DESCRIPTION
describe breaking changes from #6900