### PR TITLE
2.0.x maintenance: Order details page as guest displays empty order (GH-6480)

### DIFF
--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-details.module.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-details.module.ts
@@ -16,6 +16,7 @@ import { PageLayoutComponent } from '../../../../cms-structure/page/page-layout/
 import { CardModule } from '../../../../shared/components/card/card.module';
 import { SpinnerModule } from '../../../../shared/components/spinner/spinner.module';
 import { CartSharedModule } from '../../../cart/cart-shared/cart-shared.module';
+import { PromotionsModule } from '../../../checkout/components/promotions/promotions.module';
 import { OrderDetailActionsComponent } from './order-detail-actions/order-detail-actions.component';
 import { OrderDetailHeadlineComponent } from './order-detail-headline/order-detail-headline.component';
 import { TrackingEventsComponent } from './order-detail-items/consignment-tracking/tracking-events/tracking-events.component';
@@ -24,7 +25,6 @@ import { OrderDetailItemsComponent } from './order-detail-items/order-detail-ite
 import { OrderDetailShippingComponent } from './order-detail-shipping/order-detail-shipping.component';
 import { OrderDetailTotalsComponent } from './order-detail-totals/order-detail-totals.component';
 import { OrderDetailsService } from './order-details.service';
-import { PromotionsModule } from '../../../checkout/components/promotions/promotions.module';
 
 const moduleComponents = [
   OrderDetailActionsComponent,
@@ -49,7 +49,7 @@ const moduleComponents = [
     RouterModule.forChild([
       {
         path: null,
-        canActivate: [CmsPageGuard],
+        canActivate: [AuthGuard, CmsPageGuard],
         component: PageLayoutComponent,
         data: { pageLabel: 'order', cxRoute: 'orderGuest' },
       },


### PR DESCRIPTION
Closes GH-6480 for 2.0 maintenance

QA:
- Enable guest checkout in app module file
- Add product to cart and checkout
- Should be redirected to login page; choose the guest checkout option below login
- Checkout flow
- On order confirmation page, should receive an `order-number` (e.g. 00001234)
- visit http://localhost:4200/electronics-spa/en/USD/guest/order/00001234

Expected:
- User should be redirected to login page instead of blank order details page