### PR TITLE
feat: refactor Qualtrics integration for better extensibility

### DIFF
--- a/docs/migration/2_0.md
+++ b/docs/migration/2_0.md
@@ -267,6 +267,8 @@ Support for functions dropped:
 - `PageSlotComponent` now requires new parameter `CmsComponentsService` and `ChangeDetectorRef`. The `CmsComponentsService` is used to read the configurable _page fold_ from the layout configuration. The `ChangeDetectorRef` is needed to update the slot pending state asynchronously. 
 - `TabParagraphContainerComponent` now requires new parameter `WindowRef`. This service needs to be provided for `TabParagraphContainerComponent`.
 - `SelectiveCartService` requires new parameter now: `CartConfigService`.
+- `QualtricsLoaderService` now requires Angular's core `RendererFactory2` and no longer uses the `QualtricsConfig`. The service has been refactored for better extensibility and reuse.
+- `QualtricsComponent` now requires the `QualtricsConfig` to load the global qualtrics deployments script. This was a dependency in the `QualtricsLoaderService` in 1.x. Also, the component no longer uses 'qualtricsEnabled$' property.
 - `AmendOrderActionsComponent` requires now new parameter: `RoutingService`.
 - `FooterNavigationComponent` no longer requires `AnonymousConsentsConfig` parameter.
 - `ProductFacetNavigationComponent` no longer requires `ModalService`, `ActivatedRoute` and `ProductListComponentService`. It now requires `BreakpointService`.

--- a/projects/schematics/src/migrations/2_0/component-deprecations/component-deprecations-data.ts
+++ b/projects/schematics/src/migrations/2_0/component-deprecations/component-deprecations-data.ts
@@ -9,6 +9,7 @@ import { FOOTER_NAVIGATION_COMPONENT_MIGRATION } from './data/footer-navigation.
 import { NAVIGATION_UI_COMPONENT_MIGRATION } from './data/navigation-ui.component.migration';
 import { PRODUCT_IMAGES_COMPONENT_MIGRATION } from './data/product-images.component.migration';
 import { PRODUCT_SCROLL_COMPONENT_MIGRATION } from './data/product-scroll.component.migration';
+import { QUALTRICS_COMPONENT_MIGRATION } from './data/qualtrics.component.migration';
 import { STORE_FINDER_LIST_ITEM_MIGRATION } from './data/store-finder-list-item.component.migration';
 
 export const COMPONENT_DEPRECATION_DATA: ComponentData[] = [
@@ -23,4 +24,5 @@ export const COMPONENT_DEPRECATION_DATA: ComponentData[] = [
   NAVIGATION_UI_COMPONENT_MIGRATION,
   STORE_FINDER_LIST_ITEM_MIGRATION,
   FOOTER_NAVIGATION_COMPONENT_MIGRATION,
+  QUALTRICS_COMPONENT_MIGRATION,
 ];

--- a/projects/schematics/src/migrations/2_0/component-deprecations/data/qualtrics.component.migration.ts
+++ b/projects/schematics/src/migrations/2_0/component-deprecations/data/qualtrics.component.migration.ts
@@ -1,0 +1,14 @@
+import { QUALTRICS_COMPONENT } from '../../../../shared/constants';
+import { ComponentData } from '../../../../shared/utils/file-utils';
+
+export const QUALTRICS_COMPONENT_MIGRATION: ComponentData = {
+  // projects/storefrontlib/src/cms-components/misc/qualtrics/qualtrics.component.ts
+  selector: 'cx-qualtrics',
+  componentClassName: QUALTRICS_COMPONENT,
+  removedProperties: [
+    {
+      name: 'qualtricsEnabled$',
+      comment: `'qualtricsEnabled$' property has been removed.`,
+    },
+  ],
+};

--- a/projects/schematics/src/migrations/2_0/constructor-deprecations/constructor-deprecation-data.ts
+++ b/projects/schematics/src/migrations/2_0/constructor-deprecations/constructor-deprecation-data.ts
@@ -56,6 +56,8 @@ import { PRODUCT_LIST_COMPONENT_MIGRATION } from './data/product-list.component.
 import { PRODUCT_REVIEWS_COMPONENT_MIGRATION } from './data/product-reviews.component.migration';
 import { PRODUCT_SERVICE_MIGRATION } from './data/product-service.migration';
 import { PROMOTION_SERVICE_MIGRATION } from './data/promotion.service.migration';
+import { QUALTRICS_LOADER_MIGRATION } from './data/qualtrics-loader.service.migration';
+import { QUALTRICS_COMPONENT_MIGRATION } from './data/qualtrics.component.migration';
 import { REGISTER_COMPONENT_MIGRATIONS } from './data/register.component.migration';
 import { REVIEW_SUBMIT_COMPONENT_MIGRATIONS } from './data/review-submit.component.migration';
 import { SEARCH_BOX_COMPONENT_MIGRATION } from './data/search-box.component.migration';
@@ -155,6 +157,8 @@ export const CONSTRUCTOR_DEPRECATION_DATA: ConstructorDeprecation[] = [
   TAB_PARAGRAPH_CONTAINER_COMPONENT_MIGRATION,
   STORE_FINDER_LIST_ITEM_MIGRATION,
   SELECTIVE_CART_SERVICE_MIGRATION,
+  QUALTRICS_LOADER_MIGRATION,
+  QUALTRICS_COMPONENT_MIGRATION,
   ANONYMOUS_CONSENT_MANAGEMENT_BANNER_COMPONENT_MIGRATION,
   ANONYMOUS_CONSENT_OPEN_DIALOG_COMPONENT_MIGRATION,
   PRODUCT_FACET_NAVIGATION_COMPONENT_MIGRATION,

--- a/projects/schematics/src/migrations/2_0/constructor-deprecations/data/qualtrics-loader.service.migration.ts
+++ b/projects/schematics/src/migrations/2_0/constructor-deprecations/data/qualtrics-loader.service.migration.ts
@@ -1,0 +1,39 @@
+import {
+  ANGULAR_CORE,
+  QUALTRICS_CONFIG,
+  QUALTRICS_LOADER_SERVICE,
+  RENDERER_FACTORY_2,
+  SPARTACUS_CORE,
+  SPARTACUS_STOREFRONTLIB,
+  WINDOW_REF,
+} from '../../../../shared/constants';
+import { ConstructorDeprecation } from '../../../../shared/utils/file-utils';
+
+export const QUALTRICS_LOADER_MIGRATION: ConstructorDeprecation = {
+  // projects/storefrontlib/src/cms-components/misc/qualtrics/qualtrics-loader.service.ts
+  class: QUALTRICS_LOADER_SERVICE,
+  importPath: SPARTACUS_STOREFRONTLIB,
+
+  deprecatedParams: [
+    {
+      className: WINDOW_REF,
+      importPath: SPARTACUS_CORE,
+    },
+    {
+      className: QUALTRICS_CONFIG,
+      importPath: SPARTACUS_STOREFRONTLIB,
+    },
+  ],
+  removeParams: [
+    {
+      className: QUALTRICS_CONFIG,
+      importPath: SPARTACUS_STOREFRONTLIB,
+    },
+  ],
+  addParams: [
+    {
+      className: RENDERER_FACTORY_2,
+      importPath: ANGULAR_CORE,
+    },
+  ],
+};

--- a/projects/schematics/src/migrations/2_0/constructor-deprecations/data/qualtrics.component.migration.ts
+++ b/projects/schematics/src/migrations/2_0/constructor-deprecations/data/qualtrics.component.migration.ts
@@ -1,0 +1,25 @@
+import {
+  QUALTRICS_COMPONENT,
+  QUALTRICS_CONFIG,
+  QUALTRICS_LOADER_SERVICE,
+  SPARTACUS_STOREFRONTLIB,
+} from '../../../../shared/constants';
+import { ConstructorDeprecation } from '../../../../shared/utils/file-utils';
+
+export const QUALTRICS_COMPONENT_MIGRATION: ConstructorDeprecation = {
+  // projects/storefrontlib/src/cms-components/misc/qualtrics/qualtrics.component.ts
+  class: QUALTRICS_COMPONENT,
+  importPath: SPARTACUS_STOREFRONTLIB,
+  deprecatedParams: [
+    {
+      className: QUALTRICS_LOADER_SERVICE,
+      importPath: SPARTACUS_STOREFRONTLIB,
+    },
+  ],
+  addParams: [
+    {
+      className: QUALTRICS_CONFIG,
+      importPath: SPARTACUS_STOREFRONTLIB,
+    },
+  ],
+};

--- a/projects/schematics/src/shared/constants.ts
+++ b/projects/schematics/src/shared/constants.ts
@@ -199,6 +199,10 @@ export const STORE_FINDER_LIST_ITEM_COMPONENT = 'StoreFinderListItemComponent';
 export const CART_CONFIG_SERVICE = 'CartConfigService';
 export const MULTI_CART_SERVICE = 'MultiCartService';
 export const BASE_SITE_SERVICE = 'BaseSiteService';
+export const QUALTRICS_LOADER_SERVICE = 'QualtricsLoaderService';
+export const RENDERER_FACTORY_2 = 'RendererFactory2';
+export const QUALTRICS_CONFIG = 'QualtricsConfig';
+export const QUALTRICS_COMPONENT = 'QualtricsComponent';
 export const PRODUCT_FACET_NAVIGATION_COMPONENT =
   'ProductFacetNavigationComponent';
 export const BREAKPOINT_SERVICE = 'BreakpointService';

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/vendor/qualtrics/qualtrics.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/vendor/qualtrics/qualtrics.e2e-spec.ts
@@ -1,0 +1,66 @@
+import { verifyProductDetails } from '../../../helpers/product-details';
+
+const DEFAULT_SCRIPT_LOCATION = '/assets/qualtricsIntegration.js';
+
+function injectDummyScript(): void {
+  cy.document().then((doc) => {
+    const qualtricsScript = doc.createElement('script');
+    qualtricsScript.type = 'text/javascript';
+    qualtricsScript.src = DEFAULT_SCRIPT_LOCATION;
+    doc.getElementsByTagName('head')[0].appendChild(qualtricsScript);
+  });
+}
+
+context('Qualtrics integration', () => {
+  let loadSpy: Cypress.Agent<sinon.SinonSpy>;
+  let runSpy: Cypress.Agent<sinon.SinonSpy>;
+  const mockQsiJsApi = {
+    API: {
+      unload: (): void => {},
+      load: () => {
+        return {
+          done: (_intercept: Function) => {},
+        };
+      },
+      run: (): void => {},
+    },
+  };
+
+  beforeEach(() => {
+    cy.visit('/product/266685');
+  });
+
+  after(() => {
+    // cleanup the QSI API
+    cy.window().then((win) => (win['QSI'] = undefined));
+    // cleanup the dummy script
+    cy.document().then((doc) => {
+      const scriptNode = doc.querySelector(
+        `script[src="${DEFAULT_SCRIPT_LOCATION}"]`
+      );
+      scriptNode.parentNode.removeChild(scriptNode);
+    });
+  });
+
+  describe(`when 'qsi_js_loaded' event is fired`, () => {
+    beforeEach(() => {
+      verifyProductDetails();
+      injectDummyScript();
+
+      cy.window().then((win) => {
+        win['QSI'] = mockQsiJsApi;
+
+        loadSpy = cy.spy(win['QSI'].API, 'load');
+        runSpy = cy.spy(win['QSI'].API, 'run');
+      });
+
+      cy.window().then((win) => win.dispatchEvent(new Event('qsi_js_loaded')));
+    });
+    it('should call the QSI API load() and run() functions', () => {
+      // tslint:disable-next-line: no-unused-expression
+      expect(loadSpy).to.have.been.called;
+      // tslint:disable-next-line: no-unused-expression
+      expect(runSpy).to.have.been.called;
+    });
+  });
+});

--- a/projects/storefrontlib/src/cms-components/misc/qualtrics/config/qualtrics-config.ts
+++ b/projects/storefrontlib/src/cms-components/misc/qualtrics/config/qualtrics-config.ts
@@ -1,12 +1,25 @@
 import { Injectable } from '@angular/core';
 import { Config } from '@spartacus/core';
 
+/**
+ * Configuration options for the Qualtrics integration, which allows you to
+ * specify the qualtrics project and deployment script.
+ */
 @Injectable({
   providedIn: 'root',
   useExisting: Config,
 })
 export abstract class QualtricsConfig {
+  /**
+   * Holds the qualtrics integration options.
+   */
   qualtrics?: {
-    projectId?: string;
+    /**
+     * Deployment script, loaded from a resource, to integrate the deployment of the qualtrics project.
+     * You would typically store the file in the local assets folder.
+     *
+     * Defaults to `assets/qualtricsIntegration.js`
+     */
+    scriptSource?: string;
   };
 }

--- a/projects/storefrontlib/src/cms-components/misc/qualtrics/qualtrics.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/misc/qualtrics/qualtrics.component.spec.ts
@@ -1,17 +1,22 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Observable, of } from 'rxjs';
+import { QualtricsConfig } from './config/qualtrics-config';
 import { QualtricsLoaderService } from './qualtrics-loader.service';
 import { QualtricsComponent } from './qualtrics.component';
 
+const mockQualtricsConfig: QualtricsConfig = {
+  qualtrics: {
+    scriptSource: 'assets/deployment-script.js',
+  },
+};
+
 class MockQualtricsLoaderService {
-  load(): Observable<boolean> {
-    return of(true);
-  }
+  addScript(): void {}
 }
 
 describe('QualtricsComponent', () => {
   let component: QualtricsComponent;
   let fixture: ComponentFixture<QualtricsComponent>;
+  let service: QualtricsLoaderService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -21,25 +26,29 @@ describe('QualtricsComponent', () => {
           provide: QualtricsLoaderService,
           useClass: MockQualtricsLoaderService,
         },
+        { provide: QualtricsConfig, useValue: mockQualtricsConfig },
       ],
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(QualtricsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  describe('with config', () => {
+    beforeEach(() => {
+      service = TestBed.inject(QualtricsLoaderService);
+      spyOn(service, 'addScript').and.stub();
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+      fixture = TestBed.createComponent(QualtricsComponent);
+      component = fixture.componentInstance;
+    });
 
-  it('should be loaded', () => {
-    let result: boolean;
+    it('should create component', () => {
+      expect(component).toBeTruthy();
+    });
 
-    component.qualtricsEnabled$.subscribe((data) => (result = data));
-
-    expect(result).toBe(true);
+    it('should add qualtrics script', () => {
+      fixture.detectChanges();
+      expect(service.addScript).toHaveBeenCalledWith(
+        'assets/deployment-script.js'
+      );
+    });
   });
 });

--- a/projects/storefrontlib/src/cms-components/misc/qualtrics/qualtrics.component.ts
+++ b/projects/storefrontlib/src/cms-components/misc/qualtrics/qualtrics.component.ts
@@ -1,12 +1,25 @@
-import { Component } from '@angular/core';
+import { Component, isDevMode } from '@angular/core';
+import { QualtricsConfig } from './config/qualtrics-config';
 import { QualtricsLoaderService } from './qualtrics-loader.service';
-
+/**
+ * Adds the Qualtrics deployment script whenever the component is loaded. The
+ * deployment script is loaded from the global configuration (`qualtrics.scriptSource`).
+ */
 @Component({
   selector: 'cx-qualtrics',
-  template: ` <ng-container *ngIf="qualtricsEnabled$ | async"></ng-container> `,
+  template: ``,
 })
 export class QualtricsComponent {
-  qualtricsEnabled$ = this.qualtricsLoader.load();
-
-  constructor(private qualtricsLoader: QualtricsLoaderService) {}
+  constructor(
+    protected qualtricsLoader: QualtricsLoaderService,
+    protected config: QualtricsConfig
+  ) {
+    if (this.config.qualtrics?.scriptSource) {
+      this.qualtricsLoader.addScript(this.config.qualtrics.scriptSource);
+    } else if (isDevMode()) {
+      console.warn(
+        `We're unable to add the Qualtrics deployment code as there is no script source defined in config.qualtrics.scriptSource.`
+      );
+    }
+  }
 }

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
@@ -229,9 +229,7 @@ describe('OutletDirective', () => {
       `,
     })
     class MockDeferredOutletComponent {
-      load(_eventValue: boolean) {
-        console.log('defer loading 2...', _eventValue);
-      }
+      load(_eventValue: boolean) {}
     }
 
     let deferLoaderService: DeferLoaderService;


### PR DESCRIPTION
The integration to Qualtrics was added in version 1.3, but so far the solution wasn't extensible. We've improved the code:

- make code extensible
- expose an API that is reusable in other integration scenario's
- drop the projectId (as it is not needed)
- document the code

closes #7401