### PR TITLE
fix: update schematis - fix versions in migration.json

### DIFF
--- a/projects/schematics/src/migrations/migrations.json
+++ b/projects/schematics/src/migrations/migrations.json
@@ -1,7 +1,7 @@
 {
   "schematics": {
     "migration-v2-validate-01": {
-      "version": "2-next.7",
+      "version": "2-rc.1",
       "factory": "./2_0/validate#validate",
       "description": "Performs some validations before proceeding to upgrade Spartacus to v2"
     },
@@ -11,22 +11,22 @@
       "description": "Update CMS components state to v2"
     },
     "migration-v2-constructor-deprecations-03": {
-      "version": "2-next.7",
+      "version": "2-rc.1",
       "factory": "./2_0/constructor-deprecations/constructor-deprecations#migrate",
       "description": "Add or remove constructor parameters"
     },
     "migration-v2-removed-public-api-04": {
-      "version": "2-next.7",
+      "version": "2-rc.1",
       "factory": "./2_0/removed-public-api#migrate",
       "description": "Comment about usage of removed public api"
     },
     "migration-v2-component-deprecations-05": {
-      "version": "2-next.7",
+      "version": "2-rc.1",
       "factory": "./2_0/component-deprecations/component-deprecations#migrate",
       "description": "Handle deprecated Spartacus components"
     },
     "migration-v2-css-06": {
-      "version": "2-next.7",
+      "version": "2-rc.1",
       "factory": "./2_0/css#migrate",
       "description": "Handle deprecated CSS"
     },


### PR DESCRIPTION
This PR updates versions of certain migration scripts in `migration.json`, in order to run them during the upgrade to the latest `2.0.0-rc.1` version. For more, see this [readme](https://github.com/SAP/spartacus/blob/develop/projects/schematics/README.md#releasing-update-schematics).