### PR TITLE
Add empty object in case images.PRIMARY is undefined

### DIFF
--- a/projects/storefrontlib/src/cms-components/product/product-images/product-images.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-images/product-images.component.spec.ts
@@ -39,6 +39,13 @@ const mockDataWithMultiplePictures: Product = {
   },
 };
 
+const mockDataWitoutPrimaryPictures: Product = {
+  name: 'mockProduct1',
+  images: {
+    GALLERY: [firstImage, secondImage],
+  },
+};
+
 class MockCurrentProductService {
   getProduct(): Observable<Product> {
     return of();
@@ -177,6 +184,38 @@ describe('ProductImagesComponent', () => {
 
         const carousel = fixture.debugElement.query(By.css('cx-carousel'));
         expect(carousel).toBeNull();
+      });
+    });
+  });
+
+  describe('without pictures', () => {
+    beforeEach(() => {
+      spyOn(currentProductService, 'getProduct').and.returnValue(
+        of(mockDataWitoutPrimaryPictures)
+      );
+
+      fixture = TestBed.createComponent(ProductImagesComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should be created', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should have mainImage$', () => {
+      let result: any;
+      component.mainImage$.subscribe((value) => (result = value)).unsubscribe();
+      expect(result).toEqual({});
+    });
+
+    describe('(UI test)', () => {
+      it('should render cx-media for GALLERY image', () => {
+        component.thumbs$.subscribe();
+        fixture.detectChanges();
+
+        const media = fixture.debugElement.query(By.css('cx-media'));
+        expect(media).toBeDefined();
       });
     });
   });

--- a/projects/storefrontlib/src/cms-components/product/product-images/product-images.component.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-images/product-images.component.ts
@@ -17,9 +17,9 @@ export class ProductImagesComponent {
   > = this.currentProductService.getProduct().pipe(
     filter(Boolean),
     distinctUntilChanged(),
-    tap((p: Product) =>
-      this.mainMediaContainer.next(p.images ? p.images.PRIMARY : {})
-    )
+    tap((p: Product) => {
+      this.mainMediaContainer.next(p.images?.PRIMARY ? p.images.PRIMARY : {});
+    })
   );
 
   thumbs$: Observable<any[]> = this.product$.pipe(


### PR DESCRIPTION
We've missed an edge case in #7229 where a product has images but no PRIMARY images. While we're not rendering any of the non-PRIMARY images, we still should show an image placeholder image.