### PR TITLE
chore: update versions in package.json

### DIFF
--- a/projects/assets/package.json
+++ b/projects/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/assets",
-  "version": "2.0.0-next.7",
+  "version": "2.1.0-next.0",
   "publishConfig": {
     "access": "public"
   }

--- a/projects/assets/package.json
+++ b/projects/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/assets",
-  "version": "2.1.0-next.0",
+  "version": "2.1.0-dev.0",
   "publishConfig": {
     "access": "public"
   }

--- a/projects/cds/package.json
+++ b/projects/cds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/cds",
-  "version": "2.1.0-next.0",
+  "version": "2.1.0-dev.0",
   "description": "Context Driven Service library for Spartacus",
   "homepage": "https://github.com/SAP/cloud-commerce-spartacus-storefront",
   "keywords": [
@@ -22,7 +22,7 @@
     "@angular/core": "^9.0.0",
     "@angular/router": "^9.0.0",
     "rxjs": "^6.5.4",
-    "@spartacus/core": "2.1.0-next.0",
-    "@spartacus/storefront": "2.1.0-next.0"
+    "@spartacus/core": "2.1.0-dev.0",
+    "@spartacus/storefront": "2.1.0-dev.0"
   }
 }

--- a/projects/cds/package.json
+++ b/projects/cds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/cds",
-  "version": "2.0.0-next.7",
+  "version": "2.1.0-next.0",
   "description": "Context Driven Service library for Spartacus",
   "homepage": "https://github.com/SAP/cloud-commerce-spartacus-storefront",
   "keywords": [
@@ -22,7 +22,7 @@
     "@angular/core": "^9.0.0",
     "@angular/router": "^9.0.0",
     "rxjs": "^6.5.4",
-    "@spartacus/core": "2.0.0-next.7",
-    "@spartacus/storefront": "2.0.0-next.7"
+    "@spartacus/core": "2.1.0-next.0",
+    "@spartacus/storefront": "2.1.0-next.0"
   }
 }

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/core",
-  "version": "2.0.0-next.7",
+  "version": "2.1.0-next.0",
   "description": "Spartacus - the core framework",
   "keywords": [
     "spartacus",

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/core",
-  "version": "2.1.0-next.0",
+  "version": "2.1.0-dev.0",
   "description": "Spartacus - the core framework",
   "keywords": [
     "spartacus",

--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/schematics",
-  "version": "2.1.0-next.0",
+  "version": "2.1.0-dev.0",
   "description": "Spartacus schematics",
   "keywords": [
     "spartacus",

--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/schematics",
-  "version": "2.0.0-next.7",
+  "version": "2.1.0-next.0",
   "description": "Spartacus schematics",
   "keywords": [
     "spartacus",

--- a/projects/storefrontlib/package.json
+++ b/projects/storefrontlib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/storefront",
-  "version": "2.0.0-next.7",
+  "version": "2.1.0-next.0",
   "homepage": "https://github.com/SAP/cloud-commerce-spartacus-storefront",
   "keywords": [
     "spartacus",
@@ -25,7 +25,7 @@
     "@ng-select/ng-select": "^4.0.0",
     "@ngrx/effects": "^9.0.0",
     "@ngrx/store": "^9.0.0",
-    "@spartacus/core": "2.0.0-next.7",
+    "@spartacus/core": "2.1.0-next.0",
     "bootstrap": "^4.2.1",
     "rxjs": "^6.5.4",
     "zone.js": "^0.10.2",

--- a/projects/storefrontlib/package.json
+++ b/projects/storefrontlib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/storefront",
-  "version": "2.1.0-next.0",
+  "version": "2.1.0-dev.0",
   "homepage": "https://github.com/SAP/cloud-commerce-spartacus-storefront",
   "keywords": [
     "spartacus",
@@ -25,7 +25,7 @@
     "@ng-select/ng-select": "^4.0.0",
     "@ngrx/effects": "^9.0.0",
     "@ngrx/store": "^9.0.0",
-    "@spartacus/core": "2.1.0-next.0",
+    "@spartacus/core": "2.1.0-dev.0",
     "bootstrap": "^4.2.1",
     "rxjs": "^6.5.4",
     "zone.js": "^0.10.2",

--- a/projects/storefrontstyles/package.json
+++ b/projects/storefrontstyles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/styles",
-  "version": "2.1.0-next.0",
+  "version": "2.1.0-dev.0",
   "description": "Style library containing global styles",
   "homepage": "https://github.com/SAP/cloud-commerce-spartacus-storefront",
   "keywords": [

--- a/projects/storefrontstyles/package.json
+++ b/projects/storefrontstyles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/styles",
-  "version": "2.0.0-next.7",
+  "version": "2.1.0-next.0",
   "description": "Style library containing global styles",
   "homepage": "https://github.com/SAP/cloud-commerce-spartacus-storefront",
   "keywords": [

--- a/projects/vendor/package.json
+++ b/projects/vendor/package.json
@@ -5,6 +5,6 @@
     "@angular/common": "^9.0.0",
     "@angular/core": "^9.0.0",
     "rxjs": "^6.5.4",
-    "@spartacus/core": "2.1.0-next.0"
+    "@spartacus/core": "2.1.0-dev.0"
   }
 }

--- a/projects/vendor/package.json
+++ b/projects/vendor/package.json
@@ -5,6 +5,6 @@
     "@angular/common": "^9.0.0",
     "@angular/core": "^9.0.0",
     "rxjs": "^6.5.4",
-    "@spartacus/core": "2.0.0-next.7"
+    "@spartacus/core": "2.1.0-next.0"
   }
 }


### PR DESCRIPTION
This PR bumps the version in package.json to `2.1.0-dev.0` for all Spartacus libraries.