### PR TITLE
Move focus to active facet if the facet is not available in the list

### DIFF
--- a/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.spec.ts
@@ -7,7 +7,8 @@ import {
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
-import { I18nTestingModule } from '@spartacus/core';
+import { Breadcrumb, I18nTestingModule } from '@spartacus/core';
+import { KeyboardFocusModule } from 'projects/storefrontlib/src/layout';
 import { of } from 'rxjs';
 import { ICON_TYPE } from '../../../../misc/icon/icon.model';
 import { FacetList } from '../facet.model';
@@ -37,7 +38,7 @@ describe('ActiveFacetsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule, RouterTestingModule, KeyboardFocusModule],
       declarations: [ActiveFacetsComponent, MockCxIconComponent],
       providers: [{ provide: FacetService, useClass: MockFacetService }],
     })
@@ -84,5 +85,21 @@ describe('ActiveFacetsComponent', () => {
     fixture.detectChanges();
     const header = element.queryAll(By.css('a'));
     expect(header.length).toEqual(2);
+  });
+
+  it('should return focus key when there is no matching facet', () => {
+    const key = component.getFocusKey(
+      { facets: [{ values: [{ name: 'anyNameButNotActive' }] }] } as FacetList,
+      { facetValueName: 'activeFacet' } as Breadcrumb
+    );
+    expect(key).toEqual('activeFacet');
+  });
+
+  it('should not return focus key when there is a matching facet', () => {
+    const key = component.getFocusKey(
+      { facets: [{ values: [{ name: 'activeFacet' }] }] } as FacetList,
+      { facetValueName: 'activeFacet' } as Breadcrumb
+    );
+    expect(key).toEqual('');
   });
 });

--- a/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.ts
@@ -29,11 +29,17 @@ export class ActiveFacetsComponent {
 
   /**
    * The focus key is used to persist the focus on the facet when the DOM is being
-   * recreated. We only apply the focus key for the given facet when there are no
-   * facets available. This is a great experience for the keyboard user, who keep the
-   * focus on the activated facet all the time.
+   * recreated. We only apply the focus key for the given _active_ facet when there
+   * the original facets is not available. This happens for non multi-valued facets.
+   *
+   * With this approach, the we keep the focus, either at the facet list or on the
+   * active facets.
    */
   getFocusKey(facetList: FacetList, facet: Breadcrumb) {
-    return !facetList.facets?.length ? facet.facetValueName : '';
+    return facetList.facets?.find((f) =>
+      f.values?.find((val) => val.name === facet.facetValueName)
+    )
+      ? ''
+      : facet.facetValueName;
   }
 }


### PR DESCRIPTION
Fixed an issue for #6581: when the facet value is no longer available in the facet value list, we move the focus to active facets.