### PR TITLE
Fix: added classes for other dialog types

### DIFF
--- a/projects/storefrontlib/src/layout/launch-dialog/services/launch-render.strategy.ts
+++ b/projects/storefrontlib/src/layout/launch-dialog/services/launch-render.strategy.ts
@@ -26,19 +26,19 @@ export abstract class LaunchRenderStrategy implements Applicable {
   /**
    * Classes to apply to the component when the dialog is a DIALOG
    */
-  protected dialogClasses = ['d-block', 'fade', 'modal', 'show'];
+  protected dialogClasses = ['cx-dialog', 'fade', 'show'];
   /**
    * Classes to apply to the component when the dialog is a POPOVER
    */
-  protected popoverClasses = [];
+  protected popoverClasses = ['cx-dialog-popover'];
   /**
    * Classes to apply to the component when the dialog is a SIDEBAR_END
    */
-  protected sidebarEndClasses = [];
+  protected sidebarEndClasses = ['cx-sidebar-end'];
   /**
    * Classes to apply to the component when the dialog is a SIDEBAR_START
    */
-  protected sidebarStartClasses = [];
+  protected sidebarStartClasses = ['cx-sidebar-start'];
 
   protected renderer: Renderer2;
 

--- a/projects/storefrontlib/src/layout/launch-dialog/services/launch-render.strategy.ts
+++ b/projects/storefrontlib/src/layout/launch-dialog/services/launch-render.strategy.ts
@@ -26,7 +26,7 @@ export abstract class LaunchRenderStrategy implements Applicable {
   /**
    * Classes to apply to the component when the dialog is a DIALOG
    */
-  protected dialogClasses = ['cx-dialog', 'fade', 'show'];
+  protected dialogClasses = ['d-block', 'fade', 'modal', 'show'];
   /**
    * Classes to apply to the component when the dialog is a POPOVER
    */

--- a/projects/storefrontstyles/scss/app.scss
+++ b/projects/storefrontstyles/scss/app.scss
@@ -42,3 +42,4 @@
 @import 'cxbase/animations';
 
 @import 'misc/hamburger';
+@import 'misc/dialog';

--- a/projects/storefrontstyles/scss/misc/_dialog.scss
+++ b/projects/storefrontstyles/scss/misc/_dialog.scss
@@ -8,10 +8,6 @@
   outline: 0;
 }
 
-.cx-dialog {
-  @extend %cx-base-dialog;
-}
-
 .cx-sidebar-start {
   @extend %cx-base-dialog;
   display: flex;

--- a/projects/storefrontstyles/scss/misc/_dialog.scss
+++ b/projects/storefrontstyles/scss/misc/_dialog.scss
@@ -1,0 +1,29 @@
+%cx-base-dialog {
+  position: fixed;
+  z-index: 1050;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  outline: 0;
+}
+
+.cx-dialog {
+  @extend %cx-base-dialog;
+}
+
+.cx-sidebar-start {
+  @extend %cx-base-dialog;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.cx-sidebar-end {
+  @extend %cx-base-dialog;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cx-dialog-popover {
+  @extend %cx-base-dialog;
+}


### PR DESCRIPTION
Can be tested by adding the following to the styles.scss:
```
// Start
.cx-sidebar-start {
  .cx-anonymous-consent-dialog {
    max-width: 100% !important;
    min-width: 100% !important;

    height: 100%;
    margin: 0;

    .cx-dialog-content {
      width: 500px;
      height: 100%;

      > div {
        height: 100%;
      }
    }
  }
}
// End
.cx-sidebar-end {
  .cx-anonymous-consent-dialog {
    max-width: inherit !important;
    min-width: inherit !important;

    height: 100%;
    margin: 0;

    .cx-dialog-content {
      width: 500px;
      height: 100%;

      > div {
        height: 100%;
      }
    }
  }
}
```

Then in the `default-anonymous-consent-layout.config.ts` you can change the dialog type to `SIDEBAR_START` or `SIDEBAR_END`. When opening the anonymous consent dialog you will see the changes.
