### PR TITLE
chore: install spartacus schematics as a dev dependency

### DIFF
--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -29,6 +29,9 @@
     "shelljs": "^0.8.3",
     "typescript": "~3.8.3"
   },
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "ng-update": {
     "migrations": "./src/migrations/migrations.json",
     "packageGroup": [


### PR DESCRIPTION
In this PR we are installing `@spartacus/schematics` as a dev dependency, rather than as a runtime dependency.