### PR TITLE
Feature/gh 6581 fix ff

### DIFF
--- a/projects/storefrontlib/src/layout/a11y/keyboard-focus/lock/lock-focus.directive.spec.ts
+++ b/projects/storefrontlib/src/layout/a11y/keyboard-focus/lock/lock-focus.directive.spec.ts
@@ -332,7 +332,7 @@ describe('LockFocusDirective', () => {
       fixture.detectChanges();
     });
 
-    it('should autofocus first focusable by default', () => {
+    it('should autofocus first focusable by default', fakeAsync(() => {
       const host = fixture.debugElement.query(By.css('#a'));
       const f1 = fixture.debugElement.query(By.css('#a1')).nativeElement;
       const f2 = fixture.debugElement.query(By.css('#a2')).nativeElement;
@@ -344,11 +344,13 @@ describe('LockFocusDirective', () => {
       event.target = host.nativeElement;
       host.triggerEventHandler('keydown.enter', event);
 
+      tick(100);
+
       expect(f1.focus).toHaveBeenCalled();
       expect(f2.focus).not.toHaveBeenCalled();
-    });
+    }));
 
-    it('should autofocus if lock=true', () => {
+    it('should autofocus if lock=true', fakeAsync(() => {
       const host = fixture.debugElement.query(By.css('#b'));
       const f1 = fixture.debugElement.query(By.css('#b1')).nativeElement;
       const f2 = fixture.debugElement.query(By.css('#b2')).nativeElement;
@@ -360,9 +362,11 @@ describe('LockFocusDirective', () => {
       event.target = host.nativeElement;
       host.triggerEventHandler('keydown.enter', event);
 
+      tick(100);
+
       expect(f1.focus).toHaveBeenCalled();
       expect(f2.focus).not.toHaveBeenCalled();
-    });
+    }));
 
     it('should not autofocus if lock=false', () => {
       const host = fixture.debugElement.query(By.css('#c'));
@@ -396,12 +400,14 @@ describe('LockFocusDirective', () => {
       expect(f2.focus).not.toHaveBeenCalled();
     });
 
-    it('should find focusable with configured autofocus selector', () => {
+    it('should find focusable with configured autofocus selector', fakeAsync(() => {
       const host = fixture.debugElement.query(By.css('#e'));
       spyOn(service, 'findFirstFocusable');
 
       event.target = host.nativeElement;
       host.triggerEventHandler('keydown.enter', event);
+
+      tick(100);
 
       const hostConfig = {
         lock: true,
@@ -414,6 +420,6 @@ describe('LockFocusDirective', () => {
         hostConfig
       );
       expect(service.findFirstFocusable).toHaveBeenCalledTimes(1);
-    });
+    }));
   });
 });

--- a/projects/storefrontlib/src/layout/a11y/keyboard-focus/lock/lock-focus.directive.ts
+++ b/projects/storefrontlib/src/layout/a11y/keyboard-focus/lock/lock-focus.directive.ts
@@ -123,7 +123,7 @@ export class LockFocusDirective extends TrapFocusDirective
   ngAfterViewInit() {
     if (this.shouldLock) {
       /**
-       * If the component hosts a group of focusable children elmenents,
+       * If the component hosts a group of focusable children elements,
        * we persist the group key to the children, so that they can taken this
        * into account when they persist their focus state.
        */

--- a/projects/storefrontlib/src/layout/a11y/keyboard-focus/lock/lock-focus.directive.ts
+++ b/projects/storefrontlib/src/layout/a11y/keyboard-focus/lock/lock-focus.directive.ts
@@ -56,6 +56,7 @@ export class LockFocusDirective extends TrapFocusDirective
   handleEnter(event: KeyboardEvent) {
     if (this.shouldLock && this.host === (event.target as HTMLElement)) {
       this.unlockFocus(event);
+      event.preventDefault();
       event.stopPropagation();
     }
   }
@@ -89,7 +90,11 @@ export class LockFocusDirective extends TrapFocusDirective
     this.addTabindexToChildren(0);
     // we focus the host if the event was triggered from a child
     if (event?.target === this.host) {
-      super.handleFocus(event as KeyboardEvent);
+      // we wait a few milliseconds, mainly because firefox will otherwise apply
+      // the mouse event on the new focused child element
+      setTimeout(() => {
+        super.handleFocus(event as KeyboardEvent);
+      }, 100);
     }
   }
 


### PR DESCRIPTION
During QA of #6581 the following issue was observed in Firefox: 

> A facet (group) should be unlocked after you use enter or space key on the facet.
❌[KC]: "Space" key does not open facet group Brands on Firefox only.. It closes right away.
↩️[TO]: I’m unable to reproduce, just tried it in ff. What OS /version are you on?
↪️[KC]: Mac OS Catalina 10.15.4, Firefox: 75.0 (64-bit)

During investigation, it became apparent that the mousedown event of a locked item might cause an immediate event on the autofocused child element.

In this PR we fix this, by applying a small timeout.