### PR TITLE
[for 2.0.x] fix: avoid partial data emissions from page meta service

### DIFF
--- a/projects/core/src/cms/facade/page-meta.service.ts
+++ b/projects/core/src/cms/facade/page-meta.service.ts
@@ -1,10 +1,10 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { combineLatest, Observable, of } from 'rxjs';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { debounceTime, filter, map, switchMap } from 'rxjs/operators';
+import { resolveApplicable } from '../../util/applicable';
 import { Page, PageMeta } from '../model/page.model';
 import { PageMetaResolver } from '../page/page-meta.resolver';
 import { CmsService } from './cms.service';
-import { resolveApplicable } from '../../util/applicable';
 
 @Injectable({
   providedIn: 'root',
@@ -56,7 +56,9 @@ export class PageMetaService {
    * @param metaResolver
    */
   protected resolve(metaResolver: PageMetaResolver): Observable<PageMeta> {
-    const resolveMethods: any[] = Object.keys(this.resolverMethods)
+    const resolveMethods: Observable<PageMeta>[] = Object.keys(
+      this.resolverMethods
+    )
       .filter((key) => metaResolver[this.resolverMethods[key]])
       .map((key) =>
         metaResolver[this.resolverMethods[key]]().pipe(
@@ -67,6 +69,7 @@ export class PageMetaService {
       );
 
     return combineLatest(resolveMethods).pipe(
+      debounceTime(0), // avoid partial data emissions when all methods resolve at the same time
       map((data) => Object.assign({}, ...data))
     );
   }

--- a/projects/storefrontlib/src/cms-components/navigation/breadcrumb/breadcrumb.component.ts
+++ b/projects/storefrontlib/src/cms-components/navigation/breadcrumb/breadcrumb.component.ts
@@ -5,8 +5,8 @@ import {
   PageMetaService,
   TranslationService,
 } from '@spartacus/core';
-import { asyncScheduler, combineLatest, Observable } from 'rxjs';
-import { filter, map, observeOn } from 'rxjs/operators';
+import { combineLatest, Observable } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 
 @Component({
@@ -39,7 +39,7 @@ export class BreadcrumbComponent implements OnInit {
   private setCrumbs(): void {
     this.crumbs$ = combineLatest([
       this.pageMetaService.getMeta(),
-      this.translation.translate('common.home').pipe(observeOn(asyncScheduler)),
+      this.translation.translate('common.home'),
     ]).pipe(
       map(([meta, textHome]) =>
         meta?.breadcrumbs ? meta.breadcrumbs : [{ label: textHome, link: '/' }]


### PR DESCRIPTION
The `combineLastest` emitted the cascaded partial updates even when many the methods of the `PageMetaResolver` resolved at the same time. Now updates that happen at the same macrotask are debounced.

Also removed obsolete workaround from breadcrumb.component meant to avoid ExpressionChangedAfterItHasBeenCheckedError. It's not needed anymore.

closes #7490
closes #7413