### PR TITLE
fix: change the default occ prefix back to /rest/v2

### DIFF
--- a/projects/core/src/occ/config/default-occ-config.ts
+++ b/projects/core/src/occ/config/default-occ-config.ts
@@ -3,7 +3,7 @@ import { OccConfig } from './occ-config';
 export const defaultOccConfig: OccConfig = {
   backend: {
     occ: {
-      prefix: '/occ/v2/',
+      prefix: '/rest/v2',
     },
     media: {},
   },

--- a/projects/core/src/occ/config/default-occ-config.ts
+++ b/projects/core/src/occ/config/default-occ-config.ts
@@ -3,7 +3,7 @@ import { OccConfig } from './occ-config';
 export const defaultOccConfig: OccConfig = {
   backend: {
     occ: {
-      prefix: '/rest/v2',
+      prefix: '/rest/v2/',
     },
     media: {},
   },


### PR DESCRIPTION
This PR reverts the default OCC prefix back to `/rest/v2`