### PR TITLE
[for 2.0.x] fix: avoid re-subscribing to already registered event sources when adding a new one for the same type

### DIFF
--- a/projects/core/src/event/event.service.spec.ts
+++ b/projects/core/src/event/event.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { of, Subscription } from 'rxjs';
+import { BehaviorSubject, of, Subject, Subscription } from 'rxjs';
 import { EventService } from './event.service';
 
 class EventA {
@@ -31,7 +31,7 @@ describe('EventService', () => {
     }
   });
 
-  it('should register event sources and get event stream for given event type', () => {
+  it('should register different event sources for different types', () => {
     service.register(EventA, of(new EventA(1), new EventA(2)));
     service.register(EventB, of(new EventB(100)));
 
@@ -40,7 +40,7 @@ describe('EventService', () => {
     expect(results).toEqual([new EventA(1), new EventA(2)]);
   });
 
-  it('should register event sources and get event stream with merged sources', () => {
+  it('should register many sources for the same type', () => {
     service.register(EventA, of(new EventA(1), new EventA(2)));
     service.register(EventA, of(new EventA(3)));
     service.register(EventA, of(new EventA(4)));
@@ -55,18 +55,18 @@ describe('EventService', () => {
     ]);
   });
 
-  it('should register event sources as well as dispatch occasional events and get event stream for given event type', () => {
+  it('should allow for dispatch, register, subscribe and dispatch', () => {
     service.dispatch(new EventA(1)); // dispatch before subscription won't be detected
-    service.register(EventA, of(new EventA(2), new EventA(3)));
+    service.register(EventA, of(new EventA(2)));
 
     const results = [];
     sub = service.get(EventA).subscribe((e) => results.push(e));
-    service.dispatch(new EventA(4)); // dispatch after subscription will be detected
+    service.dispatch(new EventA(3));
 
-    expect(results).toEqual([new EventA(2), new EventA(3), new EventA(4)]);
+    expect(results).toEqual([new EventA(2), new EventA(3)]);
   });
 
-  it('register method should return a teardown function which unregisters the given event source', () => {
+  it('should allow for manual unregistering', () => {
     const unregister = service.register(
       EventA,
       of(new EventA(1), new EventA(2))
@@ -78,5 +78,54 @@ describe('EventService', () => {
     sub = service.get(EventA).subscribe((e) => results.push(e));
 
     expect(results).toEqual([new EventA(3), new EventA(4)]);
+  });
+
+  it('should register BehaviorSubject before other sources', () => {
+    const results = [];
+    sub = service.get(EventA).subscribe((e) => results.push(e.a));
+
+    const behaviorSubject$ = new BehaviorSubject(new EventA(1));
+    const subject$ = new Subject();
+    service.register(EventA, behaviorSubject$);
+    service.register(EventA, subject$);
+    subject$.next(new EventA(2));
+
+    expect(results).toEqual([1, 2]);
+  });
+
+  it('should register after the subscription', () => {
+    const results = [];
+    sub = service.get(EventA).subscribe((e) => results.push(e.a));
+
+    const of1$ = of(new EventA(1));
+    const of2$ = of(new EventA(2));
+    service.register(EventA, of1$);
+    service.register(EventA, of2$);
+
+    expect(results).toEqual([1, 2]);
+  });
+
+  it('should register before the subscription', () => {
+    const of1$ = of(new EventA(1));
+    const of2$ = of(new EventA(2));
+    service.register(EventA, of1$);
+    service.register(EventA, of2$);
+
+    const results = [];
+    sub = service.get(EventA).subscribe((e) => results.push(e.a));
+
+    expect(results).toEqual([1, 2]);
+  });
+
+  it('should allow for the re-subscription', () => {
+    const of$ = of(new EventA(1));
+    service.register(EventA, of$);
+
+    const results = [];
+    sub = service.get(EventA).subscribe((e) => results.push(e.a));
+    sub.unsubscribe();
+    sub = service.get(EventA).subscribe((e) => results.push(e.a));
+
+    expect(results).toEqual([1, 1]);
   });
 });

--- a/projects/core/src/event/utils/merging-subject.spec.ts
+++ b/projects/core/src/event/utils/merging-subject.spec.ts
@@ -1,0 +1,127 @@
+import { Subject } from 'rxjs';
+import { MergingSubject } from './merging-subject';
+
+describe('MergingSubject', () => {
+  it('should allow for add, remove and subscribe', () => {
+    const mergingSubject = new MergingSubject();
+
+    const sourceA = new Subject();
+    const sourceB = new Subject();
+
+    const results1 = [];
+    const results2 = [];
+    let sub1 = mergingSubject.output$.subscribe((x) => results1.push(x));
+    let sub2 = mergingSubject.output$.subscribe((x) => results2.push(x));
+
+    expect(results1).toEqual([]);
+    expect(results2).toEqual([]);
+
+    // add source A
+    mergingSubject.add(sourceA);
+    sourceA.next('a1');
+    sourceB.next('b1');
+    expect(results1).toEqual(['a1']);
+    expect(results2).toEqual(['a1']);
+    expect(mergingSubject.has(sourceA)).toBe(true);
+    expect(mergingSubject.has(sourceB)).toBe(false);
+
+    // add source B
+    mergingSubject.add(sourceB);
+    sourceA.next('a2');
+    sourceB.next('b2');
+    expect(results1).toEqual(['a1', 'a2', 'b2']);
+    expect(results2).toEqual(['a1', 'a2', 'b2']);
+    expect(mergingSubject.has(sourceA)).toBe(true);
+    expect(mergingSubject.has(sourceB)).toBe(true);
+
+    // remove source A
+    mergingSubject.remove(sourceA);
+    sourceA.next('a3');
+    sourceB.next('b3');
+    expect(results1).toEqual(['a1', 'a2', 'b2', 'b3']);
+    expect(results2).toEqual(['a1', 'a2', 'b2', 'b3']);
+    expect(mergingSubject.has(sourceA)).toBe(false);
+    expect(mergingSubject.has(sourceB)).toBe(true);
+
+    // remove source B
+    mergingSubject.remove(sourceB);
+    sourceA.next('a4');
+    sourceB.next('b4');
+    expect(results1).toEqual(['a1', 'a2', 'b2', 'b3']);
+    expect(results2).toEqual(['a1', 'a2', 'b2', 'b3']);
+    expect(mergingSubject.has(sourceA)).toBe(false);
+    expect(mergingSubject.has(sourceB)).toBe(false);
+
+    // add again source A an source B
+    mergingSubject.add(sourceA);
+    mergingSubject.add(sourceB);
+    sourceA.next('a5');
+    sourceB.next('b5');
+    expect(results1).toEqual(['a1', 'a2', 'b2', 'b3', 'a5', 'b5']);
+    expect(results2).toEqual(['a1', 'a2', 'b2', 'b3', 'a5', 'b5']);
+    expect(mergingSubject.has(sourceA)).toBe(true);
+    expect(mergingSubject.has(sourceB)).toBe(true);
+
+    // unsubscribe results1
+    sub1.unsubscribe();
+    sourceA.next('a6');
+    sourceB.next('b6');
+    expect(results1).toEqual(['a1', 'a2', 'b2', 'b3', 'a5', 'b5']);
+    expect(results2).toEqual(['a1', 'a2', 'b2', 'b3', 'a5', 'b5', 'a6', 'b6']);
+    expect(mergingSubject.has(sourceA)).toBe(true);
+    expect(mergingSubject.has(sourceB)).toBe(true);
+
+    // unsubscribe results2
+    sub2.unsubscribe();
+    sourceA.next('a7');
+    sourceB.next('b7');
+    expect(results1).toEqual(['a1', 'a2', 'b2', 'b3', 'a5', 'b5']);
+    expect(results2).toEqual(['a1', 'a2', 'b2', 'b3', 'a5', 'b5', 'a6', 'b6']);
+    expect(mergingSubject.has(sourceA)).toBe(true);
+    expect(mergingSubject.has(sourceB)).toBe(true);
+
+    // re-subscribe results1 and results2
+    sub1 = mergingSubject.output$.subscribe((x) => results1.push(x));
+    sub2 = mergingSubject.output$.subscribe((x) => results2.push(x));
+    sourceA.next('a8');
+    sourceB.next('b8');
+    expect(results1).toEqual(['a1', 'a2', 'b2', 'b3', 'a5', 'b5', 'a8', 'b8']);
+    expect(results2).toEqual([
+      'a1',
+      'a2',
+      'b2',
+      'b3',
+      'a5',
+      'b5',
+      'a6',
+      'b6',
+      'a8',
+      'b8',
+    ]);
+    expect(mergingSubject.has(sourceA)).toBe(true);
+    expect(mergingSubject.has(sourceB)).toBe(true);
+
+    // cleanup all
+    mergingSubject.remove(sourceA);
+    mergingSubject.remove(sourceB);
+    sub1.unsubscribe();
+    sub2.unsubscribe();
+    sourceA.next('a9');
+    sourceB.next('b9');
+    expect(results1).toEqual(['a1', 'a2', 'b2', 'b3', 'a5', 'b5', 'a8', 'b8']);
+    expect(results2).toEqual([
+      'a1',
+      'a2',
+      'b2',
+      'b3',
+      'a5',
+      'b5',
+      'a6',
+      'b6',
+      'a8',
+      'b8',
+    ]);
+    expect(mergingSubject.has(sourceA)).toBe(false);
+    expect(mergingSubject.has(sourceB)).toBe(false);
+  });
+});

--- a/projects/core/src/event/utils/merging-subject.ts
+++ b/projects/core/src/event/utils/merging-subject.ts
@@ -1,0 +1,135 @@
+import { Observable, Subscriber, Subscription } from 'rxjs';
+import { share } from 'rxjs/operators';
+
+// PRIVATE API
+
+/**
+ * Allows for dynamic adding and removing source observables
+ * and exposes them as one merged observable at a property `output$`.
+ *
+ * Thanks to the `share()` operator used inside, it subscribes to source observables
+ * only when someone subscribes to it. And it unsubscribes from source observables
+ * when the counter of consumers drops to 0.
+ *
+ * **To avoid memory leaks**, all manually added sources should be manually removed
+ * when not plan to emit values anymore. In particular closed event sources won't be
+ * automatically removed.
+ */
+export class MergingSubject<T> {
+  /**
+   * List of already added sources (but not removed yet)
+   */
+  private sources: Observable<T>[] = [];
+
+  /**
+   * For each source: it stores a subscription responsible for
+   * passing all values from source to the consumer
+   */
+  private subscriptionsToSources = new Map<Observable<T>, Subscription>();
+
+  /**
+   * Observable with all sources merged.
+   *
+   * Only after subscribing to it, under the hood it subscribes to the source observables.
+   * When the number of subscribers drops to 0, it unsubscribes from all source observables.
+   * But if later on something subscribes to it again, it subscribes to the source observables again.
+   *
+   * It multicasts the emissions for each subscriber.
+   */
+  readonly output$: Observable<T> = new Observable<T>((consumer) => {
+    // There can be only 0 or 1 consumer of this observable coming from the `share()` operator
+    // that is piped right after this observable.
+    // `share()` not only multicasts the results but also  When all end-subscribers unsubscribe from `share()` operator, it will unsubscribe
+    // from this observable (by the nature `refCount`-nature of the `share()` operator).
+
+    this.consumer = consumer;
+    this.bindAllSourcesToConsumer(consumer);
+
+    return () => {
+      this.consumer = null;
+      this.unbindAllSourcesFromConsumer();
+    };
+  }).pipe(share());
+
+  /**
+   * Reference to the subscriber coming from the `share()` operator piped to the `output$` observable.
+   * For more, see docs of the `output$` observable;
+   */
+  private consumer: Subscriber<any> = null;
+
+  /**
+   * Registers the given source to pass its values to the `output$` observable.
+   *
+   * It does nothing, when the source has been already added (but not removed yet).
+   */
+  add(source: Observable<T>): void {
+    if (this.has(source)) {
+      return;
+    }
+
+    if (this.consumer) {
+      this.bindSourceToConsumer(source, this.consumer);
+    }
+    this.sources.push(source);
+  }
+
+  /**
+   * Starts passing all values from already added sources to consumer
+   */
+  private bindAllSourcesToConsumer(consumer: Subscriber<T>) {
+    this.sources.forEach((source) =>
+      this.bindSourceToConsumer(source, consumer)
+    );
+  }
+
+  /**
+   * Stops passing all values from already added sources to consumer
+   * (if any consumer is active at the moment)
+   */
+  private unbindAllSourcesFromConsumer() {
+    this.sources.forEach((source) => this.unbindSourceFromConsumer(source));
+  }
+
+  /**
+   * Starts passing all values from a single source to consumer
+   */
+  private bindSourceToConsumer(source: Observable<T>, consumer: Subscriber<T>) {
+    const subscriptionToSource = source.subscribe((val) => consumer.next(val)); // passes all emissions from source to consumer
+    this.subscriptionsToSources.set(source, subscriptionToSource);
+  }
+
+  /**
+   * Stops passing all values from a single source to consumer
+   * (if any consumer is active at the moment)
+   */
+  private unbindSourceFromConsumer(source: Observable<T>) {
+    const subscriptionToSource = this.subscriptionsToSources.get(source);
+    if (subscriptionToSource !== undefined) {
+      subscriptionToSource.unsubscribe();
+      this.subscriptionsToSources.delete(source);
+    }
+  }
+
+  /**
+   * Unregisters the given source so it stops passing its values to `output$` observable.
+   *
+   * Should be used when a source is no longer maintained **to avoid memory leaks**.
+   */
+  remove(source: Observable<T>): void {
+    // clear binding from source to consumer (if any consumer exists at the moment)
+    this.unbindSourceFromConsumer(source);
+
+    // remove source from array
+    let i: number;
+    if ((i = this.sources.findIndex((s) => s === source)) !== -1) {
+      this.sources.splice(i, 1);
+    }
+  }
+
+  /**
+   * Returns whether the given source has been already addded
+   */
+  has(source: Observable<T>): boolean {
+    return this.sources.includes(source);
+  }
+}


### PR DESCRIPTION
Currently event service re-subscribes to already sources when a new source is being added. This can cause strange side effects.

A BehaviorSubject (or any observable stream with a replay functionality inside) re-emits last value when being re-subscribed to.

Although we don't officially support replayed observables as event sources, it would be good to at least avoid very nasty and hard to debug re-emissions from already registered observables with replay functionality, when adding yet another source. This PR fixes that.

closes GH-7581