### PR TITLE
chore: schematics - clean up build files

### DIFF
--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -7,8 +7,9 @@
     "schematics"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "test": "tsc -p tsconfig.json && jasmine \"src/**/*_spec.js\""
+    "clean": "rm -rf src/**/*.js src/**/*.js.map src/**/*.d.ts",
+    "build": "yarn clean && tsc -p tsconfig.json",
+    "test": "yarn build && jasmine \"src/**/*_spec.js\""
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
This PR adds a package.json command to cleanup build files before running the next build or a test command.