### PR TITLE
chore: add url matcher migration data

### DIFF
--- a/projects/schematics/src/migrations/2_0/methods-and-properties-deprecations/data/url-matcher-factory.service.migration.ts
+++ b/projects/schematics/src/migrations/2_0/methods-and-properties-deprecations/data/url-matcher-factory.service.migration.ts
@@ -1,0 +1,45 @@
+import {
+  GET_FALSY_URL_MATCHER,
+  GET_GLOB_URL_MATCHER,
+  GET_MULTIPLE_PATHS_URL_MATCHER,
+  GET_OPPOSITE_URL_MATCHER,
+  GET_PATH_URL_MATCHER,
+  SPARTACUS_CORE,
+  TODO_SPARTACUS,
+  URL_MATCHER_FACTORY_SERVICE,
+} from '../../../../shared/constants';
+import { MethodPropertyDeprecation } from '../../../../shared/utils/file-utils';
+
+//projects/core/src/routing/services/url-matcher.service.ts
+export const URL_MATCHER_FACTORY_SERVICE_MIGRATION: MethodPropertyDeprecation[] = [
+  {
+    class: URL_MATCHER_FACTORY_SERVICE,
+    importPath: SPARTACUS_CORE,
+    deprecatedNode: GET_FALSY_URL_MATCHER,
+    comment: `// ${TODO_SPARTACUS} Method ${GET_FALSY_URL_MATCHER} has changed the parameter order. Please use 'getFalsy' instead.`,
+  },
+  {
+    class: URL_MATCHER_FACTORY_SERVICE,
+    importPath: SPARTACUS_CORE,
+    deprecatedNode: GET_MULTIPLE_PATHS_URL_MATCHER,
+    comment: `// ${TODO_SPARTACUS} Method ${GET_MULTIPLE_PATHS_URL_MATCHER} has changed the parameter order. Please use 'getFromPaths' instead.`,
+  },
+  {
+    class: URL_MATCHER_FACTORY_SERVICE,
+    importPath: SPARTACUS_CORE,
+    deprecatedNode: GET_PATH_URL_MATCHER,
+    comment: `// ${TODO_SPARTACUS} Method ${GET_PATH_URL_MATCHER} has changed the parameter order. Please use 'getFromPath' instead.`,
+  },
+  {
+    class: URL_MATCHER_FACTORY_SERVICE,
+    importPath: SPARTACUS_CORE,
+    deprecatedNode: GET_OPPOSITE_URL_MATCHER,
+    comment: `// ${TODO_SPARTACUS} Method ${GET_OPPOSITE_URL_MATCHER} has changed the parameter order. Please use 'getOpposite' instead.`,
+  },
+  {
+    class: URL_MATCHER_FACTORY_SERVICE,
+    importPath: SPARTACUS_CORE,
+    deprecatedNode: GET_GLOB_URL_MATCHER,
+    comment: `// ${TODO_SPARTACUS} Method ${GET_GLOB_URL_MATCHER} has changed the parameter order. Please use 'getFromGlob' instead.`,
+  },
+];

--- a/projects/schematics/src/migrations/2_0/methods-and-properties-deprecations/methods-and-properties-deprecations-data.ts
+++ b/projects/schematics/src/migrations/2_0/methods-and-properties-deprecations/methods-and-properties-deprecations-data.ts
@@ -3,10 +3,12 @@ import { CMS_ACTIONS_MIGRATION } from './data/cms-group.actions.migration';
 import { CMS_SELECTORS_MIGRATION } from './data/cms-group.selectors.migration';
 import { CMS_SERVICE_MIGRATION } from './data/cms-service.migration';
 import { DYNAMIC_ATTRIBUTE_SERVICE_MIGRATION } from './data/dynamic-attribute.service.migration';
+import { URL_MATCHER_FACTORY_SERVICE_MIGRATION } from './data/url-matcher-factory.service.migration';
 
 export const METHOD_PROPERTY_DATA: MethodPropertyDeprecation[] = [
   ...CMS_SELECTORS_MIGRATION,
   ...CMS_ACTIONS_MIGRATION,
   ...CMS_SERVICE_MIGRATION,
   ...DYNAMIC_ATTRIBUTE_SERVICE_MIGRATION,
+  ...URL_MATCHER_FACTORY_SERVICE_MIGRATION,
 ];

--- a/projects/schematics/src/shared/constants.ts
+++ b/projects/schematics/src/shared/constants.ts
@@ -320,6 +320,11 @@ export const COMPONENTS_SELECTOR_FACTORY_NEW_API = 'componentsSelectorFactory';
 export const IS_LAUNCH_IN_SMART_EDIT = 'isLaunchInSmartEdit';
 export const IS_LAUNCHED_IN_SMART_EDIT = 'isLaunchedInSmartEdit';
 export const ADD_DYNAMIC_ATTRIBUTES = 'addDynamicAttributes';
+export const GET_FALSY_URL_MATCHER = 'getFalsyUrlMatcher';
+export const GET_MULTIPLE_PATHS_URL_MATCHER = 'getMultiplePathsUrlMatcher';
+export const GET_PATH_URL_MATCHER = 'getPathUrlMatcher';
+export const GET_OPPOSITE_URL_MATCHER = 'getOppositeUrlMatcher';
+export const GET_GLOB_URL_MATCHER = 'getGlobUrlMatcher';
 /***** APIs end *****/
 
 /***** Misc start *****/


### PR DESCRIPTION
This PR adds a migration data for the former UrlMatcherFactoryService's methods (now UrlMatcherService).