### PR TITLE
[for 2.0.x] fix: support navigation links containing query params and hash fragments (#7782)

### DIFF
--- a/projects/storefrontlib/src/shared/components/generic-link/generic-link.component.html
+++ b/projects/storefrontlib/src/shared/components/generic-link/generic-link.component.html
@@ -19,6 +19,8 @@
   <a
     role="link"
     [routerLink]="routerUrl"
+    [queryParams]="queryParams"
+    [fragment]="fragment"
     [attr.target]="target"
     [attr.class]="class"
     [attr.id]="id"

--- a/projects/storefrontlib/src/shared/components/generic-link/generic-link.component.spec.ts
+++ b/projects/storefrontlib/src/shared/components/generic-link/generic-link.component.spec.ts
@@ -1,7 +1,16 @@
+import { SimpleChange, SimpleChanges } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { GenericLinkComponent } from './generic-link.component';
 import { RouterTestingModule } from '@angular/router/testing';
+import { GenericLinkComponent } from './generic-link.component';
+
+/**
+ * Helper function to produce simple change for the `url` `@Input`
+ */
+function changeUrl(url: string | any[]): SimpleChanges {
+  return {
+    url: new SimpleChange(null, url, false),
+  };
+}
 
 describe('GenericLinkComponent', () => {
   let component: GenericLinkComponent;
@@ -17,7 +26,6 @@ describe('GenericLinkComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GenericLinkComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -62,19 +70,48 @@ describe('GenericLinkComponent', () => {
 
   describe('routerUrl', () => {
     it('should return absolute url wrapped in array when url is string', () => {
-      component.url = 'local/url';
-      expect(component.routerUrl).toEqual(['/local/url']);
+      component.ngOnChanges(changeUrl('local/url1'));
+      expect(component.routerUrl).toEqual(['/local/url1']);
 
-      component.url = '/local/url';
-      expect(component.routerUrl).toEqual(['/local/url']);
+      component.ngOnChanges(changeUrl('/local/url2'));
+      expect(component.routerUrl).toEqual(['/local/url2']);
+
+      component.ngOnChanges(changeUrl('/local/url3?foo=bar#anchor'));
+      expect(component.routerUrl).toEqual(['/local/url3']);
     });
 
     it('should original url when url is array', () => {
-      component.url = ['array', 'of', 'url', 'segments'];
-      expect(component.routerUrl).toEqual(['array', 'of', 'url', 'segments']);
+      component.ngOnChanges(changeUrl(['url', 'segments', 'array', '1']));
+      expect(component.routerUrl).toEqual(['url', 'segments', 'array', '1']);
 
-      component.url = ['/array', 'of', 'url', 'segments'];
-      expect(component.routerUrl).toEqual(['/array', 'of', 'url', 'segments']);
+      component.ngOnChanges(changeUrl(['/url', 'segments', 'array', '2']));
+      expect(component.routerUrl).toEqual(['/url', 'segments', 'array', '2']);
+    });
+  });
+
+  describe('queryParams', () => {
+    it('should return query params of the string url', () => {
+      component.ngOnChanges(changeUrl('?foo=1&bar=10'));
+      expect(component.queryParams).toEqual({ foo: '1', bar: '10' });
+
+      component.ngOnChanges(changeUrl('local/url?foo=2&bar=20'));
+      expect(component.queryParams).toEqual({ foo: '2', bar: '20' });
+
+      component.ngOnChanges(changeUrl('/local/url?foo=3&bar=30#anchor'));
+      expect(component.queryParams).toEqual({ foo: '3', bar: '30' });
+    });
+  });
+
+  describe('fragment', () => {
+    it('should return query params of the string url', () => {
+      component.ngOnChanges(changeUrl('#anchor1'));
+      expect(component.fragment).toEqual('anchor1');
+
+      component.ngOnChanges(changeUrl('local/url#anchor2'));
+      expect(component.fragment).toEqual('anchor2');
+
+      component.ngOnChanges(changeUrl('/local/url?foo=bar#anchor3'));
+      expect(component.fragment).toEqual('anchor3');
     });
   });
 });

--- a/projects/storefrontlib/src/shared/components/generic-link/generic-link.component.ts
+++ b/projects/storefrontlib/src/shared/components/generic-link/generic-link.component.ts
@@ -1,4 +1,17 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Params, Router } from '@angular/router';
+
+// private
+interface RouteParts {
+  /** Path in the Angular-like array format */
+  path?: string[];
+
+  /** Query params */
+  queryParams?: Params;
+
+  /** Hash fragment */
+  fragment?: string;
+}
 
 /**
  * This component navigates using [routerLink] attribute when input 'url' is a relative url. Otherwise (when it's absolute), [href] is used.
@@ -7,8 +20,27 @@ import { Component, Input } from '@angular/core';
   selector: 'cx-generic-link',
   templateUrl: './generic-link.component.html',
 })
-export class GenericLinkComponent {
-  private readonly protocolRegex: RegExp = /^https?:\/\//i;
+export class GenericLinkComponent implements OnChanges {
+  constructor(protected router: Router) {}
+
+  /**
+   * Pattern matching string starting with `http://` or `https://`.
+   */
+  private readonly PROTOCOL_REGEX: RegExp = /^https?:\/\//i;
+
+  /**
+   * Used to split url into 2 parts:
+   * 1. the path
+   * 2. query params + hash fragment
+   */
+  private readonly URL_SPLIT = /(^[^#?]*)(.*)/;
+
+  /**
+   * Parsed parts of the @Input `url`, when it's a local URL.
+   * It should not be used when the `url` is external.
+   * @see `url`
+   */
+  private routeParts: RouteParts = {};
 
   @Input() url: string | any[];
   @Input() target: string;
@@ -17,22 +49,74 @@ export class GenericLinkComponent {
   @Input() style: string;
   @Input() title: string;
 
+  /**
+   * Returns true when the @Input `url` is a string starting with `http://` or `https://`.
+   */
+  isExternalUrl(): boolean {
+    return typeof this.url === 'string' && this.PROTOCOL_REGEX.test(this.url);
+  }
+
   get rel() {
     return this.target === '_blank' ? 'noopener' : null;
   }
 
-  get routerUrl(): any[] {
-    if (typeof this.url === 'string') {
-      return [this.getAbsoluteUrl(this.url)];
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['url']) {
+      this.setUrlParts(changes['url'].currentValue);
     }
-    return this.url;
   }
 
-  isExternalUrl(): boolean {
-    return typeof this.url === 'string' && this.protocolRegex.test(this.url);
+  /**
+   * The part with the path of the local url.
+   */
+  get routerUrl(): any[] {
+    return this.routeParts.path;
   }
 
-  private getAbsoluteUrl(url: string) {
-    return url.startsWith('/') ? this.url : '/' + this.url;
+  /**
+   * The part with the query params of the local url.
+   */
+  get queryParams(): Params {
+    return this.routeParts.queryParams;
+  }
+
+  /**
+   * The part with the hash fragment of the local url.
+   */
+  get fragment(): string {
+    return this.routeParts.fragment;
+  }
+
+  /**
+   * Parses the given url and sets the property `urlParts` accordingly.
+   */
+  private setUrlParts(url: string | any[]) {
+    if (typeof url === 'string') {
+      url = this.getAbsoluteUrl(url); // string links in CMS sometimes don't have the leading slash, so fix it here
+      this.routeParts = this.splitUrl(url as string);
+    } else {
+      this.routeParts = { path: url };
+    }
+  }
+
+  /**
+   * Parses the given string into 3 parts:
+   * - string path (wrapped in an array to be compatible with Angular syntax for the `routerLink`)
+   * - query params (as an object)
+   * - hash fragment (string)
+   */
+  private splitUrl(url: string = ''): RouteParts {
+    const { queryParams, fragment } = this.router.parseUrl(url);
+    const [, path] = url.match(this.URL_SPLIT);
+
+    // wrap path in an array, to have the Angular-like path format
+    return { path: [path], queryParams, fragment };
+  }
+
+  /**
+   * Prepends a leading slash to the given URL string, in case it doesn't have it.
+   */
+  private getAbsoluteUrl(url: string): string {
+    return url.startsWith('/') ? url : '/' + url;
   }
 }


### PR DESCRIPTION
Angular `routerLink` encodes special characters including `?` and `#`. That's why when we passed a raw string URL containing query params or hash fragment to the cx-generic-link component, the output link was broken.

Now the string URL is parsed, the query params and hash fragment extracted and passed into the special inputs of the `routerLink` directive: `[queryParams]` and `[fragment]`.

closes GH-6368