### PR TITLE
(stale) fix: avoid sharing i18next instance in between SSR requests

### DIFF
--- a/projects/core/src/i18n/i18n.module.ts
+++ b/projects/core/src/i18n/i18n.module.ts
@@ -3,9 +3,7 @@ import { provideDefaultConfig } from '../config/config.module';
 import { defaultI18nConfig } from './config/default-i18n-config';
 import { CxDatePipe } from './date.pipe';
 import { i18nextProviders } from './i18next/i18next-providers';
-import { I18nextTranslationService } from './i18next/i18next-translation.service';
 import { TranslatePipe } from './translate.pipe';
-import { TranslationService } from './translation.service';
 
 @NgModule({
   declarations: [TranslatePipe, CxDatePipe],
@@ -15,11 +13,7 @@ export class I18nModule {
   static forRoot(): ModuleWithProviders<I18nModule> {
     return {
       ngModule: I18nModule,
-      providers: [
-        provideDefaultConfig(defaultI18nConfig),
-        { provide: TranslationService, useExisting: I18nextTranslationService },
-        ...i18nextProviders,
-      ],
+      providers: [provideDefaultConfig(defaultI18nConfig), ...i18nextProviders],
     };
   }
 }

--- a/projects/core/src/i18n/i18next/i18next-http-client.ts
+++ b/projects/core/src/i18n/i18next/i18next-http-client.ts
@@ -1,0 +1,38 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, InjectionToken } from '@angular/core';
+
+export type I18nextHttpClient = (
+  url: string,
+  options: object,
+  callback: Function,
+  data: object
+) => void;
+
+/**
+ * Function appropriate for i18next to make http calls for JSON files.
+ * See docs for `i18next-xhr-backend`: https://github.com/i18next/i18next-xhr-backend#backend-options
+ *
+ * It uses Angular HttpClient under the hood, so it works in SSR.
+ * @param httpClient Angular http client
+ */
+export const I18NEXT_HTTP_CLIENT = new InjectionToken<I18nextHttpClient>(
+  'Http client used by i18next for fetching translation resources from backend',
+  {
+    providedIn: 'root',
+    factory: () => {
+      const httpClient = inject(HttpClient);
+
+      return (
+        url: string,
+        _options: object,
+        callback: Function,
+        _data: object
+      ) => {
+        httpClient.get(url, { responseType: 'text' }).subscribe(
+          (data) => callback(data, { status: 200 }),
+          (error) => callback(null, { status: error.status })
+        );
+      };
+    },
+  }
+);

--- a/projects/core/src/i18n/i18next/i18next-init.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.spec.ts
@@ -5,7 +5,7 @@ import {
   TestRequest,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { getLoadPath, i18nextGetHttpClient } from './i18next-init';
+import { getLoadPath, i18nextGetHttpClient } from './i18next-initializer';
 
 describe('i18nextGetHttpClient should return a http client that', () => {
   let httpMock: HttpTestingController;

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -1,111 +1,135 @@
-import { HttpClient } from '@angular/common/http';
-import { InitOptions, i18n as I18Next } from 'i18next';
+import { Inject, Injectable, OnDestroy, Optional } from '@angular/core';
+import { i18n as I18Next, InitOptions } from 'i18next';
 import i18nextXhrBackend from 'i18next-xhr-backend';
+import { Subscription } from 'rxjs';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
+import { SERVER_REQUEST_ORIGIN } from '../../ssr';
+import { I18nConfig } from '../config/i18n-config';
 import { TranslationResources } from '../translation-resources';
+import { I18nextHttpClient, I18NEXT_HTTP_CLIENT } from './i18next-http-client';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 
-export function i18nextInit(
-  i18next: I18Next,
-  configInit: ConfigInitializerService,
-  languageService: LanguageService,
-  httpClient: HttpClient,
-  serverRequestOrigin: string
-): () => Promise<any> {
-  return () =>
-    configInit.getStableConfig('i18n').then((config) => {
-      let i18nextConfig: InitOptions = {
-        ns: [], // don't preload any namespaces
-        fallbackLng: config.i18n.fallbackLang,
-        debug: config.i18n.debug,
-        interpolation: {
-          escapeValue: false,
-        },
+/**
+ * Initializes the instance of i18next
+ */
+@Injectable({ providedIn: 'root' })
+export class I18nextInitializer implements OnDestroy {
+  constructor(
+    @Inject(I18NEXT_INSTANCE) protected i18next: I18Next,
+    @Inject(I18NEXT_HTTP_CLIENT) protected i18nextHttpClient: I18nextHttpClient,
+    protected configInitializer: ConfigInitializerService,
+    protected languageService: LanguageService,
+    @Optional()
+    @Inject(SERVER_REQUEST_ORIGIN)
+    protected serverRequestOrigin: string
+  ) {}
+
+  private initCalled = false;
+  private sub: Subscription;
+
+  /**
+   * Initializes the instance of i18next
+   */
+  async init(): Promise<any> {
+    if (this.initCalled) {
+      this.initCalled = true;
+      return Promise.resolve();
+    }
+
+    const config = await this.configInitializer.getStableConfig('i18n');
+
+    if (config.i18n.backend) {
+      this.i18next.use(i18nextXhrBackend);
+    }
+
+    const initOptions = this.getInitOptions(config);
+    return this.i18next.init(initOptions, () => {
+      // Don't use i18next's 'resources' config key for adding static translations,
+      // because it will disable loading chunks from backend. We add resources here, in the init's callback.
+      this.addTranslations(config.i18n.resources);
+      this.syncWithSiteContext();
+    });
+  }
+
+  /**
+   * Turns `I18nConfig` of Spartacus into the init options of i18next.
+   */
+  private getInitOptions(config: I18nConfig): InitOptions {
+    let i18nextConfig: InitOptions = {
+      ns: [], // don't preload any namespaces
+      fallbackLng: config.i18n.fallbackLang,
+      debug: config.i18n.debug,
+      interpolation: {
+        escapeValue: false,
+      },
+    };
+    if (config.i18n.backend) {
+      const loadPath = this.getLoadPath(
+        config.i18n.backend.loadPath,
+        this.serverRequestOrigin
+      );
+      const backend = {
+        loadPath,
+        ajax: this.i18nextHttpClient,
       };
-      if (config.i18n.backend) {
-        i18next.use(i18nextXhrBackend);
-        const loadPath = getLoadPath(
-          config.i18n.backend.loadPath,
-          serverRequestOrigin
-        );
-        const backend = {
-          loadPath,
-          ajax: i18nextGetHttpClient(httpClient),
-        };
-        i18nextConfig = { ...i18nextConfig, backend };
-      }
+      i18nextConfig = { ...i18nextConfig, backend };
+    }
+    return i18nextConfig;
+  }
 
-      return i18next.init(i18nextConfig, () => {
-        // Don't use i18next's 'resources' config key for adding static translations,
-        // because it will disable loading chunks from backend. We add resources here, in the init's callback.
-        i18nextAddTranslations(i18next, config.i18n.resources);
-        syncI18nextWithSiteContext(i18next, languageService);
+  /**
+   * Registers provided translation resources in the i18next instance.
+   */
+  private addTranslations(resources: TranslationResources = {}) {
+    Object.keys(resources).forEach((lang) => {
+      Object.keys(resources[lang]).forEach((chunkName) => {
+        this.i18next.addResourceBundle(
+          lang,
+          chunkName,
+          resources[lang][chunkName],
+          true,
+          true
+        );
       });
     });
-}
-
-export function i18nextAddTranslations(
-  i18next: I18Next,
-  resources: TranslationResources = {}
-) {
-  Object.keys(resources).forEach((lang) => {
-    Object.keys(resources[lang]).forEach((chunkName) => {
-      i18next.addResourceBundle(
-        lang,
-        chunkName,
-        resources[lang][chunkName],
-        true,
-        true
-      );
-    });
-  });
-}
-
-export function syncI18nextWithSiteContext(
-  i18next: I18Next,
-  language: LanguageService
-) {
-  // always update language of i18next on site context (language) change
-  language.getActive().subscribe((lang) => i18next.changeLanguage(lang));
-}
-
-/**
- * Returns a function appropriate for i18next to make http calls for JSON files.
- * See docs for `i18next-xhr-backend`: https://github.com/i18next/i18next-xhr-backend#backend-options
- *
- * It uses Angular HttpClient under the hood, so it works in SSR.
- * @param httpClient Angular http client
- */
-export function i18nextGetHttpClient(
-  httpClient: HttpClient
-): (url: string, options: object, callback: Function, data: object) => void {
-  return (url: string, _options: object, callback: Function, _data: object) => {
-    httpClient.get(url, { responseType: 'text' }).subscribe(
-      (data) => callback(data, { status: 200 }),
-      (error) => callback(null, { status: error.status })
-    );
-  };
-}
-
-/**
- * Resolves the relative path to the absolute one in SSR, using the server request's origin.
- * It's needed, because Angular Universal doesn't support relative URLs in HttpClient. See Angular issues:
- * - https://github.com/angular/angular/issues/19224
- * - https://github.com/angular/universal/issues/858
- */
-export function getLoadPath(path: string, serverRequestOrigin: string): string {
-  if (!path) {
-    return undefined;
   }
-  if (serverRequestOrigin && !path.match(/^http(s)?:\/\//)) {
-    if (path.startsWith('/')) {
-      path = path.slice(1);
-    }
-    if (path.startsWith('./')) {
-      path = path.slice(2);
-    }
-    const result = `${serverRequestOrigin}/${path}`;
-    return result;
+
+  /**
+   * Synchronizes the language service with the i18next instance.
+   */
+  private syncWithSiteContext(): void {
+    this.sub = this.languageService
+      .getActive()
+      .subscribe((lang) => this.i18next.changeLanguage(lang));
   }
-  return path;
+
+  ngOnDestroy() {
+    if (this.sub) {
+      this.sub.unsubscribe();
+    }
+  }
+
+  /**
+   * Resolves the relative path to the absolute one in SSR, using the server request's origin.
+   * It's needed, because Angular Universal doesn't support relative URLs in HttpClient. See Angular issues:
+   * - https://github.com/angular/angular/issues/19224
+   * - https://github.com/angular/universal/issues/858
+   */
+  private getLoadPath(path: string, serverRequestOrigin: string): string {
+    if (!path) {
+      return undefined;
+    }
+    if (serverRequestOrigin && !path.match(/^http(s)?:\/\//)) {
+      if (path.startsWith('/')) {
+        path = path.slice(1);
+      }
+      if (path.startsWith('./')) {
+        path = path.slice(2);
+      }
+      const result = `${serverRequestOrigin}/${path}`;
+      return result;
+    }
+    return path;
+  }
 }

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -1,11 +1,12 @@
 import { HttpClient } from '@angular/common/http';
-import i18next, { InitOptions } from 'i18next';
+import { InitOptions, i18n as I18Next } from 'i18next';
 import i18nextXhrBackend from 'i18next-xhr-backend';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
 import { TranslationResources } from '../translation-resources';
 
 export function i18nextInit(
+  i18next: I18Next,
   configInit: ConfigInitializerService,
   languageService: LanguageService,
   httpClient: HttpClient,
@@ -37,13 +38,16 @@ export function i18nextInit(
       return i18next.init(i18nextConfig, () => {
         // Don't use i18next's 'resources' config key for adding static translations,
         // because it will disable loading chunks from backend. We add resources here, in the init's callback.
-        i18nextAddTranslations(config.i18n.resources);
-        syncI18nextWithSiteContext(languageService);
+        i18nextAddTranslations(i18next, config.i18n.resources);
+        syncI18nextWithSiteContext(i18next, languageService);
       });
     });
 }
 
-export function i18nextAddTranslations(resources: TranslationResources = {}) {
+export function i18nextAddTranslations(
+  i18next: I18Next,
+  resources: TranslationResources = {}
+) {
   Object.keys(resources).forEach((lang) => {
     Object.keys(resources[lang]).forEach((chunkName) => {
       i18next.addResourceBundle(
@@ -57,7 +61,10 @@ export function i18nextAddTranslations(resources: TranslationResources = {}) {
   });
 }
 
-export function syncI18nextWithSiteContext(language: LanguageService) {
+export function syncI18nextWithSiteContext(
+  i18next: I18Next,
+  language: LanguageService
+) {
   // always update language of i18next on site context (language) change
   language.getActive().subscribe((lang) => i18next.changeLanguage(lang));
 }

--- a/projects/core/src/i18n/i18next/i18next-initializer.ts
+++ b/projects/core/src/i18n/i18next/i18next-initializer.ts
@@ -65,10 +65,7 @@ export class I18nextInitializer implements OnDestroy {
       },
     };
     if (config.i18n.backend) {
-      const loadPath = this.getLoadPath(
-        config.i18n.backend.loadPath,
-        this.serverRequestOrigin
-      );
+      const loadPath = this.getSSRSafeLoadPath(config.i18n.backend.loadPath);
       const backend = {
         loadPath,
         ajax: this.i18nextHttpClient,
@@ -116,18 +113,18 @@ export class I18nextInitializer implements OnDestroy {
    * - https://github.com/angular/angular/issues/19224
    * - https://github.com/angular/universal/issues/858
    */
-  private getLoadPath(path: string, serverRequestOrigin: string): string {
+  private getSSRSafeLoadPath(path: string): string {
     if (!path) {
       return undefined;
     }
-    if (serverRequestOrigin && !path.match(/^http(s)?:\/\//)) {
+    if (this.serverRequestOrigin && !path.match(/^http(s)?:\/\//)) {
       if (path.startsWith('/')) {
         path = path.slice(1);
       }
       if (path.startsWith('./')) {
         path = path.slice(2);
       }
-      const result = `${serverRequestOrigin}/${path}`;
+      const result = `${this.serverRequestOrigin}/${path}`;
       return result;
     }
     return path;

--- a/projects/core/src/i18n/i18next/i18next-instance.ts
+++ b/projects/core/src/i18n/i18next/i18next-instance.ts
@@ -1,0 +1,18 @@
+import { InjectionToken } from '@angular/core';
+import i18next, { i18n as I18Next } from 'i18next';
+
+/**
+ * The instance of i18next.
+ *
+ * Each SSR request gets its own instance of i18next.
+ *
+ * The reference to the static instance of `i18next` (`import i18next from 'i18next`)
+ * should not be used anywhere else, because otherwise it would be shared in between all SSR requests.
+ */
+export const I18NEXT_INSTANCE = new InjectionToken<I18Next>(
+  'Instance of i18next',
+  {
+    providedIn: 'root',
+    factory: () => i18next.createInstance(),
+  }
+);

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -1,22 +1,25 @@
-import { HttpClient } from '@angular/common/http';
-import { APP_INITIALIZER, Optional, Provider } from '@angular/core';
-import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
-import { LanguageService } from '../../site-context/facade/language.service';
-import { SERVER_REQUEST_ORIGIN } from '../../ssr/ssr.providers';
-import { i18nextInit } from './i18next-init';
-import { I18NEXT_INSTANCE } from './i18next-instance';
+import { APP_INITIALIZER, Provider } from '@angular/core';
+import { TranslationService } from '../translation.service';
+import { I18nextInitializer } from './i18next-init';
+import { I18nextTranslationService } from './i18next-translation.service';
+
+export function initializeI18next(
+  i18nextInitializer: I18nextInitializer
+): () => Promise<any> {
+  const result = () => i18nextInitializer.init();
+  return result;
+}
 
 export const i18nextProviders: Provider[] = [
   {
+    provide: TranslationService,
+    useExisting: I18nextTranslationService,
+  },
+
+  {
     provide: APP_INITIALIZER,
-    useFactory: i18nextInit,
-    deps: [
-      I18NEXT_INSTANCE,
-      ConfigInitializerService,
-      LanguageService,
-      HttpClient,
-      [new Optional(), SERVER_REQUEST_ORIGIN],
-    ],
+    useFactory: initializeI18next,
+    deps: [I18nextInitializer],
     multi: true,
   },
 ];

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -1,6 +1,6 @@
 import { APP_INITIALIZER, Provider } from '@angular/core';
 import { TranslationService } from '../translation.service';
-import { I18nextInitializer } from './i18next-init';
+import { I18nextInitializer } from './i18next-initializer';
 import { I18nextTranslationService } from './i18next-translation.service';
 
 export function initializeI18next(

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -4,12 +4,14 @@ import { ConfigInitializerService } from '../../config/config-initializer/config
 import { LanguageService } from '../../site-context/facade/language.service';
 import { SERVER_REQUEST_ORIGIN } from '../../ssr/ssr.providers';
 import { i18nextInit } from './i18next-init';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 
 export const i18nextProviders: Provider[] = [
   {
     provide: APP_INITIALIZER,
     useFactory: i18nextInit,
     deps: [
+      I18NEXT_INSTANCE,
       ConfigInitializerService,
       LanguageService,
       HttpClient,

--- a/projects/core/src/i18n/i18next/i18next-translation.service.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.ts
@@ -1,19 +1,36 @@
-import { Injectable, isDevMode } from '@angular/core';
-import i18next from 'i18next';
+import { Inject, Injectable, isDevMode } from '@angular/core';
+import i18next_static_instance, { i18n as I18Next } from 'i18next';
 import { Observable } from 'rxjs';
 import { I18nConfig } from '../config/i18n-config';
 import { TranslationChunkService } from '../translation-chunk.service';
 import { TranslationService } from '../translation.service';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 
 @Injectable({ providedIn: 'root' })
 export class I18nextTranslationService implements TranslationService {
   private readonly NON_BREAKING_SPACE = String.fromCharCode(160);
   protected readonly NAMESPACE_SEPARATOR = ':';
 
+  /**
+   * @deprecated use instead the constructor variant with `I18NEXT_INSTANCE` token on the 3rd parameter.
+   */
+  constructor(config: I18nConfig, translationChunk: TranslationChunkService);
+  constructor(
+    config: I18nConfig,
+    translationChunk: TranslationChunkService,
+    // tslint:disable-next-line: unified-signatures
+    i18next?: I18Next
+  );
   constructor(
     protected config: I18nConfig,
-    protected translationChunk: TranslationChunkService
-  ) {}
+    protected translationChunk: TranslationChunkService,
+    @Inject(I18NEXT_INSTANCE) protected i18next?: I18Next
+  ) {
+    /**
+     * @deprecated TODO: remove the line below. The `i18next_static_instance` should not be used anymore. @see I18NEXT_INSTANCE
+     */
+    this.i18next = this.i18next || i18next_static_instance;
+  }
 
   translate(
     key: string,
@@ -32,34 +49,34 @@ export class I18nextTranslationService implements TranslationService {
 
     return new Observable<string>((subscriber) => {
       const translate = () => {
-        if (!i18next.isInitialized) {
+        if (!this.i18next.isInitialized) {
           return;
         }
-        if (i18next.exists(namespacedKey, options)) {
-          subscriber.next(i18next.t(namespacedKey, options));
+        if (this.i18next.exists(namespacedKey, options)) {
+          subscriber.next(this.i18next.t(namespacedKey, options));
         } else {
           if (whitespaceUntilLoaded) {
             subscriber.next(this.NON_BREAKING_SPACE);
           }
-          i18next.loadNamespaces(chunkName, () => {
-            if (!i18next.exists(namespacedKey, options)) {
+          this.i18next.loadNamespaces(chunkName, () => {
+            if (!this.i18next.exists(namespacedKey, options)) {
               this.reportMissingKey(key, chunkName);
               subscriber.next(this.getFallbackValue(namespacedKey));
             } else {
-              subscriber.next(i18next.t(namespacedKey, options));
+              subscriber.next(this.i18next.t(namespacedKey, options));
             }
           });
         }
       };
 
       translate();
-      i18next.on('languageChanged', translate);
-      return () => i18next.off('languageChanged', translate);
+      this.i18next.on('languageChanged', translate);
+      return () => this.i18next.off('languageChanged', translate);
     });
   }
 
   loadChunks(chunkNames: string | string[]): Promise<any> {
-    return i18next.loadNamespaces(chunkNames);
+    return this.i18next.loadNamespaces(chunkNames);
   }
 
   /**


### PR DESCRIPTION
The i18next instance is shared in between all SSR requests. This could be buggy, i.e. when 2 requests are made at the same time for different acitive langauges. Now we create a fresh instance for each SSR request.

closes GH-8100