### PR TITLE
chore: Move assets scripts to assets library

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "ng build storefrontapp --prod",
-    "build:assets": "ng build assets --prod && yarn generate:translations:ts-2-json",
+    "build:assets": "yarn --cwd ./projects/assets build",
     "build:core:lib": "ng build core --prod && ng build storefrontlib --prod && yarn build:assets && yarn build:incubator",
     "build:incubator": "ng build incubator --prod",
     "e2e:cy:open": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:open",
@@ -41,9 +41,6 @@
     "generate:changelog": "ts-node ./scripts/changelog.ts",
     "generate:docs": "npx @compodoc/compodoc -p tsconfig.compodoc.json && ./scripts/zip-docs.sh",
     "generate:publish:docs": "yarn generate:docs && yarn publish:docs",
-    "generate:translations:ts-2-json": "ts-node ./scripts/generate-translations-ts-2-json",
-    "generate:translations:ts-2-properties": "ts-node ./scripts/generate-translations-ts-2-properties",
-    "generate:translations:properties-2-ts": "ts-node ./scripts/generate-translations-properties-2-ts && prettier './projects/assets/src/translations/**/*.ts' --write",
     "lint": "ng lint",
     "i18n-lint": "i18n-lint -t \"{{,}}\" projects/storefrontlib/src/**/*.html",
     "prettier": "prettier --config ./.prettierrc --list-different \"projects/**/*{.ts,.js,.json,.scss,.html}\"",

--- a/projects/assets/generate-translations-properties-2-ts.ts
+++ b/projects/assets/generate-translations-properties-2-ts.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs-extra';
-import { translations } from '../projects/assets/src/translations/translations';
+import { translations } from './src/translations/translations';
 
 function propertiesToJson(properties) {
   const jsonObj = {};
-  properties.forEach(property => {
+  properties.forEach((property) => {
     if (property.length > 0) {
       const name = property.split('=')[0];
       const value = property.split('=')[1];
@@ -26,11 +26,11 @@ function getJsonObj(names, value, jsonObj) {
 }
 
 const jsons = new Map();
-const files = fs.readdirSync('./lang/properties');
+const files = fs.readdirSync('../../lang/properties');
 if (files) {
-  files.forEach(file => {
+  files.forEach((file) => {
     if (file.endsWith('.properties')) {
-      const path = './lang/properties/' + file;
+      const path = '../../lang/properties/' + file;
       const properties = fs.readFileSync(path, 'utf8').split('\n');
       const json = propertiesToJson(properties);
       const key = file.substring(0, file.indexOf('.'));
@@ -39,26 +39,23 @@ if (files) {
   });
 }
 
-Object.keys(translations).forEach(lang => {
-  Object.keys(translations[lang]).forEach(chunk => {
+Object.keys(translations).forEach((lang) => {
+  Object.keys(translations[lang]).forEach((chunk) => {
     const translated = jsons.get(chunk + '_' + lang);
     if (translated) {
       translations[lang][chunk] = translated;
     }
   });
 
-  const assetsTransPath = './projects/assets/src/translations';
+  const assetsTransPath = './src/translations';
   const tsFiles = fs.readdirSync(assetsTransPath + '/' + lang);
   if (tsFiles) {
-    tsFiles.forEach(file => {
+    tsFiles.forEach((file) => {
       if (file !== 'index.ts') {
         const path = assetsTransPath + '/' + lang + '/' + file;
         const content = fs.readFileSync(path, 'utf8');
         const firstLine = content.split('=')[0];
-        const chunk = firstLine
-          .trim()
-          .split(' ')
-          .pop();
+        const chunk = firstLine.trim().split(' ').pop();
         fs.writeFileSync(
           path,
           firstLine + '=' + JSON.stringify(translations[lang][chunk], null, 2),

--- a/projects/assets/generate-translations-ts-2-json.ts
+++ b/projects/assets/generate-translations-ts-2-json.ts
@@ -1,14 +1,14 @@
 import * as fs from 'fs-extra';
-import { translations } from '../projects/assets/src/translations/translations';
+import { translations } from './src/translations/translations';
 
-const assetsDistDir = './dist/assets/';
+const assetsDistDir = '../../dist/assets/';
 const translationsDistDir = assetsDistDir + 'i18n-assets/';
 function createDir(dir) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
   }
 }
-const getLangDir = lang => `${translationsDistDir}${lang}/`;
+const getLangDir = (lang) => `${translationsDistDir}${lang}/`;
 const getFileName = (lang, chunk) => `${getLangDir(lang)}${chunk}.json`;
 
 if (!fs.existsSync(assetsDistDir)) {
@@ -21,9 +21,9 @@ if (!fs.existsSync(assetsDistDir)) {
   createDir(translationsDistDir);
 
   // generate files
-  Object.keys(translations).forEach(lang => {
+  Object.keys(translations).forEach((lang) => {
     createDir(getLangDir(lang));
-    Object.keys(translations[lang]).forEach(chunk => {
+    Object.keys(translations[lang]).forEach((chunk) => {
       const obj = translations[lang][chunk];
       const json = JSON.stringify(obj, null, 2);
       const fileName = getFileName(lang, chunk);

--- a/projects/assets/generate-translations-ts-2-properties.ts
+++ b/projects/assets/generate-translations-ts-2-properties.ts
@@ -1,17 +1,17 @@
 import * as fs from 'fs-extra';
-import { translations } from '../projects/assets/src/translations/translations';
+import { translations } from './src/translations/translations';
 
 function writeProperties(dir, fileName, properties) {
   const writeStream = fs.createWriteStream(dir + '/' + fileName, {
     autoClose: false,
   });
-  properties.forEach(property => writeStream.write(property + '\n'));
+  properties.forEach((property) => writeStream.write(property + '\n'));
   writeStream.end();
 }
 
 function jsonToProperties(jsonObj, prefix?) {
   let result = [];
-  Object.keys(jsonObj).forEach(key => {
+  Object.keys(jsonObj).forEach((key) => {
     let _prefix;
     if (jsonObj[key] && typeof jsonObj[key] === 'object') {
       const _currPrefix = key + '.';
@@ -26,13 +26,13 @@ function jsonToProperties(jsonObj, prefix?) {
 }
 
 // generate properties files
-Object.keys(translations).forEach(lang => {
-  Object.keys(translations[lang]).forEach(chunk => {
+Object.keys(translations).forEach((lang) => {
+  Object.keys(translations[lang]).forEach((chunk) => {
     const obj = translations[lang][chunk];
     const json = JSON.stringify(obj, null, 2);
     const properties = jsonToProperties(JSON.parse(json));
     writeProperties(
-      './lang/properties',
+      '../../lang/properties',
       chunk + '_' + lang + '.properties',
       properties
     );

--- a/projects/assets/package.json
+++ b/projects/assets/package.json
@@ -3,5 +3,11 @@
   "version": "2.1.0-dev.0",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "ng build assets --prod && yarn generate:translations:ts-2-json",
+    "generate:translations:ts-2-json": "ts-node ./generate-translations-ts-2-json",
+    "generate:translations:ts-2-properties": "ts-node ./generate-translations-ts-2-properties",
+    "generate:translations:properties-2-ts": "ts-node ./generate-translations-properties-2-ts && cd ../.. && npx prettier \"./projects/assets/src/translations/**/*.ts\" --write"
   }
 }

--- a/projects/assets/src/translations/en/asm.ts
+++ b/projects/assets/src/translations/en/asm.ts
@@ -4,7 +4,10 @@ export const asm = {
     mainTitle: 'Assisted Service Mode',
     logout: 'Sign Out',
     hideUi: 'Close ASM',
-    toggleUi: { collapse: 'Hide ASM', expand: 'Show ASM' },
+    toggleUi: {
+      collapse: 'Hide ASM',
+      expand: 'Show ASM',
+    },
     loginForm: {
       submit: 'Sign In',
       userId: {

--- a/projects/assets/src/translations/en/my-account.ts
+++ b/projects/assets/src/translations/en/my-account.ts
@@ -35,8 +35,7 @@ export const myAccount = {
         carrier: 'Delivery Service',
         trackingId: 'Tracking Number',
         noTracking:
-          'The package has not been dispatched from the warehouse. ' +
-          'The tracking information will be available after the package is shipped.',
+          'The package has not been dispatched from the warehouse. The tracking information will be available after the package is shipped.',
         loadingHeader: 'Consignment Tracking',
       },
     },

--- a/projects/assets/src/translations/en/user.ts
+++ b/projects/assets/src/translations/en/user.ts
@@ -3,13 +3,15 @@ export const user = {
     preferences: 'Consent Preferences',
     dialog: {
       title: 'Consent Management',
-      legalDescription: `We use cookies/browser's storage to personalize the content and improve user experience. We also might share the data about your site usage with our social media. For more, please review our privacy policy.`,
+      legalDescription:
+        "We use cookies/browser's storage to personalize the content and improve user experience. We also might share the data about your site usage with our social media. For more, please review our privacy policy.",
       selectAll: 'Select all',
       clearAll: 'Clear all',
     },
     banner: {
       title: 'This website uses cookies',
-      description: `We use cookies/browser's storage to personalize the content and improve user experience.`,
+      description:
+        "We use cookies/browser's storage to personalize the content and improve user experience.",
       allowAll: 'Allow All',
       viewDetails: 'View Details',
     },
@@ -74,7 +76,6 @@ export const user = {
       placeholder: 'Password',
     },
     newPassword: 'New Password',
-    /* tslint:disable:max-line-length */
     emailMarketing:
       'Use my personal data to receive e-mail newsletters for marketing campaigns. To change your settings, go to Consent Management in My Account.',
     confirmThatRead: 'I am confirming that I have read and agreed with the',


### PR DESCRIPTION
### Reasoning behind this PR

We plan to minimize the number of scripts in `package.json` to not overwhelm new developers and to simplify maintenance.
Additionally directory `scripts` should be renamed to `release-scripts` as only those are present there.
One other benefit for this change is colocation of files.
Now everything related to building assets library is placed in one directory. It also helps with future code owners if we will ever create them for assets library.

Another note: before this change script `generate:translations:properties-2-ts` wasn't working, because of prettier misconfiguration.