### PR TITLE
chore: Fix schematics release-notes generation

### DIFF
--- a/projects/schematics/.release-it.json
+++ b/projects/schematics/.release-it.json
@@ -9,7 +9,7 @@
   "github": {
     "release": true,
     "releaseName": "@spartacus/schematics@${version}",
-    "releaseNotes": "ts-node ../../scripts/changelog.ts --verbose --lib schematics --to schematics-${version}"
+    "releaseNotes": "cd ../.. && ts-node ./scripts/changelog.ts --verbose --lib schematics --to schematics-${version}"
   },
   "hooks": {
     "after:version:bump": "yarn build"


### PR DESCRIPTION
Port of the change done on release/2.0.x branch during 2.0.0 release.