### PR TITLE
fix: catch undefined objects during translation

### DIFF
--- a/projects/core/src/i18n/translate.pipe.spec.ts
+++ b/projects/core/src/i18n/translate.pipe.spec.ts
@@ -18,6 +18,11 @@ describe('TranslatePipe', () => {
   });
 
   describe('transform', () => {
+    it('should return falsy when input is undefined', () => {
+      const result = pipe.transform(undefined);
+      expect(result).toBeFalsy();
+    });
+
     it('should return raw string when input is object with "raw" property ', () => {
       const result = pipe.transform({ raw: 'test' });
       expect(result).toBe('test');

--- a/projects/core/src/i18n/translate.pipe.ts
+++ b/projects/core/src/i18n/translate.pipe.ts
@@ -1,13 +1,14 @@
 import {
   ChangeDetectorRef,
+  isDevMode,
   OnDestroy,
   Pipe,
   PipeTransform,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { TranslationService } from './translation.service';
 import { shallowEqualObjects } from '../util/compare-equal-objects';
 import { Translatable, TranslatableParams } from './translatable';
+import { TranslationService } from './translation.service';
 
 @Pipe({ name: 'cxTranslate', pure: false })
 export class TranslatePipe implements PipeTransform, OnDestroy {
@@ -25,6 +26,15 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     input: Translatable | string,
     options: TranslatableParams = {}
   ): string {
+    if (!input) {
+      if (isDevMode()) {
+        console.error(
+          `The given input for the cxTranslate pipe (${input}) is invalid and cannot be translated`
+        );
+      }
+      return;
+    }
+
     if ((input as Translatable).raw) {
       return (input as Translatable).raw;
     }


### PR DESCRIPTION
The `TranslatePipe` (`cxTranslate`) will no longer try to operate on an undefined object.

fixes #7885