### PR TITLE
feat: Implement B2B Order History information (GH-7765) - 2.1 branch

### DIFF
--- a/projects/assets/src/translations/en/my-account.ts
+++ b/projects/assets/src/translations/en/my-account.ts
@@ -1,7 +1,16 @@
 export const myAccount = {
   orderDetails: {
     orderId: 'Order #',
+    purchaseOrderId: 'Purchase Order #',
+    none: 'None {{value}}',
     placed: 'Placed',
+    placedBy: 'Placed By',
+    unit: 'Unit',
+    costCenter: 'Cost Center',
+    costCenterAndUnit: 'Cost Center / Unit',
+    costCenterAndUnitValue: '{{costCenterName}} / {{unitName}}',
+    payByAccount: 'Pay by Account',
+    paidByCreditCard: '(paid by credit card)',
     status: 'Status',
     shippedOn: 'Shipped on',
     deliveryStatus_IN_TRANSIT: 'In Transit',

--- a/projects/core/src/model/order.model.ts
+++ b/projects/core/src/model/order.model.ts
@@ -1,5 +1,3 @@
-import { Price, Product } from './product.model';
-import { PaginationModel, SortModel } from './misc.model';
 import { Address } from './address.model';
 import {
   DeliveryOrderEntryGroup,
@@ -8,7 +6,10 @@ import {
   PromotionResult,
   Voucher,
 } from './cart.model';
+import { PaginationModel, SortModel } from './misc.model';
+import { B2BUser, CostCenter } from './org-unit.model';
 import { PointOfService } from './point-of-service.model';
+import { Price, Product } from './product.model';
 
 export interface DeliveryMode {
   code?: string;
@@ -130,6 +131,7 @@ export interface Order {
   calculated?: boolean;
   code?: string;
   consignments?: Consignment[];
+  costCenter?: CostCenter;
   created?: Date;
   deliveryAddress?: Address;
   deliveryCost?: Price;
@@ -143,10 +145,12 @@ export interface Order {
   guid?: string;
   net?: boolean;
   orderDiscounts?: Price;
+  orgCustomer?: B2BUser;
   paymentInfo?: PaymentDetails;
   pickupItemsQuantity?: number;
   pickupOrderGroups?: PickupOrderEntryGroup[];
   productDiscounts?: Price;
+  purchaseOrderNumber?: string;
   site?: string;
   status?: string;
   statusDisplay?: string;

--- a/projects/storefrontapp/src/environments/b2b.environment.ts
+++ b/projects/storefrontapp/src/environments/b2b.environment.ts
@@ -7,7 +7,7 @@ import { Environment } from './models/environment.model';
 
 export const environment: Environment = {
   production: false,
-  occBaseUrl: 'https://dev-com-7.accdemo.b2c.ydev.hybris.com:9002',
+  occBaseUrl: 'https://dev-com-6.accdemo.b2c.ydev.hybris.com:9002',
   occApiPrefix: '/occ/v2/',
   b2b: true,
 };

--- a/projects/storefrontapp/src/environments/b2b.environment.ts
+++ b/projects/storefrontapp/src/environments/b2b.environment.ts
@@ -7,7 +7,7 @@ import { Environment } from './models/environment.model';
 
 export const environment: Environment = {
   production: false,
-  occBaseUrl: 'https://dev-com-6.accdemo.b2c.ydev.hybris.com:9002',
+  occBaseUrl: 'https://dev-com-7.accdemo.b2c.ydev.hybris.com:9002',
   occApiPrefix: '/occ/v2/',
   b2b: true,
 };

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.html
@@ -24,4 +24,43 @@
       </div>
     </div>
   </div>
+  <div *ngIf="order?.orgCustomer" class="cx-header row">
+    <div class="cx-detail col-sm-12 col-md-4">
+      <div class="cx-detail-label">
+        {{ 'orderDetails.purchaseOrderId' | cxTranslate }}
+      </div>
+      <div class="cx-detail-value">
+        {{
+          order?.purchaseOrderNumber
+            ? order?.purchaseOrderNumber
+            : ('orderDetails.none' | cxTranslate)
+        }}
+      </div>
+    </div>
+    <div class="cx-detail col-sm-12 col-md-4">
+      <div class="cx-detail-label">
+        {{ 'orderDetails.placedBy' | cxTranslate }}
+      </div>
+      <div class="cx-detail-value">{{ order?.orgCustomer?.name }}</div>
+    </div>
+    <div class="cx-detail col-sm-12 col-md-4">
+      <div class="cx-detail-label">
+        {{ 'orderDetails.costCenterAndUnit' | cxTranslate }}
+      </div>
+      <div class="cx-detail-value">
+        {{
+          order?.costCenter
+            ? ('orderDetails.costCenterAndUnitValue'
+              | cxTranslate
+                : {
+                    costCenterName: order?.costCenter?.name,
+                    unitName: order?.costCenter?.unit?.name
+                  })
+            : ('orderDetails.none'
+              | cxTranslate
+                : { value: 'orderDetails.paidByCreditCard' | cxTranslate })
+        }}
+      </div>
+    </div>
+  </div>
 </ng-container>

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.html
@@ -24,7 +24,7 @@
       </div>
     </div>
   </div>
-  <div *ngIf="order?.orgCustomer?.active" class="cx-header row">
+  <div *ngIf="order?.orgCustomer?.orgUnit" class="cx-header row">
     <div class="cx-detail col-sm-12 col-md-4">
       <div class="cx-detail-label">
         {{ 'orderDetails.purchaseOrderId' | cxTranslate }}

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.html
@@ -24,7 +24,7 @@
       </div>
     </div>
   </div>
-  <div *ngIf="order?.orgCustomer" class="cx-header row">
+  <div *ngIf="order?.orgCustomer?.active" class="cx-header row">
     <div class="cx-detail col-sm-12 col-md-4">
       <div class="cx-detail-label">
         {{ 'orderDetails.purchaseOrderId' | cxTranslate }}

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.spec.ts
@@ -58,6 +58,7 @@ const mockB2BOrder: Order = {
     },
   },
   orgCustomer: {
+    active: true,
     name: 'Rivers',
     orgUnit: {
       name: 'Rustic',

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-headline/order-detail-headline.component.spec.ts
@@ -2,11 +2,9 @@ import { DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { I18nTestingModule, Order } from '@spartacus/core';
-
 import { of } from 'rxjs';
-
-import { OrderDetailHeadlineComponent } from './order-detail-headline.component';
 import { OrderDetailsService } from '../order-details.service';
+import { OrderDetailHeadlineComponent } from './order-detail-headline.component';
 
 const mockOrder: Order = {
   code: '1',
@@ -51,23 +49,40 @@ const mockOrder: Order = {
   created: new Date('2019-02-11T13:02:58+0000'),
 };
 
+const mockB2BOrder: Order = {
+  ...mockOrder,
+  costCenter: {
+    name: 'Rustic Global',
+    unit: {
+      name: 'Rustic',
+    },
+  },
+  orgCustomer: {
+    name: 'Rivers',
+    orgUnit: {
+      name: 'Rustic',
+    },
+  },
+  purchaseOrderNumber: '123',
+};
+
+class MockOrderDetailsService {
+  getOrderDetails() {
+    return of(mockOrder);
+  }
+}
+
 describe('OrderDetailHeadlineComponent', () => {
   let component: OrderDetailHeadlineComponent;
   let fixture: ComponentFixture<OrderDetailHeadlineComponent>;
-  let mockOrderDetailsService: OrderDetailsService;
+  let orderDetailsService: OrderDetailsService;
   let el: DebugElement;
 
   beforeEach(async(() => {
-    mockOrderDetailsService = <OrderDetailsService>{
-      getOrderDetails() {
-        return of(mockOrder);
-      },
-    };
-
     TestBed.configureTestingModule({
       imports: [I18nTestingModule],
       providers: [
-        { provide: OrderDetailsService, useValue: mockOrderDetailsService },
+        { provide: OrderDetailsService, useClass: MockOrderDetailsService },
       ],
       declarations: [OrderDetailHeadlineComponent],
     }).compileComponents();
@@ -76,6 +91,8 @@ describe('OrderDetailHeadlineComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderDetailHeadlineComponent);
     el = fixture.debugElement;
+
+    orderDetailsService = TestBed.inject(OrderDetailsService);
 
     component = fixture.componentInstance;
     component.ngOnInit();
@@ -96,34 +113,89 @@ describe('OrderDetailHeadlineComponent', () => {
     expect(order).toEqual(mockOrder);
   });
 
-  it('should order details info bar be rendered', () => {
+  it('should render info bar', () => {
     fixture.detectChanges();
-    expect(el.query(By.css('.cx-header.row'))).toBeTruthy();
+    expect(el.query(By.css('.cx-header:nth-of-type(1)'))).toBeTruthy();
   });
 
-  it('should order details display correct order ID', () => {
+  it('should not render info bar when orgCustomer is not available in order', () => {
+    fixture.detectChanges();
+    expect(el.query(By.css('.cx-header:nth-of-type(2)'))).toBeFalsy();
+  });
+
+  it('should display correct order ID', () => {
     fixture.detectChanges();
     const element: DebugElement = el.query(
-      By.css('.cx-detail:first-of-type .cx-detail-value')
+      By.css(
+        '.cx-header:nth-of-type(1) .cx-detail:first-of-type .cx-detail-value'
+      )
     );
     expect(element.nativeElement.textContent).toEqual(mockOrder.code);
   });
 
-  it('should order details display correct order date', () => {
+  it('should display correct order date', () => {
     fixture.detectChanges();
     const element: DebugElement = el.query(
-      By.css('.cx-header div:nth-child(2) > div.cx-detail-value')
+      By.css('.cx-header:nth-of-type(1) div:nth-child(2) > div.cx-detail-value')
     );
     expect(element.nativeElement.textContent).toEqual('Feb 11, 2019');
   });
 
-  it('should order details display correct order status', () => {
+  it('should display correct order status', () => {
     fixture.detectChanges();
     const element: DebugElement = el.query(
-      By.css('.cx-detail:last-of-type .cx-detail-value')
+      By.css(
+        '.cx-header:nth-of-type(1) .cx-detail:last-of-type .cx-detail-value'
+      )
     );
     expect(element.nativeElement.textContent).toContain(
       mockOrder.statusDisplay
+    );
+  });
+
+  it('should display correct purchase order number', () => {
+    spyOn(orderDetailsService, 'getOrderDetails').and.returnValue(
+      of(mockB2BOrder)
+    );
+
+    fixture.detectChanges();
+    const element: DebugElement = el.query(
+      By.css(
+        '.cx-header:nth-of-type(2) .cx-detail:first-of-type .cx-detail-value'
+      )
+    );
+    expect(element.nativeElement.textContent).toContain(
+      mockB2BOrder.purchaseOrderNumber
+    );
+  });
+
+  it('should display who ordered', () => {
+    spyOn(orderDetailsService, 'getOrderDetails').and.returnValue(
+      of(mockB2BOrder)
+    );
+
+    fixture.detectChanges();
+    const element: DebugElement = el.query(
+      By.css('.cx-header:nth-of-type(2) div:nth-child(2) > div.cx-detail-value')
+    );
+    expect(element.nativeElement.textContent).toContain(
+      mockB2BOrder.orgCustomer.name
+    );
+  });
+
+  it('should display correct unit', () => {
+    spyOn(orderDetailsService, 'getOrderDetails').and.returnValue(
+      of(mockB2BOrder)
+    );
+
+    fixture.detectChanges();
+    const element: DebugElement = el.query(
+      By.css(
+        '.cx-header:nth-of-type(2) .cx-detail:last-of-type .cx-detail-value'
+      )
+    );
+    expect(element.nativeElement.textContent).toContain(
+      mockB2BOrder.costCenter.unit.name && mockB2BOrder.costCenter.name
     );
   });
 });

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.html
@@ -23,6 +23,11 @@
         [content]="getPaymentCardContent(order.paymentInfo) | async"
       ></cx-card>
     </div>
+    <div *ngIf="order.costCenter" class="cx-summary-card col-sm-12 col-md-4">
+      <cx-card
+        [content]="getAccountPaymentCardContent(order) | async"
+      ></cx-card>
+    </div>
     <div *ngIf="order.deliveryMode" class="cx-summary-card col-sm-12 col-md-4">
       <cx-card
         [content]="getShippingMethodCardContent(order.deliveryMode) | async"

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.spec.ts
@@ -58,23 +58,40 @@ const mockOrder: Order = {
   ],
 };
 
+const mockB2BOrder = {
+  ...mockOrder,
+  costCenter: {
+    name: 'Rustic Global',
+    unit: {
+      name: 'Rustic',
+    },
+  },
+  orgCustomer: {
+    name: 'Rivers',
+    orgUnit: {
+      name: 'Rustic',
+    },
+  },
+  purchaseOrderNumber: '123',
+};
+
+class MockOrderDetailsService {
+  getOrderDetails() {
+    return of(mockOrder);
+  }
+}
+
 describe('OrderDetailShippingComponent', () => {
   let component: OrderDetailShippingComponent;
   let fixture: ComponentFixture<OrderDetailShippingComponent>;
-  let mockOrderDetailsService: OrderDetailsService;
+  let orderDetailsService: OrderDetailsService;
   let el: DebugElement;
 
   beforeEach(async(() => {
-    mockOrderDetailsService = <OrderDetailsService>{
-      getOrderDetails() {
-        return of(mockOrder);
-      },
-    };
-
     TestBed.configureTestingModule({
       imports: [CardModule, I18nTestingModule],
       providers: [
-        { provide: OrderDetailsService, useValue: mockOrderDetailsService },
+        { provide: OrderDetailsService, useClass: MockOrderDetailsService },
       ],
       declarations: [OrderDetailShippingComponent],
     }).compileComponents();
@@ -83,6 +100,8 @@ describe('OrderDetailShippingComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderDetailShippingComponent);
     el = fixture.debugElement;
+
+    orderDetailsService = TestBed.inject(OrderDetailsService);
 
     component = fixture.componentInstance;
     component.ngOnInit();
@@ -103,12 +122,12 @@ describe('OrderDetailShippingComponent', () => {
     expect(order).toEqual(mockOrder);
   });
 
-  it('should order details shipping be rendered', () => {
+  it('should render shipping card', () => {
     fixture.detectChanges();
     expect(el.query(By.css('.cx-account-summary'))).toBeTruthy();
   });
 
-  it('should order details display "ship to" data', () => {
+  it('should display "ship to" data', () => {
     fixture.detectChanges();
     const element: DebugElement = el.query(
       By.css('div:nth-child(1) > cx-card .cx-card-label-container')
@@ -123,7 +142,7 @@ describe('OrderDetailShippingComponent', () => {
     );
   });
 
-  it('should order details display "bill to" data', () => {
+  it('should display "bill to" data', () => {
     fixture.detectChanges();
     const element: DebugElement = el.query(
       By.css('div:nth-child(2) > cx-card .cx-card-label-container')
@@ -138,7 +157,7 @@ describe('OrderDetailShippingComponent', () => {
     );
   });
 
-  it('should order details display "payment" data', () => {
+  it('should display "payment" data', () => {
     fixture.detectChanges();
     const element: DebugElement = el.query(
       By.css('div:nth-child(3) > cx-card .cx-card-label-container')
@@ -152,13 +171,44 @@ describe('OrderDetailShippingComponent', () => {
     );
   });
 
-  it('should order details display "shipping" data', () => {
+  it('should display "shipping" data', () => {
     fixture.detectChanges();
     const element: DebugElement = el.query(
       By.css('div:nth-child(4) > cx-card .cx-card-label-container')
     );
     expect(element.nativeElement.textContent).toContain(
       mockOrder.deliveryMode.name && mockOrder.deliveryMode.description
+    );
+  });
+
+  it('should display "account payment" data', () => {
+    spyOn(orderDetailsService, 'getOrderDetails').and.returnValue(
+      of(mockB2BOrder)
+    );
+
+    fixture.detectChanges();
+    const element: DebugElement = el.query(
+      By.css('div:nth-child(4) > cx-card .cx-card-label-container')
+    );
+    expect(element.nativeElement.textContent).toContain(
+      mockB2BOrder.purchaseOrderNumber &&
+        mockB2BOrder.costCenter &&
+        mockB2BOrder.costCenter.unit.name
+    );
+  });
+
+  it('should display "shipping" data column after "account payment" column when costCenter is available', () => {
+    spyOn(orderDetailsService, 'getOrderDetails').and.returnValue(
+      of(mockB2BOrder)
+    );
+
+    fixture.detectChanges();
+    const element: DebugElement = el.query(
+      By.css('div:nth-child(5) > cx-card .cx-card-label-container')
+    );
+
+    expect(element.nativeElement.textContent).toContain(
+      mockB2BOrder.deliveryMode.name && mockB2BOrder.deliveryMode.description
     );
   });
 });

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.spec.ts
@@ -67,6 +67,7 @@ const mockB2BOrder = {
     },
   },
   orgCustomer: {
+    active: true,
     name: 'Rivers',
     orgUnit: {
       name: 'Rustic',

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.ts
@@ -6,10 +6,10 @@ import {
   PaymentDetails,
   TranslationService,
 } from '@spartacus/core';
-import { Observable, combineLatest } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { Card } from '../../../../../shared/components/card/card.component';
 import { OrderDetailsService } from '../order-details.service';
-import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'cx-order-details-shipping',
@@ -80,6 +80,36 @@ export class OrderDetailShippingComponent implements OnInit {
           text: [payment.cardType.name, payment.cardNumber, textExpires],
         };
       })
+    );
+  }
+
+  getAccountPaymentCardContent(order: Order): Observable<Card> {
+    return combineLatest([
+      this.translation.translate('paymentForm.payment'),
+      this.translation.translate('orderDetails.payByAccount'),
+      this.translation.translate('orderDetails.purchaseOrderId'),
+      this.translation.translate('orderDetails.costCenter'),
+      this.translation.translate('orderDetails.unit'),
+    ]).pipe(
+      map(
+        ([
+          textTitle,
+          textPayByAccount,
+          textPurchaseOrderId,
+          textCostCenter,
+          textUnit,
+        ]) => {
+          return {
+            title: textTitle,
+            textBold: textPayByAccount,
+            text: [
+              `${textPurchaseOrderId}: ${order.purchaseOrderNumber}`,
+              `${textCostCenter}: ${order.costCenter.name}`,
+              `${textUnit}: ${order.costCenter.unit.name}`,
+            ],
+          };
+        }
+      )
     );
   }
 


### PR DESCRIPTION
closes GH-7765

new PR because old points to checkout, but checkout is now for 3.0, but we need this for 2.1, if ever a user orders from accelerator and views history in spartacus.