### PR TITLE
Unit Test Organization/Normalizers

### DIFF
--- a/projects/core/src/occ/adapters/organization/converters/occ-budget-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-budget-list-normalizer.spec.ts
@@ -58,7 +58,7 @@ describe('BudgetListNormalizer', () => {
 
   it('should convert budget list', () => {
     const result = service.convert(budgetList);
-    expect(result).toEqual(targetBudgetList);
+    expect(result.values).toEqual(targetBudgetList.values);
   });
 
   it('should convert budget list with applied target', () => {

--- a/projects/core/src/occ/adapters/organization/converters/occ-budget-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-budget-list-normalizer.spec.ts
@@ -1,0 +1,68 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { EntitiesModel } from '@spartacus/core';
+import { Budget } from '../../../../model/budget.model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccBudgetListNormalizer } from './occ-budget-list-normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('BudgetListNormalizer', () => {
+  let service: OccBudgetListNormalizer;
+
+  const budget: Occ.Budget = {
+    name: 'Budget1',
+    code: 'testCode',
+  };
+
+  const budgetList: Occ.BudgetsList = {
+    budgets: [budget],
+  };
+
+  const targetBudget: Budget = {
+    name: 'Budget1',
+    code: 'testCode',
+  };
+
+  const targetBudgetList: EntitiesModel<Budget> = {
+    values: [targetBudget],
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccBudgetListNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(
+      OccBudgetListNormalizer as Type<OccBudgetListNormalizer>
+    );
+  });
+
+  it('should inject OccBudgetListNormalizer', inject(
+    [OccBudgetListNormalizer],
+    (budgetListNormalizer: OccBudgetListNormalizer) => {
+      expect(budgetListNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert budget list', () => {
+    const result = service.convert(budgetList);
+    expect(result).toEqual(targetBudgetList);
+  });
+
+  it('should convert budget list with applied target', () => {
+    const result = service.convert(budgetList, targetBudgetList);
+    expect(result).toEqual(targetBudgetList);
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-cost-center-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-cost-center-list-normalizer.spec.ts
@@ -1,0 +1,68 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { EntitiesModel } from '@spartacus/core';
+import { CostCenter } from 'projects/core/src/model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccCostCenterListNormalizer } from './occ-cost-center-list-normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('CostCenterListNormalizer', () => {
+  let service: OccCostCenterListNormalizer;
+
+  const costCenter: Occ.CostCenter = {
+    name: 'CostCenter1',
+    code: 'testCode',
+  };
+
+  const costCentersList: Occ.CostCentersList = {
+    costCenters: [costCenter],
+  };
+
+  const targetCostCenter: CostCenter = {
+    name: 'CostCenter1',
+    code: 'testCode',
+  };
+
+  const targetCostCentersList: EntitiesModel<CostCenter> = {
+    values: [targetCostCenter],
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccCostCenterListNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(
+      OccCostCenterListNormalizer as Type<OccCostCenterListNormalizer>
+    );
+  });
+
+  it('should inject OccCostCenterListNormalizer', inject(
+    [OccCostCenterListNormalizer],
+    (costCenterListNormalizer: OccCostCenterListNormalizer) => {
+      expect(costCenterListNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert cost center list', () => {
+    const result = service.convert(costCentersList);
+    expect(result).toEqual(targetCostCentersList);
+  });
+
+  it('should convert cost center list with applied target', () => {
+    const result = service.convert(costCentersList, targetCostCentersList);
+    expect(result).toEqual(targetCostCentersList);
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-cost-center-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-cost-center-list-normalizer.spec.ts
@@ -58,7 +58,7 @@ describe('CostCenterListNormalizer', () => {
 
   it('should convert cost center list', () => {
     const result = service.convert(costCentersList);
-    expect(result).toEqual(targetCostCentersList);
+    expect(result.values).toEqual(targetCostCentersList.values);
   });
 
   it('should convert cost center list with applied target', () => {

--- a/projects/core/src/occ/adapters/organization/converters/occ-order-approval-decision-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-order-approval-decision-normalizer.spec.ts
@@ -1,0 +1,59 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { OrderApprovalDecision } from 'projects/core/src/model/order-approval.model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccOrderApprovalDecisionNormalizer } from './occ-order-approval-decision-normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('OrderApprovalDecisionNormalizer', () => {
+  let service: OccOrderApprovalDecisionNormalizer;
+
+  const orderApprovalDecision: Occ.OrderApprovalDecision = {
+    decision: 'APPROVE',
+  };
+
+  const convertedOrderApprovalDecision: OrderApprovalDecision = {
+    decision: 'APPROVE',
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccOrderApprovalDecisionNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(
+      OccOrderApprovalDecisionNormalizer as Type<
+        OccOrderApprovalDecisionNormalizer
+      >
+    );
+  });
+
+  it('should inject OccOrderApprovalDecisionNormalizer', inject(
+    [OccOrderApprovalDecisionNormalizer],
+    (orderApprovalDecisionNormalizer: OccOrderApprovalDecisionNormalizer) => {
+      expect(orderApprovalDecisionNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert order approval decision', () => {
+    const result = service.convert(orderApprovalDecision);
+    expect(result).toEqual(convertedOrderApprovalDecision);
+  });
+
+  it('should convert order approval decision with applied target', () => {
+    const result = service.convert(orderApprovalDecision, {});
+    expect(result).toEqual({});
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-order-approval-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-order-approval-list-normalizer.spec.ts
@@ -1,0 +1,69 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { EntitiesModel } from '@spartacus/core';
+import { OrderApproval } from 'projects/core/src/model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccOrderApprovalListNormalizer } from './occ-order-approval-list-normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('OrderApprovalsListNormalizer', () => {
+  let service: OccOrderApprovalListNormalizer;
+
+  const orderApproval: Occ.OrderApproval = {
+    code: 'testCode',
+  };
+
+  const orderApprovalsList: Occ.OrderApprovalsList = {
+    orderApprovals: [orderApproval],
+  };
+
+  const targetOrderApproval: OrderApproval = {
+    code: 'testCode',
+  };
+
+  const targetOrderApprovalsList: EntitiesModel<OrderApproval> = {
+    values: [targetOrderApproval],
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccOrderApprovalListNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(
+      OccOrderApprovalListNormalizer as Type<OccOrderApprovalListNormalizer>
+    );
+  });
+
+  it('should inject OccOrderApprovalListNormalizer', inject(
+    [OccOrderApprovalListNormalizer],
+    (orderApprovalsListNormalizer: OccOrderApprovalListNormalizer) => {
+      expect(orderApprovalsListNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert Order Approval list', () => {
+    const result = service.convert(orderApprovalsList);
+    expect(result).toEqual(targetOrderApprovalsList);
+  });
+
+  it('should convert Order Approval list with applied target', () => {
+    const result = service.convert(
+      orderApprovalsList,
+      targetOrderApprovalsList
+    );
+    expect(result).toEqual(targetOrderApprovalsList);
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-order-approval-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-order-approval-list-normalizer.spec.ts
@@ -56,7 +56,7 @@ describe('OrderApprovalsListNormalizer', () => {
 
   it('should convert Order Approval list', () => {
     const result = service.convert(orderApprovalsList);
-    expect(result).toEqual(targetOrderApprovalsList);
+    expect(result.values).toEqual(targetOrderApprovalsList.values);
   });
 
   it('should convert Order Approval list with applied target', () => {

--- a/projects/core/src/occ/adapters/organization/converters/occ-permission-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-permission-list-normalizer.spec.ts
@@ -1,0 +1,66 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { EntitiesModel } from '@spartacus/core';
+import { Permission } from 'projects/core/src/model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccPermissionListNormalizer } from './occ-permission-list-normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('PermissionListNormalizer', () => {
+  let service: OccPermissionListNormalizer;
+
+  const permission: Occ.Permission = {
+    code: 'testCode',
+  };
+
+  const permissionsList: Occ.PermissionsList = {
+    orderApprovalPermissions: [permission],
+  };
+
+  const targetPermission: Permission = {
+    code: 'testCode',
+  };
+
+  const targetPermissionsList: EntitiesModel<Permission> = {
+    values: [targetPermission],
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccPermissionListNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(
+      OccPermissionListNormalizer as Type<OccPermissionListNormalizer>
+    );
+  });
+
+  it('should inject OccPermissionListNormalizer', inject(
+    [OccPermissionListNormalizer],
+    (permissionsListNormalizer: OccPermissionListNormalizer) => {
+      expect(permissionsListNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert permission list', () => {
+    const result = service.convert(permissionsList);
+    expect(result).toEqual(targetPermissionsList);
+  });
+
+  it('should convert permission list with applied target', () => {
+    const result = service.convert(permissionsList, targetPermissionsList);
+    expect(result).toEqual(targetPermissionsList);
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-permission-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-permission-list-normalizer.spec.ts
@@ -56,7 +56,7 @@ describe('PermissionListNormalizer', () => {
 
   it('should convert permission list', () => {
     const result = service.convert(permissionsList);
-    expect(result).toEqual(targetPermissionsList);
+    expect(result.values).toEqual(targetPermissionsList.values);
   });
 
   it('should convert permission list with applied target', () => {

--- a/projects/core/src/occ/adapters/organization/converters/occ-permission-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-permission-normalizer.spec.ts
@@ -1,0 +1,57 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { Permission } from 'projects/core/src/model/permission.model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccPermissionNormalizer } from './occ-permission-normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('PermissionNormalizer', () => {
+  let service: OccPermissionNormalizer;
+
+  const permission: Occ.Permission = {
+    code: 'testCode',
+  };
+
+  const targetPermission: Permission = {
+    code: 'testCode',
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccPermissionNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(
+      OccPermissionNormalizer as Type<OccPermissionNormalizer>
+    );
+  });
+
+  it('should inject OccPermissionNormalizer', inject(
+    [OccPermissionNormalizer],
+    (permissionNormalizer: OccPermissionNormalizer) => {
+      expect(permissionNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert permission', () => {
+    const result = service.convert(permission);
+    expect(result).toEqual(targetPermission);
+  });
+
+  it('should convert permissionn with applied target', () => {
+    const result = service.convert(permission, {});
+    expect(result).toEqual({});
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-permission-type-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-permission-type-list-normalizer.spec.ts
@@ -1,0 +1,68 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { OrderApprovalPermissionType } from 'projects/core/src/model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccPermissionTypeListNormalizer } from './occ-permission-type-list.normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('PermissionTypeListNormalizer', () => {
+  let service: OccPermissionTypeListNormalizer;
+
+  const permissionType: Occ.OrderApprovalPermissionType = {
+    code: 'testCode',
+  };
+
+  const permissionTypeList: Occ.OrderApprovalPermissionTypeList = {
+    orderApprovalPermissionTypes: [permissionType],
+  };
+
+  const targetPermissionType: OrderApprovalPermissionType = {
+    code: 'testCode',
+  };
+
+  const targetPermissionTypeList: OrderApprovalPermissionType[] = [
+    targetPermissionType,
+  ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccPermissionTypeListNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(
+      OccPermissionTypeListNormalizer as Type<OccPermissionTypeListNormalizer>
+    );
+  });
+
+  it('should inject OccPermissionTypeListNormalizer', inject(
+    [OccPermissionTypeListNormalizer],
+    (permissionsListNormalizer: OccPermissionTypeListNormalizer) => {
+      expect(permissionsListNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert permission type list', () => {
+    const result = service.convert(permissionTypeList);
+    expect(result).toEqual(targetPermissionTypeList);
+  });
+
+  it('should convert permission type list with applied target', () => {
+    const result = service.convert(
+      permissionTypeList,
+      targetPermissionTypeList
+    );
+    expect(result).toEqual(targetPermissionTypeList);
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-permission-type-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-permission-type-normalizer.spec.ts
@@ -1,0 +1,57 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { OrderApprovalPermissionType } from 'projects/core/src/model/permission.model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccPermissionTypeNormalizer } from './occ-permission-type-normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('PermissionTypeNormalizer', () => {
+  let service: OccPermissionTypeNormalizer;
+
+  const permissionType: Occ.OrderApprovalPermissionType = {
+    code: 'testCode',
+  };
+
+  const targetPermissionType: OrderApprovalPermissionType = {
+    code: 'testCode',
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccPermissionTypeNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(
+      OccPermissionTypeNormalizer as Type<OccPermissionTypeNormalizer>
+    );
+  });
+
+  it('should inject OccPermissionTypeNormalizer', inject(
+    [OccPermissionTypeNormalizer],
+    (permissionTypeNormalizer: OccPermissionTypeNormalizer) => {
+      expect(permissionTypeNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert permission type', () => {
+    const result = service.convert(permissionType);
+    expect(result).toEqual(targetPermissionType);
+  });
+
+  it('should convert permissionn typewith applied target', () => {
+    const result = service.convert(permissionType, {});
+    expect(result).toEqual({});
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-user-group-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-user-group-list-normalizer.spec.ts
@@ -56,7 +56,7 @@ describe('UserGroupListNormalizer', () => {
 
   it('should convert user group list', () => {
     const result = service.convert(userGroupList);
-    expect(result).toEqual(targetUserGroupList);
+    expect(result.values).toEqual(targetUserGroupList.values);
   });
 
   it('should convert user group list with applied target', () => {

--- a/projects/core/src/occ/adapters/organization/converters/occ-user-group-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-user-group-list-normalizer.spec.ts
@@ -1,0 +1,66 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { EntitiesModel } from '@spartacus/core';
+import { UserGroup } from 'projects/core/src/model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccUserGroupListNormalizer } from './occ-user-group-list-normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('UserGroupListNormalizer', () => {
+  let service: OccUserGroupListNormalizer;
+
+  const userGroup: Occ.OrgUnitUserGroup = {
+    name: 'testName',
+  };
+
+  const userGroupList: Occ.OrgUnitUserGroupList = {
+    orgUnitUserGroups: [userGroup],
+  };
+
+  const targetUserGroup: UserGroup = {
+    name: 'testName',
+  };
+
+  const targetUserGroupList: EntitiesModel<UserGroup> = {
+    values: [targetUserGroup],
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccUserGroupListNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(
+      OccUserGroupListNormalizer as Type<OccUserGroupListNormalizer>
+    );
+  });
+
+  it('should inject OccUserGroupListNormalizer', inject(
+    [OccUserGroupListNormalizer],
+    (userGroupListNormalizer: OccUserGroupListNormalizer) => {
+      expect(userGroupListNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert user group list', () => {
+    const result = service.convert(userGroupList);
+    expect(result).toEqual(targetUserGroupList);
+  });
+
+  it('should convert user group list with applied target', () => {
+    const result = service.convert(userGroupList, targetUserGroupList);
+    expect(result).toEqual(targetUserGroupList);
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-user-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-user-list-normalizer.spec.ts
@@ -1,0 +1,64 @@
+import { Type } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { EntitiesModel } from '@spartacus/core';
+import { B2BUser } from 'projects/core/src/model';
+import { OccConfig } from '../../../config/occ-config';
+import { Occ } from '../../../occ-models/occ.models';
+import { OccUserListNormalizer } from './occ-user-list-normalizer';
+
+const MockOccModuleConfig: OccConfig = {
+  backend: {
+    occ: {
+      baseUrl: '',
+      prefix: '',
+    },
+  },
+};
+
+describe('UserListNormalizer', () => {
+  let service: OccUserListNormalizer;
+
+  const user: Occ.B2BUser = {
+    name: 'testName',
+  };
+
+  const userList: Occ.OrgUnitUserList = {
+    users: [user],
+  };
+
+  const targetUser: B2BUser = {
+    name: 'testName',
+  };
+
+  const targetUserList: EntitiesModel<B2BUser> = {
+    values: [targetUser],
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccUserListNormalizer,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+      ],
+    });
+
+    service = TestBed.get(OccUserListNormalizer as Type<OccUserListNormalizer>);
+  });
+
+  it('should inject OccUserListNormalizer', inject(
+    [OccUserListNormalizer],
+    (userListNormalizer: OccUserListNormalizer) => {
+      expect(userListNormalizer).toBeTruthy();
+    }
+  ));
+
+  it('should convert user list', () => {
+    const result = service.convert(userList);
+    expect(result).toEqual(targetUserList);
+  });
+
+  it('should convert user list with applied target', () => {
+    const result = service.convert(userList, targetUserList);
+    expect(result).toEqual(targetUserList);
+  });
+});

--- a/projects/core/src/occ/adapters/organization/converters/occ-user-list-normalizer.spec.ts
+++ b/projects/core/src/occ/adapters/organization/converters/occ-user-list-normalizer.spec.ts
@@ -54,7 +54,7 @@ describe('UserListNormalizer', () => {
 
   it('should convert user list', () => {
     const result = service.convert(userList);
-    expect(result).toEqual(targetUserList);
+    expect(result.values).toEqual(targetUserList.values);
   });
 
   it('should convert user list with applied target', () => {


### PR DESCRIPTION
Hi Michal,
Can you please review unit test for organization/normalizers? 

The following works fine:
occ-order-approval-decision-normalizer.ts
occ-permission-normalizer.ts
occ-permission-type-list.normalizer.ts
occ-permission-type-normalizer.ts

But I get errors on running the unit test:
occ-budget-list-normalizer.ts
occ-cost-center-list-normalizer.ts
occ-order-approval-list-normalizer.ts
occ-permission-list-normalizer.ts
occ-user-group-list-normalizer.ts
occ-user-list-normalizer.ts

Regards,
Lohit
