### PR TITLE
chore: optimize release-it scripts

### DIFF
--- a/projects/cds/.release-it.json
+++ b/projects/cds/.release-it.json
@@ -10,7 +10,7 @@
     "publishPath": "./../../dist/cds"
   },
   "hooks": {
-    "after:version:bump": "cd ../.. && yarn build:core:lib:cds"
+    "after:version:bump": "cd ../.. && ng build cds --prod"
   },
   "github": {
     "release": true,

--- a/projects/core/.release-it.json
+++ b/projects/core/.release-it.json
@@ -10,7 +10,7 @@
     "publishPath": "./../../dist/core"
   },
   "hooks": {
-    "after:version:bump": "cd ../.. && yarn build:core:lib"
+    "after:version:bump": "cd ../.. && ng build core --prod"
   },
   "github": {
     "release": true,

--- a/projects/storefrontlib/.release-it.json
+++ b/projects/storefrontlib/.release-it.json
@@ -10,7 +10,7 @@
     "publishPath": "./../../dist/storefrontlib"
   },
   "hooks": {
-    "after:version:bump": "cd ../.. && yarn build:core:lib"
+    "after:version:bump": "cd ../.. && ng build storefrontlib --prod"
   },
   "github": {
     "release": true,


### PR DESCRIPTION
This PR optimizes release-it scripts in a way that it builds only the required library, without its dependencies.