### PR TITLE
fix: component and directive selector prefix in the feature libs

### DIFF
--- a/docs/libs/creating-lib.md
+++ b/docs/libs/creating-lib.md
@@ -183,7 +183,7 @@ Optionally adjust the `path` property.
 
 - `tsconfig.lib.prod.json` - save to re-format it. Make sure that Ivy is off (for the time being, this will change in the future)
 - `tsconfig.spec.json` - save to re-format
-- `tslint.json` - save to re-format
+- `tslint.json` - change from `lib` to `cx` in the `directive-selector` and `component-selector`
 - the rest of the generated file should be removed
 
 ### Additional changes to existing files

--- a/feature-libs/my-account/tslint.json
+++ b/feature-libs/my-account/tslint.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tslint.json",
   "rules": {
-    "directive-selector": [true, "attribute", "lib", "camelCase"],
-    "component-selector": [true, "element", "lib", "kebab-case"]
+    "directive-selector": [true, "attribute", "cx", "camelCase"],
+    "component-selector": [true, "element", "cx", "kebab-case"]
   }
 }

--- a/feature-libs/product/tslint.json
+++ b/feature-libs/product/tslint.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tslint.json",
   "rules": {
-    "directive-selector": [true, "attribute", "lib", "camelCase"],
-    "component-selector": [true, "element", "lib", "kebab-case"]
+    "directive-selector": [true, "attribute", "cx", "camelCase"],
+    "component-selector": [true, "element", "cx", "kebab-case"]
   }
 }


### PR DESCRIPTION
This PR fixed the component and directive selector prefix from `lib` to `cx` in the feature libs