### PR TITLE
chore: exclude profiletagcomponent from deferred loading

### DIFF
--- a/projects/cds/src/profiletag/cms-components/profile-tag-cms.module.ts
+++ b/projects/cds/src/profiletag/cms-components/profile-tag-cms.module.ts
@@ -1,6 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { CmsConfig, provideDefaultConfig } from '@spartacus/core';
+import {
+  CmsConfig,
+  DeferLoadingStrategy,
+  provideDefaultConfig,
+} from '@spartacus/core';
 import { ProfileTagComponent } from './profile-tag.component';
 
 @NgModule({
@@ -10,6 +14,7 @@ import { ProfileTagComponent } from './profile-tag.component';
       cmsComponents: {
         ProfileTagComponent: {
           component: ProfileTagComponent,
+          deferLoading: DeferLoadingStrategy.INSTANT,
         },
       },
     }),


### PR DESCRIPTION
This PR excludes the ProfileTagComponent from the deferred loading mechanism. 