### PR TITLE
Fix: proper change detection for component wrapper directive

### DIFF
--- a/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/component-wrapper.directive.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   ComponentRef,
   Directive,
   ElementRef,
@@ -84,6 +85,7 @@ export class ComponentWrapperDirective implements OnInit, OnDestroy {
       ?.subscribe(({ elementRef, componentRef }) => {
         this.cmpRef = componentRef;
         this.decorate(elementRef);
+        this.injector.get(ChangeDetectorRef).markForCheck();
       });
   }
 


### PR DESCRIPTION
Lazy loaded component might not be visible at first pass if change detection happened before they were created by component handler and OnPush strategy is used.

Closes GH-8007