### PR TITLE
Organization resolver changes to work with costcenter refactor

### DIFF
--- a/projects/core/src/organization/services/organization-meta.resolver.spec.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.spec.ts
@@ -50,7 +50,7 @@ const mockRouterStateWithParams: RouterState = {
   },
 };
 
-const state = new BehaviorSubject(mockRouterStateWithoutParams);
+const state = new BehaviorSubject({ state: {} } as RouterState);
 
 class RoutingServiceStub {
   getRouterState(): Observable<RouterState> {

--- a/projects/core/src/organization/services/organization-meta.resolver.spec.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject, Observable, of } from 'rxjs';
-import { CmsService, Page } from '../../cms';
+import { Observable, of, BehaviorSubject } from 'rxjs';
+import { CmsService, Page, BreadcrumbMeta } from '../../cms';
 import { I18nTestingModule } from '../../i18n';
 import { PageType } from '../../model/cms.model';
 import { OrganizationMetaResolver } from './organization-meta.resolver';
@@ -63,7 +63,7 @@ const mockEmptyRouterState: RouterState = {
   },
 };
 
-const state = new BehaviorSubject(null as RouterState);
+const state = new BehaviorSubject<RouterState>(null);
 
 class RoutingServiceStub {
   getRouterState(): Observable<RouterState> {
@@ -90,7 +90,7 @@ describe('OrganizationMetaResolver', () => {
   it('should return empty title with empty state', () => {
     state.next(mockEmptyRouterState);
 
-    let titleWithoutState = '';
+    let titleWithoutState: string;
     resolver
       .resolveTitle()
       .subscribe((value) => (titleWithoutState = value))
@@ -114,7 +114,7 @@ describe('OrganizationMetaResolver', () => {
   it('should resolve title with parameters', () => {
     state.next(mockRouterStateWithParams);
 
-    let titleWithParameters = '';
+    let titleWithParameters: string;
     resolver
       .resolveTitle()
       .subscribe((value) => (titleWithParameters = value))
@@ -126,7 +126,7 @@ describe('OrganizationMetaResolver', () => {
   it('should resolve breadcrumbs without parameters', () => {
     state.next(mockRouterStateWithoutParams);
 
-    let result: any[];
+    let result: BreadcrumbMeta[];
     resolver
       .resolveBreadcrumbs()
       .subscribe((value) => (result = value))
@@ -141,7 +141,7 @@ describe('OrganizationMetaResolver', () => {
   it('should resolve breadcrumbs with parameters', () => {
     state.next(mockRouterStateWithParams);
 
-    let result: any[];
+    let result: BreadcrumbMeta[];
     resolver
       .resolveBreadcrumbs()
       .subscribe((value) => (result = value))

--- a/projects/core/src/organization/services/organization-meta.resolver.spec.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.spec.ts
@@ -49,20 +49,6 @@ const mockRouterStateWithParams: RouterState = {
   },
 };
 
-const mockEmptyRouterState: RouterState = {
-  navigationId: 0,
-  state: {
-    url: '',
-    queryParams: {},
-    params: {},
-    context: {
-      id: '',
-      type: PageType.CONTENT_PAGE,
-    },
-    cmsRequired: true,
-  },
-};
-
 const state = new BehaviorSubject<RouterState>(null);
 
 class RoutingServiceStub {
@@ -85,18 +71,6 @@ describe('OrganizationMetaResolver', () => {
     });
 
     resolver = TestBed.inject(OrganizationMetaResolver);
-  });
-
-  it('should return empty title with empty state', () => {
-    state.next(mockEmptyRouterState);
-
-    let titleWithoutState: string;
-    resolver
-      .resolveTitle()
-      .subscribe((value) => (titleWithoutState = value))
-      .unsubscribe();
-
-    expect(titleWithoutState).toEqual('');
   });
 
   it('should resolve title without parameters', () => {

--- a/projects/core/src/organization/services/organization-meta.resolver.spec.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.spec.ts
@@ -4,8 +4,9 @@ import { CmsService, Page } from '../../cms';
 import { I18nTestingModule } from '../../i18n';
 import { PageType } from '../../model/cms.model';
 import { OrganizationMetaResolver } from './organization-meta.resolver';
-import { ActivatedRoute } from '@angular/router';
+
 import { RoutingService } from '../../routing/facade/routing.service';
+import { RouterState } from '../../routing/store/routing-state';
 
 const mockOrganizationPage: Page = {
   type: PageType.CONTENT_PAGE,
@@ -19,96 +20,91 @@ class MockCmsService {
   }
 }
 
-class MockRoutingService {
-  getRouterState(): Observable<any> {
-    return of({
-      state: {
-        url: 'powertools-spa/en/USD/organization/purchase-limits',
-        queryParams: {},
-        params: {},
-        context: { id: '/organization/purchase-limits', type: 'ContentPage' },
-        cmsRequired: true,
-      },
-    });
+const mockRouterStateWithoutParams: RouterState = {
+  navigationId: 0,
+  state: {
+    url: 'powertools-spa/en/USD/organization/purchase-limits',
+    queryParams: {},
+    params: {},
+    context: {
+      id: '/organization/purchase-limits',
+      type: PageType.CONTENT_PAGE,
+    },
+    cmsRequired: true,
+  },
+};
+
+const mockRouterStateWithParams: RouterState = {
+  navigationId: 0,
+  state: {
+    url:
+      'powertools-spa/en/USD/organization/unit/address/Rustic%20Retail/8796098887703',
+    queryParams: {},
+    params: { code: 'Rustic Retail', id: '8796098887703' },
+    context: {
+      id: '/organization/unit/address/Rustic Retail/8796098887703',
+      type: PageType.CONTENT_PAGE,
+    },
+    cmsRequired: true,
+  },
+};
+
+class RoutingServiceStub {
+  getRouterState(): Observable<RouterState> {
+    return of(mockRouterStateWithoutParams);
   }
 }
 
 describe('OrganizationMetaResolver', () => {
   let resolver: OrganizationMetaResolver;
+  let routingService: RoutingService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [I18nTestingModule],
       providers: [
         { provide: CmsService, useClass: MockCmsService },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            snapshot: {
-              url: [],
-              params: {},
-              queryParams: {},
-              fragment: null,
-              data: {},
-              outlet: 'primary',
-              component: null,
-              routeConfig: null,
-              root: null,
-              parent: null,
-              firstChild: null,
-              children: [
-                {
-                  url: [
-                    {
-                      path: 'organization',
-                      parameters: {},
-                      parameterMap: null,
-                    },
-                    {
-                      path: 'purchase-limits',
-                      parameters: {},
-                      parameterMap: null,
-                    },
-                  ],
-                  params: {},
-                  queryParams: {},
-                  fragment: null,
-                  data: {},
-                  outlet: 'primary',
-                  component: null,
-                  routeConfig: null,
-                  root: null,
-                  parent: null,
-                  firstChild: null,
-                  children: null,
-                  pathFromRoot: null,
-                  paramMap: null,
-                  queryParamMap: null,
-                },
-              ],
-              pathFromRoot: null,
-              paramMap: null,
-              queryParamMap: null,
-            },
-          },
-        },
-        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: RoutingService, useClass: RoutingServiceStub },
       ],
     });
 
     resolver = TestBed.inject(OrganizationMetaResolver);
+    routingService = TestBed.inject(RoutingService);
   });
 
-  it('should resolve title', () => {
-    let result: string;
+  it('should resolve title without parameters', () => {
+    spyOn(routingService, 'getRouterState').and.callFake(() =>
+      of(mockRouterStateWithoutParams)
+    );
+
+    let titleWithoutParams: string;
     resolver
       .resolveTitle()
-      .subscribe((value) => (result = value))
+      .subscribe((value) => (titleWithoutParams = value))
       .unsubscribe();
-    expect(result).toEqual('breadcrumbs.purchase-limits');
+
+    expect(titleWithoutParams).toEqual('breadcrumbs.purchase-limits');
   });
 
-  it('should resolve breadcrumbs', () => {
+  it('should resolve title with parameters', () => {
+    spyOn(routingService, 'getRouterState').and.callFake(() =>
+      of(mockRouterStateWithParams)
+    );
+
+    let titleWithParameters = '';
+    resolver
+      .resolveTitle()
+      .subscribe((value) => (titleWithParameters = value))
+      .unsubscribe();
+
+    expect(titleWithParameters).toEqual('8796098887703');
+  });
+
+  it('should resolve breadcrumbs without parameters', () => {
+    spyOn(routingService, 'getRouterState').and.callFake(() =>
+      of(mockRouterStateWithoutParams)
+    );
+
     let result: any[];
     resolver
       .resolveBreadcrumbs()
@@ -118,6 +114,29 @@ describe('OrganizationMetaResolver', () => {
     expect(result).toEqual([
       { label: 'common.home', link: '/' },
       { label: 'breadcrumbs.organization', link: '/organization' },
+    ]);
+  });
+
+  it('should resolve breadcrumbs with parameters', () => {
+    spyOn(routingService, 'getRouterState').and.returnValue(
+      of(mockRouterStateWithParams)
+    );
+
+    let result: any[];
+    resolver
+      .resolveBreadcrumbs()
+      .subscribe((value) => (result = value))
+      .unsubscribe();
+
+    expect(result).toEqual([
+      { label: 'common.home', link: '/' },
+      { label: 'breadcrumbs.organization', link: '/organization' },
+      { label: 'breadcrumbs.unit', link: '/organization/unit' },
+      { label: 'breadcrumbs.address', link: '/organization/unit/address' },
+      {
+        label: 'Rustic Retail',
+        link: '/organization/unit/address/Rustic%20Retail',
+      },
     ]);
   });
 });

--- a/projects/core/src/organization/services/organization-meta.resolver.spec.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.spec.ts
@@ -7,7 +7,6 @@ import { OrganizationMetaResolver } from './organization-meta.resolver';
 
 import { RoutingService } from '../../routing/facade/routing.service';
 import { RouterState } from '../../routing/store/routing-state';
-import { tap } from 'rxjs/operators';
 
 const mockOrganizationPage: Page = {
   type: PageType.CONTENT_PAGE,
@@ -50,7 +49,21 @@ const mockRouterStateWithParams: RouterState = {
   },
 };
 
-const state = new BehaviorSubject({ state: {} } as RouterState);
+const mockEmptyRouterState: RouterState = {
+  navigationId: 0,
+  state: {
+    url: '',
+    queryParams: {},
+    params: {},
+    context: {
+      id: '',
+      type: PageType.CONTENT_PAGE,
+    },
+    cmsRequired: true,
+  },
+};
+
+const state = new BehaviorSubject(null as RouterState);
 
 class RoutingServiceStub {
   getRouterState(): Observable<RouterState> {
@@ -60,7 +73,6 @@ class RoutingServiceStub {
 
 fdescribe('OrganizationMetaResolver', () => {
   let resolver: OrganizationMetaResolver;
-  // let routingService: RoutingService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -73,20 +85,26 @@ fdescribe('OrganizationMetaResolver', () => {
     });
 
     resolver = TestBed.inject(OrganizationMetaResolver);
-    // routingService = TestBed.inject(RoutingService);
+  });
+
+  it('should return empty title with empty state', () => {
+    state.next(mockEmptyRouterState);
+
+    let titleWithoutState = '';
+    resolver
+      .resolveTitle()
+      .subscribe((value) => (titleWithoutState = value))
+      .unsubscribe();
+
+    expect(titleWithoutState).toEqual('');
   });
 
   it('should resolve title without parameters', () => {
-    // spyOn(routingService, 'getRouterState').and.returnValue(
-    //   of(mockRouterStateWithoutParams)
-    // );
     state.next(mockRouterStateWithoutParams);
-    console.log('without parameters');
 
     let titleWithoutParams: string;
     resolver
       .resolveTitle()
-      .pipe(tap(console.log))
       .subscribe((value) => (titleWithoutParams = value))
       .unsubscribe();
 
@@ -94,24 +112,18 @@ fdescribe('OrganizationMetaResolver', () => {
   });
 
   it('should resolve title with parameters', () => {
-    // spyOn(routingService, 'getRouterState').and.returnValue(
-    //   of(mockRouterStateWithParams)
-    // );
     state.next(mockRouterStateWithParams);
-    console.log('with parameters');
+
     let titleWithParameters = '';
     resolver
       .resolveTitle()
       .subscribe((value) => (titleWithParameters = value))
       .unsubscribe();
 
-    expect(titleWithParameters).toEqual(['8796098887703']);
+    expect(titleWithParameters).toEqual('8796098887703');
   });
 
   it('should resolve breadcrumbs without parameters', () => {
-    // spyOn(routingService, 'getRouterState').and.returnValue(
-    //   of(mockRouterStateWithoutParams)
-    // );
     state.next(mockRouterStateWithoutParams);
 
     let result: any[];
@@ -127,10 +139,8 @@ fdescribe('OrganizationMetaResolver', () => {
   });
 
   it('should resolve breadcrumbs with parameters', () => {
-    // spyOn(routingService, 'getRouterState').and.returnValue(
-    //   of(mockRouterStateWithParams)
-    // );
     state.next(mockRouterStateWithParams);
+
     let result: any[];
     resolver
       .resolveBreadcrumbs()

--- a/projects/core/src/organization/services/organization-meta.resolver.spec.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.spec.ts
@@ -71,7 +71,7 @@ class RoutingServiceStub {
   }
 }
 
-fdescribe('OrganizationMetaResolver', () => {
+describe('OrganizationMetaResolver', () => {
   let resolver: OrganizationMetaResolver;
 
   beforeEach(() => {

--- a/projects/core/src/organization/services/organization-meta.resolver.spec.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.spec.ts
@@ -7,6 +7,7 @@ import { OrganizationMetaResolver } from './organization-meta.resolver';
 
 import { RoutingService } from '../../routing/facade/routing.service';
 import { RouterState } from '../../routing/store/routing-state';
+import { tap } from 'rxjs/operators';
 
 const mockOrganizationPage: Page = {
   type: PageType.CONTENT_PAGE,
@@ -16,6 +17,7 @@ const mockOrganizationPage: Page = {
 
 class MockCmsService {
   getCurrentPage(): Observable<Page> {
+    console.log('getCurrentPage');
     return of(mockOrganizationPage);
   }
 }
@@ -51,11 +53,11 @@ const mockRouterStateWithParams: RouterState = {
 
 class RoutingServiceStub {
   getRouterState(): Observable<RouterState> {
-    return of(mockRouterStateWithoutParams);
+    return of();
   }
 }
 
-describe('OrganizationMetaResolver', () => {
+fdescribe('OrganizationMetaResolver', () => {
   let resolver: OrganizationMetaResolver;
   let routingService: RoutingService;
 
@@ -65,6 +67,7 @@ describe('OrganizationMetaResolver', () => {
       providers: [
         { provide: CmsService, useClass: MockCmsService },
         { provide: RoutingService, useClass: RoutingServiceStub },
+        OrganizationMetaResolver,
       ],
     });
 
@@ -73,13 +76,15 @@ describe('OrganizationMetaResolver', () => {
   });
 
   it('should resolve title without parameters', () => {
-    spyOn(routingService, 'getRouterState').and.callFake(() =>
+    spyOn(routingService, 'getRouterState').and.returnValue(
       of(mockRouterStateWithoutParams)
     );
+    console.log('without parameters');
 
     let titleWithoutParams: string;
     resolver
       .resolveTitle()
+      .pipe(tap(console.log))
       .subscribe((value) => (titleWithoutParams = value))
       .unsubscribe();
 
@@ -87,10 +92,10 @@ describe('OrganizationMetaResolver', () => {
   });
 
   it('should resolve title with parameters', () => {
-    spyOn(routingService, 'getRouterState').and.callFake(() =>
+    spyOn(routingService, 'getRouterState').and.returnValue(
       of(mockRouterStateWithParams)
     );
-
+    console.log('with parameters');
     let titleWithParameters = '';
     resolver
       .resolveTitle()
@@ -101,7 +106,7 @@ describe('OrganizationMetaResolver', () => {
   });
 
   it('should resolve breadcrumbs without parameters', () => {
-    spyOn(routingService, 'getRouterState').and.callFake(() =>
+    spyOn(routingService, 'getRouterState').and.returnValue(
       of(mockRouterStateWithoutParams)
     );
 

--- a/projects/core/src/organization/services/organization-meta.resolver.spec.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { CmsService, Page } from '../../cms';
 import { I18nTestingModule } from '../../i18n';
 import { PageType } from '../../model/cms.model';
@@ -17,7 +17,6 @@ const mockOrganizationPage: Page = {
 
 class MockCmsService {
   getCurrentPage(): Observable<Page> {
-    console.log('getCurrentPage');
     return of(mockOrganizationPage);
   }
 }
@@ -51,15 +50,17 @@ const mockRouterStateWithParams: RouterState = {
   },
 };
 
+const state = new BehaviorSubject(mockRouterStateWithoutParams);
+
 class RoutingServiceStub {
   getRouterState(): Observable<RouterState> {
-    return of();
+    return state;
   }
 }
 
 fdescribe('OrganizationMetaResolver', () => {
   let resolver: OrganizationMetaResolver;
-  let routingService: RoutingService;
+  // let routingService: RoutingService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -72,13 +73,14 @@ fdescribe('OrganizationMetaResolver', () => {
     });
 
     resolver = TestBed.inject(OrganizationMetaResolver);
-    routingService = TestBed.inject(RoutingService);
+    // routingService = TestBed.inject(RoutingService);
   });
 
   it('should resolve title without parameters', () => {
-    spyOn(routingService, 'getRouterState').and.returnValue(
-      of(mockRouterStateWithoutParams)
-    );
+    // spyOn(routingService, 'getRouterState').and.returnValue(
+    //   of(mockRouterStateWithoutParams)
+    // );
+    state.next(mockRouterStateWithoutParams);
     console.log('without parameters');
 
     let titleWithoutParams: string;
@@ -92,9 +94,10 @@ fdescribe('OrganizationMetaResolver', () => {
   });
 
   it('should resolve title with parameters', () => {
-    spyOn(routingService, 'getRouterState').and.returnValue(
-      of(mockRouterStateWithParams)
-    );
+    // spyOn(routingService, 'getRouterState').and.returnValue(
+    //   of(mockRouterStateWithParams)
+    // );
+    state.next(mockRouterStateWithParams);
     console.log('with parameters');
     let titleWithParameters = '';
     resolver
@@ -102,13 +105,14 @@ fdescribe('OrganizationMetaResolver', () => {
       .subscribe((value) => (titleWithParameters = value))
       .unsubscribe();
 
-    expect(titleWithParameters).toEqual('8796098887703');
+    expect(titleWithParameters).toEqual(['8796098887703']);
   });
 
   it('should resolve breadcrumbs without parameters', () => {
-    spyOn(routingService, 'getRouterState').and.returnValue(
-      of(mockRouterStateWithoutParams)
-    );
+    // spyOn(routingService, 'getRouterState').and.returnValue(
+    //   of(mockRouterStateWithoutParams)
+    // );
+    state.next(mockRouterStateWithoutParams);
 
     let result: any[];
     resolver
@@ -123,10 +127,10 @@ fdescribe('OrganizationMetaResolver', () => {
   });
 
   it('should resolve breadcrumbs with parameters', () => {
-    spyOn(routingService, 'getRouterState').and.returnValue(
-      of(mockRouterStateWithParams)
-    );
-
+    // spyOn(routingService, 'getRouterState').and.returnValue(
+    //   of(mockRouterStateWithParams)
+    // );
+    state.next(mockRouterStateWithParams);
     let result: any[];
     resolver
       .resolveBreadcrumbs()

--- a/projects/core/src/organization/services/organization-meta.resolver.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { combineLatest, Observable, of } from 'rxjs';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
 import { CmsService } from '../../cms/facade/cms.service';
 import { BreadcrumbMeta, Page } from '../../cms/model/page.model';
 import { PageMetaResolver } from '../../cms/page/page-meta.resolver';
@@ -27,6 +27,7 @@ export class OrganizationMetaResolver extends PageMetaResolver
     this.cms.getCurrentPage(),
     this.routingService.getRouterState(),
   ]).pipe(
+    tap((data) => console.log('organizationPageTitle$', data)),
     filter(Boolean),
     switchMap(([page, route]) =>
       // checking the template to make sure it's a 'my company' page
@@ -51,6 +52,7 @@ export class OrganizationMetaResolver extends PageMetaResolver
       this.organizationPageTitle$,
       this.routingService.getRouterState(),
     ]).pipe(
+      tap((data) => console.log('resolveTitle', data)),
       filter(([title, routerState]) => Boolean(title) && Boolean(routerState)),
       switchMap(
         ([
@@ -73,6 +75,7 @@ export class OrganizationMetaResolver extends PageMetaResolver
       this.translation.translate('common.home'),
       this.routingService.getRouterState(),
     ]).pipe(
+      tap((data) => console.log('resolveBreadcrumbs', data)),
       map(([homeLabel, routerState]: [string, RouterState]) =>
         this.resolveBreadcrumbData(homeLabel, routerState)
       )

--- a/projects/core/src/organization/services/organization-meta.resolver.ts
+++ b/projects/core/src/organization/services/organization-meta.resolver.ts
@@ -48,6 +48,8 @@ export class OrganizationMetaResolver extends PageMetaResolver
     this.pageTemplate = 'CompanyPageTemplate';
   }
 
+  protected SEPARATOR = 'organization';
+
   resolveTitle(): Observable<string> {
     return combineLatest([
       this.organizationPageTitle$,
@@ -95,7 +97,7 @@ export class OrganizationMetaResolver extends PageMetaResolver
       .split('/')
       .filter(
         (_, index, arr) =>
-          index >= arr.findIndex((e) => e === 'organization') &&
+          index >= arr.findIndex((e) => e === this.SEPARATOR) &&
           index < arr.length - 1
       )
       .forEach((url) => {


### PR DESCRIPTION
Refactor breadcrumbs to work with Cost Centers after refactor (no longer using child routes).