### PR TITLE
fix: load anonymous consent templates on each Spartacus refresh

### DIFF
--- a/projects/core/src/anonymous-consents/facade/anonymous-consents.service.ts
+++ b/projects/core/src/anonymous-consents/facade/anonymous-consents.service.ts
@@ -262,6 +262,7 @@ export class AnonymousConsentsService {
    * Otherwise, it returns `false`.
    */
   isBannerVisible(): Observable<boolean> {
+    this.loadTemplates();
     return combineLatest([
       this.isBannerDismissed(),
       this.getTemplatesUpdated(),


### PR DESCRIPTION
In order to fetch the latest consent templates, Spartacus will load them on each page refresh.
This is necessary in order to detect updated consent templates.