### PR TITLE
feat: Expose lighter version of makeErrorSerializable

### DIFF
--- a/projects/core/src/model/misc.model.ts
+++ b/projects/core/src/model/misc.model.ts
@@ -69,10 +69,15 @@ export interface ErrorModel {
 
 export interface HttpErrorModel {
   message?: string;
-  error?: any | null;
   status?: number;
   statusText?: string;
   url?: string | null;
+  details?: ErrorModel[];
+
+  /**
+   * @deprecated since 2.1
+   */
+  error?: any | null;
 }
 
 export interface BaseStore {

--- a/projects/core/src/util/index.ts
+++ b/projects/core/src/util/index.ts
@@ -4,3 +4,4 @@ export * from './glob.service';
 export * from './regex-pattern';
 export * from './withdraw-on';
 export * from './applicable';
+export * from './normalize-http-error';

--- a/projects/core/src/util/normalize-http-error.spec.ts
+++ b/projects/core/src/util/normalize-http-error.spec.ts
@@ -1,0 +1,78 @@
+import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { HttpErrorModel } from '../model/index';
+import { normalizeHttpError } from './normalize-http-error';
+
+describe('makeErrorSerializable', () => {
+  describe(`when the provided argument is not HttpError`, () => {
+    it('should return undefined', () => {
+      const error = 'xxx';
+      const result = normalizeHttpError(error);
+      expect(result).toEqual(undefined);
+    });
+  });
+
+  describe('when the provided error is an instance of HttpErrorResponse', () => {
+    it('should make it serializable', () => {
+      const mockError = new HttpErrorResponse({
+        error: 'error',
+        headers: new HttpHeaders().set('xxx', 'xxx'),
+        status: 500,
+        statusText: 'Unknown error',
+        url: '/xxx',
+      });
+
+      const result = normalizeHttpError(mockError as HttpErrorResponse);
+      expect(result).toEqual({
+        message: mockError.message,
+        status: mockError.status,
+        statusText: mockError.statusText,
+        url: mockError.url,
+      } as HttpErrorModel);
+    });
+
+    it('should serialize details', () => {
+      const mockError = new HttpErrorResponse({
+        error: { errors: [{ message: 'errorMessage' }] },
+        headers: new HttpHeaders().set('xxx', 'xxx'),
+        status: 500,
+        statusText: 'Unknown error',
+        url: '/xxx',
+      });
+      const result = normalizeHttpError(mockError as HttpErrorResponse);
+      expect(result).toEqual({
+        message: mockError.message,
+        status: mockError.status,
+        statusText: mockError.statusText,
+        url: mockError.url,
+        details: [
+          {
+            message: 'errorMessage',
+          },
+        ],
+      } as HttpErrorModel);
+    });
+
+    it('should normalize single error', () => {
+      const mockError = new HttpErrorResponse({
+        error: { error: 'errorType', error_description: 'errorMessage' },
+        headers: new HttpHeaders().set('xxx', 'xxx'),
+        status: 500,
+        statusText: 'Unknown error',
+        url: '/xxx',
+      });
+      const result = normalizeHttpError(mockError as HttpErrorResponse);
+      expect(result).toEqual({
+        message: mockError.message,
+        status: mockError.status,
+        statusText: mockError.statusText,
+        url: mockError.url,
+        details: [
+          {
+            message: 'errorMessage',
+            type: 'errorType',
+          },
+        ],
+      } as HttpErrorModel);
+    });
+  });
+});

--- a/projects/core/src/util/normalize-http-error.spec.ts
+++ b/projects/core/src/util/normalize-http-error.spec.ts
@@ -2,7 +2,7 @@ import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { HttpErrorModel } from '../model/index';
 import { normalizeHttpError } from './normalize-http-error';
 
-describe('makeErrorSerializable', () => {
+describe('normalizeHttpError', () => {
   describe(`when the provided argument is not HttpError`, () => {
     it('should return undefined', () => {
       const error = 'xxx';

--- a/projects/core/src/util/normalize-http-error.ts
+++ b/projects/core/src/util/normalize-http-error.ts
@@ -8,7 +8,7 @@ import { isDevMode } from '@angular/core';
  * Can be used as a safe and generic way for embodying http errors into
  * NgRx Action payload, as it will strip potentially unserializable parts from
  * it and warn in debug mode if passed error is not instance of HttpErrorModel
- * (which usually happens when logic in the effect is not sealed correctly)
+ * (which usually happens when logic in NgRx Effect is not sealed correctly)
  */
 export function normalizeHttpError(
   error: HttpErrorResponse | any

--- a/projects/core/src/util/normalize-http-error.ts
+++ b/projects/core/src/util/normalize-http-error.ts
@@ -1,0 +1,46 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorModel } from '../model/misc.model';
+import { isDevMode } from '@angular/core';
+
+/**
+ * This utility contains normalized HttpErrorResponse to HttpErrorModel.
+ * Can be used as a safe and generic way for embodying errors into
+ * NgRx Action payload, as it will strip potentially unserializable parts from
+ * the model and warn in debug mode if passsed error is not instance of
+ * HttpErrorModel (which could be caused by invalid logic in Effects)
+ */
+export function normalizeHttpError(
+  error: HttpErrorResponse | any
+): HttpErrorModel | undefined {
+  if (error instanceof HttpErrorResponse) {
+    const normalizedError: HttpErrorModel = {
+      message: error.message,
+      status: error.status,
+      statusText: error.statusText,
+      url: error.url,
+    };
+
+    // include backend's error details
+    if (Array.isArray(error.error.errors)) {
+      normalizedError.details = error.error.errors;
+    } else if (typeof error.error.error === 'string') {
+      normalizedError.details = [
+        {
+          type: error.error.error,
+          message: error.error.error_description,
+        },
+      ];
+    }
+
+    return normalizedError;
+  }
+
+  if (isDevMode()) {
+    console.error(
+      'Error passed to nomalizeHttpError is not HttpErrorResponse instance',
+      error
+    );
+  }
+
+  return undefined;
+}

--- a/projects/core/src/util/normalize-http-error.ts
+++ b/projects/core/src/util/normalize-http-error.ts
@@ -38,7 +38,7 @@ export function normalizeHttpError(
 
   if (isDevMode()) {
     console.error(
-      'Error passed to nomalizeHttpError is not HttpErrorResponse instance',
+      'Error passed to normalizeHttpError is not HttpErrorResponse instance',
       error
     );
   }

--- a/projects/core/src/util/normalize-http-error.ts
+++ b/projects/core/src/util/normalize-http-error.ts
@@ -5,10 +5,10 @@ import { isDevMode } from '@angular/core';
 /**
  * Normalizes HttpErrorResponse to HttpErrorModel.
  *
- * Can be used as a safe and generic way for embodying errors into
+ * Can be used as a safe and generic way for embodying http errors into
  * NgRx Action payload, as it will strip potentially unserializable parts from
- * the model and warn in debug mode if passed error is not instance of
- * HttpErrorModel (which could be caused by invalid logic in Effects)
+ * it and warn in debug mode if passed error is not instance of HttpErrorModel
+ * (which usually happens when logic in the effect is not sealed correctly)
  */
 export function normalizeHttpError(
   error: HttpErrorResponse | any

--- a/projects/core/src/util/normalize-http-error.ts
+++ b/projects/core/src/util/normalize-http-error.ts
@@ -3,10 +3,11 @@ import { HttpErrorModel } from '../model/misc.model';
 import { isDevMode } from '@angular/core';
 
 /**
- * This utility contains normalized HttpErrorResponse to HttpErrorModel.
+ * Normalizes HttpErrorResponse to HttpErrorModel.
+ *
  * Can be used as a safe and generic way for embodying errors into
  * NgRx Action payload, as it will strip potentially unserializable parts from
- * the model and warn in debug mode if passsed error is not instance of
+ * the model and warn in debug mode if passed error is not instance of
  * HttpErrorModel (which could be caused by invalid logic in Effects)
  */
 export function normalizeHttpError(

--- a/projects/core/src/util/serialization-utils.ts
+++ b/projects/core/src/util/serialization-utils.ts
@@ -2,6 +2,9 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { isObject } from '../config/utils/deep-merge';
 import { ErrorModel, HttpErrorModel } from '../model/misc.model';
 
+/**
+ * @deprecated since 2.1, use normalizeHttpError instead
+ */
 export const UNKNOWN_ERROR = {
   error: 'unknown error',
 };
@@ -19,6 +22,9 @@ const circularReplacer = () => {
   };
 };
 
+/**
+ * @deprecated since 2.1, use normalizeHttpError instead
+ */
 export function makeErrorSerializable(
   error: HttpErrorResponse | ErrorModel | any
 ): HttpErrorModel | Error | any {


### PR DESCRIPTION
The current version of 'makeErrorSerializable' is widely used as a utility but contains some complex processing of http errors.

Rename current implementation and expose new, more lightweight one, suitable to use in other libraries.

Closes #8195