### PR TITLE
fix: check for facets existing before filtering it (GH-8231)

### DIFF
--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
@@ -54,7 +54,7 @@ export class OccProductSearchPageNormalizer
    * the facets.
    */
   private normalizeUselessFacets(target: ProductSearchPage): void {
-    target.facets = target.facets.filter((facet) => {
+    target.facets = (target.facets || []).filter((facet) => {
       return (
         !target.pagination ||
         !target.pagination.totalResults ||


### PR DESCRIPTION
`OccProductSearchPageNormalizer `is trying to filter facets, but they may not exist in `/product/search` response, so it's throwing silently catched exception, and `ProductSearchService.getResult()` doesn't emmit a value.