### PR TITLE
feat: expose semantic route name in the routing state 

### DIFF
--- a/projects/core/src/routing/configurable-routes/routing-config.service.spec.ts
+++ b/projects/core/src/routing/configurable-routes/routing-config.service.spec.ts
@@ -49,4 +49,18 @@ describe('RoutingConfigService', () => {
       expect(service.getLoadStrategy()).toEqual(RouteLoadStrategy.ONCE);
     });
   });
+
+  describe('getRouteName', () => {
+    it('should return the route name for the given path', () => {
+      expect(service.getRouteName('path1')).toBe('page1');
+    });
+
+    it('should return the route name for the given path alias', () => {
+      expect(service.getRouteName('path10')).toBe('page1');
+    });
+
+    it('should return undefined for unknown path', () => {
+      expect(service.getRouteName('path/unknown')).toBe(undefined);
+    });
+  });
 });

--- a/projects/core/src/routing/configurable-routes/routing-config.service.ts
+++ b/projects/core/src/routing/configurable-routes/routing-config.service.ts
@@ -39,6 +39,17 @@ export class RoutingConfigService {
 
   /**
    * Returns the route name of the configured path.
+   *
+   * For example, when the config is:
+   * ```
+   * routing: {
+   *   routes: {
+   *      addressBook: { paths: ['my-account/address-book'] }
+   *   }
+   * }
+   * ```
+   *
+   * the `getRouteName('my-account/address-book')` returns `'addressBook'`.
    */
   getRouteName(path: string) {
     if (!this.routeNamesByPath) {

--- a/projects/core/src/routing/configurable-routes/routing-config.service.ts
+++ b/projects/core/src/routing/configurable-routes/routing-config.service.ts
@@ -1,11 +1,19 @@
 import { Injectable, isDevMode } from '@angular/core';
-import { RouteConfig } from './routes-config';
 import { RouteLoadStrategy, RoutingConfig } from './config/routing-config';
+import { RouteConfig } from './routes-config';
 
 @Injectable({ providedIn: 'root' })
 export class RoutingConfigService {
+  /**
+   * Reversed routing config for quick lookup of the route name by the configured path.
+   */
+  protected routeNamesByPath: { [path: string]: string };
+
   constructor(protected config: RoutingConfig) {}
 
+  /**
+   * Returns the route config for the given route name.
+   */
   getRouteConfig(routeName: string): RouteConfig {
     const routeConfig = this.config?.routing?.routes;
 
@@ -22,7 +30,45 @@ export class RoutingConfigService {
     }
   }
 
+  /**
+   * Returns the configured route loading strategy.
+   */
   getLoadStrategy(): RouteLoadStrategy {
     return this.config?.routing?.loadStrategy ?? RouteLoadStrategy.ALWAYS;
+  }
+
+  /**
+   * Returns the route name of the configured path.
+   */
+  getRouteName(path: string) {
+    if (!this.routeNamesByPath) {
+      this.initRouteNamesByPath();
+    }
+    return this.routeNamesByPath[path];
+  }
+
+  /**
+   * Initializes the property `routeNamesByPath`.
+   *
+   * The original config
+   * allows for reading configured path by the route name.
+   * But this method builds up a structure with a 'reversed config'
+   * to read quickly the route name by the path.
+   */
+  protected initRouteNamesByPath() {
+    this.routeNamesByPath = {};
+
+    for (const [routeName, routeConfig] of Object.entries(
+      this.config?.routing?.routes
+    )) {
+      routeConfig?.paths?.forEach((path) => {
+        if (isDevMode() && this.routeNamesByPath[path]) {
+          console.error(
+            `The same path '${path}' is configured for two different route names: '${this.routeNamesByPath[path]}' and '${routeName}`
+          );
+        }
+        this.routeNamesByPath[path] = routeName;
+      });
+    }
   }
 }

--- a/projects/core/src/routing/configurable-routes/routing-config.service.ts
+++ b/projects/core/src/routing/configurable-routes/routing-config.service.ts
@@ -50,8 +50,7 @@ export class RoutingConfigService {
   /**
    * Initializes the property `routeNamesByPath`.
    *
-   * The original config
-   * allows for reading configured path by the route name.
+   * The original config allows for reading configured path by the route name.
    * But this method builds up a structure with a 'reversed config'
    * to read quickly the route name by the path.
    */

--- a/projects/core/src/routing/store/reducers/router.reducer.spec.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.spec.ts
@@ -12,13 +12,20 @@ import { PageType } from '../../../model/cms.model';
 import { RoutingConfig } from '../../configurable-routes/config/routing-config';
 import { RouterState } from '../routing-state';
 import * as fromReducer from './router.reducer';
-import { SemanticRoutes } from './router.reducer';
 
 @Component({
   selector: 'cx-test-cmp',
   template: 'test-cmp',
 })
 class TestComponent {}
+
+export enum SemanticRoutes {
+  PRODUCT = 'product',
+  CATEGORY = 'category',
+  BRAND = 'brand',
+  SEARCH = 'search',
+  HOME = 'home',
+}
 
 describe('Router Reducer', () => {
   let router: Router;
@@ -40,13 +47,25 @@ describe('Router Reducer', () => {
         StoreModule.forRoot(fromReducer.reducerToken),
         RouterTestingModule.withRoutes([
           { path: '', component: TestComponent },
-          { path: 'category/:categoryCode', component: TestComponent },
-          { path: 'product/:productCode', component: TestComponent },
-          { path: 'brand/:brandCode', component: TestComponent },
+          {
+            path: 'category/:categoryCode',
+            component: TestComponent,
+            data: { cxRoute: SemanticRoutes.CATEGORY },
+          },
+          {
+            path: 'product/:productCode',
+            component: TestComponent,
+            data: { cxRoute: SemanticRoutes.PRODUCT },
+          },
+          {
+            path: 'brand/:brandCode',
+            component: TestComponent,
+            data: { cxRoute: SemanticRoutes.BRAND },
+          },
           {
             path: 'search/:query',
             component: TestComponent,
-            data: { cxRoute: 'search' },
+            data: { cxRoute: SemanticRoutes.SEARCH },
           },
           {
             path: 'cmsPage',
@@ -255,7 +274,7 @@ describe('Router Reducer', () => {
         context: { id: '/search/camera', type: PageType.CONTENT_PAGE },
 
         cmsRequired: false,
-        semanticRoute: 'search',
+        semanticRoute: SemanticRoutes.SEARCH,
       });
     });
 

--- a/projects/core/src/routing/store/reducers/router.reducer.spec.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.spec.ts
@@ -37,6 +37,7 @@ describe('Router Reducer', () => {
       routing: {
         routes: {
           termsAndConditions: { paths: ['terms-and-conditions'] },
+          home: { paths: [''] },
         },
       },
     };

--- a/projects/core/src/routing/store/reducers/router.reducer.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.ts
@@ -12,6 +12,14 @@ import {
   State,
 } from '../routing-state';
 
+// private enum
+export enum SemanticRoutes {
+  PRODUCT = 'product',
+  CATEGORY = 'category',
+  BRAND = 'brand',
+  HOME = 'home',
+}
+
 export const initialState: RouterState = {
   navigationId: 0,
   state: {
@@ -131,13 +139,13 @@ export class CustomSerializer
     } else {
       if (params['productCode']) {
         context = { id: params['productCode'], type: PageType.PRODUCT_PAGE };
-        semanticRoute = 'product';
+        semanticRoute = SemanticRoutes.PRODUCT;
       } else if (params['categoryCode']) {
         context = { id: params['categoryCode'], type: PageType.CATEGORY_PAGE };
-        semanticRoute = 'category';
+        semanticRoute = SemanticRoutes.CATEGORY;
       } else if (params['brandCode']) {
         context = { id: params['brandCode'], type: PageType.CATEGORY_PAGE };
-        semanticRoute = 'brand';
+        semanticRoute = SemanticRoutes.BRAND;
       } else if (state.data.pageLabel !== undefined) {
         context = { id: state.data.pageLabel, type: PageType.CONTENT_PAGE };
         // We don't assign `semanticRoute` here, because Angular Routes with defined `data.pageLabel` are assumed
@@ -158,7 +166,7 @@ export class CustomSerializer
             id: 'homepage',
             type: PageType.CONTENT_PAGE,
           };
-          semanticRoute = 'home';
+          semanticRoute = SemanticRoutes.HOME;
         }
       }
     }

--- a/projects/core/src/routing/store/reducers/router.reducer.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.ts
@@ -96,7 +96,7 @@ export class CustomSerializer
     while (state.firstChild) {
       state = state.firstChild as CmsActivatedRouteSnapshot;
 
-      // we use semantic route information embedded from any parent route or take it from current route
+      // we use semantic route information embedded from any parent route
       if (state.data?.cxRoute) {
         semanticRoute = state.data?.cxRoute;
       }
@@ -150,7 +150,9 @@ export class CustomSerializer
             id: pageLabel,
             type: PageType.CONTENT_PAGE,
           };
-          semanticRoute = semanticRoute || this.lookupSemanticRoute(pageLabel); // lookup semanticRoute by page label only if couldn't find it by data.cxRoute
+          // If `semanticRoute` couldn't be recognized using `data.cxRoute` property, let's lookup the routing configuration
+          // to find the semantic route that has exactly the same configured path as the current URL.
+          semanticRoute = semanticRoute || this.lookupSemanticRoute(pageLabel);
         } else {
           context = {
             id: 'homepage',

--- a/projects/core/src/routing/store/reducers/router.reducer.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.ts
@@ -12,14 +12,6 @@ import {
   State,
 } from '../routing-state';
 
-// private enum
-export enum SemanticRoutes {
-  PRODUCT = 'product',
-  CATEGORY = 'category',
-  BRAND = 'brand',
-  HOME = 'home',
-}
-
 export const initialState: RouterState = {
   navigationId: 0,
   state: {
@@ -139,13 +131,10 @@ export class CustomSerializer
     } else {
       if (params['productCode']) {
         context = { id: params['productCode'], type: PageType.PRODUCT_PAGE };
-        semanticRoute = SemanticRoutes.PRODUCT;
       } else if (params['categoryCode']) {
         context = { id: params['categoryCode'], type: PageType.CATEGORY_PAGE };
-        semanticRoute = SemanticRoutes.CATEGORY;
       } else if (params['brandCode']) {
         context = { id: params['brandCode'], type: PageType.CATEGORY_PAGE };
-        semanticRoute = SemanticRoutes.BRAND;
       } else if (state.data.pageLabel !== undefined) {
         context = { id: state.data.pageLabel, type: PageType.CONTENT_PAGE };
         // We don't assign `semanticRoute` here, because Angular Routes with defined `data.pageLabel` are assumed
@@ -166,7 +155,7 @@ export class CustomSerializer
             id: 'homepage',
             type: PageType.CONTENT_PAGE,
           };
-          semanticRoute = SemanticRoutes.HOME;
+          semanticRoute = 'home';
         }
       }
     }


### PR DESCRIPTION
Routing configuration is indexed by semantic routes' names and allow for:
- generating links with URLs 
- programatically navigating to an URL
- filling empty (`null`) paths in the Angular Routes (that contain the semantic name in the `data.cxRoute` property)

However sometimes there is a need, when visited an URL, to know on which semantic route we are. Such an information may be essential for CDS/tag manages to build routing events like 'search page visited' or 'product page visited'.

Now in CustomSerializer we try recognize the semantic route:
1. firstly from the activated route (if it contains property `data.cxRoute`) - which are used for complex routes, i.e. with dynamic params or custom url matchers
2. or from the current URL - in case of simple CMS content pages which have page label the same as the current url

Note: recognizing cms-driven child routes is not supported.

closes GH-8253