### PR TITLE
Run E2Es against Azure dev servers (GH-8066) - 2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prettier:fix": "prettier --config ./.prettierrc --list-different \"projects/**/*{.ts,.js,.json,.scss,.html}\" --write",
     "start": "ng serve",
     "start:ci:1905": "yarn start:prod",
-    "start:ci:2005": "cross-env SPARTACUS_BASE_URL=https://dev-com-7.accdemo.b2c.ydev.hybris.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ yarn start:prod",
+    "start:ci:2005": "cross-env SPARTACUS_BASE_URL=https://spartacus-dev3.eastus.cloudapp.azure.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ yarn start:prod",
     "start:ci:ccv2": "cross-env SPARTACUS_BASE_URL=https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com yarn start:prod",
     "start:prod": "ng serve --prod",
     "start:ssl": "ng serve --ssl",
@@ -80,7 +80,7 @@
     "e2e:cy:cds:start-run-ci": "start-server-and-test start:cds:ci:1905 http-get://localhost:4200 e2e:cy:run:ci:all",
     "start:cds": "cross-env SPARTACUS_CDS=true ng serve",
     "start:cds:ci:1905": "cross-env SPARTACUS_CDS=true ng serve --prod",
-    "start:cds:ci:2005": "cross-env SPARTACUS_BASE_URL=https://dev-com-7.accdemo.b2c.ydev.hybris.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ SPARTACUS_CDS=true ng serve --prod",
+    "start:cds:ci:2005": "cross-env SPARTACUS_BASE_URL=https://spartacus-dev3.eastus.cloudapp.azure.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ SPARTACUS_CDS=true ng serve --prod",
     "start:cds:ci:ccv2": "cross-env SPARTACUS_BASE_URL=https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com SPARTACUS_CDS=true ng serve --prod",
     "test:cds:lib": "ng test cds --code-coverage",
     "dev:cds:ssr": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 SPARTACUS_CDS=true ng run storefrontapp:serve-ssr",
@@ -88,7 +88,7 @@
     "build:cds:ssr": "cross-env SPARTACUS_CDS=true ng run storefrontapp:server:production",
     "prerender:cds": "cross-env SPARTACUS_CDS=true ng run storefrontapp:prerender",
     "release:cds:with-changelog": "cd projects/cds && release-it && cd ../..",
-    "start:b2b:ci:2005": "cross-env SPARTACUS_BASE_URL=https://dev-com-7.accdemo.b2c.ydev.hybris.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ SPARTACUS_B2B=true ng serve --prod"
+    "start:b2b:ci:2005": "cross-env SPARTACUS_BASE_URL=https://spartacus-dev3.eastus.cloudapp.azure.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ SPARTACUS_B2B=true ng serve --prod"
   },
   "private": false,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prettier:fix": "prettier --config ./.prettierrc --list-different \"projects/**/*{.ts,.js,.json,.scss,.html}\" --write",
     "start": "ng serve",
     "start:ci:1905": "yarn start:prod",
-    "start:ci:2005": "cross-env SPARTACUS_BASE_URL=https://spartacus-dev3.eastus.cloudapp.azure.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ yarn start:prod",
+    "start:ci:2005": "cross-env SPARTACUS_BASE_URL=https://spartacus-dev0.eastus.cloudapp.azure.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ yarn start:prod",
     "start:ci:ccv2": "cross-env SPARTACUS_BASE_URL=https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com yarn start:prod",
     "start:prod": "ng serve --prod",
     "start:ssl": "ng serve --ssl",
@@ -80,7 +80,7 @@
     "e2e:cy:cds:start-run-ci": "start-server-and-test start:cds:ci:1905 http-get://localhost:4200 e2e:cy:run:ci:all",
     "start:cds": "cross-env SPARTACUS_CDS=true ng serve",
     "start:cds:ci:1905": "cross-env SPARTACUS_CDS=true ng serve --prod",
-    "start:cds:ci:2005": "cross-env SPARTACUS_BASE_URL=https://spartacus-dev3.eastus.cloudapp.azure.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ SPARTACUS_CDS=true ng serve --prod",
+    "start:cds:ci:2005": "cross-env SPARTACUS_BASE_URL=https://spartacus-dev0.eastus.cloudapp.azure.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ SPARTACUS_CDS=true ng serve --prod",
     "start:cds:ci:ccv2": "cross-env SPARTACUS_BASE_URL=https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com SPARTACUS_CDS=true ng serve --prod",
     "test:cds:lib": "ng test cds --code-coverage",
     "dev:cds:ssr": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 SPARTACUS_CDS=true ng run storefrontapp:serve-ssr",
@@ -88,7 +88,7 @@
     "build:cds:ssr": "cross-env SPARTACUS_CDS=true ng run storefrontapp:server:production",
     "prerender:cds": "cross-env SPARTACUS_CDS=true ng run storefrontapp:prerender",
     "release:cds:with-changelog": "cd projects/cds && release-it && cd ../..",
-    "start:b2b:ci:2005": "cross-env SPARTACUS_BASE_URL=https://spartacus-dev3.eastus.cloudapp.azure.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ SPARTACUS_B2B=true ng serve --prod"
+    "start:b2b:ci:2005": "cross-env SPARTACUS_BASE_URL=https://spartacus-dev0.eastus.cloudapp.azure.com:9002 SPARTACUS_API_PREFIX=/occ/v2/ SPARTACUS_B2B=true ng serve --prod"
   },
   "private": false,
   "dependencies": {

--- a/projects/storefrontapp-e2e-cypress/cypress.ci.1905.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.ci.1905.json
@@ -7,7 +7,7 @@
   "env": {
     "CLIENT_ID": "mobile_android",
     "CLIENT_SECRET": "secret",
-    "API_URL": "https://dev-com-17.accdemo.b2c.ydev.hybris.com:9002",
+    "API_URL": "https://spartacus-legacy.eastus.cloudapp.azure.com:9002",
     "OCC_PREFIX": "/rest/v2",
     "BASE_SITE": "electronics-spa"
   }

--- a/projects/storefrontapp-e2e-cypress/cypress.ci.2005.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.ci.2005.json
@@ -7,7 +7,7 @@
   "env": {
     "CLIENT_ID": "mobile_android",
     "CLIENT_SECRET": "secret",
-    "API_URL": "https://dev-com-20.accdemo.b2c.ydev.hybris.com:9002",
+    "API_URL": "https://spartacus-dev0.eastus.cloudapp.azure.com:9002",
     "OCC_PREFIX": "/occ/v2",
     "BASE_SITE": "electronics-spa"
   }

--- a/projects/storefrontapp-e2e-cypress/cypress.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.json
@@ -6,7 +6,7 @@
   "env": {
     "CLIENT_ID": "mobile_android",
     "CLIENT_SECRET": "secret",
-    "API_URL": "https://dev-com-17.accdemo.b2c.ydev.hybris.com:9002",
+    "API_URL": "https://spartacus-legacy.eastus.cloudapp.azure.com:9002",
     "OCC_PREFIX": "/rest/v2",
     "BASE_SITE": "electronics-spa"
   }

--- a/projects/storefrontapp-e2e-cypress/cypress.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.json
@@ -6,8 +6,8 @@
   "env": {
     "CLIENT_ID": "mobile_android",
     "CLIENT_SECRET": "secret",
-    "API_URL": "https://spartacus-legacy.eastus.cloudapp.azure.com:9002",
-    "OCC_PREFIX": "/rest/v2",
+    "API_URL": "https://spartacus-dev0.eastus.cloudapp.azure.com:9002",
+    "OCC_PREFIX": "/occ/v2",
     "BASE_SITE": "electronics-spa"
   }
 }

--- a/projects/storefrontapp/src/environments/environment.prod.ts
+++ b/projects/storefrontapp/src/environments/environment.prod.ts
@@ -4,8 +4,8 @@ export const environment: Environment = {
   production: true,
   occBaseUrl:
     build.process.env.SPARTACUS_BASE_URL ??
-    'https://spartacus-legacy.eastus.cloudapp.azure.com:9002',
-  occApiPrefix: build.process.env.SPARTACUS_API_PREFIX ?? '/rest/v2/',
+    'https://spartacus-dev0.eastus.cloudapp.azure.com:9002',
+  occApiPrefix: build.process.env.SPARTACUS_API_PREFIX ?? '/occ/v2/',
   cds: build.process.env.SPARTACUS_CDS,
   b2b: build.process.env.SPARTACUS_B2B,
 };

--- a/projects/storefrontapp/src/environments/environment.prod.ts
+++ b/projects/storefrontapp/src/environments/environment.prod.ts
@@ -4,7 +4,7 @@ export const environment: Environment = {
   production: true,
   occBaseUrl:
     build.process.env.SPARTACUS_BASE_URL ??
-    'https://dev-com-17.accdemo.b2c.ydev.hybris.com:9002',
+    'https://spartacus-legacy.eastus.cloudapp.azure.com:9002',
   occApiPrefix: build.process.env.SPARTACUS_API_PREFIX ?? '/rest/v2/',
   cds: build.process.env.SPARTACUS_CDS,
   b2b: build.process.env.SPARTACUS_B2B,

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -8,8 +8,8 @@ import { Environment } from './models/environment.model';
 export const environment: Environment = {
   production: false,
   occBaseUrl:
-    'https://dev-com-17.accdemo.b2c.ydev.hybris.com:9002' ||
-    // 'https://dev-com-7.accdemo.b2c.ydev.hybris.com:9002' ||
+    'https://spartacus-legacy.eastus.cloudapp.azure.com:9002' ||
+    // 'https://spartacus-dev3.eastus.cloudapp.azure.com:9002' ||
     // 'https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com' ||
     build.process.env.SPARTACUS_BASE_URL,
   occApiPrefix: '/rest/v2/',

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -8,11 +8,11 @@ import { Environment } from './models/environment.model';
 export const environment: Environment = {
   production: false,
   occBaseUrl:
-    'https://spartacus-legacy.eastus.cloudapp.azure.com:9002' ||
+    'https://spartacus-dev0.eastus.cloudapp.azure.com:9002' ||
     // 'https://spartacus-dev3.eastus.cloudapp.azure.com:9002' ||
     // 'https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com' ||
     build.process.env.SPARTACUS_BASE_URL,
-  occApiPrefix: '/rest/v2/',
+  occApiPrefix: '/occ/v2/',
   b2b: false,
   cds: false,
 };


### PR DESCRIPTION
closes GH-8066

requirements:

- develop vs 2005
- develop vs 1905
- **maintenance vs 2005**  -- this pr

jenkins job for testing: https://jkmaster.test.c3po.b2c.ydev.hybris.com/job/test-azure-spartacus-regression-tests-maintenance/
builds starting after build 13 because previous builds were running on 1905 l