### PR TITLE
Revert "GH-3194 Need consistent "Default" wording for AddressBook and PaymentDetails"

### DIFF
--- a/projects/assets/src/translations/en/payment.ts
+++ b/projects/assets/src/translations/en/payment.ts
@@ -32,7 +32,7 @@ export const payment = {
     deleteConfirmation: 'Are you sure you want to delete this payment method?',
     setAsDefault: 'Set as default',
     expires: 'Expires: {{ month }}/{{ year }}',
-    defaultPaymentMethod: '✓ DEFAULT',
+    defaultPaymentMethod: 'Default Payment Method',
     selected: 'Selected',
   },
 };

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/applied-promotions.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/applied-promotions.ts
@@ -65,7 +65,7 @@ export function selectPaymentMethod() {
   cy.get('cx-order-summary .cx-summary-partials .cx-summary-total')
     .find('.cx-summary-amount')
     .should('not.be.empty');
-  cy.get('.cx-card-title').should('contain', '✓ DEFAULT');
+  cy.get('.cx-card-title').should('contain', 'Default Payment Method');
   cy.get('.card-header').should('contain', 'Selected');
   cy.get('button.btn-primary').click();
   // cannot use cy.visit here, as review order is unavailable

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -202,7 +202,7 @@ export function selectPaymentMethod() {
   cy.get('cx-order-summary .cx-summary-partials .cx-summary-total')
     .find('.cx-summary-amount')
     .should('not.be.empty');
-  cy.get('.cx-card-title').should('contain', '✓ DEFAULT');
+  cy.get('.cx-card-title').should('contain', 'Default Payment Method');
   cy.get('.card-header').should('contain', 'Selected');
   cy.get('button.btn-primary').click();
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/payment-methods.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/payment-methods.ts
@@ -96,7 +96,7 @@ export function setOtherPaymentToDefault() {
     .click({ force: true });
 
   const firstCard = cy.get('.cx-payment-card').first();
-  firstCard.should('contain', '✓ DEFAULT');
+  firstCard.should('contain', 'Default Payment Method');
   firstCard.should('contain', '1234');
   firstCard.should('contain', `Expires: 03/2126`);
 }
@@ -126,7 +126,7 @@ export function deletePayment() {
 
   // verify remaining address is now the default one
   const defaultCard = cy.get('.cx-payment-card');
-  defaultCard.should('contain', '✓ DEFAULT');
+  defaultCard.should('contain', 'Default Payment Method');
   defaultCard.should('contain', 'test user');
 }
 

--- a/projects/storefrontlib/src/cms-components/checkout/components/payment-method/payment-method.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/payment-method/payment-method.component.spec.ts
@@ -403,7 +403,7 @@ describe('PaymentMethodComponent', () => {
         component['createCard'](
           selectedPaymentMethod,
           {
-            textDefaultPaymentMethod: '✓ DEFAULT',
+            textDefaultPaymentMethod: 'Default payment method',
             textExpires: 'Expires',
             textUseThisPayment: 'Use this payment',
             textSelected: 'Selected',
@@ -411,7 +411,7 @@ describe('PaymentMethodComponent', () => {
           selectedPaymentMethod
         )
       ).toEqual({
-        title: '✓ DEFAULT',
+        title: 'Default payment method',
         textBold: 'Name',
         text: ['123456789', 'Expires'],
         img: 'CREDIT_CARD',


### PR DESCRIPTION
Reverts SAP/spartacus#8120

Reverting due to [breaking changes](https://sap.github.io/spartacus-docs/breaking-changes/#avoiding-breaking-changes). Create another PR for 3.0