### PR TITLE
feat: Allow for getting `code` from routing independently of component nesting

### DIFF
--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.spec.ts
@@ -8,10 +8,16 @@ import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/
 import { IconTestingModule } from 'projects/storefrontlib/src/cms-components/misc/icon/testing/icon-testing.module';
 import { SplitViewTestingModule } from 'projects/storefrontlib/src/shared/components/split-view/testing/spit-view-testing.module';
 import { of } from 'rxjs';
+import { CurrentCostCenterService } from '../../current-cost-center.service';
 import { CostCenterAssignBudgetsComponent } from './cost-center-assign-budget.component';
 import { CostCenterAssignBudgetListService } from './cost-center-assign-budget.service';
 
 const costCenterCode = 'costCenterCode';
+
+class MockCurrentCostCenterService
+  implements Partial<CurrentCostCenterService> {
+  code$ = of(costCenterCode);
+}
 
 const mockBudgetList: Table<Budget> = {
   data: [
@@ -65,6 +71,10 @@ describe('CostCenterAssignBudgetsComponent', () => {
         {
           provide: CostCenterAssignBudgetListService,
           useClass: MockCostCenterBudgetListService,
+        },
+        {
+          provide: CurrentCostCenterService,
+          useClass: MockCurrentCostCenterService,
         },
       ],
     }).compileComponents();
@@ -143,6 +153,14 @@ describe('CostCenterAssignBudgetsComponent', () => {
     it('should not show is-empty message', () => {
       const el = fixture.debugElement.query(By.css('p.is-empty'));
       expect(el).toBeTruthy();
+    });
+  });
+
+  describe('code$', () => {
+    it('should emit the current cost center code', () => {
+      let result;
+      component.code$.subscribe((r) => (result = r)).unsubscribe();
+      expect(result).toBe(costCenterCode);
     });
   });
 });

--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.spec.ts
@@ -1,6 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Budget, I18nTestingModule } from '@spartacus/core';
 import { Table, TableModule } from '@spartacus/storefront';
@@ -36,13 +35,6 @@ const mockBudgetList: Table<Budget> = {
   structure: { type: '' },
 };
 
-class MockActivatedRoute {
-  parent = {
-    params: of({ code: costCenterCode }),
-  };
-  snapshot = {};
-}
-
 class MockCostCenterBudgetListService {
   getTable(_code) {
     return of(mockBudgetList);
@@ -67,7 +59,6 @@ describe('CostCenterAssignBudgetsComponent', () => {
       ],
       declarations: [CostCenterAssignBudgetsComponent],
       providers: [
-        { provide: ActivatedRoute, useClass: MockActivatedRoute },
         {
           provide: CostCenterAssignBudgetListService,
           useClass: MockCostCenterBudgetListService,

--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.ts
@@ -1,29 +1,23 @@
 import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { PaginationModel } from '@spartacus/core';
 import { Table } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { pluck, switchMap } from 'rxjs/operators';
+import { CurrentCostCenterService } from '../../current-cost-center-code';
 import { CostCenterAssignBudgetListService } from './cost-center-assign-budget.service';
-import { PaginationModel } from '@spartacus/core';
 
 @Component({
   selector: 'cx-cost-center-assign-budget',
   templateUrl: './cost-center-assign-budget.component.html',
 })
 export class CostCenterAssignBudgetsComponent {
-  code$: Observable<string> = this.activateRoute.parent.parent.params.pipe(
-    map((params) => params['code'])
-  );
-
+  code$ = this.currentCostCenterService$.get().pipe(pluck('code'));
   dataTable$: Observable<Table> = this.code$.pipe(
     switchMap((code) => this.assignService.getTable(code))
   );
 
   constructor(
-    // we can't do without the router as the routingService is unable to
-    // resolve the parent routing params. `paramsInheritanceStrategy: 'always'`
-    // would actually fix that.
-    protected activateRoute: ActivatedRoute,
+    protected currentCostCenterService$: CurrentCostCenterService,
     protected assignService: CostCenterAssignBudgetListService
   ) {}
 

--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { PaginationModel } from '@spartacus/core';
 import { Table } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
-import { pluck, switchMap } from 'rxjs/operators';
+import { switchMap } from 'rxjs/operators';
 import { CurrentCostCenterService } from '../../current-cost-center-code';
 import { CostCenterAssignBudgetListService } from './cost-center-assign-budget.service';
 
@@ -11,7 +11,11 @@ import { CostCenterAssignBudgetListService } from './cost-center-assign-budget.s
   templateUrl: './cost-center-assign-budget.component.html',
 })
 export class CostCenterAssignBudgetsComponent {
-  code$ = this.currentCostCenterService$.get().pipe(pluck('code'));
+  /**
+   * The code of the current cost center.
+   */
+  code$ = this.currentCostCenterService$.code$;
+
   dataTable$: Observable<Table> = this.code$.pipe(
     switchMap((code) => this.assignService.getTable(code))
   );

--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/assign/cost-center-assign-budget.component.ts
@@ -3,7 +3,7 @@ import { PaginationModel } from '@spartacus/core';
 import { Table } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
-import { CurrentCostCenterService } from '../../current-cost-center-code';
+import { CurrentCostCenterService } from '../../current-cost-center.service';
 import { CostCenterAssignBudgetListService } from './cost-center-assign-budget.service';
 
 @Component({

--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.spec.ts
@@ -7,6 +7,7 @@ import { Table, TableModule } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { IconTestingModule } from 'projects/storefrontlib/src/cms-components/misc/icon/testing/icon-testing.module';
 import { of } from 'rxjs';
+import { CurrentCostCenterService } from '../../current-cost-center.service';
 import { CostCenterBudgetListComponent } from './cost-center-budget-list.component';
 import { CostCenterBudgetListService } from './cost-center-budget-list.service';
 
@@ -17,6 +18,11 @@ class MockActivatedRoute {
     return of({ code: costCenterCode });
   }
   snapshot = {};
+}
+
+class MockCurrentCostCenterService
+  implements Partial<CurrentCostCenterService> {
+  code$ = of(costCenterCode);
 }
 
 const mockBudgetList: Table<Budget> = {
@@ -79,6 +85,10 @@ describe('CostCenterBudgetListComponent', () => {
           provide: CostCenterBudgetListService,
           useClass: MockCostCenterBudgetListService,
         },
+        {
+          provide: CurrentCostCenterService,
+          useClass: MockCurrentCostCenterService,
+        },
       ],
     }).compileComponents();
     service = TestBed.inject(CostCenterBudgetListService);
@@ -136,6 +146,14 @@ describe('CostCenterBudgetListComponent', () => {
     it('should not show is-empty message', () => {
       const el = fixture.debugElement.query(By.css('p.is-empty'));
       expect(el).toBeTruthy();
+    });
+  });
+
+  describe('code$', () => {
+    it('should emit the current cost center code', () => {
+      let result;
+      component.code$.subscribe((r) => (result = r)).unsubscribe();
+      expect(result).toBe(costCenterCode);
     });
   });
 });

--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.spec.ts
@@ -1,6 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Budget, I18nTestingModule } from '@spartacus/core';
 import { Table, TableModule } from '@spartacus/storefront';
@@ -12,13 +11,6 @@ import { CostCenterBudgetListComponent } from './cost-center-budget-list.compone
 import { CostCenterBudgetListService } from './cost-center-budget-list.service';
 
 const costCenterCode = 'costCenterCode';
-
-class MockActivatedRoute {
-  get params() {
-    return of({ code: costCenterCode });
-  }
-  snapshot = {};
-}
 
 class MockCurrentCostCenterService
   implements Partial<CurrentCostCenterService> {
@@ -80,7 +72,6 @@ describe('CostCenterBudgetListComponent', () => {
       ],
       declarations: [CostCenterBudgetListComponent],
       providers: [
-        { provide: ActivatedRoute, useClass: MockActivatedRoute },
         {
           provide: CostCenterBudgetListService,
           useClass: MockCostCenterBudgetListService,

--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { Table } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
-import { pluck, switchMap, take } from 'rxjs/operators';
+import { switchMap, take } from 'rxjs/operators';
 import { CurrentCostCenterService } from '../../current-cost-center-code';
 import { CostCenterBudgetListService } from './cost-center-budget-list.service';
 
@@ -10,7 +10,10 @@ import { CostCenterBudgetListService } from './cost-center-budget-list.service';
   templateUrl: './cost-center-budget-list.component.html',
 })
 export class CostCenterBudgetListComponent {
-  code$ = this.currentCostCenterService$.get().pipe(pluck('code'));
+  /**
+   * The code of the current cost center.
+   */
+  code$ = this.currentCostCenterService$.code$;
 
   dataTable$: Observable<Table> = this.code$.pipe(
     switchMap((code) => this.costCenterBudgetListService.getTable(code))

--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { Table } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
 import { switchMap, take } from 'rxjs/operators';
-import { CurrentCostCenterService } from '../../current-cost-center-code';
+import { CurrentCostCenterService } from '../../current-cost-center.service';
 import { CostCenterBudgetListService } from './cost-center-budget-list.service';
 
 @Component({

--- a/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/budgets/list/cost-center-budget-list.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { Table } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
-import { map, switchMap, take } from 'rxjs/operators';
+import { pluck, switchMap, take } from 'rxjs/operators';
+import { CurrentCostCenterService } from '../../current-cost-center-code';
 import { CostCenterBudgetListService } from './cost-center-budget-list.service';
 
 @Component({
@@ -10,16 +10,14 @@ import { CostCenterBudgetListService } from './cost-center-budget-list.service';
   templateUrl: './cost-center-budget-list.component.html',
 })
 export class CostCenterBudgetListComponent {
-  code$: Observable<string> = this.route.parent.params.pipe(
-    map((routingData) => routingData['code'])
-  );
+  code$ = this.currentCostCenterService$.get().pipe(pluck('code'));
 
   dataTable$: Observable<Table> = this.code$.pipe(
     switchMap((code) => this.costCenterBudgetListService.getTable(code))
   );
 
   constructor(
-    protected route: ActivatedRoute,
+    protected currentCostCenterService$: CurrentCostCenterService,
     protected costCenterBudgetListService: CostCenterBudgetListService
   ) {}
 

--- a/feature-libs/my-account/organization/src/components/cost-center/current-cost-center-code.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/current-cost-center-code.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { CostCenter, CostCenterService } from '@spartacus/core';
+import { Observable, of } from 'rxjs';
+import {
+  distinctUntilChanged,
+  filter,
+  pluck,
+  switchMap,
+  switchMapTo,
+  tap,
+} from 'rxjs/operators';
+
+/**
+ * Provides appropriate model based on the code taken from the routing params.
+ */
+@Injectable()
+export class CurrentCostCenterService {
+  constructor(
+    protected service: CostCenterService,
+    protected route: ActivatedRoute
+  ) {}
+
+  protected readonly code$ = this.route.params.pipe(
+    pluck('code') // spike todo: this will work for many pages, not only for costCenterDetails :/
+  );
+
+  /**
+   * Emits current model or null, if there is no model available (we are on route without `code` param).
+   */
+  protected readonly model$: Observable<CostCenter> = this.code$.pipe(
+    switchMap((code: string) => {
+      return code ? this.service.get(code) : of(null);
+    }),
+    filter((x) => x !== undefined),
+    distinctUntilChanged()
+  );
+
+  protected readonly reloadingModel$ = this.code$.pipe(
+    tap((code) => this.service.load(code)),
+    switchMapTo(this.model$)
+  );
+
+  get(options?: { forceReload?: boolean }) {
+    return options.forceReload ? this.reloadingModel$ : this.model$;
+  }
+}

--- a/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.spec.ts
@@ -67,7 +67,7 @@ describe('CurrentCostCenterService', () => {
       spyOn(costCenterService, 'get').and.returnValue(of(mockCostCenter));
 
       let result;
-      service.model$.subscribe((value) => (result = value));
+      service.costCenter$.subscribe((value) => (result = value));
       mockParams.next({ code: '123' });
       expect(costCenterService.get).toHaveBeenCalledWith('123');
       expect(result).toBe(mockCostCenter);
@@ -77,7 +77,7 @@ describe('CurrentCostCenterService', () => {
       spyOn(costCenterService, 'get');
 
       let result;
-      service.model$.subscribe((value) => (result = value));
+      service.costCenter$.subscribe((value) => (result = value));
       mockParams.next({});
       expect(costCenterService.get).not.toHaveBeenCalled();
       expect(result).toBe(null);

--- a/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.spec.ts
@@ -1,0 +1,86 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { CostCenter, CostCenterService } from '@spartacus/core';
+import { of, Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { CurrentCostCenterService } from './current-cost-center.service';
+
+export class MockCostCenterService implements Partial<CostCenterService> {
+  get() {
+    return of(undefined);
+  }
+}
+
+describe('CurrentCostCenterService', () => {
+  let service: CurrentCostCenterService;
+  let costCenterService: CostCenterService;
+  let mockParams: Subject<object>;
+
+  beforeEach(() => {
+    mockParams = new Subject();
+
+    TestBed.configureTestingModule({
+      providers: [
+        CurrentCostCenterService,
+        { provide: ActivatedRoute, useValue: { params: mockParams } },
+        { provide: CostCenterService, useClass: MockCostCenterService },
+      ],
+    });
+
+    costCenterService = TestBed.inject(CostCenterService);
+    service = TestBed.inject(CurrentCostCenterService);
+  });
+
+  afterEach(() => {
+    mockParams.complete();
+  });
+
+  describe('code$', () => {
+    it('should return undefined when route param `code` is undefined', async () => {
+      const results = [];
+      service.code$.pipe(take(2)).subscribe((value) => results.push(value));
+      mockParams.next({ code: 'code1' });
+      mockParams.next({ code: 'code2' });
+      expect(results).toEqual(['code1', 'code2']);
+    });
+
+    it('should expose route param `code` from activated route', () => {
+      const results = [];
+      service.code$.subscribe((value) => results.push(value));
+      mockParams.next({ code: 'code1' });
+      mockParams.next({ code: 'code2' });
+      expect(results).toEqual(['code1', 'code2']);
+    });
+
+    it('should not emit when param `code` did not change', () => {
+      const results = [];
+      service.code$.subscribe((value) => results.push(value));
+      mockParams.next({ name: 'name1', code: 'code' });
+      mockParams.next({ name: 'name2', code: 'code' });
+      expect(results).toEqual(['code']);
+    });
+  });
+
+  describe('model$', () => {
+    it('should expose model for the current routing param `code`', () => {
+      const mockCostCenter: CostCenter = { name: 'test cost center' };
+      spyOn(costCenterService, 'get').and.returnValue(of(mockCostCenter));
+
+      let result;
+      service.model$.subscribe((value) => (result = value));
+      mockParams.next({ code: '123' });
+      expect(costCenterService.get).toHaveBeenCalledWith('123');
+      expect(result).toBe(mockCostCenter);
+    });
+
+    it('should emit null when no current param `code`', () => {
+      spyOn(costCenterService, 'get');
+
+      let result;
+      service.model$.subscribe((value) => (result = value));
+      mockParams.next({});
+      expect(costCenterService.get).not.toHaveBeenCalled();
+      expect(result).toBe(null);
+    });
+  });
+});

--- a/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.ts
@@ -7,7 +7,7 @@ import { distinctUntilChanged, pluck, switchMap } from 'rxjs/operators';
 /**
  * Provides appropriate model based on the routing params.
  *
- * It's meant not to be provided in the root injector, but on the level
+ * It's NOT meant to be provided in the root injector, BUT on the level
  * of the component activated by the route with routing params.
  */
 @Injectable()

--- a/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.ts
@@ -8,7 +8,7 @@ import { distinctUntilChanged, pluck, switchMap } from 'rxjs/operators';
  * Provides appropriate model based on the routing params.
  *
  * It's meant not to be provided in the root injector, but on the level
- * of the component activated byt the route with routing params.
+ * of the component activated by the route with routing params.
  */
 @Injectable()
 export class CurrentCostCenterService {

--- a/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.ts
@@ -25,7 +25,7 @@ export class CurrentCostCenterService {
   /**
    * Emits the current model or null, if there is no model available
    */
-  readonly model$: Observable<CostCenter> = this.code$.pipe(
+  readonly costCenter$: Observable<CostCenter> = this.code$.pipe(
     switchMap((code: string) => (code ? this.service.get(code) : of(null)))
   );
 }

--- a/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/current-cost-center.service.ts
@@ -5,12 +5,10 @@ import { Observable, of } from 'rxjs';
 import { distinctUntilChanged, pluck, switchMap } from 'rxjs/operators';
 
 /**
- * Provides appropriate model based on the `code` taken from the routing params.
+ * Provides appropriate model based on the routing params.
  *
- * It's meant to be provided on the component level so all the child components
- * can inject the model provided by the parent component. It's useful especially,
- * when child components are activated by nested <router-outlet> (so they can't
- * get the model via `@Input`).
+ * It's meant not to be provided in the root injector, but on the level
+ * of the component activated byt the route with routing params.
  */
 @Injectable()
 export class CurrentCostCenterService {

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.spec.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
   CostCenter,
@@ -39,12 +38,6 @@ class MockCostCenterService implements Partial<CostCenterService> {
   update = createSpy('update');
 }
 
-class MockActivatedRoute {
-  params = of({ code: costCenterCode });
-
-  snapshot = {};
-}
-
 class MockModalService {
   open() {}
 }
@@ -75,7 +68,6 @@ describe('CostCenterDetailsComponent', () => {
         MockCostCenterBudgetListComponent,
       ],
       providers: [
-        { provide: ActivatedRoute, useClass: MockActivatedRoute },
         { provide: CostCenterService, useClass: MockCostCenterService },
         { provide: ModalService, useClass: MockModalService },
       ],

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.spec.ts
@@ -30,7 +30,7 @@ const mockCostCenter: CostCenter = {
 class MockCurrentCostCenterService
   implements Partial<CurrentCostCenterService> {
   code$ = of(costCenterCode);
-  model$ = of(mockCostCenter);
+  costCenter$ = of(mockCostCenter);
 }
 
 class MockCostCenterService implements Partial<CostCenterService> {

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.spec.ts
@@ -30,12 +30,12 @@ const mockCostCenter: CostCenter = {
 class MockCurrentCostCenterService
   implements Partial<CurrentCostCenterService> {
   code$ = of(costCenterCode);
-  costCenter$ = of(mockCostCenter);
 }
 
 class MockCostCenterService implements Partial<CostCenterService> {
   load = createSpy('load');
   update = createSpy('update');
+  get = createSpy('get').and.returnValue(of(mockCostCenter));
 }
 
 class MockModalService {

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
@@ -21,7 +21,7 @@ export class CostCenterDetailsComponent {
     CostCenter
   > = this.currentCostCenterService.code$.pipe(
     tap((code) => this.costCenterService.load(code)),
-    switchMapTo(this.currentCostCenterService.model$),
+    switchMapTo(this.currentCostCenterService.costCenter$),
     shareReplay({ bufferSize: 1, refCount: true }) // we have side effects here, we want the to run only once
   );
 

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
@@ -1,30 +1,23 @@
 import { ChangeDetectionStrategy, Component, TemplateRef } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { CostCenter, CostCenterService } from '@spartacus/core';
 import { ModalService } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
-import { filter, map, switchMap, tap } from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
+import { CurrentCostCenterService } from '../current-cost-center-code';
 
 @Component({
   selector: 'cx-cost-center-details',
   templateUrl: './cost-center-details.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [CurrentCostCenterService],
 })
 export class CostCenterDetailsComponent {
-  protected code$: Observable<string> = this.route.params.pipe(
-    map((params) => params['code']),
-    filter((code) => Boolean(code))
-  );
-
-  costCenter$: Observable<CostCenter> = this.code$.pipe(
-    // TODO: we should do this in the facade
-    tap((code) => this.costCentersService.load(code)),
-    switchMap((code) => this.costCentersService.get(code)),
-    filter((costCenters) => Boolean(costCenters))
-  );
+  costCenter$: Observable<CostCenter> = this.currentCostCenterService
+    .get({ forceReload: true })
+    .pipe(filter((costCenters) => Boolean(costCenters)));
 
   constructor(
-    protected route: ActivatedRoute,
+    protected currentCostCenterService: CurrentCostCenterService,
     protected costCentersService: CostCenterService,
     // TODO: consider relying on css only
     protected modalService: ModalService

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
@@ -15,25 +15,25 @@ export class CostCenterDetailsComponent {
   /**
    * The model of the current cost center.
    *
-   * It reloads the model when trying to get it.
+   * It reloads the model when the code of the current cost center changes.
    */
   costCenter$: Observable<
     CostCenter
   > = this.currentCostCenterService.code$.pipe(
-    tap((code) => this.costCentersService.load(code)),
+    tap((code) => this.costCenterService.load(code)),
     switchMapTo(this.currentCostCenterService.model$),
     filter(Boolean)
   );
 
   constructor(
     protected currentCostCenterService: CurrentCostCenterService,
-    protected costCentersService: CostCenterService,
+    protected costCenterService: CostCenterService,
     // TODO: consider relying on css only
     protected modalService: ModalService
   ) {}
 
   update(costCenter: CostCenter) {
-    this.costCentersService.update(costCenter.code, costCenter);
+    this.costCenterService.update(costCenter.code, costCenter);
   }
 
   openModal(template: TemplateRef<any>): void {

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, TemplateRef } from '@angular/core';
 import { CostCenter, CostCenterService } from '@spartacus/core';
 import { ModalService } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
-import { filter, switchMapTo, tap } from 'rxjs/operators';
+import { shareReplay, switchMapTo, tap } from 'rxjs/operators';
 import { CurrentCostCenterService } from '../current-cost-center.service';
 
 @Component({
@@ -22,7 +22,7 @@ export class CostCenterDetailsComponent {
   > = this.currentCostCenterService.code$.pipe(
     tap((code) => this.costCenterService.load(code)),
     switchMapTo(this.currentCostCenterService.model$),
-    filter(Boolean)
+    shareReplay({ bufferSize: 1, refCount: true }) // we have side effects here, we want the to run only once
   );
 
   constructor(

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
@@ -3,7 +3,7 @@ import { CostCenter, CostCenterService } from '@spartacus/core';
 import { ModalService } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
 import { filter, switchMapTo, tap } from 'rxjs/operators';
-import { CurrentCostCenterService } from '../current-cost-center-code';
+import { CurrentCostCenterService } from '../current-cost-center.service';
 
 @Component({
   selector: 'cx-cost-center-details',

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, TemplateRef } from '@angular/core';
 import { CostCenter, CostCenterService } from '@spartacus/core';
 import { ModalService } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, switchMapTo, tap } from 'rxjs/operators';
 import { CurrentCostCenterService } from '../current-cost-center-code';
 
 @Component({
@@ -12,9 +12,18 @@ import { CurrentCostCenterService } from '../current-cost-center-code';
   providers: [CurrentCostCenterService],
 })
 export class CostCenterDetailsComponent {
-  costCenter$: Observable<CostCenter> = this.currentCostCenterService
-    .get({ forceReload: true })
-    .pipe(filter((costCenters) => Boolean(costCenters)));
+  /**
+   * The model of the current cost center.
+   *
+   * It reloads the model when trying to get it.
+   */
+  costCenter$: Observable<
+    CostCenter
+  > = this.currentCostCenterService.code$.pipe(
+    tap((code) => this.costCentersService.load(code)),
+    switchMapTo(this.currentCostCenterService.model$),
+    filter(Boolean)
+  );
 
   constructor(
     protected currentCostCenterService: CurrentCostCenterService,

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, TemplateRef } from '@angular/core';
 import { CostCenter, CostCenterService } from '@spartacus/core';
 import { ModalService } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
-import { shareReplay, switchMapTo, tap } from 'rxjs/operators';
+import { shareReplay, switchMap, tap } from 'rxjs/operators';
 import { CurrentCostCenterService } from '../current-cost-center.service';
 
 @Component({
@@ -21,7 +21,7 @@ export class CostCenterDetailsComponent {
     CostCenter
   > = this.currentCostCenterService.code$.pipe(
     tap((code) => this.costCenterService.load(code)),
-    switchMapTo(this.currentCostCenterService.costCenter$),
+    switchMap((code) => this.costCenterService.get(code)),
     shareReplay({ bufferSize: 1, refCount: true }) // we have side effects here, we want the to run only once
   );
 

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
@@ -3,7 +3,6 @@ import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
   CostCenter,
@@ -65,14 +64,6 @@ class MockRoutingService {
   );
 }
 
-class MockActivatedRoute {
-  parent = {
-    params: of({ code: costCenterCode }),
-  };
-  snapshot = {};
-  go() {}
-}
-
 describe('CostCenterEditComponent', () => {
   let component: CostCenterEditComponent;
   let fixture: ComponentFixture<CostCenterEditComponent>;
@@ -94,7 +85,6 @@ describe('CostCenterEditComponent', () => {
       ],
       declarations: [CostCenterEditComponent, MockCostCenterFormComponent],
       providers: [
-        { provide: ActivatedRoute, useClass: MockActivatedRoute },
         { provide: RoutingService, useClass: MockRoutingService },
         { provide: CostCenterService, useClass: MockCostCenterService },
         {

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
@@ -45,8 +45,8 @@ class MockCurrentCostCenterService
 }
 
 class MockCostCenterService implements Partial<CostCenterService> {
-  update(_costCenterCode: string, _costCenter: CostCenter) {}
-  load(_costCenterCode: string) {}
+  update = createSpy('update');
+  load = createSpy('load');
 }
 
 const mockRouterState = {
@@ -67,7 +67,7 @@ class MockRoutingService {
 describe('CostCenterEditComponent', () => {
   let component: CostCenterEditComponent;
   let fixture: ComponentFixture<CostCenterEditComponent>;
-  let costCenterService: MockCostCenterService;
+  let costCenterService: CostCenterService;
   let routingService: RoutingService;
   let saveButton;
   let costCenterFormComponent;
@@ -125,7 +125,6 @@ describe('CostCenterEditComponent', () => {
     });
 
     it('should create cost center', () => {
-      spyOn(costCenterService, 'update');
       saveButton.nativeElement.click();
       expect(costCenterService.update).toHaveBeenCalled();
     });

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
@@ -41,12 +41,12 @@ const mockCostCenter: CostCenter = {
 class MockCurrentCostCenterService
   implements Partial<CurrentCostCenterService> {
   code$ = of(costCenterCode);
-  costCenter$ = of(mockCostCenter);
 }
 
 class MockCostCenterService implements Partial<CostCenterService> {
   update = createSpy('update');
   load = createSpy('load');
+  get = createSpy('get').and.returnValue(of(mockCostCenter));
 }
 
 const mockRouterState = {

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
@@ -13,9 +14,9 @@ import {
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { IconTestingModule } from 'projects/storefrontlib/src/cms-components/misc/icon/testing/icon-testing.module';
 import { SplitViewTestingModule } from 'projects/storefrontlib/src/shared/components/split-view/testing/spit-view-testing.module';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
+import { CurrentCostCenterService } from '../current-cost-center.service';
 import { CostCenterEditComponent } from './cost-center-edit.component';
-import { By } from '@angular/platform-browser';
 import createSpy = jasmine.createSpy;
 
 @Component({
@@ -38,10 +39,13 @@ const mockCostCenter: CostCenter = {
   unit: { name: 'orgName', uid: 'orgCode' },
 };
 
+class MockCurrentCostCenterService
+  implements Partial<CurrentCostCenterService> {
+  code$ = of(costCenterCode);
+  model$ = of(mockCostCenter);
+}
+
 class MockCostCenterService implements Partial<CostCenterService> {
-  get(_costCenterCode: string): Observable<CostCenter> {
-    return of(mockCostCenter);
-  }
   update(_costCenterCode: string, _costCenter: CostCenter) {}
   load(_costCenterCode: string) {}
 }
@@ -93,6 +97,10 @@ describe('CostCenterEditComponent', () => {
         { provide: ActivatedRoute, useClass: MockActivatedRoute },
         { provide: RoutingService, useClass: MockRoutingService },
         { provide: CostCenterService, useClass: MockCostCenterService },
+        {
+          provide: CurrentCostCenterService,
+          useClass: MockCurrentCostCenterService,
+        },
       ],
     }).compileComponents();
 

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
@@ -138,4 +138,8 @@ describe('CostCenterEditComponent', () => {
       });
     });
   });
+
+  it('should trigger reload of cost center model on each code change', () => {
+    expect(costCenterService.load).toHaveBeenCalledWith(mockCostCenter.code);
+  });
 });

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.spec.ts
@@ -41,7 +41,7 @@ const mockCostCenter: CostCenter = {
 class MockCurrentCostCenterService
   implements Partial<CurrentCostCenterService> {
   code$ = of(costCenterCode);
-  model$ = of(mockCostCenter);
+  costCenter$ = of(mockCostCenter);
 }
 
 class MockCostCenterService implements Partial<CostCenterService> {

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 import {
   map,
   shareReplay,
-  switchMapTo,
+  switchMap,
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
@@ -33,7 +33,7 @@ export class CostCenterEditComponent {
     CostCenter
   > = this.currentCostCenterService.code$.pipe(
     tap((code) => this.costCenterService.load(code)),
-    switchMapTo(this.currentCostCenterService.costCenter$),
+    switchMap((code) => this.costCenterService.get(code)),
     shareReplay({ bufferSize: 1, refCount: true }) // we have side effects here, we want the to run only once
   );
 

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.ts
@@ -33,7 +33,7 @@ export class CostCenterEditComponent {
     CostCenter
   > = this.currentCostCenterService.code$.pipe(
     tap((code) => this.costCenterService.load(code)),
-    switchMapTo(this.currentCostCenterService.model$),
+    switchMapTo(this.currentCostCenterService.costCenter$),
     shareReplay({ bufferSize: 1, refCount: true }) // we have side effects here, we want the to run only once
   );
 

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.ts
@@ -11,7 +11,7 @@ import {
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
-import { CurrentCostCenterService } from '../current-cost-center-code';
+import { CurrentCostCenterService } from '../current-cost-center.service';
 import { CostCenterFormService } from '../form/cost-center-form.service';
 
 @Component({

--- a/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/edit/cost-center-edit.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute } from '@angular/router';
 import { CostCenter, CostCenterService, RoutingService } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import {
-  filter,
   map,
   shareReplay,
   switchMapTo,
@@ -35,7 +34,6 @@ export class CostCenterEditComponent {
   > = this.currentCostCenterService.code$.pipe(
     tap((code) => this.costCenterService.load(code)),
     switchMapTo(this.currentCostCenterService.model$),
-    filter(Boolean),
     shareReplay({ bufferSize: 1, refCount: true }) // we have side effects here, we want the to run only once
   );
 

--- a/feature-libs/my-account/organization/src/components/cost-center/index.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/index.ts
@@ -2,6 +2,7 @@ export * from './budgets/assign/index';
 export * from './budgets/list/index';
 export * from './cost-center-components.module';
 export * from './create/index';
+export * from './current-cost-center-code';
 export * from './details/index';
 export * from './edit/index';
 export * from './form/index';

--- a/feature-libs/my-account/organization/src/components/cost-center/index.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/index.ts
@@ -2,7 +2,7 @@ export * from './budgets/assign/index';
 export * from './budgets/list/index';
 export * from './cost-center-components.module';
 export * from './create/index';
-export * from './current-cost-center-code';
+export * from './current-cost-center.service';
 export * from './details/index';
 export * from './edit/index';
 export * from './form/index';


### PR DESCRIPTION
Opt out of `this.activatedRoute.parent.parent.parent...` by providing locally `CurrentCostCenterService` on the level of the parent component that is activated with direct access to route with params.

The service exposes `code$` as well as the `costCenter$` model

closes GH-8308 