### PR TITLE
fix: align event names

### DIFF
--- a/projects/storefrontlib/src/events/cart/cart-page-event.builder.spec.ts
+++ b/projects/storefrontlib/src/events/cart/cart-page-event.builder.spec.ts
@@ -3,9 +3,9 @@ import { Action, ActionsSubject } from '@ngrx/store';
 import { createFrom, EventService } from '@spartacus/core';
 import { Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { PageVisitedEvent } from '../page';
+import { PageEvent } from '../page';
 import { CartPageEventBuilder } from './cart-page-event.builder';
-import { CartPageVisitedEvent } from './cart-page.events';
+import { CartPageEvent } from './cart-page.events';
 
 interface ActionWithPayload extends Action {
   payload: any;
@@ -25,20 +25,20 @@ describe('CartPageEventBuilder', () => {
     eventService = TestBed.inject(EventService);
   });
 
-  it('CartPageVisitedEvent', () => {
-    let result: CartPageVisitedEvent;
+  it('CartPageEvent', () => {
+    let result: CartPageEvent;
     eventService
-      .get(CartPageVisitedEvent)
+      .get(CartPageEvent)
       .pipe(take(1))
       .subscribe((value) => (result = value));
 
-    const pageVisitedEvent = createFrom(PageVisitedEvent, {
+    const pageEvent = createFrom(PageEvent, {
       context: undefined,
       semanticRoute: 'cart',
       url: 'cart url',
       params: undefined,
     });
-    eventService.dispatch(pageVisitedEvent);
+    eventService.dispatch(pageEvent);
     expect(result).toBeTruthy();
   });
 });

--- a/projects/storefrontlib/src/events/cart/cart-page-event.builder.ts
+++ b/projects/storefrontlib/src/events/cart/cart-page-event.builder.ts
@@ -3,8 +3,8 @@ import { ActionsSubject } from '@ngrx/store';
 import { createFrom, EventService } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
-import { PageVisitedEvent } from '../page/page.events';
-import { CartPageVisitedEvent } from './cart-page.events';
+import { PageEvent } from '../page/page.events';
+import { CartPageEvent } from './cart-page.events';
 
 @Injectable({
   providedIn: 'root',
@@ -18,15 +18,13 @@ export class CartPageEventBuilder {
   }
 
   protected register(): void {
-    this.eventService.register(CartPageVisitedEvent, this.buildCartPageEvent());
+    this.eventService.register(CartPageEvent, this.buildCartPageEvent());
   }
 
-  protected buildCartPageEvent(): Observable<CartPageVisitedEvent> {
-    return this.eventService.get(PageVisitedEvent).pipe(
-      filter((pageVisitedEvent) => pageVisitedEvent.semanticRoute === 'cart'),
-      map((pageVisitedEvent) =>
-        createFrom(CartPageVisitedEvent, pageVisitedEvent)
-      )
+  protected buildCartPageEvent(): Observable<CartPageEvent> {
+    return this.eventService.get(PageEvent).pipe(
+      filter((pageEvent) => pageEvent.semanticRoute === 'cart'),
+      map((pageEvent) => createFrom(CartPageEvent, pageEvent))
     );
   }
 }

--- a/projects/storefrontlib/src/events/cart/cart-page.events.ts
+++ b/projects/storefrontlib/src/events/cart/cart-page.events.ts
@@ -1,6 +1,6 @@
-import { PageVisitedEvent } from '../page/page.events';
+import { PageEvent } from '../page/page.events';
 
 /**
  * Indicates that a user visited a cart page.
  */
-export class CartPageVisitedEvent extends PageVisitedEvent {}
+export class CartPageEvent extends PageEvent {}

--- a/projects/storefrontlib/src/events/page/page-event.builder.spec.ts
+++ b/projects/storefrontlib/src/events/page/page-event.builder.spec.ts
@@ -5,7 +5,7 @@ import { ActivatedRouterStateSnapshot, EventService } from '@spartacus/core';
 import { Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { PageEventBuilder } from './page-event.builder';
-import { HomePageVisitedEvent, PageVisitedEvent } from './page.events';
+import { HomePageEvent, PageEvent } from './page.events';
 
 interface ActionWithPayload extends Action {
   payload: any;
@@ -25,7 +25,7 @@ describe('PageEventBuilder', () => {
     eventService = TestBed.inject(EventService);
   });
 
-  it('PageVisitedEvent', () => {
+  it('PageEvent', () => {
     const payload = {
       routerState: {
         semanticRoute: 'aPage',
@@ -33,9 +33,9 @@ describe('PageEventBuilder', () => {
       } as ActivatedRouterStateSnapshot,
     };
 
-    let result: PageVisitedEvent;
+    let result: PageEvent;
     eventService
-      .get(PageVisitedEvent)
+      .get(PageEvent)
       .pipe(take(1))
       .subscribe((value) => (result = value));
 
@@ -43,7 +43,7 @@ describe('PageEventBuilder', () => {
     expect(result).toEqual(jasmine.objectContaining(payload.routerState));
   });
 
-  it('HomePageVisitedEvent', () => {
+  it('HomePageEvent', () => {
     const payload = {
       routerState: {
         semanticRoute: 'home',
@@ -51,9 +51,9 @@ describe('PageEventBuilder', () => {
       } as ActivatedRouterStateSnapshot,
     };
 
-    let result: HomePageVisitedEvent;
+    let result: HomePageEvent;
     eventService
-      .get(HomePageVisitedEvent)
+      .get(HomePageEvent)
       .pipe(take(1))
       .subscribe((value) => (result = value));
 

--- a/projects/storefrontlib/src/events/page/page-event.builder.ts
+++ b/projects/storefrontlib/src/events/page/page-event.builder.ts
@@ -9,7 +9,7 @@ import {
 } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
-import { HomePageVisitedEvent, PageVisitedEvent } from './page.events';
+import { HomePageEvent, PageEvent } from './page.events';
 
 @Injectable({
   providedIn: 'root',
@@ -23,17 +23,14 @@ export class PageEventBuilder {
   }
 
   protected register(): void {
-    this.eventService.register(PageVisitedEvent, this.buildPageVisitedEvent());
-    this.eventService.register(
-      HomePageVisitedEvent,
-      this.buildHomePageVisitedEvent()
-    );
+    this.eventService.register(PageEvent, this.buildPageEvent());
+    this.eventService.register(HomePageEvent, this.buildHomePageEvent());
   }
 
-  protected buildPageVisitedEvent(): Observable<PageVisitedEvent> {
+  protected buildPageEvent(): Observable<PageEvent> {
     return this.getNavigatedEvent().pipe(
       map((state) =>
-        createFrom(PageVisitedEvent, {
+        createFrom(PageEvent, {
           context: state.context,
           semanticRoute: state.semanticRoute,
           url: state.url,
@@ -43,12 +40,10 @@ export class PageEventBuilder {
     );
   }
 
-  protected buildHomePageVisitedEvent(): Observable<HomePageVisitedEvent> {
-    return this.buildPageVisitedEvent().pipe(
-      filter((pageVisitedEvent) => pageVisitedEvent.semanticRoute === 'home'),
-      map((pageVisitedEvent) =>
-        createFrom(HomePageVisitedEvent, pageVisitedEvent)
-      )
+  protected buildHomePageEvent(): Observable<HomePageEvent> {
+    return this.buildPageEvent().pipe(
+      filter((pageEvent) => pageEvent.semanticRoute === 'home'),
+      map((pageEvent) => createFrom(HomePageEvent, pageEvent))
     );
   }
 

--- a/projects/storefrontlib/src/events/page/page.events.ts
+++ b/projects/storefrontlib/src/events/page/page.events.ts
@@ -2,7 +2,7 @@ import { Params } from '@angular/router';
 import { PageContext } from '@spartacus/core';
 
 /**
- * Indicates either that a user visited an arbitrary page of a web presence or that the page type was unknown.
+ * Indicates that a user visited an arbitrary page.
  */
 export class PageEvent {
   context: PageContext;
@@ -12,6 +12,6 @@ export class PageEvent {
 }
 
 /**
- * Indicates that a user visited the home page of a web presence.
+ * Indicates that a user visited the home page.
  */
 export class HomePageEvent extends PageEvent {}

--- a/projects/storefrontlib/src/events/page/page.events.ts
+++ b/projects/storefrontlib/src/events/page/page.events.ts
@@ -4,7 +4,7 @@ import { PageContext } from '@spartacus/core';
 /**
  * Indicates either that a user visited an arbitrary page of a web presence or that the page type was unknown.
  */
-export class PageVisitedEvent {
+export class PageEvent {
   context: PageContext;
   semanticRoute?: string;
   url: string;
@@ -14,4 +14,4 @@ export class PageVisitedEvent {
 /**
  * Indicates that a user visited the home page of a web presence.
  */
-export class HomePageVisitedEvent extends PageVisitedEvent {}
+export class HomePageEvent extends PageEvent {}

--- a/projects/storefrontlib/src/events/product/product-page-event.builder.spec.ts
+++ b/projects/storefrontlib/src/events/product/product-page-event.builder.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '@spartacus/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { PageVisitedEvent } from '../page/page.events';
+import { PageEvent } from '../page/page.events';
 import { ProductPageEventBuilder } from './product-page-event.builder';
 import {
   CategoryPageResultsEvent,
@@ -65,13 +65,13 @@ describe('ProductPageEventModule', () => {
         .pipe(take(1))
         .subscribe((value) => (result = value));
 
-      const pageVisitedEvent = createFrom(PageVisitedEvent, {
+      const pageEvent = createFrom(PageEvent, {
         context: undefined,
         semanticRoute: 'search',
         url: 'search url',
         params: undefined,
       });
-      eventService.dispatch(pageVisitedEvent);
+      eventService.dispatch(pageEvent);
       getResultsBehavior.next(searchResults);
 
       expect(result).toEqual(
@@ -94,14 +94,14 @@ describe('ProductPageEventModule', () => {
         .get(SearchPageResultsEvent)
         .subscribe((value) => (result = value));
 
-      const pageVisitedEvent = createFrom(PageVisitedEvent, {
+      const pageEvent = createFrom(PageEvent, {
         context: undefined,
         semanticRoute: 'search',
         url: 'search url',
         params: undefined,
       });
 
-      eventService.dispatch(pageVisitedEvent);
+      eventService.dispatch(pageEvent);
       getResultsBehavior.next(searchResults);
       expect(result).toEqual(
         jasmine.objectContaining({
@@ -153,18 +153,18 @@ describe('ProductPageEventModule', () => {
       .pipe(take(1))
       .subscribe((value) => (result = value));
 
-    const pageVisitedEvent = createFrom(PageVisitedEvent, {
+    const pageEvent = createFrom(PageEvent, {
       context: { id: 'cat1' },
       semanticRoute: 'category',
       url: 'category url',
       params: undefined,
     });
-    eventService.dispatch(pageVisitedEvent);
+    eventService.dispatch(pageEvent);
     getResultsBehavior.next(searchResults);
 
     expect(result).toEqual(
       jasmine.objectContaining({
-        categoryCode: pageVisitedEvent.context.id,
+        categoryCode: pageEvent.context.id,
         categoryName: searchResults.breadcrumbs[0].facetValueName,
       } as CategoryPageResultsEvent)
     );
@@ -185,13 +185,13 @@ describe('ProductPageEventModule', () => {
         .pipe(take(1))
         .subscribe((value) => (result = value));
 
-      const productPageVisitedEvent = createFrom(PageVisitedEvent, {
+      const productPageEvent = createFrom(PageEvent, {
         context: { id: product.code },
         semanticRoute: 'product',
         url: 'product url',
         params: undefined,
       });
-      eventService.dispatch(productPageVisitedEvent);
+      eventService.dispatch(productPageEvent);
       productGetBehavior.next(product);
 
       expect(result).toEqual(
@@ -217,14 +217,14 @@ describe('ProductPageEventModule', () => {
         .get(ProductDetailsPageEvent)
         .subscribe((value) => (result = value));
 
-      const productPageVisitedEvent = createFrom(PageVisitedEvent, {
+      const productPageEvent = createFrom(PageEvent, {
         context: { id: product.code },
         semanticRoute: 'product',
         url: 'product url',
         params: undefined,
       });
 
-      eventService.dispatch(productPageVisitedEvent);
+      eventService.dispatch(productPageEvent);
       productGetBehavior.next(product);
       expect(result).toEqual(
         jasmine.objectContaining({

--- a/projects/storefrontlib/src/events/product/product-page-event.builder.spec.ts
+++ b/projects/storefrontlib/src/events/product/product-page-event.builder.spec.ts
@@ -13,9 +13,9 @@ import { take } from 'rxjs/operators';
 import { PageVisitedEvent } from '../page/page.events';
 import { ProductPageEventBuilder } from './product-page-event.builder';
 import {
-  CategoryPageResultsVisitedEvent,
-  ProductDetailsPageVisitedEvent,
-  SearchPageResultsVisitedEvent,
+  CategoryPageResultsEvent,
+  ProductDetailsPageEvent,
+  SearchPageResultsEvent,
 } from './product-page.events';
 
 const productGetBehavior = new BehaviorSubject<Product>(undefined);
@@ -51,7 +51,7 @@ describe('ProductPageEventModule', () => {
     eventService = TestBed.inject(EventService);
   });
 
-  describe('SearchPageResultsVisitedEvent', () => {
+  describe('SearchPageResultsEvent', () => {
     it('should fire when the user performs a search and navigates to the search page', () => {
       const searchResults: ProductSearchPage = {
         freeTextSearch: 'camera',
@@ -59,9 +59,9 @@ describe('ProductPageEventModule', () => {
         facets: [{ category: true }],
       };
 
-      let result: SearchPageResultsVisitedEvent;
+      let result: SearchPageResultsEvent;
       eventService
-        .get(SearchPageResultsVisitedEvent)
+        .get(SearchPageResultsEvent)
         .pipe(take(1))
         .subscribe((value) => (result = value));
 
@@ -78,7 +78,7 @@ describe('ProductPageEventModule', () => {
         jasmine.objectContaining({
           searchTerm: searchResults.freeTextSearch,
           numberOfResults: searchResults.pagination.totalResults,
-        } as SearchPageResultsVisitedEvent)
+        } as SearchPageResultsEvent)
       );
     });
 
@@ -89,9 +89,9 @@ describe('ProductPageEventModule', () => {
         facets: [{ category: true }],
       };
 
-      let result: SearchPageResultsVisitedEvent;
+      let result: SearchPageResultsEvent;
       const sub = eventService
-        .get(SearchPageResultsVisitedEvent)
+        .get(SearchPageResultsEvent)
         .subscribe((value) => (result = value));
 
       const pageVisitedEvent = createFrom(PageVisitedEvent, {
@@ -107,7 +107,7 @@ describe('ProductPageEventModule', () => {
         jasmine.objectContaining({
           searchTerm: searchResults.freeTextSearch,
           numberOfResults: searchResults.pagination.totalResults,
-        } as SearchPageResultsVisitedEvent)
+        } as SearchPageResultsEvent)
       );
 
       getResultsBehavior.next({
@@ -118,7 +118,7 @@ describe('ProductPageEventModule', () => {
         jasmine.objectContaining({
           searchTerm: 'new',
           numberOfResults: searchResults.pagination.totalResults,
-        } as SearchPageResultsVisitedEvent)
+        } as SearchPageResultsEvent)
       );
       sub.unsubscribe();
     });
@@ -130,9 +130,9 @@ describe('ProductPageEventModule', () => {
         facets: [{ category: true }],
       };
 
-      let result: SearchPageResultsVisitedEvent;
+      let result: SearchPageResultsEvent;
       eventService
-        .get(SearchPageResultsVisitedEvent)
+        .get(SearchPageResultsEvent)
         .pipe(take(1))
         .subscribe((value) => (result = value));
 
@@ -142,14 +142,14 @@ describe('ProductPageEventModule', () => {
     });
   });
 
-  it('CategoryPageResultsVisitedEvent', () => {
+  it('CategoryPageResultsEvent', () => {
     const searchResults: ProductSearchPage = {
       breadcrumbs: [{ facetValueName: 'Cat1' }],
     };
 
-    let result: CategoryPageResultsVisitedEvent;
+    let result: CategoryPageResultsEvent;
     eventService
-      .get(CategoryPageResultsVisitedEvent)
+      .get(CategoryPageResultsEvent)
       .pipe(take(1))
       .subscribe((value) => (result = value));
 
@@ -166,11 +166,11 @@ describe('ProductPageEventModule', () => {
       jasmine.objectContaining({
         categoryCode: pageVisitedEvent.context.id,
         categoryName: searchResults.breadcrumbs[0].facetValueName,
-      } as CategoryPageResultsVisitedEvent)
+      } as CategoryPageResultsEvent)
     );
   });
 
-  describe('ProductDetailsPageVisitedEvent', () => {
+  describe('ProductDetailsPageEvent', () => {
     it('should fire on PDP visit', () => {
       const product: Product = {
         code: '1234',
@@ -179,9 +179,9 @@ describe('ProductPageEventModule', () => {
         price: { value: 100 },
       };
 
-      let result: ProductDetailsPageVisitedEvent;
+      let result: ProductDetailsPageEvent;
       eventService
-        .get(ProductDetailsPageVisitedEvent)
+        .get(ProductDetailsPageEvent)
         .pipe(take(1))
         .subscribe((value) => (result = value));
 
@@ -200,7 +200,7 @@ describe('ProductPageEventModule', () => {
           categories: product.categories,
           name: product.name,
           price: product.price,
-        } as ProductDetailsPageVisitedEvent)
+        } as ProductDetailsPageEvent)
       );
     });
 
@@ -212,9 +212,9 @@ describe('ProductPageEventModule', () => {
         price: { value: 100 },
       };
 
-      let result: ProductDetailsPageVisitedEvent;
+      let result: ProductDetailsPageEvent;
       const sub = eventService
-        .get(ProductDetailsPageVisitedEvent)
+        .get(ProductDetailsPageEvent)
         .subscribe((value) => (result = value));
 
       const productPageVisitedEvent = createFrom(PageVisitedEvent, {
@@ -232,7 +232,7 @@ describe('ProductPageEventModule', () => {
           categories: product.categories,
           name: product.name,
           price: product.price,
-        } as ProductDetailsPageVisitedEvent)
+        } as ProductDetailsPageEvent)
       );
 
       productGetBehavior.next({ ...product, code: 'new' });
@@ -243,7 +243,7 @@ describe('ProductPageEventModule', () => {
           categories: product.categories,
           name: product.name,
           price: product.price,
-        } as ProductDetailsPageVisitedEvent)
+        } as ProductDetailsPageEvent)
       );
       sub.unsubscribe();
     });

--- a/projects/storefrontlib/src/events/product/product-page-event.builder.spec.ts
+++ b/projects/storefrontlib/src/events/product/product-page-event.builder.spec.ts
@@ -13,9 +13,9 @@ import { take } from 'rxjs/operators';
 import { PageVisitedEvent } from '../page/page.events';
 import { ProductPageEventBuilder } from './product-page-event.builder';
 import {
-  CategoryPageResultsEvent,
-  ProductDetailsPageEvent,
-  SearchPageResultsEvent,
+  CategoryPageResultsVisitedEvent,
+  ProductDetailsPageVisitedEvent,
+  SearchPageResultsVisitedEvent,
 } from './product-page.events';
 
 const productGetBehavior = new BehaviorSubject<Product>(undefined);
@@ -51,7 +51,7 @@ describe('ProductPageEventModule', () => {
     eventService = TestBed.inject(EventService);
   });
 
-  describe('SearchPageResultsEvent', () => {
+  describe('SearchPageResultsVisitedEvent', () => {
     it('should fire when the user performs a search and navigates to the search page', () => {
       const searchResults: ProductSearchPage = {
         freeTextSearch: 'camera',
@@ -59,9 +59,9 @@ describe('ProductPageEventModule', () => {
         facets: [{ category: true }],
       };
 
-      let result: SearchPageResultsEvent;
+      let result: SearchPageResultsVisitedEvent;
       eventService
-        .get(SearchPageResultsEvent)
+        .get(SearchPageResultsVisitedEvent)
         .pipe(take(1))
         .subscribe((value) => (result = value));
 
@@ -78,7 +78,7 @@ describe('ProductPageEventModule', () => {
         jasmine.objectContaining({
           searchTerm: searchResults.freeTextSearch,
           numberOfResults: searchResults.pagination.totalResults,
-        } as SearchPageResultsEvent)
+        } as SearchPageResultsVisitedEvent)
       );
     });
 
@@ -89,9 +89,9 @@ describe('ProductPageEventModule', () => {
         facets: [{ category: true }],
       };
 
-      let result: SearchPageResultsEvent;
+      let result: SearchPageResultsVisitedEvent;
       const sub = eventService
-        .get(SearchPageResultsEvent)
+        .get(SearchPageResultsVisitedEvent)
         .subscribe((value) => (result = value));
 
       const pageVisitedEvent = createFrom(PageVisitedEvent, {
@@ -107,7 +107,7 @@ describe('ProductPageEventModule', () => {
         jasmine.objectContaining({
           searchTerm: searchResults.freeTextSearch,
           numberOfResults: searchResults.pagination.totalResults,
-        } as SearchPageResultsEvent)
+        } as SearchPageResultsVisitedEvent)
       );
 
       getResultsBehavior.next({
@@ -118,7 +118,7 @@ describe('ProductPageEventModule', () => {
         jasmine.objectContaining({
           searchTerm: 'new',
           numberOfResults: searchResults.pagination.totalResults,
-        } as SearchPageResultsEvent)
+        } as SearchPageResultsVisitedEvent)
       );
       sub.unsubscribe();
     });
@@ -130,9 +130,9 @@ describe('ProductPageEventModule', () => {
         facets: [{ category: true }],
       };
 
-      let result: SearchPageResultsEvent;
+      let result: SearchPageResultsVisitedEvent;
       eventService
-        .get(SearchPageResultsEvent)
+        .get(SearchPageResultsVisitedEvent)
         .pipe(take(1))
         .subscribe((value) => (result = value));
 
@@ -142,14 +142,14 @@ describe('ProductPageEventModule', () => {
     });
   });
 
-  it('CategoryPageResultsEvent', () => {
+  it('CategoryPageResultsVisitedEvent', () => {
     const searchResults: ProductSearchPage = {
       breadcrumbs: [{ facetValueName: 'Cat1' }],
     };
 
-    let result: CategoryPageResultsEvent;
+    let result: CategoryPageResultsVisitedEvent;
     eventService
-      .get(CategoryPageResultsEvent)
+      .get(CategoryPageResultsVisitedEvent)
       .pipe(take(1))
       .subscribe((value) => (result = value));
 
@@ -166,11 +166,11 @@ describe('ProductPageEventModule', () => {
       jasmine.objectContaining({
         categoryCode: pageVisitedEvent.context.id,
         categoryName: searchResults.breadcrumbs[0].facetValueName,
-      } as CategoryPageResultsEvent)
+      } as CategoryPageResultsVisitedEvent)
     );
   });
 
-  describe('ProductDetailsPageEvent', () => {
+  describe('ProductDetailsPageVisitedEvent', () => {
     it('should fire on PDP visit', () => {
       const product: Product = {
         code: '1234',
@@ -179,9 +179,9 @@ describe('ProductPageEventModule', () => {
         price: { value: 100 },
       };
 
-      let result: ProductDetailsPageEvent;
+      let result: ProductDetailsPageVisitedEvent;
       eventService
-        .get(ProductDetailsPageEvent)
+        .get(ProductDetailsPageVisitedEvent)
         .pipe(take(1))
         .subscribe((value) => (result = value));
 
@@ -200,7 +200,7 @@ describe('ProductPageEventModule', () => {
           categories: product.categories,
           name: product.name,
           price: product.price,
-        } as ProductDetailsPageEvent)
+        } as ProductDetailsPageVisitedEvent)
       );
     });
 
@@ -212,9 +212,9 @@ describe('ProductPageEventModule', () => {
         price: { value: 100 },
       };
 
-      let result: ProductDetailsPageEvent;
+      let result: ProductDetailsPageVisitedEvent;
       const sub = eventService
-        .get(ProductDetailsPageEvent)
+        .get(ProductDetailsPageVisitedEvent)
         .subscribe((value) => (result = value));
 
       const productPageVisitedEvent = createFrom(PageVisitedEvent, {
@@ -232,7 +232,7 @@ describe('ProductPageEventModule', () => {
           categories: product.categories,
           name: product.name,
           price: product.price,
-        } as ProductDetailsPageEvent)
+        } as ProductDetailsPageVisitedEvent)
       );
 
       productGetBehavior.next({ ...product, code: 'new' });
@@ -243,7 +243,7 @@ describe('ProductPageEventModule', () => {
           categories: product.categories,
           name: product.name,
           price: product.price,
-        } as ProductDetailsPageEvent)
+        } as ProductDetailsPageVisitedEvent)
       );
       sub.unsubscribe();
     });

--- a/projects/storefrontlib/src/events/product/product-page-event.builder.ts
+++ b/projects/storefrontlib/src/events/product/product-page-event.builder.ts
@@ -9,9 +9,9 @@ import { EMPTY, Observable } from 'rxjs';
 import { filter, map, skip, switchMap, take } from 'rxjs/operators';
 import { PageVisitedEvent } from '../page/page.events';
 import {
-  CategoryPageResultsVisitedEvent,
-  ProductDetailsPageVisitedEvent,
-  SearchPageResultsVisitedEvent,
+  CategoryPageResultsEvent,
+  ProductDetailsPageEvent,
+  SearchPageResultsEvent,
 } from './product-page.events';
 
 @Injectable({
@@ -28,21 +28,21 @@ export class ProductPageEventBuilder {
 
   protected register(): void {
     this.eventService.register(
-      SearchPageResultsVisitedEvent,
-      this.buildSearchPageResultsVisitedEvent()
+      SearchPageResultsEvent,
+      this.buildSearchPageResultsEvent()
     );
     this.eventService.register(
-      ProductDetailsPageVisitedEvent,
-      this.buildProductDetailsPageVisitedEvent()
+      ProductDetailsPageEvent,
+      this.buildProductDetailsPageEvent()
     );
     this.eventService.register(
-      CategoryPageResultsVisitedEvent,
-      this.buildCategoryResultsPageVisitedEvent()
+      CategoryPageResultsEvent,
+      this.buildCategoryResultsPageEvent()
     );
   }
 
-  protected buildProductDetailsPageVisitedEvent(): Observable<
-    ProductDetailsPageVisitedEvent
+  protected buildProductDetailsPageEvent(): Observable<
+    ProductDetailsPageEvent
   > {
     return this.eventService.get(PageVisitedEvent).pipe(
       filter(
@@ -54,7 +54,7 @@ export class ProductPageEventBuilder {
           filter((product) => Boolean(product)),
           take(1),
           map((product) =>
-            createFrom(ProductDetailsPageVisitedEvent, {
+            createFrom(ProductDetailsPageEvent, {
               categories: product.categories,
               code: product.code,
               name: product.name,
@@ -66,8 +66,8 @@ export class ProductPageEventBuilder {
     );
   }
 
-  protected buildCategoryResultsPageVisitedEvent(): Observable<
-    CategoryPageResultsVisitedEvent
+  protected buildCategoryResultsPageEvent(): Observable<
+    CategoryPageResultsEvent
   > {
     const searchResults$ = this.productSearchService.getResults().pipe(
       // skipping the initial value, and preventing emission of the previous search state
@@ -95,16 +95,14 @@ export class ProductPageEventBuilder {
             categoryName: searchResults.breadcrumbs[0].facetValueName,
           })),
           map((categoryPage) =>
-            createFrom(CategoryPageResultsVisitedEvent, categoryPage)
+            createFrom(CategoryPageResultsEvent, categoryPage)
           )
         );
       })
     );
   }
 
-  protected buildSearchPageResultsVisitedEvent(): Observable<
-    SearchPageResultsVisitedEvent
-  > {
+  protected buildSearchPageResultsEvent(): Observable<SearchPageResultsEvent> {
     const searchResults$ = this.productSearchService.getResults().pipe(
       // skipping the initial value, and preventing emission of the previous search state
       skip(1),
@@ -112,7 +110,7 @@ export class ProductPageEventBuilder {
         searchTerm: searchResults.freeTextSearch,
         numberOfResults: searchResults.pagination.totalResults,
       })),
-      map((searchPage) => createFrom(SearchPageResultsVisitedEvent, searchPage))
+      map((searchPage) => createFrom(SearchPageResultsEvent, searchPage))
     );
 
     const searchPageVisitedEvent$ = this.eventService

--- a/projects/storefrontlib/src/events/product/product-page-event.builder.ts
+++ b/projects/storefrontlib/src/events/product/product-page-event.builder.ts
@@ -7,7 +7,7 @@ import {
 } from '@spartacus/core';
 import { EMPTY, Observable } from 'rxjs';
 import { filter, map, skip, switchMap, take } from 'rxjs/operators';
-import { PageVisitedEvent } from '../page/page.events';
+import { PageEvent } from '../page/page.events';
 import {
   CategoryPageResultsEvent,
   ProductDetailsPageEvent,
@@ -44,11 +44,9 @@ export class ProductPageEventBuilder {
   protected buildProductDetailsPageEvent(): Observable<
     ProductDetailsPageEvent
   > {
-    return this.eventService.get(PageVisitedEvent).pipe(
-      filter(
-        (pageVisitedEvent) => pageVisitedEvent.semanticRoute === 'product'
-      ),
-      map((pageVisitedEvent) => pageVisitedEvent.context.id),
+    return this.eventService.get(PageEvent).pipe(
+      filter((pageEvent) => pageEvent.semanticRoute === 'product'),
+      map((pageEvent) => pageEvent.context.id),
       switchMap((productId) =>
         this.productService.get(productId).pipe(
           filter((product) => Boolean(product)),
@@ -74,16 +72,14 @@ export class ProductPageEventBuilder {
       skip(1)
     );
 
-    const categoryPageVisitedEvent$ = this.eventService
-      .get(PageVisitedEvent)
-      .pipe(
-        map((pageVisitedEvent) => ({
-          isCategoryPage: pageVisitedEvent.semanticRoute === 'category',
-          categoryCode: pageVisitedEvent.context.id,
-        }))
-      );
+    const categoryPageEvent$ = this.eventService.get(PageEvent).pipe(
+      map((pageEvent) => ({
+        isCategoryPage: pageEvent.semanticRoute === 'category',
+        categoryCode: pageEvent.context.id,
+      }))
+    );
 
-    return categoryPageVisitedEvent$.pipe(
+    return categoryPageEvent$.pipe(
       switchMap((pageEvent) => {
         if (!pageEvent.isCategoryPage) {
           return EMPTY;
@@ -113,13 +109,11 @@ export class ProductPageEventBuilder {
       map((searchPage) => createFrom(SearchPageResultsEvent, searchPage))
     );
 
-    const searchPageVisitedEvent$ = this.eventService
-      .get(PageVisitedEvent)
-      .pipe(
-        map((pageVisitedEvent) => pageVisitedEvent.semanticRoute === 'search')
-      );
+    const searchPageEvent$ = this.eventService
+      .get(PageEvent)
+      .pipe(map((pageEvent) => pageEvent.semanticRoute === 'search'));
 
-    return searchPageVisitedEvent$.pipe(
+    return searchPageEvent$.pipe(
       switchMap((isSearchPage) => (isSearchPage ? searchResults$ : EMPTY))
     );
   }

--- a/projects/storefrontlib/src/events/product/product-page-event.builder.ts
+++ b/projects/storefrontlib/src/events/product/product-page-event.builder.ts
@@ -9,9 +9,9 @@ import { EMPTY, Observable } from 'rxjs';
 import { filter, map, skip, switchMap, take } from 'rxjs/operators';
 import { PageVisitedEvent } from '../page/page.events';
 import {
-  CategoryPageResultsEvent,
-  ProductDetailsPageEvent,
-  SearchPageResultsEvent,
+  CategoryPageResultsVisitedEvent,
+  ProductDetailsPageVisitedEvent,
+  SearchPageResultsVisitedEvent,
 } from './product-page.events';
 
 @Injectable({
@@ -28,21 +28,21 @@ export class ProductPageEventBuilder {
 
   protected register(): void {
     this.eventService.register(
-      SearchPageResultsEvent,
-      this.buildSearchPageResultsEvent()
+      SearchPageResultsVisitedEvent,
+      this.buildSearchPageResultsVisitedEvent()
     );
     this.eventService.register(
-      ProductDetailsPageEvent,
-      this.buildProductDetailsPageEvent()
+      ProductDetailsPageVisitedEvent,
+      this.buildProductDetailsPageVisitedEvent()
     );
     this.eventService.register(
-      CategoryPageResultsEvent,
-      this.buildCategoryResultsPageEvent()
+      CategoryPageResultsVisitedEvent,
+      this.buildCategoryResultsPageVisitedEvent()
     );
   }
 
-  protected buildProductDetailsPageEvent(): Observable<
-    ProductDetailsPageEvent
+  protected buildProductDetailsPageVisitedEvent(): Observable<
+    ProductDetailsPageVisitedEvent
   > {
     return this.eventService.get(PageVisitedEvent).pipe(
       filter(
@@ -54,7 +54,7 @@ export class ProductPageEventBuilder {
           filter((product) => Boolean(product)),
           take(1),
           map((product) =>
-            createFrom(ProductDetailsPageEvent, {
+            createFrom(ProductDetailsPageVisitedEvent, {
               categories: product.categories,
               code: product.code,
               name: product.name,
@@ -66,8 +66,8 @@ export class ProductPageEventBuilder {
     );
   }
 
-  protected buildCategoryResultsPageEvent(): Observable<
-    CategoryPageResultsEvent
+  protected buildCategoryResultsPageVisitedEvent(): Observable<
+    CategoryPageResultsVisitedEvent
   > {
     const searchResults$ = this.productSearchService.getResults().pipe(
       // skipping the initial value, and preventing emission of the previous search state
@@ -95,14 +95,16 @@ export class ProductPageEventBuilder {
             categoryName: searchResults.breadcrumbs[0].facetValueName,
           })),
           map((categoryPage) =>
-            createFrom(CategoryPageResultsEvent, categoryPage)
+            createFrom(CategoryPageResultsVisitedEvent, categoryPage)
           )
         );
       })
     );
   }
 
-  protected buildSearchPageResultsEvent(): Observable<SearchPageResultsEvent> {
+  protected buildSearchPageResultsVisitedEvent(): Observable<
+    SearchPageResultsVisitedEvent
+  > {
     const searchResults$ = this.productSearchService.getResults().pipe(
       // skipping the initial value, and preventing emission of the previous search state
       skip(1),
@@ -110,7 +112,7 @@ export class ProductPageEventBuilder {
         searchTerm: searchResults.freeTextSearch,
         numberOfResults: searchResults.pagination.totalResults,
       })),
-      map((searchPage) => createFrom(SearchPageResultsEvent, searchPage))
+      map((searchPage) => createFrom(SearchPageResultsVisitedEvent, searchPage))
     );
 
     const searchPageVisitedEvent$ = this.eventService

--- a/projects/storefrontlib/src/events/product/product-page.events.ts
+++ b/projects/storefrontlib/src/events/product/product-page.events.ts
@@ -4,7 +4,7 @@ import { Category, Price } from '@spartacus/core';
  * Indicates that a user visited a product details page. A visited product code value is emitted whenever the product
  * details page is visited, together with the name, the price, and the categories of that product.
  */
-export class ProductDetailsPageEvent {
+export class ProductDetailsPageVisitedEvent {
   categories?: Category[];
   code?: string;
   name?: string;
@@ -15,7 +15,7 @@ export class ProductDetailsPageEvent {
  * Indicates that a user visited a category. The code and the name of the category
  * are emitted whenever a category page is visited.
  */
-export class CategoryPageResultsEvent {
+export class CategoryPageResultsVisitedEvent {
   categoryCode: string;
   categoryName: string;
 }
@@ -25,7 +25,7 @@ export class CategoryPageResultsEvent {
  * The search term and the number of results are emitted
  * whenever a search has been executed.
  */
-export class SearchPageResultsEvent {
+export class SearchPageResultsVisitedEvent {
   searchTerm: string;
   numberOfResults: Number;
 }

--- a/projects/storefrontlib/src/events/product/product-page.events.ts
+++ b/projects/storefrontlib/src/events/product/product-page.events.ts
@@ -4,7 +4,7 @@ import { Category, Price } from '@spartacus/core';
  * Indicates that a user visited a product details page. A visited product code value is emitted whenever the product
  * details page is visited, together with the name, the price, and the categories of that product.
  */
-export class ProductDetailsPageVisitedEvent {
+export class ProductDetailsPageEvent {
   categories?: Category[];
   code?: string;
   name?: string;
@@ -15,7 +15,7 @@ export class ProductDetailsPageVisitedEvent {
  * Indicates that a user visited a category. The code and the name of the category
  * are emitted whenever a category page is visited.
  */
-export class CategoryPageResultsVisitedEvent {
+export class CategoryPageResultsEvent {
   categoryCode: string;
   categoryName: string;
 }
@@ -25,7 +25,7 @@ export class CategoryPageResultsVisitedEvent {
  * The search term and the number of results are emitted
  * whenever a search has been executed.
  */
-export class SearchPageResultsVisitedEvent {
+export class SearchPageResultsEvent {
   searchTerm: string;
   numberOfResults: Number;
 }

--- a/projects/storefrontlib/src/events/product/product-page.events.ts
+++ b/projects/storefrontlib/src/events/product/product-page.events.ts
@@ -1,8 +1,7 @@
 import { Category, Price } from '@spartacus/core';
 
 /**
- * Indicates that a user visited a product details page. A visited product code value is emitted whenever the product
- * details page is visited, together with the name, the price, and the categories of that product.
+ * Indicates that a user visited a product details page.
  */
 export class ProductDetailsPageEvent {
   categories?: Category[];
@@ -12,8 +11,7 @@ export class ProductDetailsPageEvent {
 }
 
 /**
- * Indicates that a user visited a category. The code and the name of the category
- * are emitted whenever a category page is visited.
+ * Indicates that a user visited a category page.
  */
 export class CategoryPageResultsEvent {
   categoryCode: string;
@@ -21,9 +19,8 @@ export class CategoryPageResultsEvent {
 }
 
 /**
- * Indicates that the search results have been retrieved.
- * The search term and the number of results are emitted
- * whenever a search has been executed.
+ * Indicates that the a user visited the search results page,
+ * and that the search results have been retrieved.
  */
 export class SearchPageResultsEvent {
   searchTerm: string;


### PR DESCRIPTION
This PR aligns the names of the page events by removing "Visited" part.