### PR TITLE
Form should show error when submit button is clicked - closes #8333

### DIFF
--- a/feature-libs/my-account/organization/src/components/cost-center/create/cost-center-create.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/create/cost-center-create.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, Validators } from '@angular/forms';
 import { CostCenterService, RoutingService } from '@spartacus/core';
 import { map } from 'rxjs/operators';
 import { CostCenterFormService } from '../form/cost-center-form.service';
@@ -34,6 +34,8 @@ export class CostCenterCreateComponent {
 
   save(form: FormGroup): void {
     if (form.invalid) {
+      form.get('code').setValidators(Validators.required);
+      form.get('code').updateValueAndValidity();
       form.markAllAsTouched();
     } else {
       form.disable();

--- a/feature-libs/my-account/organization/src/components/cost-center/form/cost-center-form.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/form/cost-center-form.component.ts
@@ -10,7 +10,7 @@ import { Observable } from 'rxjs';
 
 @Component({
   selector: 'cx-cost-center-form',
-  templateUrl: './cost-center-form.component.html'
+  templateUrl: './cost-center-form.component.html',
 })
 export class CostCenterFormComponent implements OnInit {
   /**

--- a/feature-libs/my-account/organization/src/components/cost-center/form/cost-center-form.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/form/cost-center-form.component.ts
@@ -10,7 +10,7 @@ import { Observable } from 'rxjs';
 
 @Component({
   selector: 'cx-cost-center-form',
-  templateUrl: './cost-center-form.component.html',
+  templateUrl: './cost-center-form.component.html'
 })
 export class CostCenterFormComponent implements OnInit {
   /**

--- a/feature-libs/my-account/organization/src/components/cost-center/form/cost-center-form.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/form/cost-center-form.component.ts
@@ -1,4 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnInit,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import {
   B2BUnitNode,
@@ -11,6 +16,7 @@ import { Observable } from 'rxjs';
 @Component({
   selector: 'cx-cost-center-form',
   templateUrl: './cost-center-form.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CostCenterFormComponent implements OnInit {
   /**

--- a/feature-libs/my-account/organization/src/components/cost-center/form/cost-center-form.component.ts
+++ b/feature-libs/my-account/organization/src/components/cost-center/form/cost-center-form.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import {
   B2BUnitNode,
@@ -16,7 +11,6 @@ import { Observable } from 'rxjs';
 @Component({
   selector: 'cx-cost-center-form',
   templateUrl: './cost-center-form.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CostCenterFormComponent implements OnInit {
   /**


### PR DESCRIPTION
Instead of removing the changeDetection Strategy on the child component, re-trigger validation on the parent component when the submit button is clicked. This is because the service setControl doesn't reflect validation of the form when the submit button is clicked

closes: #8333 