### PR TITLE
feat: util for triggering validation in all descendants of FormGroup 

### DIFF
--- a/projects/storefrontlib/src/public_api.ts
+++ b/projects/storefrontlib/src/public_api.ts
@@ -10,3 +10,4 @@ export * from './recipes/index';
 export * from './recipes/storefront.module';
 export * from './shared/index';
 export * from './storefront-config';
+export * from './utils/index';

--- a/projects/storefrontlib/src/utils/form-utils.spec.ts
+++ b/projects/storefrontlib/src/utils/form-utils.spec.ts
@@ -1,0 +1,156 @@
+import { FormBuilder, FormControl } from '@angular/forms';
+import { FormUtils } from './form-utils';
+
+describe('FormUtils', () => {
+  let fb: FormBuilder;
+
+  beforeEach(() => {
+    fb = new FormBuilder();
+  });
+
+  describe('deepUpdateValueAndValidity', () => {
+    describe('for any form control', () => {
+      it('should call #updateValueAndValidity', () => {
+        const control = new FormControl();
+        spyOn(control, 'updateValueAndValidity');
+
+        FormUtils.deepUpdateValueAndValidity(control);
+
+        expect(control.updateValueAndValidity).toHaveBeenCalledWith({
+          onlySelf: true,
+          emitEvent: undefined,
+        });
+      });
+
+      it('should call #updateValueAndValidity with `emitEvent` false', () => {
+        const control = new FormControl();
+        spyOn(control, 'updateValueAndValidity');
+
+        FormUtils.deepUpdateValueAndValidity(control, { emitEvent: false });
+
+        expect(control.updateValueAndValidity).toHaveBeenCalledWith({
+          onlySelf: true,
+          emitEvent: false,
+        });
+      });
+    });
+
+    describe('for `FormGroup`', () => {
+      it('should call #updateValueAndValidity for all descendants of `FormGroup`', () => {
+        const control = fb.group({
+          person: fb.group({ name: '', age: '' }),
+        });
+        spyOn(control, 'updateValueAndValidity');
+
+        spyOn(control.get('person'), 'updateValueAndValidity');
+        spyOn(control.get('person').get('name'), 'updateValueAndValidity');
+        spyOn(control.get('person').get('age'), 'updateValueAndValidity');
+
+        FormUtils.deepUpdateValueAndValidity(control);
+
+        const expectedOptions = {
+          onlySelf: true,
+          emitEvent: true,
+        };
+
+        // root
+        expect(control.updateValueAndValidity).toHaveBeenCalledWith(
+          expectedOptions
+        );
+
+        // person
+        expect(
+          control.get('person').updateValueAndValidity
+        ).toHaveBeenCalledWith(expectedOptions);
+        expect(
+          control.get('person').get('name').updateValueAndValidity
+        ).toHaveBeenCalledWith(expectedOptions);
+        expect(
+          control.get('person').get('age').updateValueAndValidity
+        ).toHaveBeenCalledWith(expectedOptions);
+      });
+
+      it('should call #updateValueAndValidity for all descendants with `emitEvent` false', () => {
+        const control = fb.group({
+          person: fb.group({ name: '', age: '' }),
+        });
+        spyOn(control.get('person').get('age'), 'updateValueAndValidity');
+
+        FormUtils.deepUpdateValueAndValidity(control, { emitEvent: false });
+
+        expect(control.get('person').get('age')).toHaveBeenCalledWith({
+          onlySelf: true,
+          emitEvent: false,
+        });
+      });
+    });
+
+    describe('for `FormArray`', () => {
+      it('should call #updateValueAndValidity for all descendants of `FormArray`', () => {
+        const control = fb.array([
+          fb.group({ name: '', age: '' }),
+          fb.group({ name: '', age: '' }),
+        ]);
+
+        spyOn(control, 'updateValueAndValidity');
+
+        spyOn(control.get('0'), 'updateValueAndValidity');
+        spyOn(control.get('0').get('name'), 'updateValueAndValidity');
+        spyOn(control.get('0').get('age'), 'updateValueAndValidity');
+
+        spyOn(control.get('1'), 'updateValueAndValidity');
+        spyOn(control.get('1').get('name'), 'updateValueAndValidity');
+        spyOn(control.get('1').get('age'), 'updateValueAndValidity');
+
+        FormUtils.deepUpdateValueAndValidity(control);
+
+        const expectedOptions = {
+          onlySelf: true,
+          emitEvent: true,
+        };
+
+        // root
+        expect(control.updateValueAndValidity).toHaveBeenCalledWith(
+          expectedOptions
+        );
+
+        // 0
+        expect(control.get('0').updateValueAndValidity).toHaveBeenCalledWith(
+          expectedOptions
+        );
+        expect(
+          control.get('0').get('name').updateValueAndValidity
+        ).toHaveBeenCalledWith(expectedOptions);
+        expect(
+          control.get('0').get('age').updateValueAndValidity
+        ).toHaveBeenCalledWith(expectedOptions);
+
+        // 1
+        expect(control.get('1').updateValueAndValidity).toHaveBeenCalledWith(
+          expectedOptions
+        );
+        expect(
+          control.get('1').get('name').updateValueAndValidity
+        ).toHaveBeenCalledWith(expectedOptions);
+        expect(
+          control.get('1').get('age').updateValueAndValidity
+        ).toHaveBeenCalledWith(expectedOptions);
+      });
+    });
+
+    it('should call #updateValueAndValidity for all descendants with `emitEvent` false', () => {
+      const control = fb.array([
+        fb.group({ name: '', age: '' }),
+        fb.group({ name: '', age: '' }),
+      ]);
+      spyOn(control.get('0').get('age'), 'updateValueAndValidity');
+
+      FormUtils.deepUpdateValueAndValidity(control, { emitEvent: false });
+
+      expect(control.get('0').get('age')).toHaveBeenCalledWith({
+        onlySelf: true,
+        emitEvent: false,
+      });
+    });
+  });
+});

--- a/projects/storefrontlib/src/utils/form-utils.spec.ts
+++ b/projects/storefrontlib/src/utils/form-utils.spec.ts
@@ -50,7 +50,7 @@ describe('FormUtils', () => {
 
         const expectedOptions = {
           onlySelf: true,
-          emitEvent: true,
+          emitEvent: undefined,
         };
 
         // root
@@ -78,7 +78,9 @@ describe('FormUtils', () => {
 
         FormUtils.deepUpdateValueAndValidity(control, { emitEvent: false });
 
-        expect(control.get('person').get('age')).toHaveBeenCalledWith({
+        expect(
+          control.get('person').get('age').updateValueAndValidity
+        ).toHaveBeenCalledWith({
           onlySelf: true,
           emitEvent: false,
         });
@@ -106,7 +108,7 @@ describe('FormUtils', () => {
 
         const expectedOptions = {
           onlySelf: true,
-          emitEvent: true,
+          emitEvent: undefined,
         };
 
         // root
@@ -147,7 +149,9 @@ describe('FormUtils', () => {
 
       FormUtils.deepUpdateValueAndValidity(control, { emitEvent: false });
 
-      expect(control.get('0').get('age')).toHaveBeenCalledWith({
+      expect(
+        control.get('0').get('age').updateValueAndValidity
+      ).toHaveBeenCalledWith({
         onlySelf: true,
         emitEvent: false,
       });

--- a/projects/storefrontlib/src/utils/form-utils.ts
+++ b/projects/storefrontlib/src/utils/form-utils.ts
@@ -1,0 +1,40 @@
+import { AbstractControl, FormArray, FormGroup } from '@angular/forms';
+
+/**
+ * Utils for Angular forms
+ */
+export namespace FormUtils {
+  /**
+   * Calls the native Angular method `#updateValueAndValidity` for the given from control
+   * and all its descendants (in case when it's `FormGroup` or `FormArray`).
+   *
+   * In particular it's useful for triggering re-emission of observables
+   * `valueChanges` and `statusChanges` for all descendant form controls.
+   *
+   * _Note: Dropping this function may be considered, when it's implemented natively
+   * by Angular. See https://github.com/angular/angular/issues/6170_
+   *
+   * @param control form control
+   * @param options additional options
+   * * `emitEvent`: When true or not given (the default), the `statusChanges` and
+   * `valueChanges` observables emit the latest status and value. When false,
+   * it doesn't trigger observables emission.
+   */
+  export function deepUpdateValueAndValidity(
+    control: AbstractControl,
+    options: { emitEvent?: boolean } = {}
+  ): void {
+    if (control instanceof FormGroup || control instanceof FormArray) {
+      Object.values(control.controls).forEach(
+        (childControl: AbstractControl) => {
+          deepUpdateValueAndValidity(childControl, options);
+        }
+      );
+    }
+
+    control.updateValueAndValidity({
+      onlySelf: true, // avoid calling `#updateValueAndValidity` for all ancestors
+      emitEvent: options.emitEvent,
+    });
+  }
+}

--- a/projects/storefrontlib/src/utils/index.ts
+++ b/projects/storefrontlib/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './form-utils';


### PR DESCRIPTION
Until Angular implements explicitly any method to trigger emission of the observables `valueChanges` and `statusChanges` for all descendant controls of the `FromGroup` (https://github.com/angular/angular/issues/6170), we need to implement it ourselves.

It will help us to fix the validation message bug https://github.com/SAP/spartacus/issues/8333 in the B2B forms (i.e. `CostCenterCreateComponent`).

closes #8455 