### PR TITLE
isolate my company page css under new root page templates

### DIFF
--- a/feature-libs/my-account/organization/src/styles/_organization-page.scss
+++ b/feature-libs/my-account/organization/src/styles/_organization-page.scss
@@ -1,16 +1,16 @@
-// TODO: placeholder selector
-cx-breadcrumb {
-  border-bottom: 1px solid var(--cx-color-light);
-  background: var(--cx-color-inverse);
-}
-main {
-  background-color: var(--cx-color-background);
-}
-
 .CompanyPageTemplate {
-  max-width: 1140px;
-  padding-bottom: max(calc((100vw - 1140px) / 2), var(--cx-spatial-md));
-  margin: auto;
+  cx-breadcrumb {
+    border-bottom: 1px solid var(--cx-color-light);
+    background: var(--cx-color-inverse);
+  }
+  main {
+    background-color: var(--cx-color-background);
+  }
+  cx-page-layout.CompanyPageTemplate {
+    max-width: 1140px;
+    padding-bottom: max(calc((100vw - 1140px) / 2), var(--cx-spatial-md));
+    margin: auto;
+  }
 }
 
 /**

--- a/projects/storefrontstyles/scss/components/organization/_organization-home.scss
+++ b/projects/storefrontstyles/scss/components/organization/_organization-home.scss
@@ -1,4 +1,4 @@
-.CompanyPageTemplate {
+cx-page-layout.CompanyPageTemplate {
   cx-banner {
     @extend .col-md-12;
     @extend .col-lg-5;


### PR DESCRIPTION
Since we have support for global page styles, we can now create full page specific styles. 

closes #8307