### PR TITLE
feat: Disable "enable" button for budgets, cost-centers and user if parent unit is disabled #8542

### DIFF
--- a/feature-libs/my-account/organization/src/assets/translations/en/budget.i18n.ts
+++ b/feature-libs/my-account/organization/src/assets/translations/en/budget.i18n.ts
@@ -12,6 +12,7 @@ export const budget = {
     enabled:
       'When you disable the budget, the related data will be disabled as well. ',
     disabled: 'You cannot edit a disabled Budget.',
+    disabledUnit: 'You cannot enable budget if unit is disabled.',
     deactivate: 'Are you sure you want to disable this budget?',
     deactivateHeader: 'Disable Budget',
   },

--- a/feature-libs/my-account/organization/src/assets/translations/en/cost-center.i18n.ts
+++ b/feature-libs/my-account/organization/src/assets/translations/en/cost-center.i18n.ts
@@ -10,6 +10,7 @@ export const costCenter = {
     enabled:
       'When you disable the cost center, the related data will be disabled as well. ',
     disabled: 'You cannot edit a disabled Cost Center.',
+    disabledUnit: 'You cannot enable cost center if unit is disabled.',
     deactivate: 'Are you sure you want to disable this cost center?',
     deactivateHeader: 'Disable Cost Center',
   },

--- a/feature-libs/my-account/organization/src/assets/translations/en/user.i18n.ts
+++ b/feature-libs/my-account/organization/src/assets/translations/en/user.i18n.ts
@@ -15,6 +15,7 @@ export const user = {
     enabled:
       'When you disable the user, the related data will be disabled as well. ',
     disabled: 'You cannot edit a disabled User.',
+    disabledUnit: 'You cannot enable user if unit is disabled.',
     deactivate: 'Are you sure you want to disable this user?',
     deactivateHeader: 'Disable User',
   },

--- a/feature-libs/my-account/organization/src/components/budget/details/budget-details.component.html
+++ b/feature-libs/my-account/organization/src/components/budget/details/budget-details.component.html
@@ -102,6 +102,7 @@
             {{ 'organization.disabled' | cxTranslate }}
             <button
               class="button icon"
+              [disabled]="!budget.orgUnit?.active"
               (click)="update({ code: budget.code, active: true })"
             >
               {{ 'organization.enable' | cxTranslate }}
@@ -109,6 +110,9 @@
             </button>
           </ng-template>
         </span>
+        <p class="instruction" *ngIf="!budget.orgUnit?.active">
+          {{ 'budget.messages.disabledUnit' | cxTranslate }}
+        </p>
         <p class="instruction">
           <ng-container *ngIf="budget.active; else inactiveInstruction">
             {{ 'budget.messages.enabled' | cxTranslate }}

--- a/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.html
+++ b/feature-libs/my-account/organization/src/components/cost-center/details/cost-center-details.component.html
@@ -96,6 +96,7 @@
             {{ 'organization.disabled' | cxTranslate }}
             <button
               class="button icon"
+              [disabled]="!costCenter.unit?.active"
               (click)="update({ code: costCenter.code, activeFlag: true })"
             >
               {{ 'organization.enable' | cxTranslate }}
@@ -103,6 +104,9 @@
             </button>
           </ng-template>
         </span>
+        <p class="instruction" *ngIf="!costCenter.unit?.active">
+          {{ 'costCenter.messages.disabledUnit' | cxTranslate }}
+        </p>
         <p class="instruction">
           <ng-container *ngIf="costCenter.active; else inactiveInstruction">
             {{ 'costCenter.messages.enabled' | cxTranslate }}

--- a/feature-libs/my-account/organization/src/components/unit/details/unit-details.component.html
+++ b/feature-libs/my-account/organization/src/components/unit/details/unit-details.component.html
@@ -158,24 +158,25 @@
               [disabled]="
                 orgUnit.parentOrgUnit && !orgUnit.parentOrgUnit.active
               "
-              (click)="update({ active: true })"
+              (click)="update({ uid: orgUnit.uid, active: true })"
             >
               {{ 'organization.enable' | cxTranslate }}
               <!--              <cx-icon type="OFF"></cx-icon>-->
             </button>
           </ng-template>
         </span>
+        <p
+          class="instruction"
+          *ngIf="orgUnit.parentOrgUnit && !orgUnit.parentOrgUnit.active"
+        >
+          {{ 'unit.messages.disabledParent' | cxTranslate }}
+        </p>
         <p class="instruction">
-          <ng-container
-            *ngIf="orgUnit.parentOrgUnit && !orgUnit.parentOrgUnit.active"
-          >
-            <div>{{ 'unit.messages.disabledParent' | cxTranslate }}</div>
-          </ng-container>
           <ng-container *ngIf="orgUnit.active; else inactiveInstruction">
-            <div>{{ 'unit.messages.enabled' | cxTranslate }}</div>
+            {{ 'unit.messages.enabled' | cxTranslate }}
           </ng-container>
           <ng-template #inactiveInstruction>
-            <div>{{ 'unit.messages.disabled' | cxTranslate }}</div>
+            {{ 'unit.messages.disabled' | cxTranslate }}
           </ng-template>
         </p>
       </div>

--- a/feature-libs/my-account/organization/src/components/unit/details/unit-details.component.html
+++ b/feature-libs/my-account/organization/src/components/unit/details/unit-details.component.html
@@ -54,19 +54,18 @@
 
         <div class="property" *ngIf="orgUnit.parentOrgUnit">
           <label>{{ 'unit.parentUnit' | cxTranslate }}</label>
-          <span class="value">
-            <a
-              [routerLink]="
-                {
-                  cxRoute: 'orgUnitDetails',
-                  params: orgUnit.parentOrgUnit
-                } | cxUrl
-              "
-            >
-              {{ orgUnit.parentOrgUnit?.name }}
-              <cx-icon class="open-out" type="LINK_OUT"></cx-icon>
-            </a>
-          </span>
+          <a
+            class="value"
+            [routerLink]="
+              {
+                cxRoute: 'orgUnitDetails',
+                params: orgUnit.parentOrgUnit
+              } | cxUrl
+            "
+          >
+            {{ orgUnit.parentOrgUnit?.name }}
+            <cx-icon class="open-out" type="LINK_OUT"></cx-icon>
+          </a>
         </div>
       </div>
     </section>

--- a/feature-libs/my-account/organization/src/components/unit/details/unit-details.component.ts
+++ b/feature-libs/my-account/organization/src/components/unit/details/unit-details.component.ts
@@ -20,9 +20,7 @@ export class UnitDetailsComponent {
   ) {}
 
   update(orgUnit: B2BUnit) {
-    this.orgUnit$
-      .pipe(take(1))
-      .subscribe((unit) => this.orgUnitsService.update(unit.uid, orgUnit));
+    this.orgUnitsService.update(orgUnit.uid, orgUnit);
   }
 
   openModal(template: TemplateRef<any>): void {

--- a/feature-libs/my-account/organization/src/components/user/details/user-details.component.html
+++ b/feature-libs/my-account/organization/src/components/user/details/user-details.component.html
@@ -117,6 +117,7 @@
             {{ 'organization.disabled' | cxTranslate }}
             <button
               class="button icon"
+              [disabled]="user.orgUnit && !user.orgUnit.active"
               (click)="update({ customerId: user.customerId, active: true })"
             >
               {{ 'organization.enable' | cxTranslate }}
@@ -124,6 +125,9 @@
             </button>
           </ng-template>
         </span>
+        <p class="instruction" *ngIf="user.orgUnit && !user.orgUnit.active">
+          {{ 'user.messages.disabledUnit' | cxTranslate }}
+        </p>
         <p class="instruction">
           <ng-container *ngIf="user.active; else inactiveInstruction">
             {{ 'user.messages.enabled' | cxTranslate }}


### PR DESCRIPTION
PR fixes 2 things:
 - disable "enable" button for budgets, cost-centers and user if parent unit is disabled
 - unify org unit icon in details page to be aligned to right (only unit details was wrong)

Closes #8542