### PR TITLE
Exporting of TranslationChunksConfig model (GH-8439)

### DIFF
--- a/projects/assets/src/translations/translation-chunks-config.ts
+++ b/projects/assets/src/translations/translation-chunks-config.ts
@@ -1,4 +1,4 @@
-interface TranslationChunksConfig {
+export interface TranslationChunksConfig {
   [chunk: string]: string[];
 }
 


### PR DESCRIPTION
Closes GH-8439

`TranslationChunksConfig` interface made available to the public api surface of assets