### PR TITLE
feat: Provide outlet context data for components rendered in outlets

### DIFF
--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
@@ -17,7 +17,7 @@ class MockDeferLoaderService {
   }
 }
 
-fdescribe('OutletDirective', () => {
+describe('OutletDirective', () => {
   describe('(Non-stacked)', () => {
     @Component({
       template: `

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
@@ -441,7 +441,7 @@ describe('OutletDirective', () => {
       const outletData: OutletContextData =
         testComponent.componentInstance.outlet;
 
-      expect(outletData.name).toEqual(keptOutlet);
+      expect(outletData.reference).toEqual(keptOutlet);
       expect(outletData.context).toEqual('fakeContext');
       expect(outletData.position).toEqual(OutletPosition.REPLACE);
     });

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
@@ -331,7 +331,7 @@ fdescribe('OutletDirective', () => {
     });
   });
 
-  fdescribe('ComponentFactory in outlet', () => {
+  describe('ComponentFactory in outlet', () => {
     @Component({
       template: `
         <div id="kept">

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.spec.ts
@@ -1,11 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, ComponentFactoryResolver } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FeaturesConfig } from '@spartacus/core';
 import { of } from 'rxjs';
 import { DeferLoaderService } from '../../layout/loading/defer-loader.service';
 import { OutletRefDirective } from './outlet-ref/outlet-ref.directive';
 import { OutletDirective } from './outlet.directive';
-import { OutletPosition } from './outlet.model';
+import { OutletContextData, OutletPosition } from './outlet.model';
+import { OutletService } from '@spartacus/storefront';
+import { By } from '@angular/platform-browser';
 
 const keptOutlet = 'keptOutlet';
 const replacedOutlet = 'replacedOutlet';
@@ -15,7 +17,7 @@ class MockDeferLoaderService {
   }
 }
 
-describe('OutletDirective', () => {
+fdescribe('OutletDirective', () => {
   describe('(Non-stacked)', () => {
     @Component({
       template: `
@@ -326,6 +328,122 @@ describe('OutletDirective', () => {
       hostFixture.detectChanges();
 
       expect(getContent(hostFixture)).toContain('B');
+    });
+  });
+
+  fdescribe('ComponentFactory in outlet', () => {
+    @Component({
+      template: `
+        <div id="kept">
+          <ng-template
+            [cxOutlet]="'${keptOutlet}'"
+            [cxOutletContext]="'fakeContext'"
+          >
+            <div id="original">whatever</div>
+          </ng-template>
+        </div>
+      `,
+    })
+    class MockTemplateComponent {}
+
+    @Component({
+      template: ` <div id="component">TestData</div> `,
+      selector: 'cx-test-component',
+    })
+    class MockOutletComponent {
+      constructor(public outlet: OutletContextData) {}
+    }
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [],
+        declarations: [
+          MockTemplateComponent,
+          MockOutletComponent,
+          OutletDirective,
+          OutletRefDirective,
+        ],
+        providers: [
+          {
+            provide: DeferLoaderService,
+            useClass: MockDeferLoaderService,
+          },
+          {
+            provide: FeaturesConfig,
+            useValue: { features: { level: '2.1' } } as FeaturesConfig, // deprecated, see #8201
+          },
+        ],
+      }).compileComponents();
+    }));
+
+    it('should render component', () => {
+      const outletService = TestBed.inject(OutletService);
+      const cfr = TestBed.inject(ComponentFactoryResolver);
+      outletService.add(
+        keptOutlet,
+        cfr.resolveComponentFactory(MockOutletComponent)
+      );
+      const fixture = TestBed.createComponent(MockTemplateComponent);
+      fixture.detectChanges();
+      const compiled = fixture.debugElement.nativeElement;
+      expect(compiled.querySelector('#kept #original')).toBeFalsy();
+      expect(compiled.querySelector('#kept #component')).toBeTruthy();
+    });
+
+    it('should render component BEFORE', () => {
+      const outletService = TestBed.inject(OutletService);
+      const cfr = TestBed.inject(ComponentFactoryResolver);
+      outletService.add(
+        keptOutlet,
+        cfr.resolveComponentFactory(MockOutletComponent),
+        OutletPosition.BEFORE
+      );
+      const fixture = TestBed.createComponent(MockTemplateComponent);
+      fixture.detectChanges();
+      const compiled = fixture.debugElement.nativeElement;
+      expect(compiled.querySelector('#kept #original')).toBeTruthy();
+      expect(compiled.querySelector('#kept #component')).toBeTruthy();
+      expect(
+        compiled.querySelector('cx-test-component ~ #original')
+      ).toBeTruthy();
+    });
+
+    it('should render component AFTER', () => {
+      const outletService = TestBed.inject(OutletService);
+      const cfr = TestBed.inject(ComponentFactoryResolver);
+      outletService.add(
+        keptOutlet,
+        cfr.resolveComponentFactory(MockOutletComponent),
+        OutletPosition.AFTER
+      );
+      const fixture = TestBed.createComponent(MockTemplateComponent);
+      fixture.detectChanges();
+      const compiled = fixture.debugElement.nativeElement;
+      expect(compiled.querySelector('#kept #original')).toBeTruthy();
+      expect(compiled.querySelector('#kept #component')).toBeTruthy();
+      expect(
+        compiled.querySelector('#original ~ cx-test-component')
+      ).toBeTruthy();
+    });
+
+    it('should inject OutletContextData into component', () => {
+      const outletService = TestBed.inject(OutletService);
+      const cfr = TestBed.inject(ComponentFactoryResolver);
+      outletService.add(
+        keptOutlet,
+        cfr.resolveComponentFactory(MockOutletComponent)
+      );
+      const fixture = TestBed.createComponent(MockTemplateComponent);
+      fixture.detectChanges();
+      const testComponent = fixture.debugElement.query(
+        By.css('cx-test-component')
+      );
+      const outletData: OutletContextData =
+        testComponent.componentInstance.outlet;
+
+      expect(outletData.name).toEqual(keptOutlet);
+      expect(outletData.context).toEqual('fakeContext');
+      expect(outletData.position).toEqual(OutletPosition.REPLACE);
     });
   });
 });

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
@@ -103,6 +103,8 @@ export class OutletDirective implements OnDestroy, OnChanges {
       this.outletService.get(this.cxOutlet, position, USE_STACKED_OUTLETS)
     );
 
+    templates = templates?.filter((el) => !this.renderedTemplate.includes(el));
+
     if (!templates && position === OutletPosition.REPLACE) {
       templates = [this.templateRef];
     }
@@ -112,8 +114,6 @@ export class OutletDirective implements OnDestroy, OnChanges {
     if (!Array.isArray(templates)) {
       templates = [templates];
     }
-
-    templates = templates?.filter((el) => !this.renderedTemplate.includes(el));
 
     const components = [];
     templates.forEach((obj) => {

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
@@ -158,7 +158,7 @@ export class OutletDirective implements OnDestroy, OnChanges {
    */
   private getComponentInjector(position: OutletPosition): Injector {
     const contextData: OutletContextData = {
-      name: this.cxOutlet,
+      reference: this.cxOutlet,
       position,
       context: this.cxOutletContext,
     };

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
@@ -99,11 +99,13 @@ export class OutletDirective implements OnDestroy, OnChanges {
   }
 
   private buildOutlet(position: OutletPosition): void {
-    let templates = this.outletService.get(
-      this.cxOutlet,
-      position,
-      USE_STACKED_OUTLETS
+    let templates: any[] = <any[]>(
+      this.outletService.get(this.cxOutlet, position, USE_STACKED_OUTLETS)
     );
+
+    if (!templates && position === OutletPosition.REPLACE) {
+      templates = [this.templateRef];
+    }
 
     // Just in case someone extended the `OutletService` and
     // returns a singular object.
@@ -113,11 +115,7 @@ export class OutletDirective implements OnDestroy, OnChanges {
 
     templates = templates?.filter((el) => !this.renderedTemplate.includes(el));
 
-    if (!templates && position === OutletPosition.REPLACE) {
-      templates = [this.templateRef];
-    }
-
-    const components: Array<ComponentRef<any> | EmbeddedViewRef<any>> = [];
+    const components = [];
     templates.forEach((obj) => {
       const component = this.create(obj, position);
       components.push(component);
@@ -127,7 +125,7 @@ export class OutletDirective implements OnDestroy, OnChanges {
   }
 
   private create(
-    tmplOrFactory: TemplateRef<any> | ComponentFactory<any>,
+    tmplOrFactory: any,
     position: OutletPosition
   ): ComponentRef<any> | EmbeddedViewRef<any> {
     this.renderedTemplate.push(tmplOrFactory);

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.directive.ts
@@ -50,9 +50,7 @@ export class OutletDirective implements OnDestroy, OnChanges {
   constructor(
     private vcr: ViewContainerRef,
     private templateRef: TemplateRef<any>,
-    private outletService: OutletService<
-      TemplateRef<any> | ComponentFactory<any>
-    >,
+    private outletService: OutletService,
     private deferLoaderService: DeferLoaderService,
     private outletRendererService: OutletRendererService
   ) {}
@@ -101,15 +99,11 @@ export class OutletDirective implements OnDestroy, OnChanges {
   }
 
   private buildOutlet(position: OutletPosition): void {
-    let templates: any[] = <any[]>(
-      this.outletService.get(this.cxOutlet, position, USE_STACKED_OUTLETS)
+    let templates = this.outletService.get(
+      this.cxOutlet,
+      position,
+      USE_STACKED_OUTLETS
     );
-
-    templates = templates?.filter((el) => !this.renderedTemplate.includes(el));
-
-    if (!templates && position === OutletPosition.REPLACE) {
-      templates = [this.templateRef];
-    }
 
     // Just in case someone extended the `OutletService` and
     // returns a singular object.
@@ -117,7 +111,13 @@ export class OutletDirective implements OnDestroy, OnChanges {
       templates = [templates];
     }
 
-    const components = [];
+    templates = templates?.filter((el) => !this.renderedTemplate.includes(el));
+
+    if (!templates && position === OutletPosition.REPLACE) {
+      templates = [this.templateRef];
+    }
+
+    const components: Array<ComponentRef<any> | EmbeddedViewRef<any>> = [];
     templates.forEach((obj) => {
       const component = this.create(obj, position);
       components.push(component);
@@ -127,7 +127,7 @@ export class OutletDirective implements OnDestroy, OnChanges {
   }
 
   private create(
-    tmplOrFactory: any,
+    tmplOrFactory: TemplateRef<any> | ComponentFactory<any>,
     position: OutletPosition
   ): ComponentRef<any> | EmbeddedViewRef<any> {
     this.renderedTemplate.push(tmplOrFactory);

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.model.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.model.ts
@@ -11,7 +11,16 @@ export const USE_STACKED_OUTLETS = true;
  * Token for injecting outlet related context to the component rendered in the outlet
  */
 export abstract class OutletContextData<T = any> {
-  name: string;
+  /**
+   * Provides reference of the outlet where component is rendered in
+   */
+  reference: string;
+  /**
+   * Provides position of the outlet
+   */
   position: OutletPosition;
+  /**
+   * Provides outlet context
+   */
   context: T;
 }

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.model.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.model.ts
@@ -6,3 +6,12 @@ export enum OutletPosition {
 
 export const AVOID_STACKED_OUTLETS = false;
 export const USE_STACKED_OUTLETS = true;
+
+/**
+ * Token for injecting outlet related context to the component rendered in the outlet
+ */
+export abstract class OutletContextData<T = any> {
+  name: string;
+  position: OutletPosition;
+  context: T;
+}

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.service.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, TemplateRef } from '@angular/core';
+import { ComponentFactory, Injectable, TemplateRef } from '@angular/core';
 import { FeatureConfigService } from '@spartacus/core';
 import { AVOID_STACKED_OUTLETS, OutletPosition } from './outlet.model';
 
 @Injectable({
   providedIn: 'root',
 })
-export class OutletService<T = TemplateRef<any>> {
+export class OutletService<T = TemplateRef<any> | ComponentFactory<any>> {
   /**
    * @deprecated since 2.1, see #8116
    */


### PR DESCRIPTION
With the current implementation, we can use component factories to fill in cxOutlets, but they are lacking any information on the outlet and its context.

We should provide a way to get such information, preferably using an injection token.

Closes #8660