### PR TITLE
fix: header's click listner collapseMenuIfClickOutside should check event.currentTarget

### DIFF
--- a/projects/storefrontlib/src/layout/main/storefront.component.ts
+++ b/projects/storefrontlib/src/layout/main/storefront.component.ts
@@ -63,7 +63,7 @@ export class StorefrontComponent implements OnInit, OnDestroy {
   }
 
   collapseMenuIfClickOutside(event: MouseEvent) {
-    if ((<HTMLElement>event.target).className.includes('is-expanded')) {
+    if ((<HTMLElement>event.currentTarget).className.includes('is-expanded')) {
       this.collapseMenu();
     }
   }


### PR DESCRIPTION
header's click listher collapseMenuIfClickOutside should check event.currentTarget instead of event.target.
If you click by element inside header in event.target you have other element instead of <header>

if you click by svg your application crash with error
```
ERROR TypeError: event.target.className.includes is not a function
    at CustomStorefrontComponent.collapseMenuIfClickOutside (spartacus-storefront.js:18782)
    at CustomStorefrontComponent_Template_header_click_0_listener (custom-storefront.component.html:8)
    at executeListenerWithErrorHandling (core.js:21806)
    at wrapListenerIn_markDirtyAndPreventDefault (core.js:21855)
    at HTMLElement.<anonymous> (platform-browser.js:976)
```
Because className is not type of string for svg