### PR TITLE
Allow BASE_URL and API_PREFIX to override env config

### DIFF
--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -8,11 +8,11 @@ import { Environment } from './models/environment.model';
 export const environment: Environment = {
   production: false,
   occBaseUrl:
-    'https://spartacus-dev0.eastus.cloudapp.azure.com:9002' ||
-    // 'https://spartacus-dev3.eastus.cloudapp.azure.com:9002' ||
-    // 'https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com' ||
-    build.process.env.SPARTACUS_BASE_URL,
-  occApiPrefix: '/occ/v2/',
+    build.process.env.SPARTACUS_BASE_URL ??
+    'https://spartacus-dev0.eastus.cloudapp.azure.com:9002',
+    // 'https://spartacus-dev3.eastus.cloudapp.azure.com:9002',
+    // 'https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com',
+  occApiPrefix: build.process.env.SPARTACUS_API_PREFIX ?? '/occ/v2/',
   b2b: false,
   cds: false,
   cdc: false,


### PR DESCRIPTION
This change is to align with [environment.prod.ts](https://github.com/SAP/spartacus/blob/develop/projects/storefrontapp/src/environments/environment.prod.ts), so that developers can override their local environment configuration using variables `SPARTACUS_BASE_URL` and `SPARTACUS_API_PREFIX`.