### PR TITLE
feat: Pull order details/confirmation from replenishment to b2bcheckout branch (GH-8784)

### DIFF
--- a/projects/assets/src/translations/en/checkout.ts
+++ b/projects/assets/src/translations/en/checkout.ts
@@ -24,6 +24,9 @@ export const checkout = {
     createAccount: 'Create an account?',
     createAccountForNext:
       'Create an account for <{{email}}> for a faster checkout on your next visit.',
+    placedOn: 'Placed on',
+    orderNumber: 'Order Number',
+    status: 'Status',
   },
   checkoutReview: {
     review: 'Review',

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.html
@@ -1,32 +1,70 @@
 <ng-container *ngIf="order$ | async as order">
-  <div class="cx-account-summary row">
-    <div
-      *ngIf="order.deliveryAddress"
-      class="cx-summary-card col-sm-12 col-md-4"
-    >
-      <cx-card
-        [content]="getAddressCardContent(order.deliveryAddress) | async"
-      ></cx-card>
-    </div>
-    <div
-      *ngIf="order.paymentInfo?.billingAddress"
-      class="cx-summary-card col-sm-12 col-md-4"
-    >
-      <cx-card
-        [content]="
-          getBillingAddressCardContent(order.paymentInfo.billingAddress) | async
-        "
-      ></cx-card>
-    </div>
-    <div *ngIf="order.paymentInfo" class="cx-summary-card col-sm-12 col-md-4">
-      <cx-card
-        [content]="getPaymentCardContent(order.paymentInfo) | async"
-      ></cx-card>
-    </div>
-    <div *ngIf="order.deliveryMode" class="cx-summary-card col-sm-12 col-md-4">
-      <cx-card
-        [content]="getShippingMethodCardContent(order.deliveryMode) | async"
-      ></cx-card>
+  <div class="cx-account-summary">
+    <div class="container">
+      <div class="cx-summary-card">
+        <cx-card
+          [content]="getOrderCodeCardContent(order?.code) | async"
+        ></cx-card>
+
+        <cx-card
+          [content]="getOrderCurrentDateCardContent(order?.created) | async"
+        ></cx-card>
+
+        <cx-card
+          [content]="getOrderStatusCardContent(order.statusDisplay) | async"
+        ></cx-card>
+      </div>
+
+      <ng-container
+        *ngIf="order.purchaseOrderNumber || order.purchaseOrderNumber === ''"
+      >
+        <div class="cx-summary-card">
+          <cx-card
+            [content]="
+              getPurchaseOrderNumber(order?.purchaseOrderNumber) | async
+            "
+          ></cx-card>
+
+          <cx-card
+            [content]="getMethodOfPaymentCardContent(order.paymentInfo) | async"
+          ></cx-card>
+
+          <ng-container *ngIf="order.costCenter">
+            <cx-card
+              [content]="getCostCenterCardContent(order?.costCenter) | async"
+            ></cx-card>
+          </ng-container>
+        </div>
+      </ng-container>
+
+      <div class="cx-summary-card">
+        <ng-container *ngIf="order.deliveryAddress">
+          <cx-card
+            [content]="getAddressCardContent(order?.deliveryAddress) | async"
+          ></cx-card>
+        </ng-container>
+
+        <ng-container *ngIf="order.deliveryMode">
+          <cx-card
+            [content]="getDeliveryModeCardContent(order?.deliveryMode) | async"
+          ></cx-card>
+        </ng-container>
+      </div>
+
+      <ng-container *ngIf="order.paymentInfo">
+        <div class="cx-summary-card">
+          <cx-card
+            [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
+          ></cx-card>
+
+          <cx-card
+            [content]="
+              getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
+                | async
+            "
+          ></cx-card>
+        </div>
+      </ng-container>
     </div>
   </div>
 </ng-container>

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.spec.ts
@@ -1,80 +1,105 @@
-import { DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { I18nTestingModule, Order } from '@spartacus/core';
-import { of } from 'rxjs';
+import {
+  Address,
+  DeliveryMode,
+  I18nTestingModule,
+  Order,
+  PaymentDetails,
+  TranslationService,
+} from '@spartacus/core';
+import { Observable, of } from 'rxjs';
 import { CardModule } from '../../../../../shared/components/card/card.module';
 import { OrderDetailsService } from '../order-details.service';
 import { OrderDetailShippingComponent } from './order-detail-shipping.component';
 
-const mockOrder: Order = {
-  code: '1',
-  statusDisplay: 'Shipped',
-  deliveryAddress: {
-    firstName: 'John',
-    lastName: 'Smith',
-    line1: 'Buckingham Street 5',
-    line2: '1A',
-    phone: '(+11) 111 111 111',
-    postalCode: 'MA8902',
-    town: 'London',
-    country: {
-      isocode: 'UK',
-    },
+const mockDeliveryAddress: Address = {
+  firstName: 'John',
+  lastName: 'Smith',
+  line1: 'Buckingham Street 5',
+  line2: '1A',
+  phone: '(+11) 111 111 111',
+  postalCode: 'MA8902',
+  town: 'London',
+  country: {
+    isocode: 'UK',
   },
-  deliveryMode: {
-    name: 'Standard order-detail-shipping',
-    description: '3-5 days',
-  },
-  paymentInfo: {
-    accountHolderName: 'John Smith',
-    cardNumber: '************6206',
-    expiryMonth: '12',
-    expiryYear: '2026',
-    cardType: {
-      name: 'Visa',
-    },
-    billingAddress: {
-      firstName: 'John',
-      lastName: 'Smith',
-      line1: 'Buckingham Street 5',
-      line2: '1A',
-      phone: '(+11) 111 111 111',
-      postalCode: 'MA8902',
-      town: 'London',
-      country: {
-        isocode: 'UK',
-      },
-    },
-  },
-  created: new Date('2019-02-11T13:02:58+0000'),
-  consignments: [
-    {
-      code: 'a00000341',
-      status: 'SHIPPED',
-      statusDate: new Date('2019-02-11T13:05:12+0000'),
-      entries: [{ orderEntry: {}, quantity: 1, shippedQuantity: 1 }],
-    },
-  ],
+  formattedAddress: 'test-formattedAddress',
 };
+
+const mockDeliveryMode: DeliveryMode = {
+  name: 'Standard order-detail-shipping',
+  description: '3-5 days',
+  deliveryCost: {
+    formattedValue: 'test-formatted-cosg',
+  },
+};
+
+const mockBillingAddress: Address = {
+  firstName: 'John',
+  lastName: 'Smith',
+  line1: 'Buckingham Street 5',
+  line2: '1A',
+  phone: '(+11) 111 111 111',
+  postalCode: 'MA8902',
+  town: 'London',
+  country: {
+    name: 'test-country-name',
+    isocode: 'UK',
+  },
+  formattedAddress: 'test-formattedAddress',
+};
+
+const mockPayment: PaymentDetails = {
+  accountHolderName: 'John Smith',
+  cardNumber: '************6206',
+  expiryMonth: '12',
+  expiryYear: '2026',
+  cardType: {
+    name: 'Visa',
+  },
+  billingAddress: mockBillingAddress,
+};
+
+const mockOrder: Order = {
+  code: 'test-code-412',
+  deliveryAddress: mockDeliveryAddress,
+  deliveryMode: mockDeliveryMode,
+  paymentInfo: mockPayment,
+  statusDisplay: 'test-status-display',
+  created: new Date('2019-02-11T13:02:58+0000'),
+  purchaseOrderNumber: 'test-po',
+  costCenter: {
+    name: 'Rustic Global',
+    unit: {
+      name: 'Rustic',
+    },
+  },
+};
+
+class MockOrderDetailsService {
+  getOrderDetails(): Observable<Order> {
+    return of(mockOrder);
+  }
+}
+
+class MockTranslationService {
+  translate(): Observable<string> {
+    return of();
+  }
+}
 
 describe('OrderDetailShippingComponent', () => {
   let component: OrderDetailShippingComponent;
   let fixture: ComponentFixture<OrderDetailShippingComponent>;
-  let mockOrderDetailsService: OrderDetailsService;
-  let el: DebugElement;
+  let orderDetailsService: OrderDetailsService;
+  let translationService: TranslationService;
 
   beforeEach(async(() => {
-    mockOrderDetailsService = <OrderDetailsService>{
-      getOrderDetails() {
-        return of(mockOrder);
-      },
-    };
-
     TestBed.configureTestingModule({
       imports: [CardModule, I18nTestingModule],
       providers: [
-        { provide: OrderDetailsService, useValue: mockOrderDetailsService },
+        { provide: OrderDetailsService, useClass: MockOrderDetailsService },
+        { provide: TranslationService, useClass: MockTranslationService },
       ],
       declarations: [OrderDetailShippingComponent],
     }).compileComponents();
@@ -82,17 +107,18 @@ describe('OrderDetailShippingComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderDetailShippingComponent);
-    el = fixture.debugElement;
-
+    orderDetailsService = TestBed.inject(OrderDetailsService);
+    translationService = TestBed.inject(TranslationService);
     component = fixture.componentInstance;
-    component.ngOnInit();
   });
 
   it('should create', () => {
+    component.ngOnInit();
     expect(component).toBeTruthy();
   });
 
   it('should initialize ', () => {
+    component.ngOnInit();
     fixture.detectChanges();
     let order: Order;
     component.order$
@@ -103,62 +129,233 @@ describe('OrderDetailShippingComponent', () => {
     expect(order).toEqual(mockOrder);
   });
 
-  it('should order details shipping be rendered', () => {
-    fixture.detectChanges();
-    expect(el.query(By.css('.cx-account-summary'))).toBeTruthy();
+  describe('when replenishment is NOT defined', () => {
+    beforeEach(() => {
+      spyOn(orderDetailsService, 'getOrderDetails').and.returnValue(
+        of(mockOrder)
+      );
+      spyOn(translationService, 'translate').and.returnValue(of('test'));
+    });
+
+    it('should call getOrderCodeCardContent(orderCode: string)', () => {
+      spyOn(component, 'getOrderCodeCardContent').and.callThrough();
+
+      component
+        .getOrderCodeCardContent(mockOrder.code)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual([mockOrder.code]);
+        })
+        .unsubscribe();
+
+      expect(component.getOrderCodeCardContent).toHaveBeenCalledWith(
+        mockOrder.code
+      );
+    });
+
+    it('should call getOrderCurrentDateCardContent(isoDate: string)', () => {
+      spyOn(component, 'getOrderCurrentDateCardContent').and.callThrough();
+
+      const date = component['getDate'](new Date(mockOrder.created));
+
+      component
+        .getOrderCurrentDateCardContent(date)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual([date]);
+        })
+        .unsubscribe();
+
+      expect(component.getOrderCurrentDateCardContent).toHaveBeenCalled();
+    });
+
+    it('should call getOrderStatusCardContent(status: string)', () => {
+      spyOn(component, 'getOrderStatusCardContent').and.callThrough();
+
+      component
+        .getOrderStatusCardContent(mockOrder.statusDisplay)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual(['test']);
+        })
+        .unsubscribe();
+
+      expect(component.getOrderStatusCardContent).toHaveBeenCalledWith(
+        mockOrder.statusDisplay
+      );
+    });
   });
 
-  it('should order details display "ship to" data', () => {
-    fixture.detectChanges();
-    const element: DebugElement = el.query(
-      By.css('div:nth-child(1) > cx-card .cx-card-label-container')
-    );
-    expect(element.nativeElement.textContent).toContain(
-      mockOrder.deliveryAddress.firstName &&
-        mockOrder.deliveryAddress.lastName &&
-        mockOrder.deliveryAddress.line1 &&
-        mockOrder.deliveryAddress.line2 &&
-        mockOrder.deliveryAddress.town &&
-        mockOrder.deliveryAddress.postalCode
-    );
+  describe('when purchase order number is defined', () => {
+    beforeEach(() => {
+      spyOn(orderDetailsService, 'getOrderDetails').and.returnValue(
+        of(mockOrder)
+      );
+      spyOn(translationService, 'translate').and.returnValue(of('test'));
+    });
+
+    it('should call getPurchaseOrderNumber(poNumber: string)', () => {
+      spyOn(component, 'getPurchaseOrderNumber').and.callThrough();
+
+      component
+        .getPurchaseOrderNumber(mockOrder.purchaseOrderNumber)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual([mockOrder.purchaseOrderNumber]);
+        })
+        .unsubscribe();
+
+      expect(component.getPurchaseOrderNumber).toHaveBeenCalledWith(
+        mockOrder.purchaseOrderNumber
+      );
+    });
+
+    it('should call getMethodOfPaymentCardContent(hasPaymentInfo: PaymentDetails)', () => {
+      spyOn(component, 'getMethodOfPaymentCardContent').and.callThrough();
+
+      component
+        .getMethodOfPaymentCardContent(mockOrder.paymentInfo)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual(['test']);
+        })
+        .unsubscribe();
+
+      expect(component.getMethodOfPaymentCardContent).toHaveBeenCalledWith(
+        mockOrder.paymentInfo
+      );
+    });
+
+    it('should call getCostCenterCardContent(costCenter: CostCenter)', () => {
+      spyOn(component, 'getCostCenterCardContent').and.callThrough();
+
+      component
+        .getCostCenterCardContent(mockOrder.costCenter)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(mockOrder.costCenter.name);
+          expect(data.text).toEqual([`(${mockOrder.costCenter.unit.name})`]);
+        })
+        .unsubscribe();
+
+      expect(component.getCostCenterCardContent).toHaveBeenCalledWith(
+        mockOrder.costCenter
+      );
+    });
   });
 
-  it('should order details display "bill to" data', () => {
-    fixture.detectChanges();
-    const element: DebugElement = el.query(
-      By.css('div:nth-child(2) > cx-card .cx-card-label-container')
-    );
-    expect(element.nativeElement.textContent).toContain(
-      mockOrder.paymentInfo.billingAddress.firstName &&
-        mockOrder.paymentInfo.billingAddress.lastName &&
-        mockOrder.paymentInfo.billingAddress.line1 &&
-        mockOrder.paymentInfo.billingAddress.line2 &&
-        mockOrder.paymentInfo.billingAddress.town &&
-        mockOrder.paymentInfo.billingAddress.postalCode
-    );
+  describe('when paymentInfo is defined', () => {
+    beforeEach(() => {
+      spyOn(orderDetailsService, 'getOrderDetails').and.returnValue(
+        of(mockOrder)
+      );
+      spyOn(translationService, 'translate').and.returnValue(of('test'));
+    });
+
+    it('should call getPaymentInfoCardContent(payment: PaymentDetails)', () => {
+      spyOn(component, 'getPaymentInfoCardContent').and.callThrough();
+
+      component
+        .getPaymentInfoCardContent(mockOrder.paymentInfo)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(
+            mockOrder.paymentInfo.accountHolderName
+          );
+          expect(data.text).toEqual([mockOrder.paymentInfo.cardNumber, 'test']);
+        })
+        .unsubscribe();
+
+      expect(component.getPaymentInfoCardContent).toHaveBeenCalledWith(
+        mockOrder.paymentInfo
+      );
+    });
+
+    it('should call getBillingAddressCardContent(billingAddress: Address)', () => {
+      spyOn(component, 'getBillingAddressCardContent').and.callThrough();
+
+      const billingAddress = mockOrder.paymentInfo.billingAddress;
+
+      component
+        .getBillingAddressCardContent(billingAddress)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(
+            `${billingAddress.firstName} ${billingAddress.lastName}`
+          );
+          expect(data.text).toEqual([
+            billingAddress.formattedAddress,
+            billingAddress.country.name,
+          ]);
+        })
+        .unsubscribe();
+
+      expect(component.getBillingAddressCardContent).toHaveBeenCalledWith(
+        billingAddress
+      );
+    });
   });
 
-  it('should order details display "payment" data', () => {
-    fixture.detectChanges();
-    const element: DebugElement = el.query(
-      By.css('div:nth-child(3) > cx-card .cx-card-label-container')
-    );
-    expect(element.nativeElement.textContent).toContain(
-      mockOrder.paymentInfo.accountHolderName &&
-        mockOrder.paymentInfo.cardNumber &&
-        mockOrder.paymentInfo.expiryMonth &&
-        mockOrder.paymentInfo.expiryYear &&
-        mockOrder.paymentInfo.cardType.name
-    );
-  });
+  describe('common column in all types of order', () => {
+    beforeEach(() => {
+      spyOn(orderDetailsService, 'getOrderDetails').and.returnValue(
+        of(mockOrder)
+      );
+      spyOn(translationService, 'translate').and.returnValue(of('test'));
+    });
 
-  it('should order details display "shipping" data', () => {
-    fixture.detectChanges();
-    const element: DebugElement = el.query(
-      By.css('div:nth-child(4) > cx-card .cx-card-label-container')
-    );
-    expect(element.nativeElement.textContent).toContain(
-      mockOrder.deliveryMode.name && mockOrder.deliveryMode.description
-    );
+    it('should call getAddressCardContent(deliveryAddress: Address)', () => {
+      spyOn(component, 'getAddressCardContent').and.callThrough();
+
+      const deliveryAddress = mockOrder.deliveryAddress;
+
+      component
+        .getAddressCardContent(deliveryAddress)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(
+            `${deliveryAddress.firstName} ${deliveryAddress.lastName}`
+          );
+          expect(data.text).toEqual([
+            deliveryAddress.formattedAddress,
+            deliveryAddress.country.name,
+          ]);
+        })
+        .unsubscribe();
+
+      expect(component.getAddressCardContent).toHaveBeenCalledWith(
+        deliveryAddress
+      );
+    });
+
+    it('should call getDeliveryModeCardContent(deliveryMode: DeliveryMode)', () => {
+      spyOn(component, 'getDeliveryModeCardContent').and.callThrough();
+
+      component
+        .getDeliveryModeCardContent(mockOrder.deliveryMode)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(mockOrder.deliveryMode.name);
+          expect(data.text).toEqual([
+            mockOrder.deliveryMode.description,
+            mockOrder.deliveryMode.deliveryCost.formattedValue,
+          ]);
+        })
+        .unsubscribe();
+
+      expect(component.getDeliveryModeCardContent).toHaveBeenCalledWith(
+        mockOrder.deliveryMode
+      );
+    });
   });
 });

--- a/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/order-details/order-detail-shipping/order-detail-shipping.component.ts
@@ -1,15 +1,16 @@
 import { Component, OnInit } from '@angular/core';
 import {
   Address,
+  CostCenter,
   DeliveryMode,
   Order,
   PaymentDetails,
   TranslationService,
 } from '@spartacus/core';
-import { Observable, combineLatest } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 import { Card } from '../../../../../shared/components/card/card.component';
 import { OrderDetailsService } from '../order-details.service';
-import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'cx-order-details-shipping',
@@ -27,73 +28,147 @@ export class OrderDetailShippingComponent implements OnInit {
     this.order$ = this.orderDetailsService.getOrderDetails();
   }
 
-  getAddressCardContent(address: Address): Observable<Card> {
-    return combineLatest([
-      this.translation.translate('addressCard.shipTo'),
-    ]).pipe(
-      map(([textTitle]) => {
-        return {
+  getOrderCodeCardContent(orderCode: string): Observable<Card> {
+    return this.translation
+      .translate('checkoutOrderConfirmation.orderNumber')
+      .pipe(
+        filter(() => Boolean(orderCode)),
+        map((textTitle) => ({
           title: textTitle,
-          textBold: `${address.firstName} ${address.lastName}`,
-          text: [
-            address.line1,
-            address.line2,
-            `${address.town}, ${address.country.isocode}, ${address.postalCode}`,
-            address.phone,
-          ],
-        };
-      })
+          text: [orderCode],
+        }))
+      );
+  }
+
+  getOrderCurrentDateCardContent(isoDate: string): Observable<Card> {
+    return this.translation
+      .translate('checkoutOrderConfirmation.placedOn')
+      .pipe(
+        map((textTitle) => {
+          const date = this.getDate(new Date(isoDate));
+
+          return {
+            title: textTitle,
+            text: [date],
+          };
+        })
+      );
+  }
+
+  getOrderStatusCardContent(status: string): Observable<Card> {
+    return combineLatest([
+      this.translation.translate('checkoutOrderConfirmation.status'),
+      this.translation.translate('orderDetails.statusDisplay', {
+        context: status,
+      }),
+    ]).pipe(
+      map(([textTitle, textStatus]) => ({
+        title: textTitle,
+        text: [textStatus],
+      }))
+    );
+  }
+
+  getPurchaseOrderNumber(poNumber: string): Observable<Card> {
+    return combineLatest([
+      this.translation.translate('checkoutReview.poNumber'),
+      this.translation.translate('checkoutPO.noPoNumber'),
+    ]).pipe(
+      map(([textTitle, noneTextTitle]) => ({
+        title: textTitle,
+        text: [poNumber ? poNumber : noneTextTitle],
+      }))
+    );
+  }
+
+  getMethodOfPaymentCardContent(
+    hasPaymentInfo: PaymentDetails
+  ): Observable<Card> {
+    return combineLatest([
+      this.translation.translate('checkoutProgress.methodOfPayment'),
+      this.translation.translate('paymentTypes.paymentType_ACCOUNT'),
+      this.translation.translate('paymentTypes.paymentType_CARD'),
+    ]).pipe(
+      map(([textTitle, textAccount, textCard]) => ({
+        title: textTitle,
+        text: [Boolean(hasPaymentInfo) ? textCard : textAccount],
+      }))
+    );
+  }
+
+  getCostCenterCardContent(costCenter: CostCenter): Observable<Card> {
+    return this.translation.translate('checkoutPO.costCenter').pipe(
+      filter(() => Boolean(costCenter)),
+      map((textTitle) => ({
+        title: textTitle,
+        textBold: costCenter?.name,
+        text: ['(' + costCenter?.unit?.name + ')'],
+      }))
+    );
+  }
+
+  getAddressCardContent(deliveryAddress: Address): Observable<Card> {
+    return this.translation.translate('addressCard.shipTo').pipe(
+      filter(() => Boolean(deliveryAddress)),
+      map((textTitle) => ({
+        title: textTitle,
+        textBold: `${deliveryAddress.firstName} ${deliveryAddress.lastName}`,
+        text: [deliveryAddress.formattedAddress, deliveryAddress.country.name],
+      }))
+    );
+  }
+
+  getDeliveryModeCardContent(deliveryMode: DeliveryMode): Observable<Card> {
+    return this.translation.translate('checkoutShipping.shippingMethod').pipe(
+      filter(() => Boolean(deliveryMode)),
+      map((textTitle) => ({
+        title: textTitle,
+        textBold: deliveryMode.name,
+        text: [
+          deliveryMode.description,
+          deliveryMode.deliveryCost?.formattedValue
+            ? deliveryMode.deliveryCost?.formattedValue
+            : '',
+        ],
+      }))
+    );
+  }
+
+  getPaymentInfoCardContent(payment: PaymentDetails): Observable<Card> {
+    return combineLatest([
+      this.translation.translate('paymentForm.payment'),
+      this.translation.translate('paymentCard.expires', {
+        month: Boolean(payment) ? payment.expiryMonth : '',
+        year: Boolean(payment) ? payment.expiryYear : '',
+      }),
+    ]).pipe(
+      filter(() => Boolean(payment)),
+      map(([textTitle, textExpires]) => ({
+        title: textTitle,
+        textBold: payment.accountHolderName,
+        text: [payment.cardNumber, textExpires],
+      }))
     );
   }
 
   getBillingAddressCardContent(billingAddress: Address): Observable<Card> {
-    return combineLatest([
-      this.translation.translate('addressCard.billTo'),
-    ]).pipe(
-      map(([textTitle]) => {
-        return {
-          title: textTitle,
-          textBold: `${billingAddress.firstName} ${billingAddress.lastName}`,
-          text: [
-            billingAddress.line1,
-            billingAddress.line2,
-            `${billingAddress.town}, ${billingAddress.country.isocode}, ${billingAddress.postalCode}`,
-            billingAddress.phone,
-          ],
-        };
-      })
+    return this.translation.translate('paymentForm.billingAddress').pipe(
+      filter(() => Boolean(billingAddress)),
+      map((textTitle) => ({
+        title: textTitle,
+        textBold: `${billingAddress.firstName} ${billingAddress.lastName}`,
+        text: [billingAddress.formattedAddress, billingAddress.country.name],
+      }))
     );
   }
 
-  getPaymentCardContent(payment: PaymentDetails): Observable<Card> {
-    return combineLatest([
-      this.translation.translate('paymentForm.payment'),
-      this.translation.translate('paymentCard.expires', {
-        month: payment.expiryMonth,
-        year: payment.expiryYear,
-      }),
-    ]).pipe(
-      map(([textTitle, textExpires]) => {
-        return {
-          title: textTitle,
-          textBold: payment.accountHolderName,
-          text: [payment.cardType.name, payment.cardNumber, textExpires],
-        };
-      })
-    );
-  }
+  private getDate(givenDate: Date): string {
+    const date = givenDate.toDateString().split(' ');
 
-  getShippingMethodCardContent(shipping: DeliveryMode): Observable<Card> {
-    return combineLatest([
-      this.translation.translate('checkoutShipping.shippingMethod'),
-    ]).pipe(
-      map(([textTitle]) => {
-        return {
-          title: textTitle,
-          textBold: shipping.name,
-          text: [shipping.description],
-        };
-      })
-    );
+    const month = date[1];
+    const day = date[2];
+    const year = date[3];
+
+    return month + ' ' + day + ' ' + year;
   }
 }

--- a/projects/storefrontlib/src/cms-components/order-confirmation/components/order-confirmation-overview/order-confirmation-overview.component.html
+++ b/projects/storefrontlib/src/cms-components/order-confirmation/components/order-confirmation-overview/order-confirmation-overview.component.html
@@ -1,36 +1,66 @@
 <div class="cx-order-review-summary" *ngIf="order$ | async as order">
   <div class="container">
-    <div *ngIf="order.deliveryAddress" class="summary-card">
+    <div class="summary-card">
       <cx-card
-        [content]="getAddressCardContent(order?.deliveryAddress) | async"
+        [content]="getOrderCodeCardContent(order?.code) | async"
+      ></cx-card>
+
+      <cx-card
+        [content]="getOrderCurrentDateCardContent(order?.created) | async"
+      ></cx-card>
+
+      <cx-card
+        [content]="getOrderStatusCardContent(order.statusDisplay) | async"
       ></cx-card>
     </div>
 
-    <div *ngIf="order.paymentInfo?.billingAddress" class="summary-card">
-      <cx-card
-        [content]="
-          getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
-            | async
-        "
-      ></cx-card>
+    <ng-container
+      *ngIf="order.purchaseOrderNumber || order.purchaseOrderNumber === ''"
+    >
+      <div class="summary-card">
+        <cx-card
+          [content]="getPurchaseOrderNumber(order?.purchaseOrderNumber) | async"
+        ></cx-card>
+
+        <cx-card
+          [content]="getMethodOfPaymentCardContent(order.paymentInfo) | async"
+        ></cx-card>
+
+        <ng-container *ngIf="order.costCenter">
+          <cx-card
+            [content]="getCostCenterCardContent(order?.costCenter) | async"
+          ></cx-card>
+        </ng-container>
+      </div>
+    </ng-container>
+
+    <div class="summary-card">
+      <ng-container *ngIf="order.deliveryAddress">
+        <cx-card
+          [content]="getAddressCardContent(order?.deliveryAddress) | async"
+        ></cx-card>
+      </ng-container>
+
+      <ng-container *ngIf="order.deliveryMode">
+        <cx-card
+          [content]="getDeliveryModeCardContent(order?.deliveryMode) | async"
+        ></cx-card>
+      </ng-container>
     </div>
 
-    <div *ngIf="order.deliveryMode" class="summary-card">
-      <cx-card
-        [content]="getDeliveryModeCardContent(order?.deliveryMode) | async"
-      ></cx-card>
-    </div>
+    <ng-container *ngIf="order.paymentInfo">
+      <div class="summary-card">
+        <cx-card
+          [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
+        ></cx-card>
 
-    <div *ngIf="order.paymentInfo" class="summary-card">
-      <cx-card
-        [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
-      ></cx-card>
-    </div>
-
-    <div *ngIf="order.costCenter" class="summary-card">
-      <cx-card
-        [content]="getAccountPaymentCardContent(order) | async"
-      ></cx-card>
-    </div>
+        <cx-card
+          [content]="
+            getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
+              | async
+          "
+        ></cx-card>
+      </div>
+    </ng-container>
   </div>
 </div>

--- a/projects/storefrontlib/src/cms-components/order-confirmation/components/order-confirmation-overview/order-confirmation-overview.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/order-confirmation/components/order-confirmation-overview/order-confirmation-overview.component.spec.ts
@@ -20,35 +20,69 @@ class MockCardComponent {
   content: Card;
 }
 
-const mockOrder: Order = {
-  code: 'test-code-412',
-  deliveryAddress: {
-    country: {},
+const mockDeliveryAddress: Address = {
+  firstName: 'John',
+  lastName: 'Smith',
+  line1: 'Buckingham Street 5',
+  line2: '1A',
+  phone: '(+11) 111 111 111',
+  postalCode: 'MA8902',
+  town: 'London',
+  country: {
+    name: 'test-country-name',
+    isocode: 'UK',
   },
-  deliveryMode: {},
-  paymentInfo: {
-    billingAddress: {
-      country: {},
-    },
+  formattedAddress: 'test-formattedAddress',
+};
+
+const mockDeliveryMode: DeliveryMode = {
+  name: 'Standard order-detail-shipping',
+  description: '3-5 days',
+  deliveryCost: {
+    formattedValue: 'test-formatted-cosg',
   },
 };
 
-const mockB2BOrder: Order = {
-  ...mockOrder,
+const mockBillingAddress: Address = {
+  firstName: 'John',
+  lastName: 'Smith',
+  line1: 'Buckingham Street 5',
+  line2: '1A',
+  phone: '(+11) 111 111 111',
+  postalCode: 'MA8902',
+  town: 'London',
+  country: {
+    name: 'test-country-name',
+    isocode: 'UK',
+  },
+  formattedAddress: 'test-formattedAddress',
+};
+
+const mockPayment: PaymentDetails = {
+  accountHolderName: 'John Smith',
+  cardNumber: '************6206',
+  expiryMonth: '12',
+  expiryYear: '2026',
+  cardType: {
+    name: 'Visa',
+  },
+  billingAddress: mockBillingAddress,
+};
+
+const mockOrder: Order = {
+  code: 'test-code-412',
+  deliveryAddress: mockDeliveryAddress,
+  deliveryMode: mockDeliveryMode,
+  paymentInfo: mockPayment,
+  statusDisplay: 'test-status-display',
+  created: new Date('2019-02-11T13:02:58+0000'),
+  purchaseOrderNumber: 'test-po',
   costCenter: {
     name: 'Rustic Global',
     unit: {
       name: 'Rustic',
     },
   },
-  orgCustomer: {
-    active: true,
-    name: 'Rivers',
-    orgUnit: {
-      name: 'Rustic',
-    },
-  },
-  purchaseOrderNumber: '123',
 };
 
 class MockCheckoutService {
@@ -64,47 +98,6 @@ class MockTranslationService {
     return of();
   }
 }
-
-const mockDeliveryAddress: Address = {
-  firstName: 'John',
-  lastName: 'Smith',
-  line1: 'Buckingham Street 5',
-  line2: '1A',
-  phone: '(+11) 111 111 111',
-  postalCode: 'MA8902',
-  town: 'London',
-  country: {
-    isocode: 'UK',
-  },
-};
-
-const mockDeliveryMode: DeliveryMode = {
-  name: 'Standard order-detail-shipping',
-  description: '3-5 days',
-};
-
-const mockBillingAddress: Address = {
-  firstName: 'John',
-  lastName: 'Smith',
-  line1: 'Buckingham Street 5',
-  line2: '1A',
-  phone: '(+11) 111 111 111',
-  postalCode: 'MA8902',
-  town: 'London',
-  country: {
-    isocode: 'UK',
-  },
-};
-
-const mockPayment: PaymentDetails = {
-  accountHolderName: 'John Smith',
-  cardNumber: '************6206',
-  expiryMonth: '12',
-  expiryYear: '2026',
-  cardType: {
-    name: 'Visa',
-  },
-};
 
 describe('OrderConfirmationOverviewComponent', () => {
   let component: OrderConfirmationOverviewComponent;
@@ -135,70 +128,225 @@ describe('OrderConfirmationOverviewComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call getAddressCardContent(deliveryAddress: Address)', () => {
-    spyOn(component, 'getAddressCardContent').and.callThrough();
-    spyOn(translationService, 'translate').and.returnValue(of('test'));
-    component.getAddressCardContent(mockDeliveryAddress).subscribe((data) => {
-      expect(data).toBeTruthy();
-      expect(data.title).toEqual('test');
+  describe('when replenishment is NOT defined', () => {
+    beforeEach(() => {
+      spyOn(checkoutService, 'getOrderDetails').and.returnValue(of(mockOrder));
+      spyOn(translationService, 'translate').and.returnValue(of('test'));
     });
-    expect(component.getAddressCardContent).toHaveBeenCalledWith(
-      mockDeliveryAddress
-    );
+
+    it('should call getOrderCodeCardContent(orderCode: string)', () => {
+      spyOn(component, 'getOrderCodeCardContent').and.callThrough();
+
+      component
+        .getOrderCodeCardContent(mockOrder.code)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual([mockOrder.code]);
+        })
+        .unsubscribe();
+
+      expect(component.getOrderCodeCardContent).toHaveBeenCalledWith(
+        mockOrder.code
+      );
+    });
+
+    it('should call getOrderCurrentDateCardContent(isoDate: string)', () => {
+      spyOn(component, 'getOrderCurrentDateCardContent').and.callThrough();
+
+      const date = component['getDate'](mockOrder.created);
+
+      component
+        .getOrderCurrentDateCardContent(mockOrder.created.toDateString())
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual([date]);
+        })
+        .unsubscribe();
+
+      expect(component.getOrderCurrentDateCardContent).toHaveBeenCalled();
+    });
+
+    it('should call getOrderStatusCardContent(status: string)', () => {
+      spyOn(component, 'getOrderStatusCardContent').and.callThrough();
+
+      component
+        .getOrderStatusCardContent(mockOrder.statusDisplay)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual(['test']);
+        })
+        .unsubscribe();
+
+      expect(component.getOrderStatusCardContent).toHaveBeenCalledWith(
+        mockOrder.statusDisplay
+      );
+    });
   });
 
-  it('should call getDeliveryModeCardContent(deliveryMode: DeliveryMode)', () => {
-    spyOn(component, 'getDeliveryModeCardContent').and.callThrough();
-    spyOn(translationService, 'translate').and.returnValue(of('test'));
-    component.getDeliveryModeCardContent(mockDeliveryMode).subscribe((data) => {
-      expect(data).toBeTruthy();
-      expect(data.title).toEqual('test');
+  describe('when purchase order number is defined', () => {
+    beforeEach(() => {
+      spyOn(checkoutService, 'getOrderDetails').and.returnValue(of(mockOrder));
+      spyOn(translationService, 'translate').and.returnValue(of('test'));
     });
-    component.getDeliveryModeCardContent(mockDeliveryMode);
-    expect(component.getDeliveryModeCardContent).toHaveBeenCalledWith(
-      mockDeliveryMode
-    );
+
+    it('should call getPurchaseOrderNumber(poNumber: string)', () => {
+      spyOn(component, 'getPurchaseOrderNumber').and.callThrough();
+
+      component
+        .getPurchaseOrderNumber(mockOrder.purchaseOrderNumber)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual([mockOrder.purchaseOrderNumber]);
+        })
+        .unsubscribe();
+
+      expect(component.getPurchaseOrderNumber).toHaveBeenCalledWith(
+        mockOrder.purchaseOrderNumber
+      );
+    });
+
+    it('should call getMethodOfPaymentCardContent(hasPaymentInfo: PaymentDetails)', () => {
+      spyOn(component, 'getMethodOfPaymentCardContent').and.callThrough();
+
+      component
+        .getMethodOfPaymentCardContent(mockOrder.paymentInfo)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.text).toEqual(['test']);
+        })
+        .unsubscribe();
+
+      expect(component.getMethodOfPaymentCardContent).toHaveBeenCalledWith(
+        mockOrder.paymentInfo
+      );
+    });
+
+    it('should call getCostCenterCardContent(costCenter: CostCenter)', () => {
+      spyOn(component, 'getCostCenterCardContent').and.callThrough();
+
+      component
+        .getCostCenterCardContent(mockOrder.costCenter)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(mockOrder.costCenter.name);
+          expect(data.text).toEqual([`(${mockOrder.costCenter.unit.name})`]);
+        })
+        .unsubscribe();
+
+      expect(component.getCostCenterCardContent).toHaveBeenCalledWith(
+        mockOrder.costCenter
+      );
+    });
   });
 
-  it('should call getBillingAddressCardContent(billingAddress: Address)', () => {
-    spyOn(component, 'getBillingAddressCardContent').and.callThrough();
-    spyOn(translationService, 'translate').and.returnValue(of('test'));
-    component
-      .getBillingAddressCardContent(mockBillingAddress)
-      .subscribe((data) => {
-        expect(data).toBeTruthy();
-        expect(data.title).toEqual('test');
-      });
-    component.getBillingAddressCardContent(mockBillingAddress);
-    expect(component.getBillingAddressCardContent).toHaveBeenCalledWith(
-      mockBillingAddress
-    );
+  describe('when paymentInfo is defined', () => {
+    beforeEach(() => {
+      spyOn(checkoutService, 'getOrderDetails').and.returnValue(of(mockOrder));
+      spyOn(translationService, 'translate').and.returnValue(of('test'));
+    });
+
+    it('should call getPaymentInfoCardContent(payment: PaymentDetails)', () => {
+      spyOn(component, 'getPaymentInfoCardContent').and.callThrough();
+
+      component
+        .getPaymentInfoCardContent(mockOrder.paymentInfo)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(
+            mockOrder.paymentInfo.accountHolderName
+          );
+          expect(data.text).toEqual([mockOrder.paymentInfo.cardNumber, 'test']);
+        })
+        .unsubscribe();
+
+      expect(component.getPaymentInfoCardContent).toHaveBeenCalledWith(
+        mockOrder.paymentInfo
+      );
+    });
+
+    it('should call getBillingAddressCardContent(billingAddress: Address)', () => {
+      spyOn(component, 'getBillingAddressCardContent').and.callThrough();
+
+      const billingAddress = mockOrder.paymentInfo.billingAddress;
+
+      component
+        .getBillingAddressCardContent(billingAddress)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(
+            `${billingAddress.firstName} ${billingAddress.lastName}`
+          );
+          expect(data.text).toEqual([
+            billingAddress.formattedAddress,
+            billingAddress.country.name,
+          ]);
+        })
+        .unsubscribe();
+
+      expect(component.getBillingAddressCardContent).toHaveBeenCalledWith(
+        billingAddress
+      );
+    });
   });
 
-  it('should call getPaymentInfoCardContent(payment: PaymentDetails)', () => {
-    spyOn(component, 'getPaymentInfoCardContent').and.callThrough();
-    spyOn(translationService, 'translate').and.returnValue(of('test'));
-    component.getPaymentInfoCardContent(mockPayment).subscribe((data) => {
-      expect(data).toBeTruthy();
-      expect(data.title).toEqual('test');
+  describe('common column in all types of order', () => {
+    beforeEach(() => {
+      spyOn(checkoutService, 'getOrderDetails').and.returnValue(of(mockOrder));
+      spyOn(translationService, 'translate').and.returnValue(of('test'));
     });
-    component.getPaymentInfoCardContent(mockPayment);
-    expect(component.getPaymentInfoCardContent).toHaveBeenCalledWith(
-      mockPayment
-    );
-  });
 
-  it('should call getAccountPaymentCardContent(order: Order)', () => {
-    spyOn(checkoutService, 'getOrderDetails').and.returnValue(of(mockB2BOrder));
-    spyOn(component, 'getAccountPaymentCardContent').and.callThrough();
-    spyOn(translationService, 'translate').and.returnValue(of('test'));
-    component.getAccountPaymentCardContent(mockB2BOrder).subscribe((data) => {
-      expect(data).toBeTruthy();
-      expect(data.title).toEqual('test');
+    it('should call getAddressCardContent(deliveryAddress: Address)', () => {
+      spyOn(component, 'getAddressCardContent').and.callThrough();
+
+      const deliveryAddress = mockOrder.deliveryAddress;
+
+      component
+        .getAddressCardContent(deliveryAddress)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(
+            `${deliveryAddress.firstName} ${deliveryAddress.lastName}`
+          );
+          expect(data.text).toEqual([
+            deliveryAddress.formattedAddress,
+            deliveryAddress.country.name,
+          ]);
+        })
+        .unsubscribe();
+
+      expect(component.getAddressCardContent).toHaveBeenCalledWith(
+        deliveryAddress
+      );
     });
-    component.getAccountPaymentCardContent(mockB2BOrder);
-    expect(component.getAccountPaymentCardContent).toHaveBeenCalledWith(
-      mockB2BOrder
-    );
+
+    it('should call getDeliveryModeCardContent(deliveryMode: DeliveryMode)', () => {
+      spyOn(component, 'getDeliveryModeCardContent').and.callThrough();
+
+      component
+        .getDeliveryModeCardContent(mockOrder.deliveryMode)
+        .subscribe((data) => {
+          expect(data).toBeTruthy();
+          expect(data.title).toEqual('test');
+          expect(data.textBold).toEqual(mockOrder.deliveryMode.name);
+          expect(data.text).toEqual([
+            mockOrder.deliveryMode.description,
+            mockOrder.deliveryMode.deliveryCost.formattedValue,
+          ]);
+        })
+        .unsubscribe();
+
+      expect(component.getDeliveryModeCardContent).toHaveBeenCalledWith(
+        mockOrder.deliveryMode
+      );
+    });
   });
 });

--- a/projects/storefrontlib/src/cms-components/order-confirmation/components/order-confirmation-overview/order-confirmation-overview.component.ts
+++ b/projects/storefrontlib/src/cms-components/order-confirmation/components/order-confirmation-overview/order-confirmation-overview.component.ts
@@ -7,6 +7,7 @@ import {
 import {
   Address,
   CheckoutService,
+  CostCenter,
   DeliveryMode,
   Order,
   PaymentDetails,
@@ -37,18 +38,92 @@ export class OrderConfirmationOverviewComponent implements OnInit, OnDestroy {
     this.checkoutService.clearCheckoutData();
   }
 
+  getOrderCodeCardContent(orderCode: string): Observable<Card> {
+    return this.translation
+      .translate('checkoutOrderConfirmation.orderNumber')
+      .pipe(
+        filter(() => Boolean(orderCode)),
+        map((textTitle) => ({
+          title: textTitle,
+          text: [orderCode],
+        }))
+      );
+  }
+
+  getOrderCurrentDateCardContent(isoDate: string): Observable<Card> {
+    return this.translation
+      .translate('checkoutOrderConfirmation.placedOn')
+      .pipe(
+        map((textTitle) => {
+          const date = this.getDate(new Date(isoDate));
+
+          return {
+            title: textTitle,
+            text: [date],
+          };
+        })
+      );
+  }
+
+  getOrderStatusCardContent(status: string): Observable<Card> {
+    return combineLatest([
+      this.translation.translate('checkoutOrderConfirmation.status'),
+      this.translation.translate('orderDetails.statusDisplay', {
+        context: status,
+      }),
+    ]).pipe(
+      map(([textTitle, textStatus]) => ({
+        title: textTitle,
+        text: [textStatus],
+      }))
+    );
+  }
+
+  getPurchaseOrderNumber(poNumber: string): Observable<Card> {
+    return combineLatest([
+      this.translation.translate('checkoutReview.poNumber'),
+      this.translation.translate('checkoutPO.noPoNumber'),
+    ]).pipe(
+      map(([textTitle, noneTextTitle]) => ({
+        title: textTitle,
+        text: [poNumber ? poNumber : noneTextTitle],
+      }))
+    );
+  }
+
+  getMethodOfPaymentCardContent(
+    hasPaymentInfo: PaymentDetails
+  ): Observable<Card> {
+    return combineLatest([
+      this.translation.translate('checkoutProgress.methodOfPayment'),
+      this.translation.translate('paymentTypes.paymentType_ACCOUNT'),
+      this.translation.translate('paymentTypes.paymentType_CARD'),
+    ]).pipe(
+      map(([textTitle, textAccount, textCard]) => ({
+        title: textTitle,
+        text: [Boolean(hasPaymentInfo) ? textCard : textAccount],
+      }))
+    );
+  }
+
+  getCostCenterCardContent(costCenter: CostCenter): Observable<Card> {
+    return this.translation.translate('checkoutPO.costCenter').pipe(
+      filter(() => Boolean(costCenter)),
+      map((textTitle) => ({
+        title: textTitle,
+        textBold: costCenter?.name,
+        text: ['(' + costCenter?.unit?.name + ')'],
+      }))
+    );
+  }
+
   getAddressCardContent(deliveryAddress: Address): Observable<Card> {
     return this.translation.translate('addressCard.shipTo').pipe(
       filter(() => Boolean(deliveryAddress)),
       map((textTitle) => ({
         title: textTitle,
         textBold: `${deliveryAddress.firstName} ${deliveryAddress.lastName}`,
-        text: [
-          deliveryAddress.line1,
-          deliveryAddress.line2,
-          `${deliveryAddress.town}, ${deliveryAddress.country.isocode}, ${deliveryAddress.postalCode}`,
-          deliveryAddress.phone,
-        ],
+        text: [deliveryAddress.formattedAddress, deliveryAddress.country.name],
       }))
     );
   }
@@ -59,54 +134,13 @@ export class OrderConfirmationOverviewComponent implements OnInit, OnDestroy {
       map((textTitle) => ({
         title: textTitle,
         textBold: deliveryMode.name,
-        text: [deliveryMode.description],
-      }))
-    );
-  }
-
-  getBillingAddressCardContent(billingAddress: Address): Observable<Card> {
-    return this.translation.translate('addressCard.billTo').pipe(
-      filter(() => Boolean(billingAddress)),
-      map((textTitle) => ({
-        title: textTitle,
-        textBold: `${billingAddress.firstName} ${billingAddress.lastName}`,
         text: [
-          billingAddress.line1,
-          billingAddress.line2,
-          `${billingAddress.town}, ${billingAddress.country.isocode}, ${billingAddress.postalCode}`,
-          billingAddress.phone,
+          deliveryMode.description,
+          deliveryMode.deliveryCost?.formattedValue
+            ? deliveryMode.deliveryCost?.formattedValue
+            : '',
         ],
       }))
-    );
-  }
-
-  getAccountPaymentCardContent(order: Order): Observable<Card> {
-    return combineLatest([
-      this.translation.translate('paymentForm.payment'),
-      this.translation.translate('orderDetails.payByAccount'),
-      this.translation.translate('orderDetails.purchaseOrderId'),
-      this.translation.translate('orderDetails.costCenter'),
-      this.translation.translate('orderDetails.unit'),
-    ]).pipe(
-      map(
-        ([
-          textTitle,
-          textPayByAccount,
-          textPurchaseOrderId,
-          textCostCenter,
-          textUnit,
-        ]) => {
-          return {
-            title: textTitle,
-            textBold: textPayByAccount,
-            text: [
-              `${textPurchaseOrderId}: ${order.purchaseOrderNumber}`,
-              `${textCostCenter}: ${order.costCenter.name}`,
-              `${textUnit}: ${order.costCenter.unit.name}`,
-            ],
-          };
-        }
-      )
     );
   }
 
@@ -125,5 +159,26 @@ export class OrderConfirmationOverviewComponent implements OnInit, OnDestroy {
         text: [payment.cardNumber, textExpires],
       }))
     );
+  }
+
+  getBillingAddressCardContent(billingAddress: Address): Observable<Card> {
+    return this.translation.translate('paymentForm.billingAddress').pipe(
+      filter(() => Boolean(billingAddress)),
+      map((textTitle) => ({
+        title: textTitle,
+        textBold: `${billingAddress.firstName} ${billingAddress.lastName}`,
+        text: [billingAddress.formattedAddress, billingAddress.country.name],
+      }))
+    );
+  }
+
+  private getDate(givenDate: Date): string {
+    const date = givenDate.toDateString().split(' ');
+
+    const month = date[1];
+    const day = date[2];
+    const year = date[3];
+
+    return month + ' ' + day + ' ' + year;
   }
 }

--- a/projects/storefrontstyles/scss/components/checkout/order-confirmation/_order-confirmation-overview.scss
+++ b/projects/storefrontstyles/scss/components/checkout/order-confirmation/_order-confirmation-overview.scss
@@ -7,14 +7,14 @@
     border-style: solid;
     border-color: var(--cx-color-light);
 
-    @include media-breakpoint-down(md) {
+    @include media-breakpoint-down(sm) {
       background-color: var(--cx-color-inverse);
     }
 
     .container {
       display: flex;
       flex-wrap: wrap;
-      padding: 0;
+      padding: 15px 0;
 
       @include media-breakpoint-down(md) {
         max-width: 100%;
@@ -28,6 +28,13 @@
 
       .summary-card {
         flex: 1;
+        padding: 0 15px;
+
+        &:not(:last-of-type) {
+          @include media-breakpoint-up(lg) {
+            border-inline-end: 1px solid var(--cx-color-text);
+          }
+        }
 
         @include media-breakpoint-down(md) {
           flex: 0 0 33%;
@@ -40,6 +47,11 @@
           border-style: solid;
           border-color: var(--cx-color-light);
           margin: 0.625rem 0;
+        }
+
+        .cx-card-title {
+          @include type('4');
+          font-weight: bold;
         }
       }
     }

--- a/projects/storefrontstyles/scss/layout/page-templates/_order-detail-page.scss
+++ b/projects/storefrontstyles/scss/layout/page-templates/_order-detail-page.scss
@@ -88,28 +88,59 @@
   }
 
   cx-order-details-shipping {
-    .cx-summary {
-      margin-bottom: 48px;
-    }
-
     .cx-account-summary {
       background-color: var(--cx-color-background);
-
-      @include media-breakpoint-up(md) {
-        padding: 5px 18px 12px;
-      }
+      border-width: 0 0 1px 0;
+      border-style: solid;
+      border-color: var(--cx-color-light);
 
       @include media-breakpoint-down(sm) {
-        margin: 0 -24px;
+        background-color: var(--cx-color-inverse);
       }
 
-      .cx-card-title {
-        @include type('4');
-        font-weight: bold;
-      }
+      .container {
+        display: flex;
+        flex-wrap: wrap;
+        padding: 15px 0;
 
-      .cx-card-label-bold {
-        font-weight: bold;
+        @include media-breakpoint-down(md) {
+          max-width: 100%;
+          min-width: 100%;
+          padding: 0 1.25rem;
+        }
+        @include media-breakpoint-down(sm) {
+          flex-direction: column;
+          padding: 1.25rem;
+        }
+
+        .cx-summary-card {
+          flex: 1;
+          padding: 0 15px;
+
+          &:not(:last-of-type) {
+            @include media-breakpoint-up(lg) {
+              border-inline-end: 1px solid var(--cx-color-text);
+            }
+          }
+
+          @include media-breakpoint-down(md) {
+            flex: 0 0 33%;
+          }
+
+          @include media-breakpoint-down(sm) {
+            flex: 1;
+            background-color: var(--cx-color-inverse);
+            border-width: 1px;
+            border-style: solid;
+            border-color: var(--cx-color-light);
+            margin: 0.625rem 0;
+          }
+
+          .cx-card-title {
+            @include type('4');
+            font-weight: bold;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
closes GH-8784

Note:
- only includes changes related to the overview part of order confirmation and shipping part of order details
- Bill said to disregard the headline in the order details part
- pulled from replenishment branch and massaged it to remove replenishment things 