### PR TITLE
Revert "fix: header's listner collapseMenuIfClickOutside should check event.currentTarget instead of event.target (GH-8673)"

### DIFF
--- a/projects/storefrontlib/src/layout/main/storefront.component.ts
+++ b/projects/storefrontlib/src/layout/main/storefront.component.ts
@@ -63,7 +63,7 @@ export class StorefrontComponent implements OnInit, OnDestroy {
   }
 
   collapseMenuIfClickOutside(event: MouseEvent) {
-    if ((<HTMLElement>event.currentTarget).className.includes('is-expanded')) {
+    if ((<HTMLElement>event.target).className.includes('is-expanded')) {
       this.collapseMenu();
     }
   }


### PR DESCRIPTION
This reverts commit c1371e9b79c0f0e025129259523fc15f54708fcc.

Reverting because of the following key points:
- no longer able to open the hamburger menu when in mobile view
- breaks e2e
- no unit test related to that function which would most likely of caught the error as well