### PR TITLE
chore: avoid duplicated config in b2b.feature and b2c.feature

### DIFF
--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -3,16 +3,11 @@ import localeDe from '@angular/common/locales/de';
 import localeJa from '@angular/common/locales/ja';
 import localeZh from '@angular/common/locales/zh';
 import { NgModule } from '@angular/core';
-import {
-  BrowserModule,
-  BrowserTransferStateModule,
-} from '@angular/platform-browser';
+import { BrowserModule, BrowserTransferStateModule } from '@angular/platform-browser';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
-import { TestConfigModule } from '@spartacus/core';
-import {
-  JsonLdBuilderModule,
-  StorefrontComponent,
-} from '@spartacus/storefront';
+import { translationChunksConfig, translations } from '@spartacus/assets';
+import { ConfigModule, TestConfigModule } from '@spartacus/core';
+import { JsonLdBuilderModule, StorefrontComponent } from '@spartacus/storefront';
 import { b2bFeature } from '../environments/b2b/b2b.feature';
 import { b2cFeature } from '../environments/b2c/b2c.feature';
 import { cdcFeature } from '../environments/cdc/cdc.feature';
@@ -50,10 +45,38 @@ if (environment.cdc) {
     BrowserModule.withServerTransition({ appId: 'spartacus-app' }),
     BrowserTransferStateModule,
     JsonLdBuilderModule,
+    ConfigModule.withConfig({
+      backend: {
+        occ: {
+          baseUrl: environment.occBaseUrl,
+          prefix: environment.occApiPrefix,
+        },
+      },
+      
+      // custom routing configuration for e2e testing
+      routing: {
+        routes: {
+          product: {
+            paths: ['product/:productCode/:name', 'product/:productCode'],
+          },
+        },
+      },
+
+      // we bring in static translations to be up and running soon right away
+      i18n: {
+        resources: translations,
+        chunks: translationChunksConfig,
+        fallbackLang: 'en',
+      },
+      
+      features: {
+        level: '2.1',
+      },
+    }),
     ...additionalImports,
     TestOutletModule, // custom usages of cxOutletRef only for e2e testing
     TestConfigModule.forRoot({ cookie: 'cxConfigE2E' }), // Injects config dynamically from e2e tests. Should be imported after other config modules.
-
+    
     ...devImports,
   ],
 

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -3,11 +3,17 @@ import localeDe from '@angular/common/locales/de';
 import localeJa from '@angular/common/locales/ja';
 import localeZh from '@angular/common/locales/zh';
 import { NgModule } from '@angular/core';
-import { BrowserModule, BrowserTransferStateModule } from '@angular/platform-browser';
+import {
+  BrowserModule,
+  BrowserTransferStateModule,
+} from '@angular/platform-browser';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { translationChunksConfig, translations } from '@spartacus/assets';
 import { ConfigModule, TestConfigModule } from '@spartacus/core';
-import { JsonLdBuilderModule, StorefrontComponent } from '@spartacus/storefront';
+import {
+  JsonLdBuilderModule,
+  StorefrontComponent,
+} from '@spartacus/storefront';
 import { b2bFeature } from '../environments/b2b/b2b.feature';
 import { b2cFeature } from '../environments/b2c/b2c.feature';
 import { cdcFeature } from '../environments/cdc/cdc.feature';
@@ -52,7 +58,7 @@ if (environment.cdc) {
           prefix: environment.occApiPrefix,
         },
       },
-      
+
       // custom routing configuration for e2e testing
       routing: {
         routes: {
@@ -68,7 +74,7 @@ if (environment.cdc) {
         chunks: translationChunksConfig,
         fallbackLang: 'en',
       },
-      
+
       features: {
         level: '2.1',
       },
@@ -76,7 +82,7 @@ if (environment.cdc) {
     ...additionalImports,
     TestOutletModule, // custom usages of cxOutletRef only for e2e testing
     TestConfigModule.forRoot({ cookie: 'cxConfigE2E' }), // Injects config dynamically from e2e tests. Should be imported after other config modules.
-    
+
     ...devImports,
   ],
 

--- a/projects/storefrontapp/src/environments/b2b/b2b.feature.ts
+++ b/projects/storefrontapp/src/environments/b2b/b2b.feature.ts
@@ -1,39 +1,12 @@
-import { translationChunksConfig, translations } from '@spartacus/assets';
 import { B2bStorefrontModule } from '@spartacus/storefront';
-import { environment } from '../environment';
 import { FeatureEnvironment } from '../models/feature.model';
 
 export const b2bFeature: FeatureEnvironment = {
   imports: [
     B2bStorefrontModule.withConfig({
-      backend: {
-        occ: {
-          baseUrl: environment.occBaseUrl,
-          prefix: environment.occApiPrefix,
-        },
-      },
       context: {
         urlParameters: ['baseSite', 'language', 'currency'],
         baseSite: ['powertools-spa'],
-      },
-
-      // custom routing configuration for e2e testing
-      routing: {
-        routes: {
-          product: {
-            paths: ['product/:productCode/:name', 'product/:productCode'],
-          },
-        },
-      },
-      // we bring in static translations to be up and running soon right away
-      i18n: {
-        resources: translations,
-        chunks: translationChunksConfig,
-        fallbackLang: 'en',
-      },
-
-      features: {
-        level: '2.0',
       },
     }),
   ],

--- a/projects/storefrontapp/src/environments/b2c/b2c.feature.ts
+++ b/projects/storefrontapp/src/environments/b2c/b2c.feature.ts
@@ -1,17 +1,9 @@
-import { translationChunksConfig, translations } from '@spartacus/assets';
 import { B2cStorefrontModule } from '@spartacus/storefront';
-import { environment } from '../environment';
 import { FeatureEnvironment } from '../models/feature.model';
 
 export const b2cFeature: FeatureEnvironment = {
   imports: [
     B2cStorefrontModule.withConfig({
-      backend: {
-        occ: {
-          baseUrl: environment.occBaseUrl,
-          prefix: environment.occApiPrefix,
-        },
-      },
       context: {
         urlParameters: ['baseSite', 'language', 'currency'],
         baseSite: [
@@ -21,24 +13,6 @@ export const b2cFeature: FeatureEnvironment = {
           'apparel-uk',
           'apparel-uk-spa',
         ],
-      },
-
-      // custom routing configuration for e2e testing
-      routing: {
-        routes: {
-          product: {
-            paths: ['product/:productCode/:name', 'product/:productCode'],
-          },
-        },
-      },
-      // we bring in static translations to be up and running soon right away
-      i18n: {
-        resources: translations,
-        chunks: translationChunksConfig,
-        fallbackLang: 'en',
-      },
-      features: {
-        level: '2.1',
       },
       cart: {
         selectiveCart: {


### PR DESCRIPTION
Currently some config is duplicated, which makes it harder to maintain. Common part should be extracted to one common place. Moreover, default translations should be configured in one place, but not re-declared in all feature-recpipes (in case of using multiple of them at once), which would make the config chunks unnecesarily bigger and slower to load (deep merge).

closes #8952 