### PR TITLE
Introduce tree service, fix a few issues

### DIFF
--- a/feature-libs/my-account/organization/components/unit/list/toggle-link/toggle-link-cell.component.html
+++ b/feature-libs/my-account/organization/components/unit/list/toggle-link/toggle-link-cell.component.html
@@ -3,7 +3,7 @@
   [tabIndex]="tabIndex"
 >
   <button
-    *ngIf="count > 0 && depthLevel > 0"
+    *ngIf="isSwitchable"
     class="button tree-item-toggle"
     type="button"
     (click)="toggleItem($event)"

--- a/feature-libs/my-account/organization/components/unit/list/toggle-link/toggle-link-cell.component.ts
+++ b/feature-libs/my-account/organization/components/unit/list/toggle-link/toggle-link-cell.component.ts
@@ -5,7 +5,7 @@ import {
   TableDataOutletContext,
 } from '@spartacus/storefront';
 import { OrganizationCellComponent } from '../../../shared/organization-table/organization-cell.component';
-import { UnitListService } from '../../services/unit-list.service';
+import { UnitTreeService } from '../../services/unit-tree.service';
 
 @Component({
   templateUrl: './toggle-link-cell.component.html',
@@ -19,7 +19,7 @@ export class ToggleLinkCellComponent extends OrganizationCellComponent {
 
   constructor(
     protected outlet: OutletContextData<TableDataOutletContext>,
-    protected unitListService: UnitListService
+    protected unitTreeService: UnitTreeService
   ) {
     super(outlet);
   }
@@ -32,12 +32,29 @@ export class ToggleLinkCellComponent extends OrganizationCellComponent {
     return this.model.expanded;
   }
 
+  get level() {
+    return this.model.level;
+  }
+
+  /**
+   * Counts the number of descendants
+   */
   get count() {
     return this.model.count;
   }
 
   toggleItem(event: Event) {
     event.preventDefault();
-    this.unitListService.toggle((this.model as unknown) as B2bUnitTreeNode);
+    this.unitTreeService.toggle((this.model as unknown) as B2bUnitTreeNode);
+  }
+
+  /**
+   * Indicates whether the tree item should have a toggle navigation.
+   *
+   * The toggle navigation is used in case the tree item has descendants,
+   * and if the tree item level is not configured to be shown anyway.
+   */
+  get isSwitchable(): boolean {
+    return this.count > 0;
   }
 }

--- a/feature-libs/my-account/organization/components/unit/list/unit-list.component.html
+++ b/feature-libs/my-account/organization/components/unit/list/unit-list.component.html
@@ -1,8 +1,10 @@
 <cx-organization-list>
-  <button actions class="link" (click)="expandAll()">
-    {{ 'unit.tree.expandAll' | cxTranslate }}
-  </button>
-  <button actions class="link" (click)="collapseAll()">
-    {{ 'unit.tree.collapseAll' | cxTranslate }}
-  </button>
+  <ng-container actions *ngIf="root$ | async as rootId">
+    <button class="link" (click)="expandAll(rootId)">
+      {{ 'unit.tree.expandAll' | cxTranslate }}
+    </button>
+    <button class="link" (click)="collapseAll(rootId)">
+      {{ 'unit.tree.collapseAll' | cxTranslate }}
+    </button>
+  </ng-container>
 </cx-organization-list>

--- a/feature-libs/my-account/organization/components/unit/list/unit-list.component.ts
+++ b/feature-libs/my-account/organization/components/unit/list/unit-list.component.ts
@@ -1,18 +1,27 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { map } from 'rxjs/operators';
 import { UnitListService } from '../services/unit-list.service';
+import { UnitTreeService } from '../services/unit-tree.service';
 
 @Component({
   templateUrl: './unit-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UnitListComponent {
-  constructor(protected unitListService: UnitListService) {}
+  root$ = this.unitListService
+    .getTable()
+    .pipe(map((list) => list.data?.[0].id));
 
-  expandAll() {
-    this.unitListService.expandAll();
+  constructor(
+    protected unitListService: UnitListService,
+    protected unitTreeService: UnitTreeService
+  ) {}
+
+  expandAll(unitId: string) {
+    this.unitTreeService.expandAll(unitId);
   }
 
-  collapseAll() {
-    this.unitListService.collapseAll();
+  collapseAll(unitId: string) {
+    this.unitTreeService.collapseAll(unitId);
   }
 }

--- a/feature-libs/my-account/organization/components/unit/services/unit-list.service.ts
+++ b/feature-libs/my-account/organization/components/unit/services/unit-list.service.ts
@@ -2,11 +2,13 @@ import { Injectable } from '@angular/core';
 import { B2BUnitNode, B2bUnitTreeNode, EntitiesModel } from '@spartacus/core';
 import { OrgUnitService } from '@spartacus/my-account/organization/core';
 import { TableService } from '@spartacus/storefront';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { first, map, switchMap, withLatestFrom } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import { OrganizationListService } from '../../shared/organization-list/organization-list.service';
 import { OrganizationTableType } from '../../shared/organization.model';
 import { UnitItemService } from './unit-item.service';
+import { TREE_TOGGLE } from './unit-tree.model';
+import { UnitTreeService } from './unit-tree.service';
 
 /**
  * Service to populate Unit data to `Table` data. Unit
@@ -18,70 +20,65 @@ import { UnitItemService } from './unit-item.service';
 export class UnitListService extends OrganizationListService<B2bUnitTreeNode> {
   protected tableType = OrganizationTableType.UNIT;
 
-  protected initialExpanded = 1;
-
-  protected treeState = new Map<string, B2bUnitTreeNode>();
-  protected update$ = new BehaviorSubject(undefined);
-
   constructor(
     protected tableService: TableService,
     protected unitService: OrgUnitService,
-    protected unitItemService: UnitItemService
+    protected unitItemService: UnitItemService,
+    protected uts: UnitTreeService
   ) {
     super(tableService);
-    this.waitForKey();
-  }
-
-  protected waitForKey() {
-    this.unitService
-      .getTree()
-      .pipe(
-        withLatestFrom(this.unitItemService.key$),
-        first(([_tree, id]) => Boolean(id))
-      )
-      .subscribe(([tree, id]) => {
-        this.expandBranch(id, tree);
-        this.update$.next(true);
-      });
   }
 
   protected load(): Observable<EntitiesModel<B2bUnitTreeNode>> {
-    return this.update$.pipe(
-      switchMap(() =>
-        this.unitService
-          .getTree()
-          .pipe(map((tree: B2BUnitNode) => this.convertListItem(tree)))
-      )
+    return this.unitService.getTree().pipe(
+      switchMap((node) =>
+        this.unitItemService.key$.pipe(
+          map((key) => {
+            this.uts.initialize(node, key);
+            return node;
+          })
+        )
+      ),
+      switchMap((tree) => this.uts.treeToggle$.pipe(map(() => tree))),
+      map((tree: B2BUnitNode) => this.convertListItem(tree))
     );
   }
 
   protected convertListItem(
     unit: B2BUnitNode,
     depthLevel = 0,
-    pagination = { totalResults: 0 }
+    pagination = { totalResults: 0 },
+    parentToggleState?: TREE_TOGGLE
   ): EntitiesModel<B2bUnitTreeNode> {
     let values = [];
-    const expanded = this.isExpanded(unit.id, depthLevel);
-    const treeNode: B2bUnitTreeNode = {
+    if (!unit) {
+      return;
+    }
+
+    if (!parentToggleState) {
+      parentToggleState = this.uts.getToggleState(unit.id);
+    }
+
+    const node: B2bUnitTreeNode = {
       ...unit,
       count: unit.children?.length ?? 0,
-      expanded,
+      expanded: this.uts.isExpanded(unit.id, depthLevel, parentToggleState),
       depthLevel,
       // tmp, should be normalized
       uid: unit.id,
     };
-    this.treeState.set(treeNode.uid, treeNode);
 
-    values.push(treeNode);
+    values.push(node);
     pagination.totalResults++;
 
     unit.children.forEach((childUnit) => {
       const childList = this.convertListItem(
         childUnit,
         depthLevel + 1,
-        pagination
+        pagination,
+        parentToggleState
       )?.values;
-      if (treeNode.expanded && childList.length > 0) {
+      if (node.expanded && childList.length > 0) {
         values = values.concat(childList);
       }
     });
@@ -89,48 +86,7 @@ export class UnitListService extends OrganizationListService<B2bUnitTreeNode> {
     return { values, pagination };
   }
 
-  /**
-   * Indicates whether the unit is expanded.
-   */
-  protected isExpanded(unitId: string, level: number): boolean {
-    return this.treeState.get(unitId)?.expanded ?? level < this.initialExpanded;
-  }
-
-  toggle(unit: B2bUnitTreeNode) {
-    this.treeState.set(unit.uid, { ...unit, expanded: !unit.expanded });
-    this.update$.next(true);
-  }
-
   key(): string {
     return 'uid';
-  }
-
-  collapseAll() {
-    this.treeState.forEach((treeNode, id) => {
-      if (treeNode.depthLevel >= this.initialExpanded)
-        this.treeState.set(id, { ...treeNode, expanded: false });
-    });
-    this.update$.next(true);
-  }
-
-  expandAll() {
-    this.treeState.forEach((treeNode, id) =>
-      this.treeState.set(id, { ...treeNode, expanded: true })
-    );
-    this.update$.next(true);
-  }
-
-  protected expandBranch(id: string, unit: B2BUnitNode) {
-    if (this.findInTree(id, unit).length > 0) {
-      const treeNode = this.treeState.get(unit.id);
-      this.treeState.set(unit.id, { ...treeNode, expanded: true });
-      unit.children?.forEach((child) => this.expandBranch(id, child));
-    }
-  }
-
-  protected findInTree(id, unit: B2BUnitNode): B2BUnitNode[] {
-    return unit.id === id
-      ? [unit]
-      : unit.children.flatMap((child) => this.findInTree(id, child));
   }
 }

--- a/feature-libs/my-account/organization/components/unit/services/unit-tree.model.ts
+++ b/feature-libs/my-account/organization/components/unit/services/unit-tree.model.ts
@@ -1,0 +1,6 @@
+export enum TREE_TOGGLE {
+  EXPANDED = 1,
+  COLLAPSED,
+  EXPAND_ALL,
+  COLLAPSE_ALL,
+}

--- a/feature-libs/my-account/organization/components/unit/services/unit-tree.service.ts
+++ b/feature-libs/my-account/organization/components/unit/services/unit-tree.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@angular/core';
+import { B2BUnitNode, B2bUnitTreeNode } from '@spartacus/core';
+import { BehaviorSubject } from 'rxjs';
+import { TREE_TOGGLE } from './unit-tree.model';
+
+/**
+ * Service to populate Unit data to `Table` data. Unit
+ * data is driven by the table configuration, using the `OrganizationTables.UNIT`.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class UnitTreeService {
+  protected minimalExpanded = 1;
+
+  treeToggle$: BehaviorSubject<Map<string, TREE_TOGGLE>> = new BehaviorSubject(
+    new Map()
+  );
+
+  initialize(root: B2BUnitNode, key: string): void {
+    if (key) {
+      this.expandUntilActiveNode(root, key);
+    }
+  }
+
+  collapseAll(unitId: string) {
+    this.minimalExpanded = 0;
+    this.treeToggle$.next(new Map().set(unitId, TREE_TOGGLE.COLLAPSE_ALL));
+  }
+
+  expandAll(unitId: string) {
+    this.treeToggle$.next(new Map().set(unitId, TREE_TOGGLE.EXPAND_ALL));
+  }
+
+  isExpanded(unitId: string, level: number, parent: TREE_TOGGLE): boolean {
+    const toggle = this.treeToggle$.value?.get(unitId);
+    return (
+      toggle === TREE_TOGGLE.EXPANDED ||
+      toggle === TREE_TOGGLE.EXPAND_ALL ||
+      parent === TREE_TOGGLE.EXPAND_ALL ||
+      (toggle !== TREE_TOGGLE.COLLAPSED && level < this.minimalExpanded) ||
+      (toggle === TREE_TOGGLE.COLLAPSE_ALL && level < this.minimalExpanded)
+    );
+  }
+
+  toggle(unit: B2bUnitTreeNode) {
+    const treeState = this.treeToggle$.value;
+    const currentState =
+      treeState.get(unit.uid) === TREE_TOGGLE.EXPANDED
+        ? TREE_TOGGLE.COLLAPSED
+        : TREE_TOGGLE.EXPANDED;
+    treeState.set(unit.uid, currentState);
+    this.treeToggle$.next(treeState);
+  }
+
+  getToggleState(unitId): TREE_TOGGLE {
+    return this.treeToggle$.value?.get(unitId);
+  }
+
+  /**
+   * Expands all tree nodes till the active unit, to ensure that the
+   * full tree is collapsed till the active item.
+   *
+   * This is useful while navigating the tree by the router.
+   */
+  protected expandUntilActiveNode(node: B2BUnitNode, activeUnitId: string) {
+    const hasActiveChild = (n: B2BUnitNode, id: string): boolean =>
+      !!n.children?.find(
+        (child) => child.id === id || hasActiveChild(child, id)
+      );
+
+    const findInvolvedTreeNodes = (
+      n: B2BUnitNode,
+      activeItems = []
+    ): string[] => {
+      if (hasActiveChild(n, activeUnitId)) {
+        activeItems.push(n.id);
+      }
+      n.children.forEach((child) => {
+        findInvolvedTreeNodes(child, activeItems);
+      });
+      return activeItems;
+    };
+
+    const m = this.treeToggle$.value;
+    findInvolvedTreeNodes(node).forEach((activeId) => {
+      if (m.get(activeId) !== TREE_TOGGLE.EXPANDED) {
+        m.set(activeId, TREE_TOGGLE.EXPANDED);
+      }
+    });
+    if (m !== this.treeToggle$.value) {
+      this.treeToggle$.next(m);
+    }
+  }
+}

--- a/feature-libs/my-account/organization/styles/_list.scss
+++ b/feature-libs/my-account/organization/styles/_list.scss
@@ -383,7 +383,7 @@ cx-organization-form {
 .unit {
   .name {
     ng-component {
-      padding-inline-start: calc(var(--cx-depth-level) * 1.5rem);
+      padding-inline-start: calc((var(--cx-depth-level) + 1) * 20px);
       button.tree-item-toggle {
         padding-top: 2rem;
         padding-bottom: 2rem;


### PR DESCRIPTION
refactor list service and fix a number of shortcomings:

- (issue) The active tree item is not expanded if you navigate browser history
- (issue) The active item is also expanded, but it shouldn't imho. we should only open the tree until the active item instead.
- (limitation) We could think of collapsing/expanding all items for a specific part of the tree. This would mean that it's another state
- (refactor) I'd rather not traverse the full tree map all time when toggling items, it's not really needed.
- (refactor) The list service becomes a bit busy, i'd move tree related stuff to tree service.
- (ux) use a toggle icon for all tree items, including root
- (ux) collapsing all tree nodes, including root children
- (configurability) make the (initial) `minimalExpanded` children extensible.