### PR TITLE
#8490 part 2: add activated routes service

### DIFF
--- a/projects/core/src/routing/services/activated-routes.service.spec.ts
+++ b/projects/core/src/routing/services/activated-routes.service.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  NavigationCancel,
+  NavigationEnd,
+  NavigationError,
+  NavigationStart,
+  Router,
+  RouterEvent,
+  RouterState,
+} from '@angular/router';
+import { Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { ActivatedRoutesService } from './activated-routes.service';
+
+describe('ActivatedRoutesService', () => {
+  let service: ActivatedRoutesService;
+  let router: Router;
+  let mockRouterEvents$: Subject<RouterEvent>;
+
+  beforeEach(() => {
+    mockRouterEvents$ = new Subject<RouterEvent>();
+
+    class MockRouter implements Partial<Router> {
+      events = mockRouterEvents$;
+      routerState = { snapshot: { root: {} } } as any;
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Router,
+          useClass: MockRouter,
+        },
+      ],
+    });
+    service = TestBed.inject(ActivatedRoutesService);
+    router = TestBed.inject(Router);
+  });
+
+  afterEach(() => mockRouterEvents$.complete());
+
+  describe(`routes$`, () => {
+    it('should emit on subscription', async () => {
+      expect(await service.routes$.pipe(take(1)).toPromise()).toEqual([
+        router.routerState.snapshot.root,
+      ]);
+    });
+
+    it('should emit on every NavigationEnd event', async () => {
+      const results = [];
+      service.routes$.subscribe((res) => results.push(res));
+      expect(results.length).toBe(1);
+      mockRouterEvents$.next(new NavigationEnd(null, null, null));
+      expect(results.length).toBe(2);
+    });
+
+    it('should not emit on other Navigation events', async () => {
+      const results = [];
+      service.routes$.subscribe((res) => results.push(res));
+      expect(results.length).toBe(1);
+      mockRouterEvents$.next(new NavigationStart(null, null, null));
+      mockRouterEvents$.next(new NavigationCancel(null, null, null));
+      mockRouterEvents$.next(new NavigationError(null, null, null));
+      expect(results.length).toBe(1);
+    });
+
+    it('should emit array of activated routes', async () => {
+      const mockRouterState: RouterState = <RouterState>{
+        snapshot: {
+          root: {
+            component: null,
+            firstChild: {
+              component: 'parent',
+              firstChild: {
+                component: 'child',
+                firstChild: null,
+              },
+            },
+          },
+        },
+      };
+      (router as any).routerState = mockRouterState; // as any => mitigate readonly
+
+      expect(await service.routes$.pipe(take(1)).toPromise()).toEqual([
+        mockRouterState.snapshot.root,
+        mockRouterState.snapshot.root.firstChild,
+        mockRouterState.snapshot.root.firstChild.firstChild,
+      ]);
+    });
+  });
+});

--- a/projects/core/src/routing/services/activated-routes.service.ts
+++ b/projects/core/src/routing/services/activated-routes.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { filter, map, shareReplay, startWith } from 'rxjs/operators';
+
+/**
+ * Helper service to expose all activated routes
+ */
+@Injectable({ providedIn: 'root' })
+export class ActivatedRoutesService {
+  constructor(protected router: Router) {}
+
+  /**
+   * Array of currently activated routes from all the nested the primary router outlets
+   * (from the root route to the leaf route).
+   */
+  readonly routes$: Observable<
+    ActivatedRouteSnapshot[]
+  > = this.router.events.pipe(
+    filter((event) => event instanceof NavigationEnd),
+    // tslint:disable-next-line: deprecation https://github.com/ReactiveX/rxjs/issues/4772
+    startWith(undefined), // emit value for consumer who subscribed lately after NavigationEnd event
+    map(() => {
+      let route = this.router.routerState.snapshot.root;
+      const routes: ActivatedRouteSnapshot[] = [route];
+
+      // traverse to the leaf route:
+      while ((route = route.firstChild)) {
+        routes.push(route);
+      }
+
+      return routes;
+    }),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+}

--- a/projects/core/src/routing/services/index.ts
+++ b/projects/core/src/routing/services/index.ts
@@ -1,1 +1,2 @@
+export * from './activated-routes.service';
 export * from './url-matcher.service';


### PR DESCRIPTION
Extract to a separate service the logic of collecting all activated routes (from root to the leaf route). Reuse it in RoutingParamsService. It will be useful for breadcrumbs mechanism in Part 4

---

Part 1 https://github.com/SAP/spartacus/pull/9017 - hide org breadcrumb when on Org page
Part 2 https://github.com/SAP/spartacus/pull/9018 - add activated routes service
Part 3 https://github.com/SAP/spartacus/pull/9019 - add config for parent cms route 
Part 4 https://github.com/SAP/spartacus/pull/9020 - add routing page meta resolver
Part 5 #9071 - use route breadcrumbs in My Org