### PR TITLE
#8490 part 3: add config for parent cms route

### DIFF
--- a/projects/core/src/cms/config/cms-config.ts
+++ b/projects/core/src/cms/config/cms-config.ts
@@ -1,9 +1,9 @@
 import { Injectable, StaticProvider } from '@angular/core';
-import { Routes } from '@angular/router';
+import { Route } from '@angular/router';
 import { AuthConfig } from '../../auth/config/auth-config';
+import { Config } from '../../config/config-tokens';
 import { KymaConfig } from '../../kyma/config/kyma-config';
 import { OccConfig } from '../../occ/config/occ-config';
-import { Config } from '../../config/config-tokens';
 
 export interface StandardCmsComponentConfig {
   CMSSiteContextComponent?: CmsComponentMapping;
@@ -37,10 +37,25 @@ export interface JspIncludeCmsComponentConfig {
 export const JSP_INCLUDE_CMS_COMPONENT_TYPE = 'JspIncludeComponent';
 export const CMS_FLEX_COMPONENT_TYPE = 'CMSFlexComponent';
 
+/**
+ * Configuration of the CMS component's child routes
+ */
+export interface CmsComponentChildRoutesConfig {
+  /**
+   * Route `data` property to apply on the parent (host) route of the CMS child routes.
+   */
+  parent?: Pick<Route, 'data'>;
+
+  /**
+   * Child routes defined by the existence of the CMS component on the page.
+   */
+  children?: Route[];
+}
+
 export interface CmsComponentMapping {
   component?: any;
   providers?: StaticProvider[];
-  childRoutes?: Routes;
+  childRoutes?: Route[] | CmsComponentChildRoutesConfig;
   disableSSR?: boolean;
   i18nKeys?: string[];
   guards?: any[];

--- a/projects/storefrontlib/src/cms-structure/services/cms-components.service.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/services/cms-components.service.spec.ts
@@ -1,8 +1,8 @@
 import { PLATFORM_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { CmsConfig, DeferLoadingStrategy } from '@spartacus/core';
-import { CmsComponentsService } from './cms-components.service';
 import { Subject } from 'rxjs';
+import { CmsComponentsService } from './cms-components.service';
 import { FeatureModulesService } from './feature-modules.service';
 import createSpy = jasmine.createSpy;
 
@@ -22,6 +22,13 @@ const mockConfig: CmsConfig = {
       i18nKeys: ['key-1', 'key-2'],
       guards: ['guard1'],
       deferLoading: DeferLoadingStrategy.INSTANT,
+    },
+    exampleMapping3: {
+      component: 'selector-3',
+      childRoutes: {
+        parent: { data: { test: 'parent data' } },
+        children: [{ path: 'route1' }, { path: 'route2' }],
+      },
     },
   },
 };
@@ -114,11 +121,18 @@ describe('CmsComponentsService', () => {
   });
 
   describe('getChildRoutes', () => {
-    it('should get routes from page data', () => {
-      expect(service.getChildRoutes(mockComponents)).toEqual([
-        { path: 'route1' },
-        { path: 'route2' },
-      ]);
+    it('should get child routes from page data', () => {
+      expect(service.getChildRoutes(mockComponents)).toEqual({
+        parent: undefined,
+        children: [{ path: 'route1' }, { path: 'route2' }],
+      });
+    });
+
+    it('should get parent and child routes from page data', () => {
+      expect(service.getChildRoutes(['exampleMapping3'])).toEqual({
+        parent: { data: { test: 'parent data' } },
+        children: [{ path: 'route1' }, { path: 'route2' }],
+      });
     });
   });
 

--- a/projects/storefrontlib/src/cms-structure/services/cms-components.service.ts
+++ b/projects/storefrontlib/src/cms-structure/services/cms-components.service.ts
@@ -1,12 +1,13 @@
+import { isPlatformServer } from '@angular/common';
 import { Inject, Injectable, Injector, PLATFORM_ID } from '@angular/core';
+import { Route } from '@angular/router';
 import {
+  CmsComponentChildRoutesConfig,
   CmsComponentMapping,
   CmsConfig,
   deepMerge,
   DeferLoadingStrategy,
 } from '@spartacus/core';
-import { Route } from '@angular/router';
-import { isPlatformServer } from '@angular/common';
 import { defer, forkJoin, Observable, of } from 'rxjs';
 import { mapTo, share, tap } from 'rxjs/operators';
 import { FeatureModulesService } from './feature-modules.service';
@@ -154,14 +155,44 @@ export class CmsComponentsService {
   /**
    * Get cms driven child routes for components
    */
-  getChildRoutes(componentTypes: string[]): Route[] {
-    const routes = [];
+  getChildRoutes(componentTypes: string[]): CmsComponentChildRoutesConfig {
+    const configs = [];
     for (const componentType of componentTypes) {
       if (this.shouldRender(componentType)) {
-        routes.push(...(this.getMapping(componentType)?.childRoutes ?? []));
+        configs.push(this.getMapping(componentType)?.childRoutes ?? []);
       }
     }
-    return routes;
+
+    return this.standardizeChildRoutes(configs);
+  }
+
+  /**
+   * Standardizes the format to an object with defined parent and children routes, even if parent is undefined
+   *
+   * Some `childRoutes` configs are simple arrays of Routes (without the notion of the parent route).
+   * But some configs can be an object with children routes and their parent defined in separate property.
+   */
+  private standardizeChildRoutes(
+    childRoutesConfigs: (Route[] | CmsComponentChildRoutesConfig)[]
+  ): CmsComponentChildRoutesConfig {
+    return (childRoutesConfigs || []).reduce<CmsComponentChildRoutesConfig>(
+      (result, config) =>
+        Array.isArray(config)
+          ? // config is an array of child routes:
+            {
+              parent: result.parent,
+              children: [...result.children, ...config],
+            }
+          : // config is an object with `parent` and `children` properties:
+            {
+              parent: config.parent ?? result.parent,
+              children: [...result.children, ...config.children],
+            },
+      {
+        parent: undefined,
+        children: [],
+      }
+    );
   }
 
   /**

--- a/projects/storefrontlib/src/cms-structure/services/cms-routes-impl.service.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/services/cms-routes-impl.service.spec.ts
@@ -27,7 +27,7 @@ describe('CmsRoutesImplService', () => {
   ];
 
   const mockCmsComponentsService = {
-    getChildRoutes: () => [{ path: 'sub-route' }],
+    getChildRoutes: () => ({ children: [{ path: 'sub-route' }] }),
   };
 
   beforeEach(() => {
@@ -103,6 +103,36 @@ describe('CmsRoutesImplService', () => {
       expect(mockRouter.resetConfig).toHaveBeenCalledWith(expectedConfig);
     });
 
+    it('should include configured `data` property for cms driven route', () => {
+      spyOn(cmsMappingService, 'getChildRoutes').and.returnValue({
+        parent: { data: { test: 'test data' } },
+        children: [{ path: 'sub-route' }],
+      });
+      service.handleCmsRoutesInGuard(
+        mockPageContext,
+        [],
+        '/testRoute2',
+        '/testRoute2'
+      );
+
+      const expectedConfig = [
+        {
+          path: 'testRoute2',
+          component: PageLayoutComponent,
+          children: [{ path: 'sub-route' }],
+          data: {
+            cxCmsRouteContext: {
+              id: '/testRoute2',
+              type: mockPageContext.type,
+            },
+            test: 'test data',
+          },
+        },
+        ...mockRouterConfig,
+      ];
+      expect(mockRouter.resetConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+
     it('should add new route for content page using page label, not current url', () => {
       service.handleCmsRoutesInGuard(
         mockPageContext,
@@ -139,7 +169,7 @@ describe('CmsRoutesImplService', () => {
     });
 
     it('should return true for content pages without cms driven route', () => {
-      spyOn(cmsMappingService, 'getChildRoutes').and.returnValue([]);
+      spyOn(cmsMappingService, 'getChildRoutes').and.returnValue({});
 
       expect(
         service.handleCmsRoutesInGuard(

--- a/projects/storefrontlib/src/cms-structure/services/cms-routes-impl.service.ts
+++ b/projects/storefrontlib/src/cms-structure/services/cms-routes-impl.service.ts
@@ -1,6 +1,12 @@
 import { Injectable } from '@angular/core';
-import { Route, Router } from '@angular/router';
-import { CmsRoute, PageContext, PageType } from '@spartacus/core';
+import { Router } from '@angular/router';
+import {
+  CmsComponentChildRoutesConfig,
+  CmsRoute,
+  deepMerge,
+  PageContext,
+  PageType,
+} from '@spartacus/core';
 import { PageLayoutComponent } from '../page/page-layout/page-layout.component';
 import { CmsComponentsService } from './cms-components.service';
 
@@ -49,11 +55,14 @@ export class CmsRoutesImplService {
       return true;
     }
 
-    const componentRoutes = this.cmsComponentsService.getChildRoutes(
+    const childRoutesConfig = this.cmsComponentsService.getChildRoutes(
       componentTypes
     );
-    if (componentRoutes.length) {
-      if (this.updateRouting(pageContext, currentPageLabel, componentRoutes)) {
+
+    if (childRoutesConfig?.children?.length) {
+      if (
+        this.updateRouting(pageContext, currentPageLabel, childRoutesConfig)
+      ) {
         this.router.navigateByUrl(currentUrl);
         return false;
       }
@@ -64,7 +73,7 @@ export class CmsRoutesImplService {
   private updateRouting(
     pageContext: PageContext,
     pageLabel: string,
-    routes: Route[]
+    childRoutesConfig: CmsComponentChildRoutesConfig
   ): boolean {
     if (
       pageContext.type === PageType.CONTENT_PAGE &&
@@ -74,13 +83,13 @@ export class CmsRoutesImplService {
       const newRoute: CmsRoute = {
         path: pageLabel.substr(1),
         component: PageLayoutComponent,
-        children: routes,
-        data: {
+        children: childRoutesConfig.children,
+        data: deepMerge({}, childRoutesConfig?.parent?.data ?? {}, {
           cxCmsRouteContext: {
             type: pageContext.type,
             id: pageLabel,
           },
-        },
+        }),
       };
 
       this.router.resetConfig([newRoute, ...this.router.config]);


### PR DESCRIPTION
Cms mapping allowed for configuring `childRoutes` as array. Now it allows _also_ for a structure `{ children: [], parent: {}}`.

BREAKING CHANGE: `CmsComponentsService.getChildRoutes()` normalizes the configs and returns only the new strucutre (not array of routes anymore).

---

Part 1 https://github.com/SAP/spartacus/pull/9017 - hide org breadcrumb when on Org page
Part 2 https://github.com/SAP/spartacus/pull/9018 - add activated routes service
Part 3 https://github.com/SAP/spartacus/pull/9019 - add config for parent cms route 
Part 4 https://github.com/SAP/spartacus/pull/9020 - add routing page meta resolver
Part 5 #9071 - use route breadcrumbs in My Org