### PR TITLE
#8490 part 4: add routing page meta resolver

### DIFF
--- a/projects/core/src/cms/page/content-page-meta.resolver.spec.ts
+++ b/projects/core/src/cms/page/content-page-meta.resolver.spec.ts
@@ -6,6 +6,7 @@ import { PageType } from '../../model/cms.model';
 import { PageMetaService } from '../facade';
 import { BreadcrumbMeta } from '../model/page.model';
 import { ContentPageMetaResolver } from './content-page-meta.resolver';
+import { RoutingPageMetaResolver } from './routing/routing-page-meta.resolver';
 
 const mockContentPage: Page = {
   type: PageType.CONTENT_PAGE,
@@ -13,20 +14,27 @@ const mockContentPage: Page = {
   slots: {},
 };
 
-class MockCmsService {
+class MockCmsService implements Partial<CmsService> {
   getCurrentPage(): Observable<Page> {
     return of(mockContentPage);
   }
 }
 
-class MockTranslationService {
+class MockTranslationService implements Partial<TranslationService> {
   translate(key) {
     return of(key);
   }
 }
 
+class MockRoutingPageMetaResolver implements Partial<RoutingPageMetaResolver> {
+  resolveBreadcrumbs() {
+    return of([]);
+  }
+}
+
 describe('ContentPageMetaResolver', () => {
   let service: ContentPageMetaResolver;
+  let routingPageMetaResolver: RoutingPageMetaResolver;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -43,10 +51,15 @@ describe('ContentPageMetaResolver', () => {
           provide: TranslationService,
           useClass: MockTranslationService,
         },
+        {
+          provide: RoutingPageMetaResolver,
+          useClass: MockRoutingPageMetaResolver,
+        },
       ],
     });
 
     service = TestBed.inject(ContentPageMetaResolver);
+    routingPageMetaResolver = TestBed.inject(RoutingPageMetaResolver);
   });
 
   it('should inject service', () => {
@@ -77,5 +90,25 @@ describe('ContentPageMetaResolver', () => {
     expect(result.length).toEqual(1);
     expect(result[0].label).toEqual('common.home');
     expect(result[0].link).toEqual('/');
+  });
+
+  it('should breadcrumbs for Angular child routes', () => {
+    let result: BreadcrumbMeta[];
+
+    spyOn(routingPageMetaResolver, 'resolveBreadcrumbs').and.returnValue(
+      of([{ label: 'child route breadcrumb', link: '/child' }])
+    );
+    service
+      .resolveBreadcrumbs()
+      .subscribe((meta) => {
+        result = meta;
+      })
+      .unsubscribe();
+    expect(result.length).toEqual(2);
+    expect(result[0]).toEqual({ label: 'common.home', link: '/' });
+    expect(result[1]).toEqual({
+      label: 'child route breadcrumb',
+      link: '/child',
+    });
   });
 });

--- a/projects/core/src/cms/page/content-page-meta.resolver.ts
+++ b/projects/core/src/cms/page/content-page-meta.resolver.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { combineLatest, defer, Observable } from 'rxjs';
+import { filter, map, shareReplay } from 'rxjs/operators';
 import { TranslationService } from '../../i18n/translation.service';
 import { PageType } from '../../model/cms.model';
 import { CmsService } from '../facade/cms.service';
 import { BreadcrumbMeta, Page } from '../model/page.model';
 import { PageMetaResolver } from './page-meta.resolver';
 import { PageBreadcrumbResolver, PageTitleResolver } from './page.resolvers';
+import { RoutingPageMetaResolver } from './routing/routing-page-meta.resolver';
 
 /**
  * Resolves the page data for all Content Pages based on the `PageType.CONTENT_PAGE`.
@@ -21,14 +22,31 @@ import { PageBreadcrumbResolver, PageTitleResolver } from './page.resolvers';
 export class ContentPageMetaResolver
   extends PageMetaResolver
   implements PageTitleResolver, PageBreadcrumbResolver {
-  /** helper to provie access to the current CMS page */
+  /** helper to provide access to the current CMS page */
   protected cms$: Observable<Page> = this.cms
     .getCurrentPage()
     .pipe(filter((p) => Boolean(p)));
 
+  private _homeBreadcrumb$: Observable<
+    BreadcrumbMeta[]
+  > = this.translation
+    .translate('common.home')
+    .pipe(map((label) => [{ label: label, link: '/' }] as BreadcrumbMeta[]));
+
+  private _breadcrumbs$: Observable<BreadcrumbMeta[]> = combineLatest([
+    this._homeBreadcrumb$,
+    defer(() => this.routingPageMetaResolver.resolveBreadcrumbs()),
+  ]).pipe(
+    map(
+      (breadcrumbs) => breadcrumbs.flat(),
+      shareReplay({ bufferSize: 1, refCount: true })
+    )
+  );
+
   constructor(
     protected cms: CmsService,
-    protected translation: TranslationService
+    protected translation: TranslationService,
+    protected routingPageMetaResolver: RoutingPageMetaResolver
   ) {
     super();
     this.pageType = PageType.CONTENT_PAGE;
@@ -47,8 +65,6 @@ export class ContentPageMetaResolver
    * The home page label is resolved from the translation service.
    */
   resolveBreadcrumbs(): Observable<BreadcrumbMeta[]> {
-    return this.translation
-      .translate('common.home')
-      .pipe(map((label) => [{ label: label, link: '/' }] as BreadcrumbMeta[]));
+    return this._breadcrumbs$;
   }
 }

--- a/projects/core/src/cms/page/index.ts
+++ b/projects/core/src/cms/page/index.ts
@@ -1,3 +1,4 @@
-export * from './page-meta.resolver';
 export * from './content-page-meta.resolver';
+export * from './page-meta.resolver';
 export * from './page.resolvers';
+export * from './routing/index';

--- a/projects/core/src/cms/page/routing/default-route-page-meta.resolver.spec.ts
+++ b/projects/core/src/cms/page/routing/default-route-page-meta.resolver.spec.ts
@@ -1,0 +1,77 @@
+import { TestBed } from '@angular/core/testing';
+import { Observable, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { TranslationService } from '../../../i18n/translation.service';
+import { DefaultRoutePageMetaResolver } from './default-route-page-meta.resolver';
+
+class MockTranslationService implements Partial<TranslationService> {
+  translate(key: string): Observable<string> {
+    return of(`translated ${key}`);
+  }
+}
+
+describe('DefaultRouteBreadcrumbResolver', () => {
+  let resolver: DefaultRoutePageMetaResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: TranslationService, useClass: MockTranslationService },
+      ],
+    });
+    resolver = TestBed.inject(DefaultRoutePageMetaResolver);
+  });
+
+  describe(`resolveBreadcrumbs`, () => {
+    it('should emit breadcrumb with given path and i18n key (as string)', async () => {
+      expect(
+        await resolver
+          .resolveBreadcrumbs({
+            url: '/testPath',
+            pageMetaConfig: { breadcrumb: 'test.key' },
+          })
+          .pipe(take(1))
+          .toPromise()
+      ).toEqual([
+        {
+          link: '/testPath',
+          label: 'translated test.key',
+        },
+      ]);
+    });
+
+    it('should emit breadcrumb with given path and i18n key (as object property)', async () => {
+      expect(
+        await resolver
+          .resolveBreadcrumbs({
+            url: '/testPath',
+            pageMetaConfig: { breadcrumb: { i18n: 'test.key' } },
+          })
+          .pipe(take(1))
+          .toPromise()
+      ).toEqual([
+        {
+          link: '/testPath',
+          label: 'translated test.key',
+        },
+      ]);
+    });
+
+    it('should emit breadcrumb with given path and raw text', async () => {
+      expect(
+        await resolver
+          .resolveBreadcrumbs({
+            url: '/testPath',
+            pageMetaConfig: { breadcrumb: { raw: 'raw test' } },
+          })
+          .pipe(take(1))
+          .toPromise()
+      ).toEqual([
+        {
+          link: '/testPath',
+          label: 'raw test',
+        },
+      ]);
+    });
+  });
+});

--- a/projects/core/src/cms/page/routing/default-route-page-meta.resolver.ts
+++ b/projects/core/src/cms/page/routing/default-route-page-meta.resolver.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+import { TranslationService } from '../../../i18n/translation.service';
+import { BreadcrumbMeta } from '../../model/page.model';
+import {
+  RouteBreadcrumbResolver,
+  RouteBreadcrumbResolverParams,
+} from './route-page-meta.model';
+
+/**
+ * Resolves the breadcrumb for the Angular ActivatedRouteSnapshot
+ */
+@Injectable({ providedIn: 'root' })
+export abstract class DefaultRoutePageMetaResolver
+  implements RouteBreadcrumbResolver {
+  constructor(protected translation: TranslationService) {}
+
+  /**
+   * Resolves breadcrumb based on the given url and the breadcrumb config.
+   *
+   * - When breadcrumb config is empty, it returns an empty breadcrumb.
+   * - When breadcrumb config is a string or object with `i18n` property,
+   *    it translates it and use as a label of the returned breadcrumb.
+   * - When breadcrumb config is an object with property `raw`, then
+   *    it's used as a label of the returned breadcrumb.
+   */
+  resolveBreadcrumbs({
+    url,
+    pageMetaConfig,
+  }: RouteBreadcrumbResolverParams): Observable<BreadcrumbMeta[]> {
+    const breadcrumbConfig = pageMetaConfig?.breadcrumb;
+
+    if (!breadcrumbConfig) {
+      return of([]);
+    }
+
+    if (typeof breadcrumbConfig !== 'string' && breadcrumbConfig.raw) {
+      return of([{ link: url, label: breadcrumbConfig.raw }]);
+    }
+
+    const i18nKey =
+      typeof breadcrumbConfig === 'string'
+        ? breadcrumbConfig
+        : breadcrumbConfig.i18n;
+
+    const label$ = this.getBreadcrumbParams().pipe(
+      switchMap((params) => this.translation.translate(i18nKey, params ?? {}))
+    );
+
+    return label$.pipe(map((label) => [{ label, link: url }]));
+  }
+
+  /**
+   * Resolves dynamic params for the translation key used for the breadcrumb label.
+   */
+  protected getBreadcrumbParams(): Observable<object> {
+    return this.getParams();
+  }
+
+  /**
+   * Resolves dynamic data for the whole resolver.
+   */
+  protected getParams(): Observable<{ [_: string]: any }> {
+    return of({});
+  }
+}

--- a/projects/core/src/cms/page/routing/index.ts
+++ b/projects/core/src/cms/page/routing/index.ts
@@ -1,0 +1,6 @@
+export * from './default-route-page-meta.resolver';
+export * from './route-page-meta.model';
+export {
+  RoutingPageMetaResolver,
+  RoutingResolveBreadcrumbsOptions,
+} from './routing-page-meta.resolver';

--- a/projects/core/src/cms/page/routing/route-page-meta.model.ts
+++ b/projects/core/src/cms/page/routing/route-page-meta.model.ts
@@ -1,0 +1,73 @@
+import { Type } from '@angular/core';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { Observable } from 'rxjs';
+import { BreadcrumbMeta } from '../../model/page.model';
+
+/**
+ * Angular ActivatedRouteSnapshot extended with the custom configuration
+ * of the page meta in the property `data.cxPageMeta`.
+ */
+export interface ActivatedRouteSnapshotWithPageMeta
+  extends ActivatedRouteSnapshot {
+  routeConfig: ActivatedRouteSnapshot['routeConfig'] & {
+    data?: ActivatedRouteSnapshot['routeConfig']['data'] & {
+      cxPageMeta?: RoutePageMetaConfig;
+    };
+  };
+}
+
+/**
+ * Configuration of the breadcrumb for the Route.
+ */
+export interface RoutePageMetaConfig {
+  breadcrumb?: string | RouteBreadcrumbConfig;
+
+  /**
+   * Optional resolver class implementing `RoutePageMetaResolver`.
+   * The resolver instance will be implicitly inherited by all the
+   * child routes of the route with defined resolver (unless some
+   * child route defines its own resolver).
+   */
+  resolver?: Type<any>;
+}
+
+/**
+ * Configuration of the breadcrumb for specific route
+ */
+export interface RouteBreadcrumbConfig {
+  /**
+   * Raw text to be used for a breadcrumb.
+   */
+  raw?: string;
+
+  /**
+   * I18n key for the breadcrumb label. The method `RoutePageMetaResolver#getBreadcrumbParams` can provide
+   * dynamic params for the translation key.
+   * */
+  i18n?: string;
+}
+
+/**
+ * Params for the breadcrumb resolver of a single activated route.
+ */
+export interface RouteBreadcrumbResolverParams {
+  url?: string;
+  pageMetaConfig?: RoutePageMetaConfig;
+  route?: ActivatedRouteSnapshot;
+}
+
+/**
+ * Breadcrumb resolver interface for a single route
+ */
+export interface RouteBreadcrumbResolver {
+  /**
+   * Turns the route definition (with its breadcrumb config) into the resolved breadcrumb.
+   *
+   * @param url precalculated absolute link based on the route snapshot and its ancestors in the routes tree
+   * @param pageMetaConfig page meta config for the route, including the breadcrumb config
+   * @param route the route snapshot
+   */
+  resolveBreadcrumbs(
+    params: RouteBreadcrumbResolverParams
+  ): Observable<BreadcrumbMeta[]>;
+}

--- a/projects/core/src/cms/page/routing/routing-page-meta.resolver.spec.ts
+++ b/projects/core/src/cms/page/routing/routing-page-meta.resolver.spec.ts
@@ -1,0 +1,378 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { ActivatedRoutesService } from '../../../routing/services/activated-routes.service';
+import { DefaultRoutePageMetaResolver } from './default-route-page-meta.resolver';
+import { ActivatedRouteSnapshotWithPageMeta } from './route-page-meta.model';
+import { RoutingPageMetaResolver } from './routing-page-meta.resolver';
+
+@Injectable({ providedIn: 'root' })
+class ResolverA {}
+
+@Injectable({ providedIn: 'root' })
+class ResolverB {}
+
+@Injectable({ providedIn: 'root' })
+class ResolverC {}
+
+@Injectable()
+class MockDefaultRoutePageMetaResolver
+  implements Partial<DefaultRoutePageMetaResolver> {
+  resolveBreadcrumbs() {
+    return of([]);
+  }
+}
+
+describe('RoutingPageMetaResolver', () => {
+  let resolver: RoutingPageMetaResolver;
+  let mockActivatedRoutes$: BehaviorSubject<
+    ActivatedRouteSnapshotWithPageMeta[]
+  >;
+
+  beforeEach(() => {
+    mockActivatedRoutes$ = new BehaviorSubject([]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ActivatedRoutesService,
+          useValue: {
+            routes$: mockActivatedRoutes$,
+          } as Partial<ActivatedRoutesService>,
+        },
+        {
+          provide: DefaultRoutePageMetaResolver,
+          useClass: MockDefaultRoutePageMetaResolver,
+        },
+      ],
+    });
+
+    resolver = TestBed.inject(RoutingPageMetaResolver);
+  });
+
+  describe('routes$', () => {
+    it('should emit activated routes, but not the special root route', async () => {
+      mockActivatedRoutes$.next([
+        { url: [] }, // root route
+        { url: [{ path: 'parent' }] },
+        { url: [{ path: 'child' }] },
+      ] as ActivatedRouteSnapshot[]);
+
+      const result = await resolver['routes$'].pipe(take(1)).toPromise();
+      expect(result).toEqual([
+        { url: [{ path: 'parent' }] },
+        { url: [{ path: 'child' }] },
+      ] as ActivatedRouteSnapshotWithPageMeta[]);
+    });
+  });
+
+  describe('routesWithExtras$', () => {
+    it('should emit routes', async () => {
+      mockActivatedRoutes$.next([
+        { url: [] }, // root route
+        { url: [{ path: 'parent' }] },
+        { url: [{ path: 'child' }] },
+      ] as ActivatedRouteSnapshotWithPageMeta[]);
+
+      const result = await resolver['routesWithExtras$']
+        .pipe(take(1))
+        .toPromise();
+      expect(result).toEqual([
+        jasmine.objectContaining({ route: { url: [{ path: 'parent' }] } }),
+        jasmine.objectContaining({ route: { url: [{ path: 'child' }] } }),
+      ]);
+    });
+
+    it('should emit precalculated URLs for routes', async () => {
+      mockActivatedRoutes$.next([
+        { url: [] }, // root route
+        { url: [{ path: 'grandparent' }] },
+        { url: [{ path: 'test' }, { path: 'parent' }] },
+        { url: [{ path: 'child' }] },
+      ] as ActivatedRouteSnapshotWithPageMeta[]);
+
+      const result = await resolver['routesWithExtras$']
+        .pipe(take(1))
+        .toPromise();
+      expect(result).toEqual([
+        jasmine.objectContaining({ url: '/grandparent' }),
+        jasmine.objectContaining({ url: '/grandparent/test/parent' }),
+        jasmine.objectContaining({ url: '/grandparent/test/parent/child' }),
+      ]);
+    });
+
+    it('should emit precalculated resolver instances', async () => {
+      mockActivatedRoutes$.next([
+        { url: [] }, // root route
+        {
+          url: [{ path: 'grandparent' }],
+          routeConfig: { data: { cxPageMeta: { resolver: ResolverA } } },
+        },
+        {
+          url: [{ path: 'parent' }],
+          routeConfig: { data: { cxPageMeta: { resolver: ResolverB } } },
+        },
+        {
+          url: [{ path: 'child' }],
+          routeConfig: { data: { cxPageMeta: { resolver: ResolverC } } },
+        },
+      ] as ActivatedRouteSnapshotWithPageMeta[]);
+
+      const resolverInstanceA = TestBed.inject(ResolverA);
+      const resolverInstanceB = TestBed.inject(ResolverB);
+      const resolverInstanceC = TestBed.inject(ResolverC);
+
+      const result = await resolver['routesWithExtras$']
+        .pipe(take(1))
+        .toPromise();
+
+      expect(result).toEqual([
+        jasmine.objectContaining({ resolver: resolverInstanceA }),
+        jasmine.objectContaining({ resolver: resolverInstanceB }),
+        jasmine.objectContaining({ resolver: resolverInstanceC }),
+      ]);
+    });
+
+    it('should emit inherited resolver instances', async () => {
+      mockActivatedRoutes$.next([
+        { url: [] }, // root route
+        {
+          url: [{ path: 'grandparent' }],
+          routeConfig: { data: { cxPageMeta: { resolver: ResolverA } } },
+        },
+        {
+          url: [{ path: 'parent' }],
+        },
+        {
+          url: [{ path: 'child' }],
+          routeConfig: { data: { cxPageMeta: { resolver: ResolverC } } },
+        },
+      ] as ActivatedRouteSnapshotWithPageMeta[]);
+
+      const resolverInstanceA = TestBed.inject(ResolverA);
+      const resolverInstanceC = TestBed.inject(ResolverC);
+
+      const result = await resolver['routesWithExtras$']
+        .pipe(take(1))
+        .toPromise();
+
+      expect(result).toEqual([
+        jasmine.objectContaining({ resolver: resolverInstanceA }),
+        jasmine.objectContaining({ resolver: resolverInstanceA }),
+        jasmine.objectContaining({ resolver: resolverInstanceC }),
+      ]);
+    });
+
+    it('should emit default resolver instance as a fallback', async () => {
+      mockActivatedRoutes$.next([
+        { url: [] }, // root route
+        { url: [{ path: 'grandparent' }] },
+        { url: [{ path: 'parent' }] },
+        {
+          url: [{ path: 'child' }],
+          routeConfig: { data: { cxPageMeta: { resolver: ResolverC } } },
+        },
+      ] as ActivatedRouteSnapshotWithPageMeta[]);
+      const resolverInstanceC = TestBed.inject(ResolverC);
+      const defaultResolverInstance = TestBed.inject(
+        DefaultRoutePageMetaResolver
+      );
+
+      const result = await resolver['routesWithExtras$']
+        .pipe(take(1))
+        .toPromise();
+
+      expect(result).toEqual([
+        jasmine.objectContaining({ resolver: defaultResolverInstance }),
+        jasmine.objectContaining({ resolver: defaultResolverInstance }),
+        jasmine.objectContaining({ resolver: resolverInstanceC }),
+      ]);
+    });
+  });
+
+  describe('resolveBreadcrumbs', () => {
+    let defaultResolver: DefaultRoutePageMetaResolver;
+
+    beforeEach(() => {
+      defaultResolver = TestBed.inject(DefaultRoutePageMetaResolver);
+      spyOn(
+        defaultResolver,
+        'resolveBreadcrumbs'
+      ).and.callFake(({ url, pageMetaConfig }) =>
+        pageMetaConfig?.breadcrumb
+          ? of([{ link: url, label: pageMetaConfig?.breadcrumb as string }])
+          : of([])
+      );
+    });
+
+    it('should return empty breadcrumb when given no routes', async () => {
+      mockActivatedRoutes$.next([
+        { url: [] }, // root route
+      ] as ActivatedRouteSnapshotWithPageMeta[]);
+
+      const result = await resolver
+        .resolveBreadcrumbs()
+        .pipe(take(1))
+        .toPromise();
+      expect(result).toEqual([]);
+      expect(defaultResolver.resolveBreadcrumbs).not.toHaveBeenCalled();
+    });
+
+    it(`should NOT return breadcrumb for the current route`, async () => {
+      mockActivatedRoutes$.next([
+        { url: [] }, // root route
+        {
+          url: [{ path: 'test' }],
+          routeConfig: {
+            data: { cxPageMeta: { breadcrumb: 'test.breadcrumb' } },
+          },
+        },
+      ] as ActivatedRouteSnapshotWithPageMeta[]);
+
+      expect(
+        await resolver.resolveBreadcrumbs().pipe(take(1)).toPromise()
+      ).toEqual([]);
+      expect(defaultResolver.resolveBreadcrumbs).not.toHaveBeenCalled();
+    });
+
+    it(`should NOT return breadcrumb for the current route '(case with '' path)`, async () => {
+      mockActivatedRoutes$.next([
+        { url: [] }, // root route
+        {
+          url: [{ path: 'test' }],
+          routeConfig: {
+            data: { cxPageMeta: { breadcrumb: 'test.breadcrumb' } },
+          },
+        },
+        {
+          url: [], // last route with empty '' path
+        },
+      ] as ActivatedRouteSnapshotWithPageMeta[]);
+
+      expect(
+        await resolver.resolveBreadcrumbs().pipe(take(1)).toPromise()
+      ).toEqual([]);
+      expect(defaultResolver.resolveBreadcrumbs).not.toHaveBeenCalled();
+    });
+
+    it(`should return breadcrumbs only for the ancestors of the current route`, async () => {
+      const testRoutes = [
+        { url: [] }, // root route
+        {
+          url: [{ path: 'grandparent' }],
+          routeConfig: {
+            data: { cxPageMeta: { breadcrumb: 'grandparent.breadcrumb' } },
+          },
+        },
+        {
+          url: [{ path: 'parent' }],
+          routeConfig: {
+            data: { cxPageMeta: { breadcrumb: 'parent.breadcrumb' } },
+          },
+        },
+        {
+          url: [{ path: 'child' }],
+          routeConfig: {
+            data: { cxPageMeta: { breadcrumb: 'child.breadcrumb' } },
+          },
+        },
+      ] as ActivatedRouteSnapshotWithPageMeta[];
+
+      mockActivatedRoutes$.next(testRoutes);
+
+      expect(
+        await resolver.resolveBreadcrumbs().pipe(take(1)).toPromise()
+      ).toEqual([
+        { link: '/grandparent', label: 'grandparent.breadcrumb' },
+        { link: '/grandparent/parent', label: 'parent.breadcrumb' },
+      ]);
+      expect(defaultResolver.resolveBreadcrumbs).toHaveBeenCalledWith({
+        url: '/grandparent',
+        pageMetaConfig: testRoutes[1].routeConfig.data.cxPageMeta,
+        route: testRoutes[1],
+      });
+      expect(defaultResolver.resolveBreadcrumbs).toHaveBeenCalledWith({
+        url: '/grandparent/parent',
+        pageMetaConfig: testRoutes[2].routeConfig.data.cxPageMeta,
+        route: testRoutes[2],
+      });
+    });
+
+    it(`should return breadcrumbs only for the ancestor routes (case with '' path)`, async () => {
+      const testRoutes = [
+        { url: [] }, // root route
+        {
+          url: [{ path: 'grandparent' }],
+          routeConfig: {
+            data: { cxPageMeta: { breadcrumb: 'grandparent.breadcrumb' } },
+          },
+        },
+        {
+          url: [{ path: 'parent' }],
+          routeConfig: {
+            data: { cxPageMeta: { breadcrumb: 'parent.breadcrumb' } },
+          },
+        },
+        {
+          url: [{ path: 'child' }],
+          routeConfig: {
+            data: { cxPageMeta: { breadcrumb: 'child.breadcrumb' } },
+          },
+        },
+        {
+          url: [], // route with empty '' path
+        },
+      ] as ActivatedRouteSnapshotWithPageMeta[];
+
+      mockActivatedRoutes$.next(testRoutes);
+
+      expect(
+        await resolver.resolveBreadcrumbs().pipe(take(1)).toPromise()
+      ).toEqual([
+        { link: '/grandparent', label: 'grandparent.breadcrumb' },
+        { link: '/grandparent/parent', label: 'parent.breadcrumb' },
+      ]);
+    });
+
+    describe('when passed option includeCurrentRoute = true', () => {
+      it(`should return breadcrumbs for all activated routes (including current route)`, async () => {
+        const testRoutes = [
+          { url: [] }, // root route
+          {
+            url: [{ path: 'grandparent' }],
+            routeConfig: {
+              data: { cxPageMeta: { breadcrumb: 'grandparent.breadcrumb' } },
+            },
+          },
+          {
+            url: [{ path: 'parent' }],
+            routeConfig: {
+              data: { cxPageMeta: { breadcrumb: 'parent.breadcrumb' } },
+            },
+          },
+          {
+            url: [{ path: 'child' }],
+            routeConfig: {
+              data: { cxPageMeta: { breadcrumb: 'child.breadcrumb' } },
+            },
+          },
+        ] as ActivatedRouteSnapshotWithPageMeta[];
+
+        mockActivatedRoutes$.next(testRoutes);
+
+        expect(
+          await resolver
+            .resolveBreadcrumbs({ includeCurrentRoute: true })
+            .pipe(take(1))
+            .toPromise()
+        ).toEqual([
+          { link: '/grandparent', label: 'grandparent.breadcrumb' },
+          { link: '/grandparent/parent', label: 'parent.breadcrumb' },
+          { link: '/grandparent/parent/child', label: 'child.breadcrumb' },
+        ]);
+      });
+    });
+  });
+});

--- a/projects/core/src/cms/page/routing/routing-page-meta.resolver.ts
+++ b/projects/core/src/cms/page/routing/routing-page-meta.resolver.ts
@@ -1,0 +1,193 @@
+import { Injectable, Injector } from '@angular/core';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { combineLatest, Observable, of } from 'rxjs';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
+import { ActivatedRoutesService } from '../../../routing/services/activated-routes.service';
+import { BreadcrumbMeta } from '../../model/page.model';
+import { DefaultRoutePageMetaResolver } from './default-route-page-meta.resolver';
+import {
+  ActivatedRouteSnapshotWithPageMeta,
+  RouteBreadcrumbResolver,
+  RoutePageMetaConfig,
+} from './route-page-meta.model';
+
+// PRIVATE
+export interface RouteWithExtras {
+  route: ActivatedRouteSnapshotWithPageMeta;
+  resolver: any;
+  url: string;
+}
+
+export interface RoutingResolveBreadcrumbsOptions {
+  /**
+   * When true, includes in the breadcrumbs the page title of the current route. False by default.
+   */
+  includeCurrentRoute?: boolean;
+}
+
+/**
+ * Resolves the page meta based on the Angular Activated Routes
+ */
+@Injectable({ providedIn: 'root' })
+export class RoutingPageMetaResolver {
+  constructor(
+    protected activatedRoutesService: ActivatedRoutesService,
+    protected injector: Injector
+  ) {}
+
+  /**
+   * Array of activated routes, excluding the special Angular `root` route.
+   */
+  protected readonly routes$ = this.activatedRoutesService.routes$.pipe(
+    map((routes) => (routes = routes.slice(1, routes.length))) // drop the first route - the special `root` route
+  );
+
+  /**
+   * Array of activated routes together with precalculated extras:
+   *
+   * - route's page meta resolver
+   * - route's absolute string URL
+   *
+   * In case when there is no page meta resolver configured for a specific route,
+   * it inherits its parent's resolver.
+   *
+   * When there is no page meta resolver configured for the highest parent in the hierarchy,
+   * it uses the `DefaultRoutePageMetaResolver`.
+   */
+  protected readonly routesWithExtras$: Observable<
+    RouteWithExtras[]
+  > = this.routes$.pipe(
+    map((routes) =>
+      routes.reduce<RouteWithExtras[]>((results, route) => {
+        const parent = results.length
+          ? results[results.length - 1]
+          : {
+              route: null,
+              resolver: this.injector.get(DefaultRoutePageMetaResolver),
+              url: '',
+            };
+
+        const resolver = this.getResolver(route) ?? parent.resolver; // fallback to parent's resolver
+
+        const urlPart = this.getUrlPart(route);
+        const url = parent.url + (urlPart ? `/${urlPart}` : ''); // don't add slash for a route with path '', to avoid double slash ...//...
+
+        return results.concat({ route, resolver, url });
+      }, [])
+    ),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  /**
+   * Array of breadcrumbs defined for all the activated routes (from the root route to the leaf route).
+   * It emits on every completed routing navigation.
+   */
+  resolveBreadcrumbs(
+    options?: RoutingResolveBreadcrumbsOptions
+  ): Observable<BreadcrumbMeta[]> {
+    return this.routesWithExtras$.pipe(
+      map((routesWithExtras) =>
+        options?.includeCurrentRoute
+          ? routesWithExtras
+          : this.trimCurrentRoute(routesWithExtras)
+      ),
+      switchMap((routesWithExtras) =>
+        routesWithExtras.length
+          ? combineLatest(
+              routesWithExtras.map((routeWithExtras) =>
+                this.resolveRouteBreadcrumb(routeWithExtras)
+              )
+            )
+          : of([])
+      ),
+      map((breadcrumbArrays) => breadcrumbArrays.flat())
+    );
+  }
+
+  /**
+   * Returns the instance of the RoutePageMetaResolver configured for the given activated route.
+   * Returns null in case there the resolver can't be injected or is undefined.
+   *
+   * @param route route to resolve
+   */
+  protected getResolver(route: ActivatedRouteSnapshotWithPageMeta): any {
+    const pageMetaConfig = this.getPageMetaConfig(route);
+
+    if (typeof pageMetaConfig !== 'string' && pageMetaConfig?.resolver) {
+      return this.injector.get(pageMetaConfig.resolver, null);
+    }
+    return null;
+  }
+
+  /**
+   * Resolvers breadcrumb for a specific route
+   */
+  protected resolveRouteBreadcrumb({
+    route,
+    resolver,
+    url,
+  }: RouteWithExtras): Observable<BreadcrumbMeta[]> {
+    const breadcrumbResolver = resolver as RouteBreadcrumbResolver;
+
+    if (typeof breadcrumbResolver.resolveBreadcrumbs === 'function') {
+      return breadcrumbResolver.resolveBreadcrumbs({
+        route,
+        url,
+        pageMetaConfig: this.getPageMetaConfig(route),
+      });
+    }
+    return of([]);
+  }
+
+  /**
+   * By default in breadcrumbs list we don't want to show a link to the current page, so this function
+   * trims the last breadcrumb (the breadcrumb of the current route).
+   *
+   * This function also handles special case when the current route has a configured empty path ('' route).
+   * The '' routes are often a _technical_ routes to organize other routes, assign common guards for its children, etc.
+   * It shouldn't happen that '' route has a defined breadcrumb config.
+   *
+   * In that case, we trim not only the last route ('' route), but also its parent route with non-empty path
+   * (which likely defines the breadcrumb config).
+   */
+  private trimCurrentRoute(
+    routesWithExtras: RouteWithExtras[]
+  ): RouteWithExtras[] {
+    // If the last route is '', we trim:
+    // - the '' route
+    // - all parent '' routes (until we meet route with non-empty path)
+
+    let i = routesWithExtras.length - 1;
+    while (routesWithExtras[i]?.route?.url.length === 0 && i >= 0) {
+      i--;
+    }
+
+    // Finally we trim the last route (the one with non-empty path)
+    return routesWithExtras.slice(0, i);
+  }
+
+  /**
+   * Returns the URL path for the given activated route in a string format.
+   * (ActivatedRouteSnapshot#url contains an array of `UrlSegment`s, not a string)
+   */
+  private getUrlPart(route: ActivatedRouteSnapshot): string {
+    return route.url.map((urlSegment) => urlSegment.path).join('/');
+  }
+
+  /**
+   * Returns the breadcrumb config placed in the route's `data` configuration.
+   */
+  protected getPageMetaConfig(
+    route: ActivatedRouteSnapshotWithPageMeta
+  ): RoutePageMetaConfig {
+    // Note: we use `route.routeConfig.data` (not `route.data`) to save us from
+    // an edge case bug. In Angular, by design the `data` of ActivatedRoute is inherited
+    // from the parent route, if only the child has an empty path ''.
+    // But in any case we don't want the page meta configs to be inherited, so we
+    // read data from the original `routeConfig` which is static.
+    //
+    // Note: we may inherit the parent's page meta resolver in case we don't define it,
+    // but we don't want to inherit parent's page meta config!
+    return route?.routeConfig?.data?.cxPageMeta;
+  }
+}


### PR DESCRIPTION
Created a mechanism for reading page meta (breadcrumb) configs from Routes' configs. Reused it in the `ContentPageMetaResolver`. Now any cms-driven child routes of a content page, can contribute to the breadcrumb meta. 

Introduced base `DefaultRouteBreadcrumbResolver` for resolving breadcrumb of a single route. It's able to resolve i18n keys from route's breadcrumb config out of the box.

Moreover it can be extended by the specific route resolvers by overriding the method `getParams()` that provides data (i.e. cost center object). The data will be used as dynamic params of i18n key (i.e. `Budgets for {{ name }}`).

---

Part 1 https://github.com/SAP/spartacus/pull/9017 - hide org breadcrumb when on Org page
Part 2 https://github.com/SAP/spartacus/pull/9018 - add activated routes service
Part 3 https://github.com/SAP/spartacus/pull/9019 - add config for parent cms route 
Part 4 https://github.com/SAP/spartacus/pull/9020 - add routing page meta resolver
Part 5 #9071 - use route breadcrumbs in My Org