### PR TITLE
#8490 part 5: use route breadcrumbs in My Org

### DIFF
--- a/feature-libs/my-account/organization/assets/translations/en/budget.i18n.ts
+++ b/feature-libs/my-account/organization/assets/translations/en/budget.i18n.ts
@@ -42,6 +42,11 @@ export const budget = {
   links: {
     costCenters: 'Cost Centers',
   },
+
+  breadcrumbs: {
+    list: 'All budgets',
+    details: '{{name}}',
+  },
 };
 
 export const budgetAssignedCostCenters = {

--- a/feature-libs/my-account/organization/assets/translations/en/cost-center.i18n.ts
+++ b/feature-libs/my-account/organization/assets/translations/en/cost-center.i18n.ts
@@ -43,6 +43,12 @@ export const costCenter = {
   budget: {
     link: 'Budgets',
   },
+
+  breadcrumbs: {
+    list: 'All cost centers',
+    details: '{{name}}',
+    budgets: 'Budgets',
+  },
 };
 
 export const costCenterAssignedBudgets = {

--- a/feature-libs/my-account/organization/assets/translations/en/permission.i18n.ts
+++ b/feature-libs/my-account/organization/assets/translations/en/permission.i18n.ts
@@ -42,4 +42,9 @@ export const permission = {
     QUARTER: 'per quarter',
     YEAR: 'per year',
   },
+
+  breadcrumbs: {
+    list: 'All purchase limits',
+    details: '{{code}}',
+  },
 };

--- a/feature-libs/my-account/organization/assets/translations/en/units.i18n.ts
+++ b/feature-libs/my-account/organization/assets/translations/en/units.i18n.ts
@@ -78,6 +78,16 @@ export const unit = {
   //   header: 'Cost centers in {{code}}',
   //   new: 'New cost center',
   // },
+
+  breadcrumbs: {
+    list: 'All units',
+    details: '{{name}}',
+    children: 'Child units',
+    users: 'Users',
+    approvers: 'Approvers',
+    addresses: 'Shipping addresses',
+    addressDetails: '{{formattedAddress}}',
+  },
 };
 
 export const unitChildren = {

--- a/feature-libs/my-account/organization/assets/translations/en/user-group.i18n.ts
+++ b/feature-libs/my-account/organization/assets/translations/en/user-group.i18n.ts
@@ -30,6 +30,13 @@ export const userGroup = {
     user: 'Users',
     permission: 'Purchase limits',
   },
+
+  breadcrumbs: {
+    list: 'All user groups',
+    details: '{{name}}',
+    users: 'Users',
+    permissions: 'Purchase limits',
+  },
 };
 
 export const userGroupAssignedUsers = {

--- a/feature-libs/my-account/organization/assets/translations/en/user.i18n.ts
+++ b/feature-libs/my-account/organization/assets/translations/en/user.i18n.ts
@@ -37,7 +37,7 @@ export const user = {
     password: 'Change password',
     approvers: 'Approvers',
     userGroup: 'User groups',
-    permission: 'Permission',
+    permission: 'Permissions',
   },
 
   messages: {
@@ -99,6 +99,14 @@ export const user = {
     subtitle: '',
     newPassword: 'New password',
     confirmPassword: 'Retype new password',
+  },
+
+  breadcrumbs: {
+    list: 'All users',
+    details: '{{name}}',
+    userGroups: 'User groups',
+    approvers: 'Approvers',
+    permissions: 'Permissions',
   },
 };
 

--- a/feature-libs/my-account/organization/components/budget/budget.config.ts
+++ b/feature-libs/my-account/organization/components/budget/budget.config.ts
@@ -23,6 +23,7 @@ import { ActiveBudgetGuard } from './guards/active-budget.guard';
 import { ExistBudgetGuard } from './guards/exist-budget.guard';
 import { BudgetItemService } from './services/budget-item.service';
 import { BudgetListService } from './services/budget-list.service';
+import { BudgetRoutePageMetaResolver } from './services/budget-route-page-meta.resolver';
 
 const listPath = `organization/budgets/:${ROUTE_PARAMS.budgetCode}`;
 const paramsMapping: ParamsMapping = {
@@ -68,28 +69,43 @@ export const budgetCmsConfig: CmsConfig = {
           useExisting: BudgetItemService,
         },
       ],
-      childRoutes: [
-        {
-          path: 'create',
-          component: BudgetFormComponent,
-        },
-        {
-          path: `:${ROUTE_PARAMS.budgetCode}`,
-          component: BudgetDetailsComponent,
-          canActivate: [ExistBudgetGuard],
-          children: [
-            {
-              path: `edit`,
-              component: BudgetFormComponent,
-              canActivate: [ActiveBudgetGuard],
+      childRoutes: {
+        parent: {
+          data: {
+            cxPageMeta: {
+              breadcrumb: 'budget.breadcrumbs.list',
+              resolver: BudgetRoutePageMetaResolver,
             },
-            {
-              path: 'cost-centers',
-              component: BudgetCostCenterListComponent,
-            },
-          ],
+          },
         },
-      ],
+        children: [
+          {
+            path: 'create',
+            component: BudgetFormComponent,
+          },
+          {
+            path: `:${ROUTE_PARAMS.budgetCode}`,
+            component: BudgetDetailsComponent,
+            canActivate: [ExistBudgetGuard],
+            data: {
+              cxPageMeta: {
+                breadcrumb: 'budget.breadcrumbs.details',
+              },
+            },
+            children: [
+              {
+                path: `edit`,
+                component: BudgetFormComponent,
+                canActivate: [ActiveBudgetGuard],
+              },
+              {
+                path: 'cost-centers',
+                component: BudgetCostCenterListComponent,
+              },
+            ],
+          },
+        ],
+      },
       guards: [AuthGuard, AdminGuard],
     },
   },

--- a/feature-libs/my-account/organization/components/budget/services/budget-route-page-meta.resolver.spec.ts
+++ b/feature-libs/my-account/organization/components/budget/services/budget-route-page-meta.resolver.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { I18nTestingModule } from '@spartacus/core';
+import { Budget } from '@spartacus/my-account/organization/core';
+import { Observable, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { BudgetRoutePageMetaResolver } from './budget-route-page-meta.resolver';
+import { CurrentBudgetService } from './current-budget.service';
+
+class MockCurrentItemService implements Partial<CurrentBudgetService> {
+  item$: Observable<Budget> = of({ code: 'testCode' });
+}
+
+describe('BudgetRoutePageMetaResolver', () => {
+  let resolver: BudgetRoutePageMetaResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      providers: [
+        {
+          provide: CurrentBudgetService,
+          useClass: MockCurrentItemService,
+        },
+      ],
+    });
+
+    resolver = TestBed.inject(BudgetRoutePageMetaResolver);
+  });
+
+  it('should emit breadcrumb with translated i18n key, using current item as params', async () => {
+    expect(
+      await resolver
+        .resolveBreadcrumbs({
+          url: 'testPath',
+          pageMetaConfig: { breadcrumb: { i18n: 'testTranslation' } },
+        })
+        .pipe(take(1))
+        .toPromise()
+    ).toEqual([{ label: 'testTranslation code:testCode', link: 'testPath' }]);
+  });
+});

--- a/feature-libs/my-account/organization/components/budget/services/budget-route-page-meta.resolver.ts
+++ b/feature-libs/my-account/organization/components/budget/services/budget-route-page-meta.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import {
+  DefaultRoutePageMetaResolver,
+  TranslationService,
+} from '@spartacus/core';
+import { Budget } from '@spartacus/my-account/organization/core';
+import { Observable } from 'rxjs';
+import { CurrentBudgetService } from './current-budget.service';
+
+@Injectable({ providedIn: 'root' })
+export class BudgetRoutePageMetaResolver extends DefaultRoutePageMetaResolver {
+  constructor(
+    translation: TranslationService,
+    protected currentItemService: CurrentBudgetService
+  ) {
+    super(translation);
+  }
+
+  protected getParams(): Observable<Budget> {
+    return this.currentItemService.item$;
+  }
+}

--- a/feature-libs/my-account/organization/components/cost-center/cost-center.config.ts
+++ b/feature-libs/my-account/organization/components/cost-center/cost-center.config.ts
@@ -24,6 +24,7 @@ import { ActiveCostCenterGuard } from './guards/active-cost-center.guard';
 import { ExistCostCenterGuard } from './guards/exist-cost-center.guard';
 import { CostCenterItemService } from './services/cost-center-item.service';
 import { CostCenterListService } from './services/cost-center-list.service';
+import { CostCenterRoutePageMetaResolver } from './services/cost-center-route-page-meta.resolver';
 
 const listPath = `organization/cost-centers/:${ROUTE_PARAMS.costCenterCode}`;
 const paramsMapping: ParamsMapping = {
@@ -70,33 +71,55 @@ export const costCenterCmsConfig: CmsConfig = {
           useExisting: CostCenterItemService,
         },
       ],
-      childRoutes: [
-        {
-          path: 'create',
-          component: CostCenterFormComponent,
+      childRoutes: {
+        parent: {
+          data: {
+            cxPageMeta: {
+              breadcrumb: 'costCenter.breadcrumbs.list',
+              resolver: CostCenterRoutePageMetaResolver,
+            },
+          },
         },
-
-        {
-          path: `:${ROUTE_PARAMS.costCenterCode}`,
-          component: CostCenterDetailsComponent,
-          canActivate: [ExistCostCenterGuard],
-          children: [
-            {
-              path: 'edit',
-              component: CostCenterFormComponent,
-              canActivate: [ActiveCostCenterGuard],
+        children: [
+          {
+            path: 'create',
+            component: CostCenterFormComponent,
+          },
+          {
+            path: `:${ROUTE_PARAMS.costCenterCode}`,
+            component: CostCenterDetailsComponent,
+            canActivate: [ExistCostCenterGuard],
+            data: {
+              cxPageMeta: { breadcrumb: 'costCenter.breadcrumbs.details' },
             },
-            {
-              path: 'budgets',
-              component: CostCenterAssignedBudgetListComponent,
-            },
-            {
-              path: 'budgets/assign',
-              component: CostCenterBudgetListComponent,
-            },
-          ],
-        },
-      ],
+            children: [
+              {
+                path: 'edit',
+                component: CostCenterFormComponent,
+                canActivate: [ActiveCostCenterGuard],
+              },
+              {
+                path: 'budgets',
+                data: {
+                  cxPageMeta: {
+                    breadcrumb: 'costCenter.breadcrumbs.budgets',
+                  },
+                },
+                children: [
+                  {
+                    path: '',
+                    component: CostCenterAssignedBudgetListComponent,
+                  },
+                  {
+                    path: 'assign',
+                    component: CostCenterBudgetListComponent,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
       guards: [AuthGuard, AdminGuard],
     },
   },

--- a/feature-libs/my-account/organization/components/cost-center/services/cost-center-route-page-meta.resolver.spec.ts
+++ b/feature-libs/my-account/organization/components/cost-center/services/cost-center-route-page-meta.resolver.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { CostCenter, I18nTestingModule } from '@spartacus/core';
+import { Observable, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { CostCenterRoutePageMetaResolver } from './cost-center-route-page-meta.resolver';
+import { CurrentCostCenterService } from './current-cost-center.service';
+
+class MockCurrentItemService implements Partial<CurrentCostCenterService> {
+  item$: Observable<CostCenter> = of({ code: 'testCode' });
+}
+
+describe('CostCenterRouteBreadcrumbResolver', () => {
+  let resolver: CostCenterRoutePageMetaResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      providers: [
+        {
+          provide: CurrentCostCenterService,
+          useClass: MockCurrentItemService,
+        },
+      ],
+    });
+
+    resolver = TestBed.inject(CostCenterRoutePageMetaResolver);
+  });
+
+  it('should emit breadcrumb with translated i18n key, using current item as params', async () => {
+    expect(
+      await resolver
+        .resolveBreadcrumbs({
+          url: 'testPath',
+          pageMetaConfig: { breadcrumb: { i18n: 'testTranslation' } },
+        })
+        .pipe(take(1))
+        .toPromise()
+    ).toEqual([{ label: 'testTranslation code:testCode', link: 'testPath' }]);
+  });
+});

--- a/feature-libs/my-account/organization/components/cost-center/services/cost-center-route-page-meta.resolver.ts
+++ b/feature-libs/my-account/organization/components/cost-center/services/cost-center-route-page-meta.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import {
+  CostCenter,
+  DefaultRoutePageMetaResolver,
+  TranslationService,
+} from '@spartacus/core';
+import { Observable } from 'rxjs';
+import { CurrentCostCenterService } from './current-cost-center.service';
+
+@Injectable({ providedIn: 'root' })
+export class CostCenterRoutePageMetaResolver extends DefaultRoutePageMetaResolver {
+  constructor(
+    translation: TranslationService,
+    protected currentItemService: CurrentCostCenterService
+  ) {
+    super(translation);
+  }
+
+  protected getParams(): Observable<CostCenter> {
+    return this.currentItemService.item$;
+  }
+}

--- a/feature-libs/my-account/organization/components/permission/permission.config.ts
+++ b/feature-libs/my-account/organization/components/permission/permission.config.ts
@@ -21,6 +21,7 @@ import { ActivePermissionGuard } from './guards/active-permission.guard';
 import { ExistPermissionGuard } from './guards/exist-permission.guard';
 import { PermissionItemService } from './services/permission-item.service';
 import { PermissionListService } from './services/permission-list.service';
+import { PermissionRoutePageMetaResolver } from './services/permission-route-page-meta.resolver';
 
 const listPath = `organization/purchase-limits/:${ROUTE_PARAMS.permissionCode}`;
 const paramsMapping: ParamsMapping = {
@@ -62,24 +63,37 @@ export const permissionCmsConfig: CmsConfig = {
           useExisting: PermissionItemService,
         },
       ],
-      childRoutes: [
-        {
-          path: 'create',
-          component: PermissionFormComponent,
-        },
-        {
-          path: `:${ROUTE_PARAMS.permissionCode}`,
-          component: PermissionDetailsComponent,
-          canActivate: [ExistPermissionGuard],
-          children: [
-            {
-              path: 'edit',
-              component: PermissionFormComponent,
-              canActivate: [ActivePermissionGuard],
+      childRoutes: {
+        parent: {
+          data: {
+            cxPageMeta: {
+              breadcrumb: 'permission.breadcrumbs.list',
+              resolver: PermissionRoutePageMetaResolver,
             },
-          ],
+          },
         },
-      ],
+        children: [
+          {
+            path: 'create',
+            component: PermissionFormComponent,
+          },
+          {
+            path: `:${ROUTE_PARAMS.permissionCode}`,
+            component: PermissionDetailsComponent,
+            canActivate: [ExistPermissionGuard],
+            data: {
+              cxPageMeta: { breadcrumb: 'permission.breadcrumbs.details' },
+            },
+            children: [
+              {
+                path: 'edit',
+                component: PermissionFormComponent,
+                canActivate: [ActivePermissionGuard],
+              },
+            ],
+          },
+        ],
+      },
       guards: [AuthGuard, AdminGuard],
     },
   },

--- a/feature-libs/my-account/organization/components/permission/services/permission-route-page-meta.resolver.spec.ts
+++ b/feature-libs/my-account/organization/components/permission/services/permission-route-page-meta.resolver.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { I18nTestingModule, Permission } from '@spartacus/core';
+import { Observable, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { CurrentPermissionService } from './current-permission.service';
+import { PermissionRoutePageMetaResolver } from './permission-route-page-meta.resolver';
+
+class MockCurrentItemService implements Partial<CurrentPermissionService> {
+  item$: Observable<Permission> = of({ code: 'testCode' });
+}
+
+describe('PermissionRoutePageMetaResolver', () => {
+  let resolver: PermissionRoutePageMetaResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      providers: [
+        {
+          provide: CurrentPermissionService,
+          useClass: MockCurrentItemService,
+        },
+      ],
+    });
+
+    resolver = TestBed.inject(PermissionRoutePageMetaResolver);
+  });
+
+  it('should emit breadcrumb with translated i18n key, using current item as params', async () => {
+    expect(
+      await resolver
+        .resolveBreadcrumbs({
+          url: 'testPath',
+          pageMetaConfig: { breadcrumb: { i18n: 'testTranslation' } },
+        })
+        .pipe(take(1))
+        .toPromise()
+    ).toEqual([{ label: 'testTranslation code:testCode', link: 'testPath' }]);
+  });
+});

--- a/feature-libs/my-account/organization/components/permission/services/permission-route-page-meta.resolver.ts
+++ b/feature-libs/my-account/organization/components/permission/services/permission-route-page-meta.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import {
+  DefaultRoutePageMetaResolver,
+  Permission,
+  TranslationService,
+} from '@spartacus/core';
+import { Observable } from 'rxjs';
+import { CurrentPermissionService } from './current-permission.service';
+
+@Injectable({ providedIn: 'root' })
+export class PermissionRoutePageMetaResolver extends DefaultRoutePageMetaResolver {
+  constructor(
+    translation: TranslationService,
+    protected currentItemService: CurrentPermissionService
+  ) {
+    super(translation);
+  }
+
+  protected getParams(): Observable<Permission> {
+    return this.currentItemService.item$;
+  }
+}

--- a/feature-libs/my-account/organization/components/unit/services/unit-address-route-page-meta.resolver.spec.ts
+++ b/feature-libs/my-account/organization/components/unit/services/unit-address-route-page-meta.resolver.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { B2BUnit, I18nTestingModule } from '@spartacus/core';
+import { Observable, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { CurrentUnitService } from '../current-unit.service';
+import { UnitRoutePageMetaResolver } from './unit-route-page-meta.resolver';
+
+class MockCurrentItemService implements Partial<CurrentUnitService> {
+  item$: Observable<B2BUnit> = of({ name: 'testName' });
+}
+
+describe('UnitAddressRoutePageMetaResolver', () => {
+  let resolver: UnitAddressRoutePageMetaResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      providers: [
+        {
+          provide: CurrentUnitService,
+          useClass: MockCurrentItemService,
+        },
+      ],
+    });
+
+    resolver = TestBed.inject(UnitRoutePageMetaResolver);
+  });
+
+  it('should emit breadcrumb with translated i18n key, using current item as params', async () => {
+    expect(
+      await resolver
+        .resolveBreadcrumbs({
+          url: 'testPath',
+          pageMetaConfig: { breadcrumb: { i18n: 'testTranslation' } },
+        })
+        .pipe(take(1))
+        .toPromise()
+    ).toEqual([{ label: 'testTranslation name:testName', link: 'testPath' }]);
+  });
+});

--- a/feature-libs/my-account/organization/components/unit/services/unit-address-route-page-meta.resolver.ts
+++ b/feature-libs/my-account/organization/components/unit/services/unit-address-route-page-meta.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import {
+  B2BAddress,
+  DefaultRoutePageMetaResolver,
+  TranslationService,
+} from '@spartacus/core';
+import { Observable } from 'rxjs';
+import { CurrentUnitAddressService } from '../links/addresses/services/current-unit-address.service';
+
+@Injectable({ providedIn: 'root' })
+export class UnitAddressRoutePageMetaResolver extends DefaultRoutePageMetaResolver {
+  constructor(
+    translation: TranslationService,
+    protected currentItemService: CurrentUnitAddressService
+  ) {
+    super(translation);
+  }
+
+  protected getParams(): Observable<B2BAddress> {
+    return this.currentItemService.item$;
+  }
+}

--- a/feature-libs/my-account/organization/components/unit/services/unit-route-page-meta.resolver.spec.ts
+++ b/feature-libs/my-account/organization/components/unit/services/unit-route-page-meta.resolver.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { B2BUnit, I18nTestingModule } from '@spartacus/core';
+import { Observable, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { CurrentUnitService } from '../current-unit.service';
+import { UnitRoutePageMetaResolver } from './unit-route-page-meta.resolver';
+
+class MockCurrentItemService implements Partial<CurrentUnitService> {
+  item$: Observable<B2BUnit> = of({ name: 'testName' });
+}
+
+describe('UnitRoutePageMetaResolver', () => {
+  let resolver: UnitRoutePageMetaResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      providers: [
+        {
+          provide: CurrentUnitService,
+          useClass: MockCurrentItemService,
+        },
+      ],
+    });
+
+    resolver = TestBed.inject(UnitRoutePageMetaResolver);
+  });
+
+  it('should emit breadcrumb with translated i18n key, using current item as params', async () => {
+    expect(
+      await resolver
+        .resolveBreadcrumbs({
+          url: 'testPath',
+          pageMetaConfig: { breadcrumb: { i18n: 'testTranslation' } },
+        })
+        .pipe(take(1))
+        .toPromise()
+    ).toEqual([{ label: 'testTranslation name:testName', link: 'testPath' }]);
+  });
+});

--- a/feature-libs/my-account/organization/components/unit/services/unit-route-page-meta.resolver.ts
+++ b/feature-libs/my-account/organization/components/unit/services/unit-route-page-meta.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import {
+  B2BUnit,
+  DefaultRoutePageMetaResolver,
+  TranslationService,
+} from '@spartacus/core';
+import { Observable } from 'rxjs';
+import { CurrentUnitService } from '../current-unit.service';
+
+@Injectable({ providedIn: 'root' })
+export class UnitRoutePageMetaResolver extends DefaultRoutePageMetaResolver {
+  constructor(
+    translation: TranslationService,
+    protected currentItemService: CurrentUnitService
+  ) {
+    super(translation);
+  }
+
+  protected getParams(): Observable<B2BUnit> {
+    return this.currentItemService.item$;
+  }
+}

--- a/feature-libs/my-account/organization/components/unit/units.config.ts
+++ b/feature-libs/my-account/organization/components/unit/units.config.ts
@@ -29,8 +29,10 @@ import { UnitUserRolesCellComponent } from './links/users/list/unit-user-link-ce
 import { UnitUserListComponent } from './links/users/list/unit-user-list.component';
 import { UnitUserRolesFormComponent } from './links/users/roles/unit-user-roles.component';
 import { UnitListComponent } from './list/unit-list.component';
+import { UnitAddressRoutePageMetaResolver } from './services/unit-address-route-page-meta.resolver';
 import { UnitItemService } from './services/unit-item.service';
 import { UnitListService } from './services/unit-list.service';
+import { UnitRoutePageMetaResolver } from './services/unit-route-page-meta.resolver';
 
 const listPath = `organization/units/:${ROUTE_PARAMS.unitCode}`;
 const paramsMapping: ParamsMapping = {
@@ -118,75 +120,117 @@ export const unitsCmsConfig: CmsConfig = {
           useExisting: UnitItemService,
         },
       ],
-      childRoutes: [
-        {
-          path: 'create',
-          component: UnitFormComponent,
+      childRoutes: {
+        parent: {
+          data: {
+            cxPageMeta: {
+              breadcrumb: 'unit.breadcrumbs.list',
+              resolver: UnitRoutePageMetaResolver,
+            },
+          },
         },
-        {
-          path: `:${ROUTE_PARAMS.unitCode}`,
-          component: UnitDetailsComponent,
-          canActivate: [ExistUnitGuard],
-          children: [
-            {
-              path: 'edit',
-              component: UnitFormComponent,
-              canActivate: [ActiveUnitGuard],
+        children: [
+          {
+            path: 'create',
+            component: UnitFormComponent,
+          },
+          {
+            path: `:${ROUTE_PARAMS.unitCode}`,
+            component: UnitDetailsComponent,
+            canActivate: [ExistUnitGuard],
+            data: {
+              cxPageMeta: { breadcrumb: 'unit.breadcrumbs.details' },
             },
-            {
-              path: 'children',
-              component: UnitChildrenComponent,
-              children: [
-                {
-                  path: 'create',
-                  component: UnitFormComponent,
+            children: [
+              {
+                path: 'edit',
+                component: UnitFormComponent,
+                canActivate: [ActiveUnitGuard],
+              },
+              {
+                path: 'children',
+                component: UnitChildrenComponent,
+                data: {
+                  cxPageMeta: { breadcrumb: 'unit.breadcrumbs.children' },
                 },
-              ],
-            },
-            {
-              path: 'approvers',
-              component: UnitAssignedApproverListComponent,
-            },
-            {
-              path: 'approvers/assign',
-              component: UnitApproverListComponent,
-            },
-            {
-              path: 'users',
-              component: UnitUserListComponent,
-              children: [
-                {
-                  path: ':userCode/roles',
-                  component: UnitUserRolesFormComponent,
+                children: [
+                  {
+                    path: 'create',
+                    component: UnitFormComponent,
+                  },
+                ],
+              },
+              {
+                path: 'approvers',
+                data: {
+                  cxPageMeta: { breadcrumb: 'unit.breadcrumbs.approvers' },
                 },
-              ],
-            },
-            {
-              path: 'cost-centers',
-              component: UnitCostCenterListComponent,
-            },
-            {
-              path: 'addresses',
-              component: UnitAddressListComponent,
-              children: [
-                {
-                  path: 'create',
-                  component: UnitAddressFormComponent,
+                children: [
+                  {
+                    path: '',
+                    component: UnitAssignedApproverListComponent,
+                  },
+                  {
+                    path: 'assign',
+                    component: UnitApproverListComponent,
+                  },
+                ],
+              },
+              {
+                path: 'users',
+                component: UnitUserListComponent,
+                data: {
+                  cxPageMeta: { breadcrumb: 'unit.breadcrumbs.users' },
                 },
-                {
-                  path: ':addressId',
-                  component: UnitAddressDetailsComponent,
+                children: [
+                  {
+                    path: `:${ROUTE_PARAMS.userCode}/roles`,
+                    component: UnitUserRolesFormComponent,
+                  },
+                ],
+              },
+              {
+                path: 'cost-centers',
+                component: UnitCostCenterListComponent,
+              },
+              {
+                path: 'addresses',
+                component: UnitAddressListComponent,
+                data: {
+                  cxPageMeta: {
+                    breadcrumb: 'unit.breadcrumbs.addresses',
+                    resolver: UnitAddressRoutePageMetaResolver,
+                  },
                 },
-                {
-                  path: ':addressId/edit',
-                  component: UnitAddressFormComponent,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-
+                children: [
+                  {
+                    path: 'create',
+                    component: UnitAddressFormComponent,
+                  },
+                  {
+                    path: `:${ROUTE_PARAMS.addressCode}`,
+                    data: {
+                      cxPageMeta: {
+                        breadcrumb: 'unit.breadcrumbs.addressDetails',
+                      },
+                    },
+                    children: [
+                      {
+                        path: '',
+                        component: UnitAddressDetailsComponent,
+                      },
+                      {
+                        path: 'edit',
+                        component: UnitAddressFormComponent,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
       guards: [AuthGuard, AdminGuard],
     },
   },

--- a/feature-libs/my-account/organization/components/user-group/services/user-group-page-meta.resolver.spec.ts
+++ b/feature-libs/my-account/organization/components/user-group/services/user-group-page-meta.resolver.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { I18nTestingModule } from '@spartacus/core';
+import { UserGroup } from '@spartacus/my-account/organization/core';
+import { Observable, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { CurrentUserGroupService } from './current-user-group.service';
+import { UserGroupRoutePageMetaResolver } from './user-group-route-page-meta.resolver';
+
+class MockCurrentItemService implements Partial<CurrentUserGroupService> {
+  item$: Observable<UserGroup> = of({ name: 'testName' });
+}
+
+describe('UserGroupRoutePageMetaResolver', () => {
+  let resolver: UserGroupRoutePageMetaResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      providers: [
+        {
+          provide: CurrentUserGroupService,
+          useClass: MockCurrentItemService,
+        },
+      ],
+    });
+
+    resolver = TestBed.inject(UserGroupRoutePageMetaResolver);
+  });
+
+  it('should emit breadcrumb with translated i18n key, using current item as params', async () => {
+    expect(
+      await resolver
+        .resolveBreadcrumbs({
+          url: 'testPath',
+          pageMetaConfig: { breadcrumb: { i18n: 'testTranslation' } },
+        })
+        .pipe(take(1))
+        .toPromise()
+    ).toEqual([{ label: 'testTranslation name:testName', link: 'testPath' }]);
+  });
+});

--- a/feature-libs/my-account/organization/components/user-group/services/user-group-route-page-meta.resolver.ts
+++ b/feature-libs/my-account/organization/components/user-group/services/user-group-route-page-meta.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import {
+  DefaultRoutePageMetaResolver,
+  TranslationService,
+} from '@spartacus/core';
+import { UserGroup } from '@spartacus/my-account/organization/core';
+import { Observable } from 'rxjs';
+import { CurrentUserGroupService } from './current-user-group.service';
+
+@Injectable({ providedIn: 'root' })
+export class UserGroupRoutePageMetaResolver extends DefaultRoutePageMetaResolver {
+  constructor(
+    translation: TranslationService,
+    protected currentItemService: CurrentUserGroupService
+  ) {
+    super(translation);
+  }
+
+  protected getParams(): Observable<UserGroup> {
+    return this.currentItemService.item$;
+  }
+}

--- a/feature-libs/my-account/organization/components/user-group/user-group.config.ts
+++ b/feature-libs/my-account/organization/components/user-group/user-group.config.ts
@@ -22,6 +22,7 @@ import { UserGroupPermissionListComponent } from './permissions';
 import { UserGroupAssignedPermissionListComponent } from './permissions/assigned/user-group-assigned-permission-list.component';
 import { UserGroupListService } from './services';
 import { UserGroupItemService } from './services/user-group-item.service';
+import { UserGroupRoutePageMetaResolver } from './services/user-group-route-page-meta.resolver';
 import { UserGroupAssignedUserListComponent } from './users/assigned/user-group-assigned-user-list.component';
 import { UserGroupUserListComponent } from './users/user-group-user-list.component';
 
@@ -82,39 +83,70 @@ export const userGroupCmsConfig: CmsConfig = {
           useExisting: UserGroupItemService,
         },
       ],
-      childRoutes: [
-        {
-          path: 'create',
-          component: UserGroupFormComponent,
+      childRoutes: {
+        parent: {
+          data: {
+            cxPageMeta: {
+              breadcrumb: 'userGroup.breadcrumbs.list',
+              resolver: UserGroupRoutePageMetaResolver,
+            },
+          },
         },
-        {
-          path: `:${ROUTE_PARAMS.userGroupCode}`,
-          component: UserGroupDetailsComponent,
-          canActivate: [ExistUserGroupGuard],
-          children: [
-            {
-              path: 'edit',
-              component: UserGroupFormComponent,
+        children: [
+          {
+            path: 'create',
+            component: UserGroupFormComponent,
+          },
+          {
+            path: `:${ROUTE_PARAMS.userGroupCode}`,
+            component: UserGroupDetailsComponent,
+            canActivate: [ExistUserGroupGuard],
+            data: {
+              cxPageMeta: { breadcrumb: 'userGroup.breadcrumbs.details' },
             },
-            {
-              path: 'users',
-              component: UserGroupAssignedUserListComponent,
-            },
-            {
-              path: 'users/assign',
-              component: UserGroupUserListComponent,
-            },
-            {
-              path: 'purchase-limits',
-              component: UserGroupAssignedPermissionListComponent,
-            },
-            {
-              path: 'purchase-limits/assign',
-              component: UserGroupPermissionListComponent,
-            },
-          ],
-        },
-      ],
+            children: [
+              {
+                path: 'edit',
+                component: UserGroupFormComponent,
+              },
+              {
+                path: 'users',
+                data: {
+                  cxPageMeta: { breadcrumb: 'userGroup.breadcrumbs.users' },
+                },
+                children: [
+                  {
+                    path: '',
+                    component: UserGroupAssignedUserListComponent,
+                  },
+                  {
+                    path: 'assign',
+                    component: UserGroupUserListComponent,
+                  },
+                ],
+              },
+              {
+                path: 'purchase-limits',
+                data: {
+                  cxPageMeta: {
+                    breadcrumb: 'userGroup.breadcrumbs.permissions',
+                  },
+                },
+                children: [
+                  {
+                    path: '',
+                    component: UserGroupAssignedPermissionListComponent,
+                  },
+                  {
+                    path: 'assign',
+                    component: UserGroupPermissionListComponent,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
       guards: [AuthGuard, AdminGuard],
     },
   },

--- a/feature-libs/my-account/organization/components/user/services/user-route-page-meta.resolver.spec.ts
+++ b/feature-libs/my-account/organization/components/user/services/user-route-page-meta.resolver.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { B2BUser, I18nTestingModule } from '@spartacus/core';
+import { Observable, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { CurrentUserService } from './current-user.service';
+import { UserRoutePageMetaResolver } from './user-route-page-meta.resolver';
+
+class MockCurrentItemService implements Partial<CurrentUserService> {
+  item$: Observable<B2BUser> = of({ name: 'testName' });
+}
+
+describe('UserRoutePageMetaResolver', () => {
+  let resolver: UserRoutePageMetaResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      providers: [
+        {
+          provide: CurrentUserService,
+          useClass: MockCurrentItemService,
+        },
+      ],
+    });
+
+    resolver = TestBed.inject(UserRoutePageMetaResolver);
+  });
+
+  it('should emit breadcrumb with translated i18n key, using current item as params', async () => {
+    expect(
+      await resolver
+        .resolveBreadcrumbs({
+          url: 'testPath',
+          pageMetaConfig: { breadcrumb: { i18n: 'testTranslation' } },
+        })
+        .pipe(take(1))
+        .toPromise()
+    ).toEqual([{ label: 'testTranslation name:testName', link: 'testPath' }]);
+  });
+});

--- a/feature-libs/my-account/organization/components/user/services/user-route-page-meta.resolver.ts
+++ b/feature-libs/my-account/organization/components/user/services/user-route-page-meta.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import {
+  B2BUser,
+  DefaultRoutePageMetaResolver,
+  TranslationService,
+} from '@spartacus/core';
+import { Observable } from 'rxjs';
+import { CurrentUserService } from './current-user.service';
+
+@Injectable({ providedIn: 'root' })
+export class UserRoutePageMetaResolver extends DefaultRoutePageMetaResolver {
+  constructor(
+    translation: TranslationService,
+    protected currentItemService: CurrentUserService
+  ) {
+    super(translation);
+  }
+
+  protected getParams(): Observable<B2BUser> {
+    return this.currentItemService.item$;
+  }
+}

--- a/feature-libs/my-account/organization/components/user/user.config.ts
+++ b/feature-libs/my-account/organization/components/user/user.config.ts
@@ -30,6 +30,7 @@ import { UserAssignedPermissionListComponent } from './permissions';
 import { UserPermissionListComponent } from './permissions/user-permission-list.component';
 import { UserItemService } from './services/user-item.service';
 import { UserListService } from './services/user-list.service';
+import { UserRoutePageMetaResolver } from './services/user-route-page-meta.resolver';
 import { UserUserGroupListComponent } from './user-groups';
 import { UserAssignedUserGroupListComponent } from './user-groups/assigned/user-assigned-user-group-list.component';
 
@@ -101,53 +102,89 @@ export const userCmsConfig: CmsConfig = {
           useExisting: UserItemService,
         },
       ],
-      childRoutes: [
-        {
-          path: 'create',
-          component: UserFormComponent,
+      childRoutes: {
+        parent: {
+          data: {
+            cxPageMeta: {
+              breadcrumb: 'user.breadcrumbs.list',
+              resolver: UserRoutePageMetaResolver,
+            },
+          },
         },
-        {
-          path: `:${ROUTE_PARAMS.userCode}`,
-          component: UserDetailsComponent,
-          canActivate: [ExistUserGuard],
-          children: [
-            {
-              path: `edit`,
-              component: UserFormComponent,
-              canActivate: [ActiveUserGuard],
+        children: [
+          {
+            path: 'create',
+            component: UserFormComponent,
+          },
+          {
+            path: `:${ROUTE_PARAMS.userCode}`,
+            component: UserDetailsComponent,
+            canActivate: [ExistUserGuard],
+            data: {
+              cxPageMeta: { breadcrumb: 'user.breadcrumbs.details' },
             },
-            {
-              path: `change-password`,
-              component: ChangePasswordFormComponent,
-            },
-
-            {
-              path: 'user-groups',
-              component: UserAssignedUserGroupListComponent,
-            },
-            {
-              path: 'user-groups/assign',
-              component: UserUserGroupListComponent,
-            },
-            {
-              path: 'approvers',
-              component: UserAssignedApproverListComponent,
-            },
-            {
-              path: 'approvers/assign',
-              component: UserApproverListComponent,
-            },
-            {
-              path: 'purchase-limits',
-              component: UserAssignedPermissionListComponent,
-            },
-            {
-              path: 'purchase-limits/assign',
-              component: UserPermissionListComponent,
-            },
-          ],
-        },
-      ],
+            children: [
+              {
+                path: `edit`,
+                component: UserFormComponent,
+                canActivate: [ActiveUserGuard],
+              },
+              {
+                path: `change-password`,
+                component: ChangePasswordFormComponent,
+              },
+              {
+                path: 'user-groups',
+                data: {
+                  cxPageMeta: { breadcrumb: 'user.breadcrumbs.userGroups' },
+                },
+                children: [
+                  {
+                    path: '',
+                    component: UserAssignedUserGroupListComponent,
+                  },
+                  {
+                    path: 'assign',
+                    component: UserUserGroupListComponent,
+                  },
+                ],
+              },
+              {
+                path: 'approvers',
+                data: {
+                  cxPageMeta: { breadcrumb: 'user.breadcrumbs.approvers' },
+                },
+                children: [
+                  {
+                    path: '',
+                    component: UserAssignedApproverListComponent,
+                  },
+                  {
+                    path: 'assign',
+                    component: UserApproverListComponent,
+                  },
+                ],
+              },
+              {
+                path: 'purchase-limits',
+                data: {
+                  cxPageMeta: { breadcrumb: 'user.breadcrumbs.permissions' },
+                },
+                children: [
+                  {
+                    path: '',
+                    component: UserAssignedPermissionListComponent,
+                  },
+                  {
+                    path: 'assign',
+                    component: UserPermissionListComponent,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
       guards: [AuthGuard, AdminGuard],
     },
   },


### PR DESCRIPTION
Use route breadcrumbs in all MyOrg features.

i) created route page meta resolvers (using data layer from Current Item Service)
ii) used them in `cxPageMeta` of Routes
iii) added translations for breadcrumbs
iv) introduced `''` routes in the routes structure - to allow for nested breadcrumbs, but but avoid nested router-outlets

---
Part 1 https://github.com/SAP/spartacus/pull/9017 - hide org breadcrumb when on Org page
Part 2 https://github.com/SAP/spartacus/pull/9018 - add activated routes service
Part 3 https://github.com/SAP/spartacus/pull/9019 - add config for parent cms route 
Part 4 https://github.com/SAP/spartacus/pull/9020 - add routing page meta resolver
Part 5 https://github.com/SAP/spartacus/pull/9071- use route breadcrumbs in My Org