### PR TITLE
Second tier of Improvements to ssr optimized engine

### DIFF
--- a/projects/storefrontapp/optimized-ssr-engine.ts
+++ b/projects/storefrontapp/optimized-ssr-engine.ts
@@ -33,6 +33,10 @@ class RenderingCache {
 
   constructor(private options: OptimizedSsrOptions) {}
 
+  prepare(key) {
+    this.renderedUrls[key] = {};
+  }
+
   store(key, err, html) {
     this.renderedUrls[key] = { err, html };
     if (this.options.ttl) {
@@ -129,6 +133,7 @@ export function optimizedSsrEngine(
           fallbackToCsr();
         }
 
+        renderingCache.prepare(renderingKey);
         expressEngine(filePath, options, (err, html) => {
           currentConcurrency--;
           if (waitingForRender) {

--- a/projects/storefrontapp/optimized-ssr-engine.ts
+++ b/projects/storefrontapp/optimized-ssr-engine.ts
@@ -29,7 +29,7 @@ export interface OptimizedSsrOptions {
   ttl?: number;
 
   /**
-   * Allows to override default key generator for custom differentiating
+   * Allows overriding default key generator for custom differentiating
    * between rendered pages. By default it uses req.originalUrl
    *
    * @param req
@@ -37,7 +37,7 @@ export interface OptimizedSsrOptions {
   renderKeyResolver?: (req) => string;
 
   /**
-   * Allows to define custom rendering strategy per request
+   * Allows defining custom rendering strategy per request
    *
    * @param req
    */

--- a/projects/storefrontapp/optimized-ssr-engine.ts
+++ b/projects/storefrontapp/optimized-ssr-engine.ts
@@ -88,7 +88,7 @@ export function optimizedSsrEngine(
   ) {
     const res = options.res || options.req.res;
 
-    const renderingKey = filePath;
+    const renderingKey = options.req.originalUrl;
 
     /**
      * When SSR page can not be returned in time, we're returning index.html of

--- a/projects/storefrontapp/optimized-ssr-engine.ts
+++ b/projects/storefrontapp/optimized-ssr-engine.ts
@@ -17,13 +17,14 @@ export interface OptimizedSsrOptions {
   concurrency?: number;
 
   /**
-   * Time in milliseconds to wait for SSR rendering to happen.
+   * Time in milliseconds after prerendered page is becoming stale and should
+   * be rendered again.
    */
   ttl?: number;
 
   /**
-   * Possible to override default key generator for custom differentiating
-   * between rendered pages. By default it uses req.url
+   * Allows to override default key generator for custom differentiating
+   * between rendered pages. By default it uses req.originalUrl
    *
    * @param req
    */

--- a/projects/storefrontapp/optimized-ssr-engine.ts
+++ b/projects/storefrontapp/optimized-ssr-engine.ts
@@ -44,7 +44,7 @@ export interface OptimizedSsrOptions {
   renderingStrategyResolver?: (req) => RenderingStrategy;
 
   /**
-   * Time in milliseconds to wait for SSR rendering in SSR_ALWAYS render strategy.
+   * Time in milliseconds to wait for rendering when SSR_ALWAYS render strategy is set for the request.
    * Default value is 60 seconds.
    */
   forcedSsrTimeout?: number;

--- a/projects/storefrontapp/server.ts
+++ b/projects/storefrontapp/server.ts
@@ -31,6 +31,9 @@ export function app() {
       {
         cache: false,
         timeout: 2000,
+        concurrency: 5,
+        ttl: 3600000,
+        // renderKeyResolver: (req) => req.originalUrl,
       }
     )
   );


### PR DESCRIPTION
We added additional options:

  - **concurrency:** limit number of concurrent rendering
  - **ttl:** time in milliseconds after the prerendered page is becoming stale and should be rendered again.
  - **renderKeyResolver:** allows overriding default key generator for custom differentiating between rendered pages. 
  - **renderingStrategyResolver:** allows defining custom rendering strategy per request, possible values are `ALWAYS_CSR`, `DEFAULT` and `ALWAYS_SSR`,
  - **forcedSsrTimeout:** time in milliseconds to wait for rendering when `SSR_ALWAYS` render strategy is set for the request
