### PR TITLE
chore: Add tags to cypress recordings

### DIFF
--- a/projects/storefrontapp-e2e-cypress/package.json
+++ b/projects/storefrontapp-e2e-cypress/package.json
@@ -7,20 +7,20 @@
   "scripts": {
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "cy:run:ci:1905": "cypress run --config-file cypress.ci.1905.json --record --key $CYPRESS_KEY --spec \"cypress/integration/!(vendor|b2b)/**/*.e2e-spec.ts\"",
-    "cy:run:ci:2005": "cypress run --config-file cypress.ci.2005.json --record --key $CYPRESS_KEY --spec \"cypress/integration/!(vendor|b2b)/**/*.e2e-spec.ts\"",
-    "cy:run:ci:ccv2": "cypress run --config-file cypress.ci.ccv2.json --record --key $CYPRESS_KEY --spec \"cypress/integration/!(vendor|b2b)/**/*.e2e-spec.ts\"",
+    "cy:run:ci:1905": "cypress run --config-file cypress.ci.1905.json --record --key $CYPRESS_KEY --tag \"1905,all\" --spec \"cypress/integration/!(vendor|b2b)/**/*.e2e-spec.ts\"",
+    "cy:run:ci:2005": "cypress run --config-file cypress.ci.2005.json --record --key $CYPRESS_KEY --tag \"2005,all\" --spec \"cypress/integration/!(vendor|b2b)/**/*.e2e-spec.ts\"",
+    "cy:run:ci:ccv2": "cypress run --config-file cypress.ci.ccv2.json --record --key $CYPRESS_KEY --tag \"ccv2,all\" --spec \"cypress/integration/!(vendor|b2b)/**/*.e2e-spec.ts\"",
     "cy:run:mobile": "cypress run --spec \"cypress/integration/mobile/**/*\"",
     "cy:run:mobile:ci": "cypress run --config-file cypress.ci.1905.json --spec \"cypress/integration/mobile/**/*\"",
     "cy:run:regression": "cypress run --spec \"cypress/integration/regression/**/*\"",
     "cy:cds:run:vendor": "cypress run --spec \"cypress/integration/vendor/cds/**/*\"",
     "cy:run:regression:ci": "cypress run --config-file cypress.ci.1905.json --spec \"cypress/integration/regression/**/*\"",
     "cy:run:smoke": "cypress run --spec \"cypress/integration/smoke/**/*\"",
-    "cy:run:smoke:ci:1905": "cypress run --config-file cypress.ci.1905.json --record --key $CYPRESS_KEY --spec \"cypress/integration/smoke/**/*\"",
-    "cy:run:smoke:ci:2005": "cypress run --config-file cypress.ci.2005.json --record --key $CYPRESS_KEY --spec \"cypress/integration/smoke/**/*\"",
-    "cy:run:smoke:ci:ccv2": "cypress run --config-file cypress.ci.ccv2.json --record --key $CYPRESS_KEY --spec \"cypress/integration/smoke/**/*\"",
+    "cy:run:smoke:ci:1905": "cypress run --config-file cypress.ci.1905.json --record --key $CYPRESS_KEY --tag \"1905,smoke\" --spec \"cypress/integration/smoke/**/*\"",
+    "cy:run:smoke:ci:2005": "cypress run --config-file cypress.ci.2005.json --record --key $CYPRESS_KEY --tag \"2005,smoke\" --spec \"cypress/integration/smoke/**/*\"",
+    "cy:run:smoke:ci:ccv2": "cypress run --config-file cypress.ci.ccv2.json --record --key $CYPRESS_KEY --tag \"ccv2,smoke\" --spec \"cypress/integration/smoke/**/*\"",
     "cy:run:b2b": "cypress run --spec \"cypress/integration/b2b/**/*\"",
-    "cy:run:b2b:ci": "cypress run --config-file cypress.ci.2005.json --record --key $CYPRESS_KEY --spec \"cypress/integration/b2b/**/*\""
+    "cy:run:b2b:ci": "cypress run --config-file cypress.ci.2005.json --record --key $CYPRESS_KEY --tag \"2005,b2b\" --spec \"cypress/integration/b2b/**/*\""
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^4.0.3",


### PR DESCRIPTION
Added tags for cypress jobs just to help with inspection of the recording in cypress dashboard.

Convention:
- 1 tag for backend env: 1905 | 2005 | ccv2
- 2 tag for test suite: all | smoke | b2b