### PR TITLE
cleanup tests

### DIFF
--- a/projects/storefrontlib/src/cms-components/asm/asm-main-ui/asm-main-ui.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/asm/asm-main-ui/asm-main-ui.component.spec.ts
@@ -59,6 +59,12 @@ class MockUserService {
 }
 
 @Component({
+  selector: 'cx-asm-toggle-ui',
+  template: '',
+})
+class MockAsmToggleUiComponent {}
+
+@Component({
   selector: 'cx-asm-session-timer',
   template: '',
 })
@@ -130,6 +136,7 @@ describe('AsmMainUiComponent', () => {
       imports: [I18nTestingModule],
       declarations: [
         AsmMainUiComponent,
+        MockAsmToggleUiComponent,
         MockCSAgentLoginFormComponent,
         MockCustomerSelectionComponent,
         MockAsmSessionTimerComponent,

--- a/projects/storefrontlib/src/cms-components/cart/cart-coupon/cart-coupon.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/cart/cart-coupon/cart-coupon.component.spec.ts
@@ -13,19 +13,10 @@ import {
   I18nTestingModule,
   Voucher,
 } from '@spartacus/core';
-import { ICON_TYPE } from '@spartacus/storefront';
 import { cold, getTestScheduler, hot } from 'jasmine-marbles';
 import { of } from 'rxjs';
-import { CartCouponComponent } from './cart-coupon.component';
 import { FormErrorsModule } from '../../../shared/index';
-
-@Component({
-  selector: 'cx-icon',
-  template: '',
-})
-class MockCxIconComponent {
-  @Input() type: ICON_TYPE;
-}
+import { CartCouponComponent } from './cart-coupon.component';
 
 @Component({
   selector: 'cx-applied-coupons',
@@ -88,11 +79,7 @@ describe('CartCouponComponent', () => {
         FeaturesConfigModule,
         FormErrorsModule,
       ],
-      declarations: [
-        CartCouponComponent,
-        MockAppliedCouponsComponent,
-        MockCxIconComponent,
-      ],
+      declarations: [CartCouponComponent, MockAppliedCouponsComponent],
       providers: [
         { provide: ActiveCartService, useValue: mockActiveCartService },
         { provide: AuthService, useValue: mockAuthService },

--- a/projects/storefrontlib/src/cms-components/cart/cart-details/cart-details.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/cart/cart-details/cart-details.component.spec.ts
@@ -170,14 +170,14 @@ describe('CartDetailsComponent', () => {
         code: 'PR0000',
       },
     };
-    mockAuthService.isUserLoggedIn.and.returnValue(false);
+    mockAuthService.isUserLoggedIn.and.returnValue(of(false));
     component.saveForLater(mockItem);
     fixture.detectChanges();
     expect(mockRoutingService.go).toHaveBeenCalled();
   });
 
   it('should not show save for later when selective cart is disabled', () => {
-    mockSelectiveCartService.isEnabled.and.returnValue(false);
+    mockSelectiveCartService.isEnabled.and.returnValue(of(false));
     fixture.detectChanges();
     const el = fixture.debugElement.query(By.css('button'));
     expect(el).toBe(null);

--- a/projects/storefrontlib/src/cms-components/checkout/components/checkout-order-summary/checkout-order-summary.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/checkout-order-summary/checkout-order-summary.component.spec.ts
@@ -1,4 +1,3 @@
-import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   ActiveCartService,
@@ -10,18 +9,9 @@ import { BehaviorSubject } from 'rxjs';
 import { OrderSummaryComponent } from '../../../../cms-components/cart/cart-shared/order-summary/order-summary.component';
 import { MockFeatureLevelDirective } from '../../../../shared/test/mock-feature-level-directive';
 import { AppliedCouponsComponent } from '../../../cart/cart-coupon/applied-coupons/applied-coupons.component';
-import { ICON_TYPE } from '../../../misc/icon';
 import { PromotionsComponent } from '../promotions/promotions.component';
 import { CheckoutOrderSummaryComponent } from './checkout-order-summary.component';
 import createSpy = jasmine.createSpy;
-
-@Component({
-  selector: 'cx-icon',
-  template: '',
-})
-class MockCxIconComponent {
-  @Input() type: ICON_TYPE;
-}
 
 describe('CheckoutOrderSummaryComponent', () => {
   let component: CheckoutOrderSummaryComponent;
@@ -45,7 +35,6 @@ describe('CheckoutOrderSummaryComponent', () => {
         OrderSummaryComponent,
         PromotionsComponent,
         AppliedCouponsComponent,
-        MockCxIconComponent,
         MockFeatureLevelDirective,
       ],
       providers: [

--- a/projects/storefrontlib/src/cms-components/checkout/components/payment-method/payment-method.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/payment-method/payment-method.component.spec.ts
@@ -17,8 +17,8 @@ import {
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { CardComponent } from '../../../../shared/components/card/card.component';
 import { ICON_TYPE } from '../../../misc/index';
-import { PaymentMethodComponent } from './payment-method.component';
 import { CheckoutStepService } from '../../services/checkout-step.service';
+import { PaymentMethodComponent } from './payment-method.component';
 import createSpy = jasmine.createSpy;
 
 @Component({
@@ -61,6 +61,7 @@ class MockCheckoutPaymentService {
   getPaymentDetails(): Observable<PaymentDetails> {
     return of(mockPaymentDetails);
   }
+  paymentProcessSuccess() {}
 }
 class MockCheckoutDeliveryService {
   getDeliveryAddress(): Observable<PaymentDetails> {

--- a/projects/storefrontlib/src/cms-components/checkout/components/review-submit/review-submit.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/review-submit/review-submit.component.spec.ts
@@ -26,6 +26,7 @@ import { PromotionsModule } from '../../..';
 import { Item } from '../../../../cms-components/cart/index';
 import { Card } from '../../../../shared/components/card/card.component';
 import { PromotionService } from '../../../../shared/services/promotion/promotion.service';
+import { IconTestingModule } from '../../../misc/icon/testing/icon-testing.module';
 import { CheckoutStep, CheckoutStepType } from '../../model/index';
 import { CheckoutStepService } from '../../services/index';
 import { ReviewSubmitComponent } from './review-submit.component';
@@ -204,7 +205,12 @@ describe('ReviewSubmitComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, PromotionsModule, RouterTestingModule],
+      imports: [
+        I18nTestingModule,
+        PromotionsModule,
+        RouterTestingModule,
+        IconTestingModule,
+      ],
       declarations: [
         ReviewSubmitComponent,
         MockCartItemListComponent,

--- a/projects/storefrontlib/src/cms-components/checkout/components/schedule-replenishment-order/schedule-replenishment-order.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/schedule-replenishment-order/schedule-replenishment-order.component.spec.ts
@@ -8,7 +8,7 @@ import {
   ScheduleReplenishmentForm,
 } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
-import { IconModule } from '../../../misc/index';
+import { IconTestingModule } from '../../../misc/icon/testing/icon-testing.module';
 import { CheckoutReplenishmentFormService } from '../../services/checkout-replenishment-form-service';
 import { ScheduleReplenishmentOrderComponent } from './schedule-replenishment-order.component';
 
@@ -48,7 +48,7 @@ describe('ScheduleReplenishmentOrderComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule, IconModule],
+      imports: [RouterTestingModule, I18nTestingModule, IconTestingModule],
       declarations: [ScheduleReplenishmentOrderComponent],
       providers: [
         { provide: CheckoutService, useClass: MockCheckoutService },

--- a/projects/storefrontlib/src/cms-components/checkout/guards/checkout-steps-set.guard.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/guards/checkout-steps-set.guard.spec.ts
@@ -179,7 +179,7 @@ describe(`CheckoutStepsSetGuard`, () => {
     describe('step1 (shipping address) data set', () => {
       beforeEach(() => {
         spyOn(checkoutDetailsService, 'getDeliveryAddress').and.returnValue(
-          of({ id: 'test-ddress' })
+          of({ id: 'test-address' })
         );
       });
 
@@ -266,6 +266,7 @@ describe(`CheckoutStepsSetGuard`, () => {
 
     describe('PAYMENT_DETAILS is not valid any more', () => {
       it('go to step3 (payment details), should return to checkout', (done) => {
+        spyOn(console, 'warn');
         guard
           .canActivate(<any>{ url: ['checkout', 'route3'] }, undefined)
           .subscribe((result) => {
@@ -342,7 +343,7 @@ describe(`CheckoutStepsSetGuard`, () => {
     describe('step1 (shipping address) data set', () => {
       beforeEach(() => {
         spyOn(checkoutDetailsService, 'getDeliveryAddress').and.returnValue(
-          of({ id: 'test-ddress' })
+          of({ id: 'test-address' })
         );
       });
 

--- a/projects/storefrontlib/src/cms-components/checkout/guards/delivery-mode-set.guard.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/guards/delivery-mode-set.guard.spec.ts
@@ -6,8 +6,8 @@ import { Observable, of } from 'rxjs';
 import { defaultStorefrontRoutesConfig } from '../../../cms-structure/routing/default-routing-config';
 import { CheckoutConfig } from '../config/checkout-config';
 import { defaultCheckoutConfig } from '../config/default-checkout-config';
-import { CheckoutStepService } from '../services/checkout-step.service';
 import { CheckoutDetailsService } from '../services/checkout-details.service';
+import { CheckoutStepService } from '../services/checkout-step.service';
 import { DeliveryModeSetGuard } from './delivery-mode-set.guard';
 
 const MockCheckoutConfig: CheckoutConfig = defaultCheckoutConfig;
@@ -56,6 +56,8 @@ describe(`DeliveryModeSetGuard`, () => {
     mockCheckoutConfig = TestBed.inject(CheckoutConfig);
     mockRoutingConfigService = TestBed.inject(RoutingConfigService);
     mockCheckoutStepService = TestBed.inject(CheckoutStepService);
+
+    spyOn(console, 'warn');
   });
 
   describe(`delivery mode step is disabled`, () => {
@@ -97,7 +99,6 @@ describe(`DeliveryModeSetGuard`, () => {
       mockCheckoutDetailsService,
       'getSelectedDeliveryModeCode'
     ).and.returnValue(of(''));
-    spyOn(console, 'warn');
     mockCheckoutConfig.checkout.steps = [];
 
     guard.canActivate().subscribe((result: boolean | UrlTree) => {

--- a/projects/storefrontlib/src/cms-components/checkout/guards/payment-details-set.guard.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/guards/payment-details-set.guard.spec.ts
@@ -5,8 +5,8 @@ import { Observable, of } from 'rxjs';
 import { defaultStorefrontRoutesConfig } from '../../../cms-structure/routing/default-routing-config';
 import { CheckoutConfig } from '../config/checkout-config';
 import { defaultCheckoutConfig } from '../config/default-checkout-config';
-import { CheckoutStepService } from '../services/checkout-step.service';
 import { CheckoutDetailsService } from '../services/checkout-details.service';
+import { CheckoutStepService } from '../services/checkout-step.service';
 import { PaymentDetailsSetGuard } from './payment-details-set.guard';
 
 // deep copy to avoid issues with mutating imported symbols
@@ -59,6 +59,9 @@ describe(`PaymentDetailsSetGuard`, () => {
     mockCheckoutConfig = TestBed.inject(CheckoutConfig);
     mockRoutingConfigService = TestBed.inject(RoutingConfigService);
     mockCheckoutStepService = TestBed.inject(CheckoutStepService);
+
+    // suppress warnings in test console
+    spyOn(console, 'warn');
   });
 
   describe(`when there is NO payment details present`, () => {
@@ -87,7 +90,6 @@ describe(`PaymentDetailsSetGuard`, () => {
       spyOn(mockCheckoutDetailsService, 'getPaymentDetails').and.returnValue(
         of({})
       );
-      spyOn(console, 'warn');
       mockCheckoutConfig.checkout.steps = [];
 
       guard.canActivate().subscribe((result) => {

--- a/projects/storefrontlib/src/cms-components/checkout/guards/shipping-address-set.guard.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/guards/shipping-address-set.guard.spec.ts
@@ -5,8 +5,8 @@ import { Observable, of } from 'rxjs';
 import { defaultStorefrontRoutesConfig } from '../../../cms-structure/routing/default-routing-config';
 import { CheckoutConfig } from '../config/checkout-config';
 import { defaultCheckoutConfig } from '../config/default-checkout-config';
-import { CheckoutStepService } from '../services/checkout-step.service';
 import { CheckoutDetailsService } from '../services/checkout-details.service';
+import { CheckoutStepService } from '../services/checkout-step.service';
 import { ShippingAddressSetGuard } from './shipping-address-set.guard';
 
 const MockRoutesConfig: RoutesConfig = JSON.parse(
@@ -58,6 +58,8 @@ describe(`ShippingAddressSetGuard`, () => {
     mockCheckoutConfig = TestBed.inject(CheckoutConfig);
     mockRoutingConfigService = TestBed.inject(RoutingConfigService);
     mockCheckoutStepService = TestBed.inject(CheckoutStepService);
+
+    spyOn(console, 'warn');
   });
 
   describe(`shipping address step is disabled`, () => {
@@ -99,7 +101,6 @@ describe(`ShippingAddressSetGuard`, () => {
       spyOn(mockCheckoutDetailsService, 'getDeliveryAddress').and.returnValue(
         of({})
       );
-      spyOn(console, 'warn');
       mockCheckoutConfig.checkout.steps = [];
 
       guard.canActivate().subscribe((result) => {

--- a/projects/storefrontlib/src/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.spec.ts
@@ -107,6 +107,8 @@ describe('TabParagraphContainerComponent', () => {
     component = fixture.componentInstance;
     cmsService = TestBed.inject(CmsService);
     windowRef = TestBed.inject(WindowRef);
+
+    spyOn(console, 'warn');
   });
 
   it('should create', () => {

--- a/projects/storefrontlib/src/cms-components/myaccount/order/replenishment-order-details/replenishment-order-cancellation/replenishment-order-cancellation.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/replenishment-order-details/replenishment-order-cancellation/replenishment-order-cancellation.component.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   ReplenishmentOrder,
@@ -31,6 +32,7 @@ class MockUserReplenishmentOrderService {
   getReplenishmentOrderDetails(): Observable<ReplenishmentOrder> {
     return mockReplenishmentOrder$.asObservable();
   }
+  clearReplenishmentOrderDetails() {}
 }
 
 class MockReplenishmentOrderCancellationLaunchDialogService {
@@ -52,7 +54,7 @@ describe('ReplenishmentOrderCancellationComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule],
+      imports: [I18nTestingModule, RouterTestingModule],
       declarations: [ReplenishmentOrderCancellationComponent, MockUrlPipe],
       providers: [
         {

--- a/projects/storefrontlib/src/cms-components/navigation/search-box/search-box-component.service.spec.ts
+++ b/projects/storefrontlib/src/cms-components/navigation/search-box/search-box-component.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import {
   CmsComponent,
+  I18nTestingModule,
   ProductSearchPage,
   RoutingService,
   SearchboxService,
@@ -25,11 +26,11 @@ const searchBoxConfig: SearchBoxConfig = {
   displayProductImages: false,
 };
 
-class MockSearchboxService {
-  getSuggestionResults(): Observable<Suggestion[]> {
+class MockSearchBoxService {
+  getResults(): Observable<ProductSearchPage> {
     return of();
   }
-  getResults(): Observable<ProductSearchPage> {
+  getSuggestionResults(): Observable<Suggestion[]> {
     return of();
   }
 }
@@ -72,9 +73,10 @@ const mockSearchResults: ProductSearchPage = {
 
 describe('SearchBoxComponentService', () => {
   let service: SearchBoxComponentService;
-  let searchBoxservice: SearchboxService;
+  let searchBoxService: SearchboxService;
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
       providers: [
         {
           provide: CmsComponentData,
@@ -86,7 +88,7 @@ describe('SearchBoxComponentService', () => {
         },
         {
           provide: SearchboxService,
-          useClass: MockSearchboxService,
+          useClass: MockSearchBoxService,
         },
         { provide: TranslationService, useClass: MockTranslationService },
         SearchBoxComponentService,
@@ -94,7 +96,7 @@ describe('SearchBoxComponentService', () => {
       ],
     });
     service = TestBed.inject(SearchBoxComponentService);
-    searchBoxservice = TestBed.inject(SearchboxService);
+    searchBoxService = TestBed.inject(SearchboxService);
   });
 
   it('should be created', () => {
@@ -112,22 +114,18 @@ describe('SearchBoxComponentService', () => {
     });
   });
 
-  it('should get suggestions from search)', () => {
-    const searchConfig = { pageSize: 5 };
-    service.getResults(searchBoxConfig).subscribe(() => {
-      expect(searchBoxservice.searchSuggestions).toHaveBeenCalledWith(
-        'testQuery',
-        searchConfig
-      );
-    });
+  it('should get suggestions results', () => {
+    spyOn(searchBoxService, 'getSuggestionResults').and.callThrough();
+    service.getResults(searchBoxConfig).subscribe().unsubscribe();
+    expect(searchBoxService.getSuggestionResults).toHaveBeenCalledWith();
   });
 
   it('should return 2 products', () => {
     let result: SearchResults;
-    spyOn(searchBoxservice, 'getResults').and.returnValue(
+    spyOn(searchBoxService, 'getResults').and.returnValue(
       of(mockSearchResults)
     );
-    spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(of([]));
+    spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(of([]));
     service
       .getResults(searchBoxConfig)
       .subscribe((results) => (result = results));
@@ -135,7 +133,7 @@ describe('SearchBoxComponentService', () => {
   });
 
   it('should not return products when config.displayProducts = false', () => {
-    spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(
+    spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(
       of(['sug1', 'sug2'] as any)
     );
 
@@ -149,13 +147,13 @@ describe('SearchBoxComponentService', () => {
   describe('search result suggestions', () => {
     let result: SearchResults;
     beforeEach(() => {
-      spyOn(searchBoxservice, 'getResults').and.returnValue(
+      spyOn(searchBoxService, 'getResults').and.returnValue(
         of(mockSearchResults)
       );
     });
 
     it('should return 2 suggestions', () => {
-      spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(
         of(['sug1', 'sug2'] as any)
       );
 
@@ -166,7 +164,7 @@ describe('SearchBoxComponentService', () => {
     });
 
     it('should not return suggestions when config.displaySuggestions = false', () => {
-      spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(
         of(['sug1', 'sug2'] as any)
       );
 
@@ -177,7 +175,7 @@ describe('SearchBoxComponentService', () => {
     });
 
     it('should have exact match suggestion when there are no suggestions but at least one product', () => {
-      spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(of([]));
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(of([]));
 
       service
         .getResults(searchBoxConfig)
@@ -188,7 +186,7 @@ describe('SearchBoxComponentService', () => {
     });
 
     it('should not get an exact match suggestion when there are suggestions returned', () => {
-      spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(
         of(['sug1'] as any)
       );
 
@@ -205,18 +203,18 @@ describe('SearchBoxComponentService', () => {
     let result: SearchResults;
 
     it('should not get a message when there are no results ', () => {
-      spyOn(searchBoxservice, 'getResults').and.returnValue(of({}));
-      spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(of([]));
+      spyOn(searchBoxService, 'getResults').and.returnValue(of({}));
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(of([]));
 
       service.getResults(searchBoxConfig).subscribe((r) => (result = r));
       expect(result.message).toBeFalsy();
     });
 
     it('should get a not found message when there are no products and suggestions ', () => {
-      spyOn(searchBoxservice, 'getResults').and.returnValue(
+      spyOn(searchBoxService, 'getResults').and.returnValue(
         of({ products: [] })
       );
-      spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(of([]));
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(of([]));
 
       service.getResults(searchBoxConfig).subscribe((r) => (result = r));
       expect(result.message).toBeTruthy();
@@ -225,18 +223,18 @@ describe('SearchBoxComponentService', () => {
     });
 
     it('should not get a message when there are products ', () => {
-      spyOn(searchBoxservice, 'getResults').and.returnValue(
+      spyOn(searchBoxService, 'getResults').and.returnValue(
         of(mockSearchResults)
       );
-      spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(of([]));
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(of([]));
 
       service.getResults(searchBoxConfig).subscribe((r) => (result = r));
       expect(result.message).toBeFalsy();
     });
 
     it('should not get a message when there are suggestions ', () => {
-      spyOn(searchBoxservice, 'getResults').and.returnValue(of());
-      spyOn(searchBoxservice, 'getSuggestionResults').and.returnValue(
+      spyOn(searchBoxService, 'getResults').and.returnValue(of());
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(
         of(['sug1'] as any)
       );
 

--- a/projects/storefrontlib/src/cms-components/product/product-variants/variant-style-icons/style-icons.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-variants/variant-style-icons/style-icons.component.spec.ts
@@ -1,8 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { VariantStyleIconsComponent } from './variant-style-icons.component';
 import { OccConfig, VariantOption, VariantQualifier } from '@spartacus/core';
+import { VariantStyleIconsComponent } from './variant-style-icons.component';
 
-const mockOccBackendUrl = 'abc';
+const mockOccBackendUrl = 'https://';
 const mockVariants: VariantOption[] = [
   {
     code: 'code_1',
@@ -12,14 +12,14 @@ const mockVariants: VariantOption[] = [
         name: 'test2',
         qualifier: VariantQualifier.ROLLUP_PROPERTY,
         image: {
-          url: 'http://test1-rollup.com',
+          url: '/test1-rollup.jpg',
         },
       },
       {
         name: 'test1',
         qualifier: VariantQualifier.THUMBNAIL,
         image: {
-          url: 'http://test1-thumbnail.com',
+          url: '/test1-thumbnail.jpg',
         },
       },
     ],

--- a/projects/storefrontlib/src/cms-components/product/product-variants/variant-style-selector/variant-style-selector.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/product/product-variants/variant-style-selector/variant-style-selector.component.spec.ts
@@ -1,20 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
+  BaseOption,
   I18nTestingModule,
   OccConfig,
-  UrlCommandRoute,
-  BaseOption,
-  VariantType,
-  ProductService,
   Product,
+  ProductService,
   RoutingService,
+  UrlCommandRoute,
+  VariantType,
 } from '@spartacus/core';
-import { VariantStyleSelectorComponent } from './variant-style-selector.component';
-import { Pipe, PipeTransform } from '@angular/core';
 import { Observable, of } from 'rxjs';
+import { VariantStyleSelectorComponent } from './variant-style-selector.component';
 
-const mockOccBackendUrl = 'abc';
+const mockOccBackendUrl = 'https://base.com';
 const mockVariant: BaseOption = {
   selected: {
     code: 'test',
@@ -22,7 +22,7 @@ const mockVariant: BaseOption = {
       {
         value: '123',
         image: {
-          url: 'http://test1-thumbnail.com',
+          url: '/test1-thumbnail.jpg',
         },
       },
     ],
@@ -71,7 +71,7 @@ describe('VariantStyleSelectorComponent', () => {
       providers: [
         {
           provide: OccConfig,
-          useValue: { backend: { occ: { baseUrl: 'abc' } } },
+          useValue: { backend: { occ: { baseUrl: mockOccBackendUrl } } },
         },
         {
           provide: ProductService,

--- a/projects/storefrontlib/src/cms-components/user/login-register/login-register.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/user/login-register/login-register.component.spec.ts
@@ -2,6 +2,7 @@ import { DebugElement, Pipe, PipeTransform } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { CheckoutConfigService } from '@spartacus/storefront';
 import { LoginRegisterComponent } from './login-register.component';
@@ -34,7 +35,7 @@ describe('LoginRegisterComponent', () => {
   }
 
   const testBedDefaults = {
-    imports: [I18nTestingModule],
+    imports: [RouterTestingModule, I18nTestingModule],
     declarations: [LoginRegisterComponent, MockUrlPipe],
     providers: [
       { provide: CheckoutConfigService, useClass: MockCheckoutConfigService },

--- a/projects/storefrontlib/src/cms-structure/page/component/services/component-handler.service.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/component/services/component-handler.service.spec.ts
@@ -1,10 +1,10 @@
-import { TestBed } from '@angular/core/testing';
-
-import { ComponentHandlerService } from './component-handler.service';
-import { ComponentHandler } from '../handlers/component-handler';
 import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { CmsComponentMapping } from '@spartacus/core';
 import { of } from 'rxjs';
+import { ComponentHandler } from '../handlers/component-handler';
+import { ComponentHandlerService } from './component-handler.service';
+
 import createSpy = jasmine.createSpy;
 
 @Injectable()
@@ -52,7 +52,9 @@ describe('ComponentHandlerService', () => {
         undefined
       );
     });
+
     it('should return undefined if not matched', () => {
+      spyOn(console, 'warn').and.stub();
       const launcher = service.getLauncher(
         { component: 'unknown' },
         undefined,

--- a/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/page/slot/page-slot.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Renderer2 } from '@angular/core';
+import { Component, Directive, Input, Renderer2 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import {
@@ -82,7 +82,12 @@ class MockDeferLoaderService {
 class MockCmsComponentsService {
   getDeferLoadingStrategy = () => {};
 }
-
+@Directive({
+  selector: '[cxComponentWrapper]',
+})
+class MockComponentWrapperDirective {
+  @Input() cxComponentWrapper;
+}
 const providers = [
   Renderer2,
   {
@@ -123,6 +128,7 @@ describe('PageSlotComponent', () => {
         SkipLinkDirective,
         MockHostComponent,
         MockHostWithDivComponent,
+        MockComponentWrapperDirective,
       ],
       providers,
     }).compileComponents();

--- a/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld-script.factory.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld-script.factory.spec.ts
@@ -40,6 +40,9 @@ describe('JsonLdScriptFactory', () => {
     });
 
     describe('sanitized', () => {
+      beforeEach(() => {
+        spyOn(console, 'warn').and.stub();
+      });
       it('should sanitize malicious code', () => {
         service.build([{ foo: 'bar-2<script>alert()</script>' }]);
         const scriptElement = winRef.document.getElementById('json-ld');
@@ -102,7 +105,7 @@ describe('JsonLdScriptFactory', () => {
       service.build([{ foo: 'bar-b' }]);
       const scriptElement = winRef.document.getElementById('json-ld');
       // we might have left over script tag generated in former tests, so
-      // let's explicitely test the innerHTML
+      // let's explicitly test the innerHTML
       expect(scriptElement.innerHTML).not.toEqual('[{"foo":"bar-b"}]');
     });
   });

--- a/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld.directive.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/seo/structured-data/json-ld.directive.spec.ts
@@ -54,6 +54,7 @@ describe('JsonLdDirective', () => {
   // a single test for sanitization as more tests are created in the json-ld script factort
   it('should sanitize malicious code', () => {
     const template = `<span [cxJsonLd]="{foo: 'bar<script>alert(1)</script>'}">hello</span>`;
+    spyOn(console, 'warn').and.stub();
     fixture = createTestComponent(template);
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML).toContain(

--- a/projects/storefrontlib/src/cms-structure/services/cms-components.service.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/services/cms-components.service.spec.ts
@@ -10,6 +10,7 @@ let service: CmsComponentsService;
 
 const mockConfig: CmsConfig = {
   cmsComponents: {
+    testCode: {},
     exampleMapping1: {
       component: 'selector-1',
       i18nKeys: ['key-1'],

--- a/projects/storefrontlib/src/layout/breakpoint/breakpoint.service.ts
+++ b/projects/storefrontlib/src/layout/breakpoint/breakpoint.service.ts
@@ -2,7 +2,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { WindowRef } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
-import { distinctUntilChanged, map, tap } from 'rxjs/operators';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 import {
   BreakPoint,
   BREAKPOINT,
@@ -81,7 +81,6 @@ export class BreakpointService {
    */
   isDown(breakpoint: BREAKPOINT): Observable<boolean> {
     return this.breakpoint$.pipe(
-      tap((br) => console.log('isDown', br, this.breakpoints)),
       map((br) =>
         this.breakpoints
           .slice(0, this.breakpoints.indexOf(breakpoint) + 1)

--- a/projects/storefrontlib/src/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.spec.ts
+++ b/projects/storefrontlib/src/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.spec.ts
@@ -8,6 +8,7 @@ import {
   ConsentTemplate,
   I18nTestingModule,
 } from '@spartacus/core';
+import { KeyboardFocusTestingModule } from 'projects/storefrontlib/src/layout/a11y/keyboard-focus/focus-testing.module';
 import { Observable, of } from 'rxjs';
 import { LaunchDialogService } from '../../../layout/launch-dialog/index';
 import { AnonymousConsentDialogComponent } from './anonymous-consent-dialog.component';
@@ -81,7 +82,7 @@ describe('AnonymousConsentsDialogComponent', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule],
+      imports: [I18nTestingModule, KeyboardFocusTestingModule],
       declarations: [
         AnonymousConsentDialogComponent,
         MockCxIconComponent,

--- a/projects/storefrontlib/src/shared/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.spec.ts
+++ b/projects/storefrontlib/src/shared/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.spec.ts
@@ -7,6 +7,7 @@ import {
   Translatable,
   UserReplenishmentOrderService,
 } from '@spartacus/core';
+import { KeyboardFocusTestingModule } from 'projects/storefrontlib/src/layout/a11y/keyboard-focus/focus-testing.module';
 import { Observable, of } from 'rxjs';
 import { LaunchDialogService } from '../../../layout/launch-dialog/index';
 import { ReplenishmentOrderCancellationDialogComponent } from './replenishment-order-cancellation-dialog.component';
@@ -57,7 +58,7 @@ describe('ReplenishmentOrderCancellationDialogComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule],
+      imports: [I18nTestingModule, KeyboardFocusTestingModule],
       declarations: [ReplenishmentOrderCancellationDialogComponent],
       providers: [
         {

--- a/projects/storefrontlib/src/shared/components/table/table.service.spec.ts
+++ b/projects/storefrontlib/src/shared/components/table/table.service.spec.ts
@@ -232,6 +232,7 @@ describe('TableService', () => {
         describe('"unknown" table type', () => {
           it('should generate table structure based on first data item', () => {
             let result: TableStructure;
+            spyOn(console, 'warn').and.stub();
             tableService
               .buildStructure(
                 'unknown',
@@ -247,6 +248,7 @@ describe('TableService', () => {
 
         it('should generate random table structure', () => {
           let result: TableStructure;
+          spyOn(console, 'warn').and.stub();
           tableService
             .buildStructure('unknown')
             .subscribe((structure) => (result = structure));


### PR DESCRIPTION
The storefrontlib was polluted with a lot of unit test warnings, which became cumbersome to go through test logs. We like to clean that up. 