### PR TITLE
fix: umd build warnings for my-account and setup libraries

### DIFF
--- a/core-libs/setup/ng-package.json
+++ b/core-libs/setup/ng-package.json
@@ -6,6 +6,8 @@
     "umdModuleIds": {
       "@spartacus/core": "core",
       "@spartacus/storefront": "storefront",
+      "@spartacus/my-account": "my-account",
+      "@spartacus/my-account/organization": "organization",
       "rxjs": "rxjs"
     }
   }

--- a/feature-libs/my-account/organization/core/ng-package.json
+++ b/feature-libs/my-account/organization/core/ng-package.json
@@ -3,7 +3,9 @@
   "lib": {
     "entryFile": "./public_api.ts",
     "umdModuleIds": {
-      "@spartacus/core": "core"
+      "@spartacus/core": "core",
+      "@ngrx/effects": "effects",
+      "@ngrx/store": "store"
     }
   }
 }


### PR DESCRIPTION
This PR fixes UMD build warnings for `my-account` and `setup` libraries.