### PR TITLE
chore: add default when process env args are not provided for cds, b2b, cdc

### DIFF
--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -14,6 +14,6 @@ export const environment: Environment = {
   // 'https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com',
   occApiPrefix: build.process.env.SPARTACUS_API_PREFIX ?? '/occ/v2/',
   cds: build.process.env.SPARTACUS_CDS ?? false,
-  b2b: build.process.env.SPARTACUS_B2B ?? true,
+  b2b: build.process.env.SPARTACUS_B2B ?? false,
   cdc: build.process.env.SPARTACUS_CDC ?? false,
 };

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -9,11 +9,11 @@ export const environment: Environment = {
   production: false,
   occBaseUrl:
     build.process.env.SPARTACUS_BASE_URL ??
-    // 'https://spartacus-legacy.eastus.cloudapp.azure.com:9002',
     'https://spartacus-dev0.eastus.cloudapp.azure.com:9002',
+  // 'https://spartacus-dev3.eastus.cloudapp.azure.com:9002',
   // 'https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com',
   occApiPrefix: build.process.env.SPARTACUS_API_PREFIX ?? '/occ/v2/',
   cds: build.process.env.SPARTACUS_CDS ?? false,
-  b2b: build.process.env.SPARTACUS_B2B ?? false,
+  b2b: build.process.env.SPARTACUS_B2B ?? true,
   cdc: build.process.env.SPARTACUS_CDC ?? false,
 };

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -9,11 +9,11 @@ export const environment: Environment = {
   production: false,
   occBaseUrl:
     build.process.env.SPARTACUS_BASE_URL ??
+    // 'https://spartacus-legacy.eastus.cloudapp.azure.com:9002',
     'https://spartacus-dev0.eastus.cloudapp.azure.com:9002',
-  // 'https://spartacus-dev3.eastus.cloudapp.azure.com:9002',
   // 'https://api.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com',
   occApiPrefix: build.process.env.SPARTACUS_API_PREFIX ?? '/occ/v2/',
-  cds: build.process.env.SPARTACUS_CDS,
-  b2b: build.process.env.SPARTACUS_B2B,
-  cdc: build.process.env.SPARTACUS_CDC,
+  cds: build.process.env.SPARTACUS_CDS ?? false,
+  b2b: build.process.env.SPARTACUS_B2B ?? false,
+  cdc: build.process.env.SPARTACUS_CDC ?? false,
 };


### PR DESCRIPTION
Update environment.ts to include default boolean values when using `yarn start` instead of package scripts with appropriate `cross env` 