### PR TITLE
fix: failing pagination component while rendering ghost data

### DIFF
--- a/feature-libs/my-account/organization/components/shared/organization-item.service.ts
+++ b/feature-libs/my-account/organization/components/shared/organization-item.service.ts
@@ -81,7 +81,7 @@ export abstract class OrganizationItemService<T> {
   launchDetails(item: T): void {
     const cxRoute = this.getDetailsRoute();
     const params = this.getRouteParams(item);
-    if (cxRoute && Object.keys(item).length > 0) {
+    if (cxRoute && item && Object.keys(item).length > 0) {
       this.routingService.go({ cxRoute, params });
     }
   }

--- a/feature-libs/my-account/organization/components/shared/organization-list/organization-list.component.html
+++ b/feature-libs/my-account/organization/components/shared/organization-list/organization-list.component.html
@@ -50,7 +50,6 @@
 
       <div class="footer">
         <cx-pagination
-          *ngIf="data.pagination?.currentPage >= 0"
           [pagination]="data.pagination"
           (viewPageEvent)="browse(data.pagination, $event)"
         ></cx-pagination>

--- a/feature-libs/my-account/organization/components/shared/organization-list/organization-list.service.ts
+++ b/feature-libs/my-account/organization/components/shared/organization-list/organization-list.service.ts
@@ -31,14 +31,13 @@ export abstract class OrganizationListService<T, P = PaginationModel> {
     lg: { options: { layout: TableLayout.VERTICAL } },
   };
 
-  protected ghostData = {
-    values: [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}],
-    pagination: {
-      totalPages: 1,
-      // sort: ' ',
-    },
-    sorts: [],
-  } as EntitiesModel<T>;
+  /**
+   * The ghost data contains an empty list of objects that is used in the UI
+   * to render the HTML elements.
+   *
+   * This list contains 10 items, so that the ghost will show 10 rows by default.
+   */
+  protected ghostData = { values: new Array(10) } as EntitiesModel<T>;
 
   notification$: Subject<any> = new Subject();
 

--- a/feature-libs/my-account/organization/components/shared/organization-sub-list/organization-sub-list.service.ts
+++ b/feature-libs/my-account/organization/components/shared/organization-sub-list/organization-sub-list.service.ts
@@ -18,14 +18,10 @@ export abstract class OrganizationSubListService<
     options: { layout: TableLayout.VERTICAL },
   };
 
-  protected ghostData = {
-    values: [{}, {}, {}],
-    pagination: {
-      totalPages: 1,
-      sort: ' ',
-    },
-    sorts: [],
-  } as EntitiesModel<T>;
+  /**
+   * @override This sub list will show 3 items.
+   */
+  protected ghostData = { values: new Array(3) } as EntitiesModel<T>;
 
   // TODO: abstract
   assign(_key: string, ..._args: any) {}

--- a/feature-libs/my-account/organization/components/unit/links/addresses/services/unit-address-item.service.ts
+++ b/feature-libs/my-account/organization/components/unit/links/addresses/services/unit-address-item.service.ts
@@ -5,13 +5,7 @@ import {
   OrgUnitService,
 } from '@spartacus/my-account/organization/core';
 import { Observable } from 'rxjs';
-import {
-  distinctUntilChanged,
-  filter,
-  first,
-  pluck,
-  tap,
-} from 'rxjs/operators';
+import { distinctUntilChanged, filter, first, pluck } from 'rxjs/operators';
 import { ROUTE_PARAMS } from '../../../../constants';
 import { OrganizationItemService } from '../../../../shared/organization-item.service';
 import { UnitAddressFormService } from '../form/unit-address-form.service';
@@ -52,7 +46,7 @@ export class UnitAddressItemService extends OrganizationItemService<Address> {
 
   protected create(value: Address) {
     this.unitRouteParam$
-      .pipe(first(), tap(console.log))
+      .pipe(first())
       .subscribe((unitCode) => this.unitService.createAddress(unitCode, value));
   }
 

--- a/feature-libs/my-account/organization/components/unit/list/unit-list.component.ts
+++ b/feature-libs/my-account/organization/components/unit/list/unit-list.component.ts
@@ -11,7 +11,7 @@ import { UnitTreeService } from '../services/unit-tree.service';
 export class UnitListComponent {
   root$ = this.unitListService
     .getData()
-    .pipe(map((list) => list.values?.[0].id));
+    .pipe(map((list) => list.values?.[0]?.id));
 
   constructor(
     protected unitListService: UnitListService,

--- a/feature-libs/my-account/organization/styles/_list.scss
+++ b/feature-libs/my-account/organization/styles/_list.scss
@@ -27,7 +27,9 @@
           position: relative;
 
           .text {
-            min-height: 74px;
+            @include media-breakpoint-up(md) {
+              min-height: 74px;
+            }
             display: flex;
           }
 
@@ -35,33 +37,33 @@
             content: '';
             position: absolute;
             width: calc(100% - 25px);
-            height: 25px;
+            height: 20px;
             background: var(--cx-color-ghost);
             border-radius: var(--cx-ghost-radius);
-            top: 25px;
-            left: 0;
+
+            @include media-breakpoint-up(md) {
+              top: 25px;
+              left: 0;
+            }
           }
         }
 
         @include media-breakpoint-down(md) {
           tr td:before {
-            top: initial;
-            bottom: 2px;
-            height: 20px;
-            margin-inline-start: 40px;
+            margin-top: -10px;
             width: calc(100% - 60px);
-          }
-          tr:last-child td:before {
-            bottom: 22px;
           }
         }
       }
     }
   }
 
-  cx-organization-sub-list.ghost cx-table.vertical table td:before {
-    width: calc(100% - 50px);
+  cx-organization-sub-list.ghost cx-table.vertical table tr td:before {
+    // width: calc(100% - 50px);
+    // left: 25px;
+    margin-top: 25px;
     left: 25px;
+    width: calc(100% - 50px);
   }
 }
 

--- a/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.builder.spec.ts
+++ b/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.builder.spec.ts
@@ -57,7 +57,7 @@ describe('PaginationBuilder', () => {
     return TestBed.inject(PaginationBuilder);
   };
 
-  describe('Default config', () => {
+  fdescribe('Default config', () => {
     let service: PaginationBuilder;
     beforeEach(() => {
       service = setup({});
@@ -65,6 +65,17 @@ describe('PaginationBuilder', () => {
 
     it('should inject service', () => {
       expect(service).toBeTruthy();
+    });
+
+    describe('undefined', () => {
+      let pages: PaginationItem[];
+      beforeEach(() => {
+        pages = service.paginate(undefined, undefined);
+      });
+
+      it('should have 0 items', () => {
+        expect(pages.length).toEqual(0);
+      });
     });
 
     describe('(no pages)', () => {

--- a/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.builder.spec.ts
+++ b/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.builder.spec.ts
@@ -57,7 +57,7 @@ describe('PaginationBuilder', () => {
     return TestBed.inject(PaginationBuilder);
   };
 
-  fdescribe('Default config', () => {
+  describe('Default config', () => {
     let service: PaginationBuilder;
     beforeEach(() => {
       service = setup({});
@@ -73,7 +73,7 @@ describe('PaginationBuilder', () => {
         pages = service.paginate(undefined, undefined);
       });
 
-      it('should have 0 items', () => {
+      it('should have no items', () => {
         expect(pages.length).toEqual(0);
       });
     });

--- a/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.builder.ts
+++ b/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.builder.ts
@@ -19,7 +19,7 @@ const FALLBACK_PAGINATION_OPTIONS: PaginationOptions = {
 /**
  * Builds a pagination structures based on a pageCount and current page number.
  * There are various {@link PaginationConfig} options which can be used to configure
- * the behaviour of the build. Alternatively, CSS can be used to further customise
+ * the behavior of the build. Alternatively, CSS can be used to further customize
  * the pagination.
  *
  * Examples:
@@ -58,7 +58,7 @@ export class PaginationBuilder {
    */
   paginate(pageCount: number, current: number): PaginationItem[] {
     const pages: PaginationItem[] = [];
-    if (pageCount < 2) {
+    if (!pageCount || pageCount < 2) {
       return pages;
     }
     this.addPages(pages, pageCount, current);
@@ -113,13 +113,13 @@ export class PaginationBuilder {
         const isGap =
           !this.config.substituteDotsForSingularPage ||
           firstItemNumber !== gapNumber + 1;
-        const isSubstitued =
+        const isSubstituted =
           this.config.addFirst &&
           this.config.substituteDotsForSingularPage &&
           gapNumber === 0;
         const type = isGap
           ? PaginationItemType.GAP
-          : isSubstitued
+          : isSubstituted
           ? PaginationItemType.FIRST
           : PaginationItemType.PAGE;
         return [
@@ -138,7 +138,7 @@ export class PaginationBuilder {
       const nextPageNumber = pages[pages.length - 1].number + 1;
       const last = pageCount - (this.config.addLast ? 2 : 1);
       if (nextPageNumber <= last) {
-        const isSubstitued =
+        const isSubstituted =
           this.config.addLast &&
           this.config.substituteDotsForSingularPage &&
           nextPageNumber === last;
@@ -150,7 +150,7 @@ export class PaginationBuilder {
 
         const type = isGap
           ? PaginationItemType.GAP
-          : isSubstitued
+          : isSubstituted
           ? PaginationItemType.LAST
           : PaginationItemType.PAGE;
         return [
@@ -217,7 +217,7 @@ export class PaginationBuilder {
     current: number
   ): void {
     const before = this.getBeforeLinks(current);
-    const after = this.getAfter(pageCount, current);
+    const after = this.getAfterLinks(pageCount, current);
     const pos = this.config.navigationPosition;
     if (!pos || pos === PaginationNavigationPosition.ASIDE) {
       pages.unshift(...before);
@@ -235,7 +235,7 @@ export class PaginationBuilder {
   /**
    * Returns the start and previous links, if applicable.
    */
-  private getBeforeLinks(current: number): PaginationItem[] {
+  protected getBeforeLinks(current: number): PaginationItem[] {
     const list = [];
 
     if (this.config.addStart) {
@@ -268,7 +268,10 @@ export class PaginationBuilder {
   /**
    * Returns the next and end links, if applicable.
    */
-  private getAfter(pageCount: number, current: number): PaginationItem[] {
+  protected getAfterLinks(
+    pageCount: number,
+    current: number
+  ): PaginationItem[] {
     const list = [];
 
     if (this.config.addNext) {
@@ -306,7 +309,7 @@ export class PaginationBuilder {
    * @param pageCount The total number of pages.
    * @param current The current page number, 0-index based.
    */
-  private getStartOfRange(pageCount: number, current: number): number {
+  protected getStartOfRange(pageCount: number, current: number): number {
     const count = this.config.rangeCount - 1;
     // the least number of pages before and after the current
     const delta = Math.round(count / 2);
@@ -320,7 +323,29 @@ export class PaginationBuilder {
     return Math.min(maxStart, minStart);
   }
 
-  private get config(): PaginationOptions {
+  /**
+   * Returns the pagination configuration. The configuration is driven by the
+   * (default) application configuration.
+   *
+   * The default application is limited to adding the start and end link:
+   * ```ts
+   *   addStart: true,
+   *   addEnd: true
+   * ```
+   *
+   * The application configuration is however merged into the following static configuration:
+   * ```ts
+   * {
+   *   rangeCount: 3,
+   *   dotsLabel: '...',
+   *   startLabel: '«',
+   *   previousLabel: '‹',
+   *   nextLabel: '›',
+   *   endLabel: '»'
+   * }
+   * ```
+   */
+  protected get config(): PaginationOptions {
     return Object.assign(
       FALLBACK_PAGINATION_OPTIONS,
       this.paginationConfig.pagination

--- a/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.component.ts
+++ b/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.component.ts
@@ -52,6 +52,9 @@ export class PaginationComponent {
   ) {}
 
   protected render(pagination: PaginationModel): void {
+    if (!pagination) {
+      return;
+    }
     this.pages = this.paginationBuilder.paginate(
       pagination.totalPages,
       pagination.currentPage

--- a/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.component.ts
+++ b/projects/storefrontlib/src/shared/components/list-navigation/pagination/pagination.component.ts
@@ -51,7 +51,7 @@ export class PaginationComponent {
     private activatedRoute: ActivatedRoute
   ) {}
 
-  private render(pagination: PaginationModel) {
+  protected render(pagination: PaginationModel): void {
     this.pages = this.paginationBuilder.paginate(
       pagination.totalPages,
       pagination.currentPage

--- a/projects/storefrontstyles/scss/components/misc/pagination/_pagination.scss
+++ b/projects/storefrontstyles/scss/components/misc/pagination/_pagination.scss
@@ -5,11 +5,10 @@
   align-content: center;
   align-items: stretch;
 
-  height: 48px;
-
   a {
     color: var(--cx-color-text);
     width: 48px;
+    height: 46px;
 
     border: solid 1px var(--cx-color-light);
     box-sizing: content-box;

--- a/projects/storefrontstyles/scss/layout/_ghost.scss
+++ b/projects/storefrontstyles/scss/layout/_ghost.scss
@@ -36,12 +36,4 @@
     /* Adding animation */
     animation: loading 0.9s infinite;
   }
-  .gi {
-    color: var(--cx-color-ghost) !important;
-    z-index: -1;
-  }
-  button.gi {
-    background-color: currentColor;
-    border-color: currentColor;
-  }
 }


### PR DESCRIPTION
The pagination component is failing often when the data is incomplete. This is an increasing issue when we move towards skeletons of the components, where the pagination data is empty by default. 

fixes #9349