### PR TITLE
fix: Cypress configurations to let smoke/checkout-flow.e2e-spec.ts pass using normal config (GH-9477)

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress.ci.1905.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.ci.1905.json
@@ -13,6 +13,8 @@
     "CLIENT_SECRET": "secret",
     "API_URL": "https://spartacus-legacy.eastus.cloudapp.azure.com:9002",
     "OCC_PREFIX": "/rest/v2",
+    "OCC_PREFIX_USER_ENDPOINT": "users",
+    "OCC_PREFIX_ORDER_ENDPOINT": "orders",
     "BASE_SITE": "electronics-spa"
   }
 }

--- a/projects/storefrontapp-e2e-cypress/cypress.ci.2005.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.ci.2005.json
@@ -15,7 +15,6 @@
     "OCC_PREFIX": "/occ/v2",
     "OCC_PREFIX_USER_ENDPOINT": "users",
     "OCC_PREFIX_ORDER_ENDPOINT": "orders",
-    "BASE_SITE": "electronics-spa",
-    "B2B": false
+    "BASE_SITE": "electronics-spa"
   }
 }

--- a/projects/storefrontapp-e2e-cypress/cypress.ci.ccv2.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.ci.ccv2.json
@@ -13,6 +13,8 @@
     "CLIENT_SECRET": "secret",
     "API_URL": "https://spartacus-demo.eastus.cloudapp.azure.com:8443",
     "OCC_PREFIX": "/rest/v2",
+    "OCC_PREFIX_USER_ENDPOINT": "users",
+    "OCC_PREFIX_ORDER_ENDPOINT": "orders",
     "BASE_SITE": "electronics-spa"
   }
 }

--- a/projects/storefrontapp-e2e-cypress/cypress.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.json
@@ -12,7 +12,6 @@
     "OCC_PREFIX": "/occ/v2",
     "OCC_PREFIX_USER_ENDPOINT": "users",
     "OCC_PREFIX_ORDER_ENDPOINT": "orders",
-    "BASE_SITE": "electronics-spa",
-    "B2B": false
+    "BASE_SITE": "electronics-spa"
   }
 }

--- a/projects/storefrontapp-e2e-cypress/cypress.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.json
@@ -10,6 +10,9 @@
     "CLIENT_SECRET": "secret",
     "API_URL": "https://spartacus-dev0.eastus.cloudapp.azure.com:9002",
     "OCC_PREFIX": "/occ/v2",
-    "BASE_SITE": "electronics-spa"
+    "OCC_PREFIX_USER_ENDPOINT": "users",
+    "OCC_PREFIX_ORDER_ENDPOINT": "orders",
+    "BASE_SITE": "electronics-spa",
+    "B2B": false
   }
 }


### PR DESCRIPTION
closes GH-9477

NOTE:
- added in other `configs` as those values are mandatory to have a default value