### PR TITLE
fix: Wait for complete logout before redirect on email update

### DIFF
--- a/projects/storefrontlib/src/cms-components/myaccount/update-email/update-email.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/update-email/update-email.component.spec.ts
@@ -162,7 +162,7 @@ describe('UpdateEmailComponent', () => {
 
   describe('onSuccess', () => {
     describe('when the user was successfully updated', () => {
-      it('should add a global message and navigate to a url ', () => {
+      it('should add a global message and navigate to a url ', async () => {
         spyOn(userService, 'updateEmail').and.stub();
         spyOn(authService, 'logout').and.stub();
 
@@ -173,7 +173,7 @@ describe('UpdateEmailComponent', () => {
         spyOn(globalMessageService, 'add').and.stub();
         spyOn(routingService, 'go').and.stub();
 
-        component.onSuccess(true);
+        await component.onSuccess(true);
 
         expect(globalMessageService.add).toHaveBeenCalledWith(
           {

--- a/projects/storefrontlib/src/cms-components/myaccount/update-email/update-email.component.ts
+++ b/projects/storefrontlib/src/cms-components/myaccount/update-email/update-email.component.ts
@@ -43,7 +43,7 @@ export class UpdateEmailComponent implements OnInit, OnDestroy {
     this.userService.updateEmail(password, newUid);
   }
 
-  onSuccess(success: boolean): void {
+  async onSuccess(success: boolean): Promise<void> {
     if (success) {
       this.globalMessageService.add(
         {
@@ -52,7 +52,7 @@ export class UpdateEmailComponent implements OnInit, OnDestroy {
         },
         GlobalMessageType.MSG_TYPE_CONFIRMATION
       );
-      this.authService.logout();
+      await this.authService.logout();
       this.routingService.go({ cxRoute: 'login' }, null, {
         state: {
           newUid: this.newUid,


### PR DESCRIPTION
I'm unable to reproduce the failure of e2e test locally. However I think this fix might be related to the problem happening on e2e test run.

Closes #9543