### PR TITLE
fix: Unit address is not saved after changing country #8907

### DIFF
--- a/projects/assets/src/translations/en/common.ts
+++ b/projects/assets/src/translations/en/common.ts
@@ -60,6 +60,8 @@ export const common = {
     badGateway: 'A server error occurred. Please try again later.',
     badRequestPleaseLoginAgain: '{{ errorMessage }}. Please login again.',
     badRequestOldPasswordIncorrect: 'Old password incorrect.',
+    addressConversionError:
+      'We can not update this address. Please create a new one instead.',
     conflict: 'Already exists',
     forbidden:
       'You are not authorized to perform this action. Please contact your administrator if you think this is a mistake.',

--- a/projects/core/src/global-message/http-interceptors/handlers/bad-request/bad-request.handler.spec.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/bad-request/bad-request.handler.spec.ts
@@ -90,6 +90,17 @@ const MockVoucherOperationErrorResponse = {
   },
 } as HttpErrorResponse;
 
+const MockAddressConversionError = {
+  error: {
+    errors: [
+      {
+        message: 'No region with the code CN-11 found.',
+        type: 'ConversionError',
+      },
+    ],
+  },
+} as HttpErrorResponse;
+
 class MockGlobalMessageService {
   add() {}
   remove() {}
@@ -177,6 +188,14 @@ describe('BadRequestHandler', () => {
     service.handleError(MockRequest, MockBadCartResponse);
     expect(globalMessageService.add).toHaveBeenCalledWith(
       { key: 'httpHandlers.cartNotFound' },
+      GlobalMessageType.MSG_TYPE_ERROR
+    );
+  });
+
+  it('should conversion error', () => {
+    service.handleError(MockRequest, MockAddressConversionError);
+    expect(globalMessageService.add).toHaveBeenCalledWith(
+      { key: 'httpHandlers.addressConversionError' },
       GlobalMessageType.MSG_TYPE_ERROR
     );
   });

--- a/projects/core/src/global-message/http-interceptors/handlers/bad-request/bad-request.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/bad-request/bad-request.handler.ts
@@ -21,6 +21,7 @@ export class BadRequestHandler extends HttpErrorHandler {
     this.handleBadCartRequest(request, response);
     this.handleValidationError(request, response);
     this.handleVoucherOperationError(request, response);
+    this.handleConversionError(request, response);
   }
 
   protected handleBadPassword(
@@ -103,6 +104,24 @@ export class BadRequestHandler extends HttpErrorHandler {
       .forEach(() => {
         this.globalMessageService.add(
           { key: 'httpHandlers.invalidCodeProvided' },
+          GlobalMessageType.MSG_TYPE_ERROR
+        );
+      });
+  }
+
+  protected handleConversionError(
+    _request: HttpRequest<any>,
+    response: HttpErrorResponse
+  ) {
+    this.getErrors(response)
+      .filter(
+        (error) =>
+          error.type === 'ConversionError' &&
+          error.message.startsWith('No region with the code')
+      )
+      .forEach(() => {
+        this.globalMessageService.add(
+          { key: 'httpHandlers.addressConversionError' },
           GlobalMessageType.MSG_TYPE_ERROR
         );
       });


### PR DESCRIPTION
After discuss with @Platonn decided to add global message handler for address conversion error. 
As it's only workaround for backend issue, that is the least invasive method:
- catch only one broken case of changing country (from 4 available, other works well)
- needn't changes after fix backend
- avoid of breaking changes

Closes #8907