### PR TITLE
fix: organization library should compile without core style library

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -28,7 +28,10 @@
               "projects/storefrontapp/src/manifest.json",
               "projects/storefrontapp/src/webApplicationInjector.js"
             ],
-            "styles": ["projects/storefrontapp/src/styles.scss"],
+            "styles": [
+              "projects/storefrontapp/src/styles.scss",
+              "projects/storefrontapp/src/styles/lib-organization.scss"
+            ],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "./projects",

--- a/feature-libs/organization/_index.scss
+++ b/feature-libs/organization/_index.scss
@@ -1,2 +1,15 @@
+// we require a few bootstrap files for the CSS in this code
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/_mixins';
+
+@mixin visible-focus {
+  outline-style: solid;
+  outline-color: var(--cx-color-visual-focus);
+  outline-width: var(--cx-visual-focus-width, 2px);
+  outline-offset: var(--cx-visual-focus-offset, 4px);
+  transition: none;
+}
+
 @import './administration/index';
 @import './order-approval/index';

--- a/feature-libs/organization/_index.scss
+++ b/feature-libs/organization/_index.scss
@@ -7,7 +7,7 @@
   outline-style: solid;
   outline-color: var(--cx-color-visual-focus);
   outline-width: var(--cx-visual-focus-width, 2px);
-  outline-offset: var(--cx-visual-focus-offset, 4px);
+  outline-offset: 4px;
   transition: none;
 }
 

--- a/feature-libs/organization/administration/styles/_buttons.scss
+++ b/feature-libs/organization/administration/styles/_buttons.scss
@@ -1,6 +1,5 @@
-@import 'node_modules/bootstrap/scss/buttons';
-
 %buttons {
+  @import 'node_modules/bootstrap/scss/buttons';
   a.link,
   button.link {
     @extend .btn, .btn-link, .btn-sm;

--- a/feature-libs/organization/order-approval/styles/_order-approval-detail-form.scss
+++ b/feature-libs/organization/order-approval/styles/_order-approval-detail-form.scss
@@ -7,7 +7,9 @@ cx-order-approval-detail-form {
     background-color: var(--cx-color-background);
 
     .cx-approval-form-label {
-      @include type('4');
+      font-size: var(--cx-font-size, 1.125rem);
+      font-weight: var(--cx-font-weight-bold);
+      line-height: var(--cx-line-height, 1.2222222222);
     }
   }
 

--- a/feature-libs/organization/order-approval/styles/_order-approval-list.scss
+++ b/feature-libs/organization/order-approval/styles/_order-approval-list.scss
@@ -88,7 +88,9 @@ cx-order-approval-list {
     color: var(--cx-color-secondary);
 
     @include media-breakpoint-down(sm) {
-      @include type('8');
+      font-size: var(--cx-font-size, 0.875rem);
+      font-weight: var(--cx-font-weight-bold);
+      line-height: var(--cx-line-height, 1.2222222222);
       min-width: 110px;
     }
   }
@@ -97,8 +99,9 @@ cx-order-approval-list {
     color: var(--cx-color-text);
 
     @include media-breakpoint-down(sm) {
-      @include type('5');
+      font-size: var(--cx-font-size, 1rem);
       font-weight: $font-weight-normal;
+      line-height: var(--cx-line-height, 1.2222222222);
     }
   }
 
@@ -144,8 +147,9 @@ cx-order-approval-list {
   }
 
   .cx-order-approval-no-order {
-    @include type('5');
+    font-size: var(--cx-font-size, 1rem);
     font-weight: $font-weight-normal;
+    line-height: var(--cx-line-height, 1.2222222222);
     min-height: 415px;
 
     @include media-breakpoint-down(sm) {

--- a/feature-libs/organization/order-approval/styles/_order-detail-permission-results.scss
+++ b/feature-libs/organization/order-approval/styles/_order-detail-permission-results.scss
@@ -7,7 +7,9 @@ cx-order-detail-permission-results {
     background-color: var(--cx-color-background);
 
     .cx-approval-label {
-      @include type('4');
+      font-size: var(--cx-font-size, 1.125rem);
+      font-weight: var(--cx-font-weight-bold);
+      line-height: var(--cx-line-height, 1.2222222222);
     }
   }
 
@@ -57,7 +59,9 @@ cx-order-detail-permission-results {
       color: var(--cx-color-secondary);
 
       @include media-breakpoint-down(sm) {
-        @include type('8');
+        font-size: var(--cx-font-size, 0.875rem);
+        font-weight: var(--cx-font-weight-bold);
+        line-height: var(--cx-line-height, 1.2222222222);
         min-width: 110px;
         max-width: 110px;
       }

--- a/feature-libs/organization/package.json
+++ b/feature-libs/organization/package.json
@@ -37,6 +37,7 @@
     "@angular/core": "^10.1.0",
     "@angular/router": "^10.1.0",
     "@angular-devkit/schematics": "^10.1.0",
+    "bootstrap": "^4.0",
     "rxjs": "^6.6.0",
     "@spartacus/core": "3.0.0-next.6",
     "@spartacus/storefront": "3.0.0-next.6",

--- a/projects/storefrontapp/src/styles.scss
+++ b/projects/storefrontapp/src/styles.scss
@@ -4,4 +4,3 @@
 $useLatestStyles: true;
 
 @import 'storefrontstyles/index';
-@import 'organization';

--- a/projects/storefrontapp/src/styles/lib-organization.scss
+++ b/projects/storefrontapp/src/styles/lib-organization.scss
@@ -1,0 +1,1 @@
+@import 'organization';


### PR DESCRIPTION
The organization library requires a few small mixins/vars from the core style library. We're adding a dependency to bootstrap and further decouple the organization library from the core style library.

fix #9627