### PR TITLE
chore: migration 3.0 - remove deprecated code and constructor from OutletService

### DIFF
--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.service.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.service.spec.ts
@@ -6,7 +6,6 @@ import {
   TemplateRef,
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FeaturesConfig } from '@spartacus/core';
 import { OutletRefDirective } from './outlet-ref/outlet-ref.directive';
 import { OutletPosition, USE_STACKED_OUTLETS } from './outlet.model';
 import { OutletService } from './outlet.service';
@@ -53,13 +52,7 @@ describe('OutletService', () => {
     TestBed.configureTestingModule({
       imports: [AnyModule],
       declarations: [TestContainerComponent, OutletRefDirective],
-      providers: [
-        OutletService,
-        {
-          provide: FeaturesConfig,
-          useValue: { features: { level: '2.1' } } as FeaturesConfig, // deprecated since 2.1, see #8116
-        },
-      ],
+      providers: [OutletService],
     }).compileComponents();
 
     outletService = TestBed.inject(OutletService);

--- a/projects/storefrontlib/src/cms-structure/outlet/outlet.service.ts
+++ b/projects/storefrontlib/src/cms-structure/outlet/outlet.service.ts
@@ -1,19 +1,10 @@
 import { ComponentFactory, Injectable, TemplateRef } from '@angular/core';
-import { FeatureConfigService } from '@spartacus/core';
 import { AVOID_STACKED_OUTLETS, OutletPosition } from './outlet.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class OutletService<T = TemplateRef<any> | ComponentFactory<any>> {
-  /**
-   * @deprecated since 2.1, see #8116
-   */
-  constructor();
-  // tslint:disable-next-line: unified-signatures
-  constructor(features: FeatureConfigService);
-  constructor(protected features?: FeatureConfigService) {}
-
   private templatesRefs = {
     [OutletPosition.BEFORE]: new Map<string, T[]>(),
     [OutletPosition.REPLACE]: new Map<string, T[]>(),
@@ -103,12 +94,7 @@ export class OutletService<T = TemplateRef<any> | ComponentFactory<any>> {
     } else if (value && store.has(outlet)) {
       let existing = store.get(outlet);
 
-      if (this.features?.isLevel('2.1')) {
-        existing = existing.filter((val) => val !== value);
-      } else {
-        // deprecated since 2.1, see #8116:
-        existing = existing.filter((val) => val === value);
-      }
+      existing = existing.filter((val) => val !== value);
 
       store.set(outlet, existing);
     }


### PR DESCRIPTION
No planned migration docs for this change. It's an obvious bugfix. Small impact on customers.

closes #8116 