### PR TITLE
chore: migration 3.0 - document typo fix in translation key 'managementInMyAccount'

### DIFF
--- a/docs/migration/3_0.md
+++ b/docs/migration/3_0.md
@@ -2,6 +2,10 @@
 
 ## Breaking Changes
 
+### Translations (i18n) changed
+- fixed the typo in the key `user.register.managementInMyAccount` (previously ...`managmentInMyAccount`)
+
+
 ### Default Router options changed
 The Angular router can be initialized with so-called `ExtraOptions` in the `forRoot` method fo the `RouterModule`. See https://angular.io/api/router/ExtraOptions for more information on those options. 
 

--- a/docs/migration/3_0.md
+++ b/docs/migration/3_0.md
@@ -5,7 +5,6 @@
 ### Translations (i18n) changed
 - fixed the typo in the key `user.register.managementInMyAccount` (previously ...`managmentInMyAccount`)
 
-
 ### Default Router options changed
 The Angular router can be initialized with so-called `ExtraOptions` in the `forRoot` method fo the `RouterModule`. See https://angular.io/api/router/ExtraOptions for more information on those options. 
 


### PR DESCRIPTION
closes #9038 