### PR TITLE
fix: remove CSS transition from focus in Home organization page

### DIFF
--- a/feature-libs/organization/administration/styles/_company-page-template.scss
+++ b/feature-libs/organization/administration/styles/_company-page-template.scss
@@ -65,8 +65,6 @@
 
       padding: 25px 25px 25px 30px;
 
-      transition: var(--cx-transition-duration);
-
       border: solid 1px var(--cx-color-light);
       &:hover {
         text-decoration: none;


### PR DESCRIPTION
Fixes: #9526 