### PR TITLE
feat: leverage native lazy loading for images

### DIFF
--- a/projects/storefrontlib/src/recipes/config/default-media.config.ts
+++ b/projects/storefrontlib/src/recipes/config/default-media.config.ts
@@ -2,30 +2,14 @@ import { MediaConfig } from '../../shared/components/media/media.config';
 
 export const mediaConfig: MediaConfig = {
   mediaFormats: {
-    mobile: {
-      width: 400,
-    },
-    tablet: {
-      width: 770,
-    },
-    desktop: {
-      width: 1140,
-    },
-    widescreen: {
-      width: 1400,
-    },
+    mobile: { width: 400 },
+    tablet: { width: 770 },
+    desktop: { width: 1140 },
+    widescreen: { width: 1400 },
     // product media
-    cartIcon: {
-      width: 65,
-    },
-    thumbnail: {
-      width: 96,
-    },
-    product: {
-      width: 284,
-    },
-    zoom: {
-      width: 515,
-    },
+    cartIcon: { width: 65 },
+    thumbnail: { width: 96 },
+    product: { width: 284 },
+    zoom: { width: 515 },
   },
 };

--- a/projects/storefrontlib/src/shared/components/media/media.component.html
+++ b/projects/storefrontlib/src/shared/components/media/media.component.html
@@ -3,6 +3,7 @@
   [attr.src]="media.src"
   [attr.srcset]="media.srcset"
   [attr.alt]="media.alt"
+  [attr.loading]="loadingStrategy"
   (load)="loadHandler()"
   (error)="errorHandler()"
 />

--- a/projects/storefrontlib/src/shared/components/media/media.component.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.component.ts
@@ -7,7 +7,7 @@ import {
   OnChanges,
   Output,
 } from '@angular/core';
-import { Media, MediaContainer } from './media.model';
+import { ImageLoadingStrategy, Media, MediaContainer } from './media.model';
 import { MediaService } from './media.service';
 
 @Component({
@@ -94,6 +94,15 @@ export class MediaComponent implements OnChanges {
     this.isInitialized = true;
     this.isMissing = false;
     this.loaded.emit(true);
+  }
+
+  /**
+   * Indicates whether the browser should lazy load the image.
+   */
+  get loadingStrategy(): string {
+    return this.mediaService.loadingStrategy === ImageLoadingStrategy.LAZY
+      ? 'lazy'
+      : null;
   }
 
   /**

--- a/projects/storefrontlib/src/shared/components/media/media.config.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.config.ts
@@ -1,6 +1,6 @@
-import { MediaFormatSize } from './media.model';
 import { Injectable } from '@angular/core';
 import { Config } from '@spartacus/core';
+import { ImageLoadingStrategy, MediaFormatSize } from './media.model';
 
 /**
  * Provides configuration specific to Media, such as images. This is used to optimize
@@ -22,4 +22,16 @@ export abstract class MediaConfig {
      */
     [format: string]: MediaFormatSize;
   };
+
+  /**
+   * Indicates how the browser should load the image. There's only one
+   * global strategy for all media cross media in Spartacus.
+   *
+   * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img for more
+   * information.
+   *
+   * If the `lazy` strategy is in place, the `loading="lazy"` attribute is added to the
+   * img element.
+   */
+  imageLoadingStrategy?: ImageLoadingStrategy;
 }

--- a/projects/storefrontlib/src/shared/components/media/media.model.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.model.ts
@@ -27,7 +27,7 @@ export interface MediaContainer {
 }
 
 /**
- * Specificies media size information that can be used to generate information for the
+ * Specifies media size information that can be used to generate information for the
  * browser to resolve the right media for the right layout or device.
  */
 export interface MediaFormatSize {
@@ -37,4 +37,28 @@ export interface MediaFormatSize {
    * different media's can be used in a responsive layout.
    */
   width?: number;
+}
+
+/**
+ * Indicates how the browser should load the image.
+ *
+ * While this might not add too much value in some scenarios, as we have other
+ * optimizations to defer loading of larger pieces of the DOM, there might be
+ * components who haven't implemented other lazy loading techniques. Moreover,
+ * a server sides rendered page that lands directly in the browser could benefit
+ * enormously from the lazy loading of images.
+ */
+export enum ImageLoadingStrategy {
+  /**
+   * Loads the image immediately, regardless of whether or not the image
+   * is currently within the visible viewport (this is the default value).
+   */
+  EAGER = 'eager',
+  /**
+   * Defers loading the image until it reaches a calculated distance from the viewport,
+   * as defined by the browser. The intent is to avoid the network and storage bandwidth
+   * needed to handle the image until it's reasonably certain that it will be needed.
+   * This generally improves the performance of the content in most typical use cases.
+   */
+  LAZY = 'lazy',
 }

--- a/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { Config, Image } from '@spartacus/core';
 import { LayoutConfig } from '../../../layout/config/layout-config';
 import { StorefrontConfig } from '../../../storefront-config';
-import { MediaContainer } from './media.model';
+import { ImageLoadingStrategy, MediaContainer } from './media.model';
 import { MediaService } from './media.service';
 
 const MockStorefrontConfig: StorefrontConfig = {
@@ -78,146 +78,190 @@ const mockUrlContainer = {
 };
 
 describe('MediaService', () => {
-  let mediaService: MediaService;
+  describe('eager loaded config', () => {
+    let mediaService: MediaService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        MediaService,
-        { provide: Config, useValue: MockStorefrontConfig },
-        { provide: LayoutConfig, useValue: {} },
-      ],
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          MediaService,
+          { provide: Config, useValue: MockStorefrontConfig },
+          { provide: LayoutConfig, useValue: {} },
+        ],
+      });
+      mediaService = TestBed.inject(MediaService);
     });
-    mediaService = TestBed.inject(MediaService);
+
+    it('should inject service', () => {
+      expect(mediaService).toBeTruthy();
+    });
+
+    describe('getMedia', () => {
+      describe('without format', () => {
+        it('should return best media', () => {
+          expect(mediaService.getMedia(mockBestFormatMediaContainer).src).toBe(
+            'base:format-600.url'
+          );
+        });
+
+        it('should return the first media if there is no configured format', () => {
+          expect(mediaService.getMedia(mockUnknownMediaContainer).src).toBe(
+            'base:random1.url'
+          );
+        });
+
+        it('should return media', () => {
+          expect(mediaService.getMedia(mockMedia).src).toBe('base:media.url');
+        });
+
+        it('should not return src if there are no medias in the container', () => {
+          expect(mediaService.getMedia({}).src).toBeFalsy();
+        });
+
+        it('should not return src if there is no media url', () => {
+          expect(
+            mediaService.getMedia({ altText: 'whatever' }).src
+          ).toBeFalsy();
+        });
+      });
+
+      describe('with format', () => {
+        it('should ignore format if no media container is passed', () => {
+          expect(mediaService.getMedia(mockMedia, 'any').src).toBe(
+            'base:media.url'
+          );
+        });
+
+        it('should return media for format', () => {
+          expect(
+            mediaService.getMedia(mockBestFormatMediaContainer, 'format400').src
+          ).toBe('base:format-400.url');
+        });
+
+        it('should return best media for unknown format', () => {
+          expect(
+            mediaService.getMedia(mockBestFormatMediaContainer, 'unknown').src
+          ).toBe('base:format-600.url');
+        });
+
+        it('should return random media for unknown format and unknown media formats', () => {
+          expect(
+            mediaService.getMedia(mockUnknownMediaContainer, 'unknown').src
+          ).toBe('base:random1.url');
+        });
+
+        it('should not return src if the media container does not contain a url', () => {
+          expect(
+            mediaService.getMedia({ cont: { format: 'xyz' } }, 'xyz').src
+          ).toBeFalsy();
+        });
+      });
+
+      describe('alt text', () => {
+        it('should return alt text for media', () => {
+          expect(mediaService.getMedia(mockMedia).alt).toBe(
+            'alt text for media'
+          );
+        });
+
+        it('should return alt text for best media', () => {
+          expect(mediaService.getMedia(mockBestFormatMediaContainer).alt).toBe(
+            'alt text for format-600'
+          );
+        });
+
+        it('should return alt text for specific format', () => {
+          expect(
+            mediaService.getMedia(mockBestFormatMediaContainer, 'format400').alt
+          ).toBe('alt text for format-400');
+        });
+
+        it('should return alt text for best format', () => {
+          expect(
+            mediaService.getMedia(mockBestFormatMediaContainer, 'unknown').alt
+          ).toBe('alt text for format-600');
+        });
+
+        it('should return alt text for random format', () => {
+          expect(
+            mediaService.getMedia(mockUnknownMediaContainer, 'unknown').alt
+          ).toBe('alt text for unknown-1');
+        });
+
+        it('should return given alt text', () => {
+          expect(
+            mediaService.getMedia(
+              mockBestFormatMediaContainer,
+              'format400',
+              'custom alt'
+            ).alt
+          ).toEqual('custom alt');
+        });
+      });
+
+      describe('srcset', () => {
+        it('should return srcset', () => {
+          expect(
+            mediaService.getMedia(mockBestFormatMediaContainer).srcset
+          ).toBe(
+            'base:format-1.url 1w, base:format-400.url 400w, base:format-600.url 600w'
+          );
+        });
+
+        it('should not return srcset for media', () => {
+          expect(mediaService.getMedia(mockMedia).srcset).toBeFalsy();
+        });
+      });
+    });
+
+    describe('absolute URL', () => {
+      it('should avoid baseUrl if absolute image is provided', () => {
+        expect(mediaService.getMedia(mockUrlContainer, 'absolute').src).toBe(
+          'http://absolute.jpg'
+        );
+      });
+
+      it('should add OCC baseUrl for relative image', () => {
+        expect(mediaService.getMedia(mockUrlContainer, 'relative').src).toBe(
+          'base:relative.jpg'
+        );
+      });
+    });
+
+    describe('loadingStrategy', () => {
+      it('should resolve eager loading strategy', () => {
+        expect(mediaService.loadingStrategy).toEqual(
+          ImageLoadingStrategy.EAGER
+        );
+      });
+    });
   });
 
-  it('should inject service', () => {
-    expect(mediaService).toBeTruthy();
-  });
+  describe('lazy loaded config', () => {
+    let mediaService: MediaService;
 
-  describe('getMedia', () => {
-    describe('without format', () => {
-      it('should return best media', () => {
-        expect(mediaService.getMedia(mockBestFormatMediaContainer).src).toBe(
-          'base:format-600.url'
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          MediaService,
+          {
+            provide: Config,
+            useValue: {
+              ...MockStorefrontConfig,
+              mediaLoadingStrategy: ImageLoadingStrategy.LAZY,
+            },
+          },
+          { provide: LayoutConfig, useValue: {} },
+        ],
+      });
+      mediaService = TestBed.inject(MediaService);
+    });
+    describe('loadingStrategy', () => {
+      it('should resolve lazy loading strategy', () => {
+        expect(mediaService.loadingStrategy).toEqual(
+          ImageLoadingStrategy.EAGER
         );
       });
-
-      it('should return the first media if there is no configured format', () => {
-        expect(mediaService.getMedia(mockUnknownMediaContainer).src).toBe(
-          'base:random1.url'
-        );
-      });
-
-      it('should return media', () => {
-        expect(mediaService.getMedia(mockMedia).src).toBe('base:media.url');
-      });
-
-      it('should not return src if there are no medias in the container', () => {
-        expect(mediaService.getMedia({}).src).toBeFalsy();
-      });
-
-      it('should not return src if there is no media url', () => {
-        expect(mediaService.getMedia({ altText: 'whatever' }).src).toBeFalsy();
-      });
-    });
-
-    describe('with format', () => {
-      it('should ignore format if no media container is passed', () => {
-        expect(mediaService.getMedia(mockMedia, 'any').src).toBe(
-          'base:media.url'
-        );
-      });
-
-      it('should return media for format', () => {
-        expect(
-          mediaService.getMedia(mockBestFormatMediaContainer, 'format400').src
-        ).toBe('base:format-400.url');
-      });
-
-      it('should return best media for unknown format', () => {
-        expect(
-          mediaService.getMedia(mockBestFormatMediaContainer, 'unknown').src
-        ).toBe('base:format-600.url');
-      });
-
-      it('should return random media for unknown format and unknown media formats', () => {
-        expect(
-          mediaService.getMedia(mockUnknownMediaContainer, 'unknown').src
-        ).toBe('base:random1.url');
-      });
-
-      it('should not return src if the media container does not contain a url', () => {
-        expect(
-          mediaService.getMedia({ cont: { format: 'xyz' } }, 'xyz').src
-        ).toBeFalsy();
-      });
-    });
-
-    describe('alt text', () => {
-      it('should return alt text for media', () => {
-        expect(mediaService.getMedia(mockMedia).alt).toBe('alt text for media');
-      });
-
-      it('should return alt text for best media', () => {
-        expect(mediaService.getMedia(mockBestFormatMediaContainer).alt).toBe(
-          'alt text for format-600'
-        );
-      });
-
-      it('should return alt text for specific format', () => {
-        expect(
-          mediaService.getMedia(mockBestFormatMediaContainer, 'format400').alt
-        ).toBe('alt text for format-400');
-      });
-
-      it('should return alt text for best format', () => {
-        expect(
-          mediaService.getMedia(mockBestFormatMediaContainer, 'unknown').alt
-        ).toBe('alt text for format-600');
-      });
-
-      it('should return alt text for random format', () => {
-        expect(
-          mediaService.getMedia(mockUnknownMediaContainer, 'unknown').alt
-        ).toBe('alt text for unknown-1');
-      });
-
-      it('should return given alt text', () => {
-        expect(
-          mediaService.getMedia(
-            mockBestFormatMediaContainer,
-            'format400',
-            'custom alt'
-          ).alt
-        ).toEqual('custom alt');
-      });
-    });
-
-    describe('srcset', () => {
-      it('should return srcset', () => {
-        expect(mediaService.getMedia(mockBestFormatMediaContainer).srcset).toBe(
-          'base:format-1.url 1w, base:format-400.url 400w, base:format-600.url 600w'
-        );
-      });
-
-      it('should not return srcset for media', () => {
-        expect(mediaService.getMedia(mockMedia).srcset).toBeFalsy();
-      });
-    });
-  });
-
-  describe('absolute URL', () => {
-    it('should avoid baseUrl if absolute image is provided', () => {
-      expect(mediaService.getMedia(mockUrlContainer, 'absolute').src).toBe(
-        'http://absolute.jpg'
-      );
-    });
-
-    it('should add OCC baseUrl for relative image', () => {
-      expect(mediaService.getMedia(mockUrlContainer, 'relative').src).toBe(
-        'base:relative.jpg'
-      );
     });
   });
 });

--- a/projects/storefrontlib/src/shared/components/media/media.service.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.ts
@@ -3,7 +3,12 @@ import { Config, Image, OccConfig } from '@spartacus/core';
 import { BreakpointService } from '../../../layout/breakpoint/breakpoint.service';
 import { StorefrontConfig } from '../../../storefront-config';
 import { MediaConfig } from './media.config';
-import { Media, MediaContainer, MediaFormatSize } from './media.model';
+import {
+  ImageLoadingStrategy,
+  Media,
+  MediaContainer,
+  MediaFormatSize,
+} from './media.model';
 
 /**
  * Service which generates media URLs. It leverage the MediaContainer and MediaFormats so
@@ -34,6 +39,8 @@ export class MediaService {
      * The BreakpointService is no longer used in version 2.0 as the different size formats are
      * driven by configuration only. There's however a change that this service will play a role
      * in the near future, which is why we keep the constructor as-is.
+     *
+     * @deprecated
      */
     protected breakpointService: BreakpointService
   ) {}
@@ -60,6 +67,18 @@ export class MediaService {
       alt: alt || mainMedia?.altText,
       srcset: this.resolveSrcSet(mediaContainer),
     };
+  }
+
+  /**
+   * Reads the loading strategy from the `MediaConfig`.
+   *
+   * Defaults to `ImageLoadingStrategy.EAGER`.
+   */
+  get loadingStrategy(): ImageLoadingStrategy {
+    return (
+      (this.config as MediaConfig)?.imageLoadingStrategy ??
+      ImageLoadingStrategy.EAGER
+    );
   }
 
   /**
@@ -125,7 +144,7 @@ export class MediaService {
   }
 
   /**
-   * Returns a set of media for the available media formats. Additionally, the congiured media
+   * Returns a set of media for the available media formats. Additionally, the configured media
    * format width is added to the srcset, so that browsers can select the appropriate media.
    */
   protected resolveSrcSet(media: MediaContainer | Image): string {


### PR DESCRIPTION
While lazy loading images might not add too much value in quite a few scenarios, as we have other optimisations to defer loading of larger pieces of the DOM, there might be components who haven't implemented other lazy loading techniques. Moreover, a server sides rendered page that lands directly in the browser could benefit enormously from the lazy loading of images.

This feature is _not_ enabled by default, but you can easily switch it on by providing the following config:

```ts
provideConfig({
  imageLoadingStrategy: ImageLoadingStrategy.LAZY
} as MediaConfig)
```

closes #6429