### PR TITLE
chore: avoid double Travis job for PRs from feature branch to develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ git:
 branches:
   only:
     - develop
-    - "/^feature\\/.*$/"
     - "/^epic\\/.*$/"
     - "/^hotfix\\/.*$/"
     - "/^release\\/.*$/"


### PR DESCRIPTION
Followup on #9772. The previous solution was too greedy - it caused double Travis jobs on every PR from `feature/...` branch to `develop` branch. 

Note: we still run a Travis job for PRs to `epic/...`, `hotfix/...` and `release/...` branches

related to #9289