### PR TITLE
chore: fix incorrect migration - from AddedToCartDialogComponent to AddToCartComponent

### DIFF
--- a/docs/migration/3_0.md
+++ b/docs/migration/3_0.md
@@ -132,8 +132,8 @@ Before v3.0, when an instance of `OutletRefDirective` was destroyed (removed fro
 ### CartItemListComponent
 There can be more than one cart entry with the same product code. So now they are referenced by the property `entryNumber` instead of the product code in `CartItemListComponent`.
 
-### AddedToCartDialogComponent lost members
-`AddedToCartDialogComponent` lost members: 
+### AddToCartComponent lost members
+`AddToCartComponent` lost members: 
 - `increment` - use new `numberOfEntriesBeforeAdd` instead
 - `cartEntry$` - use `activeCartService.getLastEntry(productCode)` instead
 
@@ -430,7 +430,7 @@ The property `userToken$` of `CloseAccountModalComponent` has been replaced with
 ### UserService
 - Method `loadOrderList` of `UserService` also loads replenishment orders when the url contains a replenishment code. 
 
-### UserOrderService
+
 - Method `getTitles` of `UserOrderService` will load titles when it is empty.
 
 ## Automated Migrations for Version 3

--- a/docs/migration/3_0.md
+++ b/docs/migration/3_0.md
@@ -430,7 +430,7 @@ The property `userToken$` of `CloseAccountModalComponent` has been replaced with
 ### UserService
 - Method `loadOrderList` of `UserService` also loads replenishment orders when the url contains a replenishment code. 
 
-
+### UserOrderService
 - Method `getTitles` of `UserOrderService` will load titles when it is empty.
 
 ## Automated Migrations for Version 3

--- a/projects/schematics/src/migrations/3_0/component-deprecations/component-deprecations.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/component-deprecations.ts
@@ -1,16 +1,16 @@
 import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { ComponentData } from '../../../shared/utils/file-utils';
 import { migrateComponentMigration } from '../../mechanism/component-deprecations/component-deprecations';
-import { ADDED_TO_CART_DIALOG_COMPONENT_MIGRATION } from './data/added-to-cart-dialog.component.migration';
+import { ADD_TO_CART_COMPONENT_MIGRATION } from './data/added-to-cart-dialog.component.migration';
 import { CART_ITEM_COMPONENT_MIGRATION } from './data/cart-item.component.migration';
 import { CHECKOUT_PROGRESS_MOBILE_BOTTOM_COMPONENT_MIGRATION } from './data/checkout-progress-mobile-bottom.component.migration';
 import { CHECKOUT_PROGRESS_MOBILE_TOP_COMPONENT_MIGRATION } from './data/checkout-progress-mobile-top.component.migration';
 import { CHECKOUT_PROGRESS_COMPONENT_MIGRATION } from './data/checkout-progress.component.migration';
+import { CLOSE_ACCOUNT_MODAL_COMPONENT_MIGRATION } from './data/close-account-modal.component.migration';
 import { DELIVERY_MODE_COMPONENT_MIGRATION } from './data/delivery-mode.component.migration';
 import { ORDER_DETAIL_SHIPPING_COMPONENT_MIGRATION } from './data/order-detail-shipping.component.migration';
 import { PAYMENT_METHOD_COMPONENT_MIGRATION } from './data/payment-method.component.migration';
 import { SHIPPING_ADDRESS_COMPONENT_MIGRATION } from './data/shipping-address.component.migration';
-import { CLOSE_ACCOUNT_MODAL_COMPONENT_MIGRATION } from './data/close-account-modal.component.migration';
 import { STAR_RATING_COMPONENT_MIGRATION } from './data/star-rating.component.migration';
 
 export const COMPONENT_DEPRECATION_DATA: ComponentData[] = [
@@ -21,7 +21,7 @@ export const COMPONENT_DEPRECATION_DATA: ComponentData[] = [
   PAYMENT_METHOD_COMPONENT_MIGRATION,
   SHIPPING_ADDRESS_COMPONENT_MIGRATION,
   ORDER_DETAIL_SHIPPING_COMPONENT_MIGRATION,
-  ADDED_TO_CART_DIALOG_COMPONENT_MIGRATION,
+  ADD_TO_CART_COMPONENT_MIGRATION,
   CART_ITEM_COMPONENT_MIGRATION,
   CLOSE_ACCOUNT_MODAL_COMPONENT_MIGRATION,
   STAR_RATING_COMPONENT_MIGRATION,

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/added-to-cart-dialog.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/added-to-cart-dialog.component.migration.ts
@@ -1,9 +1,9 @@
-import { ADDED_TO_CART_DIALOG_COMPONENT } from '../../../../shared/constants';
+import { ADD_TO_CART_COMPONENT } from '../../../../shared/constants';
 import { ComponentData } from '../../../../shared/utils/file-utils';
 
-export const ADDED_TO_CART_DIALOG_COMPONENT_MIGRATION: ComponentData = {
-  selector: 'cx-added-to-cart-dialog',
-  componentClassName: ADDED_TO_CART_DIALOG_COMPONENT,
+export const ADD_TO_CART_COMPONENT_MIGRATION: ComponentData = {
+  selector: 'cx-add-to-cart',
+  componentClassName: ADD_TO_CART_COMPONENT,
   removedProperties: [
     {
       name: 'increment',


### PR DESCRIPTION
In https://github.com/SAP/spartacus/pull/9653 we've added migration for wrong file. Now it's fixed - changed from `AddedToCartDialogComponent` to `AddToCartComponent`.

fix #9871 