### PR TITLE
chore: align CheckoutProgressMobileTopComponent constructor deps to migration

### DIFF
--- a/projects/storefrontlib/src/cms-components/checkout/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.component.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.component.ts
@@ -15,8 +15,8 @@ export class CheckoutProgressMobileTopComponent implements OnInit {
     .steps$;
 
   constructor(
-    protected checkoutStepService: CheckoutStepService,
-    protected activeCartService: ActiveCartService
+    protected activeCartService: ActiveCartService,
+    protected checkoutStepService: CheckoutStepService
   ) {}
 
   cart$: Observable<Cart>;


### PR DESCRIPTION
Automatic migration can't inject constructor param at the start. It will always be at the end. To fix the automatic migration we change order of parameters in a component constructor.

Related to migration we've added in https://github.com/SAP/spartacus/pull/9640/files#diff-f4622be66d9d7eaef68d2bc9deaa4b0ae930d85d5c6b97b7d862b2156a0aeda3R18

fix #9876