### PR TITLE
chore: align DeliveryModeComponentconstructor deps to migration

### DIFF
--- a/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.ts
@@ -36,8 +36,8 @@ export class DeliveryModeComponent implements OnInit, OnDestroy {
     private fb: FormBuilder,
     private checkoutDeliveryService: CheckoutDeliveryService,
     private checkoutConfigService: CheckoutConfigService,
-    protected checkoutStepService: CheckoutStepService,
-    private activatedRoute: ActivatedRoute
+    private activatedRoute: ActivatedRoute,
+    protected checkoutStepService: CheckoutStepService
   ) {}
 
   ngOnInit() {


### PR DESCRIPTION
Automatic migration can't inject constructor param at the start. It will always be at the end. To fix the automatic migration we change order of parameters in a component constructor.

Related to migration we've added in https://github.com/SAP/spartacus/pull/9640/files#diff-72b8001f7e1522831617b3152500194d9cbf28b7325bb0671d25a97b8d62b3e3R16

fix #9878