### PR TITLE
fix: drop page template on root component. 

### DIFF
--- a/projects/storefrontlib/src/cms-structure/page/page-layout/page-layout.module.ts
+++ b/projects/storefrontlib/src/cms-structure/page/page-layout/page-layout.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { APP_BOOTSTRAP_LISTENER, ComponentRef, NgModule } from '@angular/core';
+import { ComponentRef, NgModule } from '@angular/core';
 import { FeatureConfigService } from '@spartacus/core';
 import { PageSlotModule } from '../../../cms-structure/page/slot/page-slot.module';
 import { OutletModule } from '../../outlet/outlet.module';
@@ -22,14 +22,5 @@ export function initPageTemplateStyle(
   imports: [CommonModule, OutletModule, PageSlotModule],
   declarations: [PageLayoutComponent],
   exports: [PageLayoutComponent],
-
-  providers: [
-    {
-      provide: APP_BOOTSTRAP_LISTENER,
-      multi: true,
-      useFactory: initPageTemplateStyle,
-      deps: [PageTemplateStyleService, FeatureConfigService],
-    },
-  ],
 })
 export class PageLayoutModule {}


### PR DESCRIPTION
The page template added to the root storefront element (#8449) has proven to introduce bugs in version 2.1. This has been fixed for version 3.0, but we're dropping it altogether in 2.1.

fixes #9239