### PR TITLE
chore: drop the console warning when inssuficient params to build URL

### DIFF
--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.html
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.html
@@ -1,6 +1,5 @@
 <cx-org-card *ngIf="model$ | async as model" i18nRoot="unit.details">
   <a
-    *ngIf="model.uid"
     actions
     class="link edit"
     [class.disabled]="!model.active || (isInEditMode$ | async)"

--- a/projects/core/src/routing/configurable-routes/url-translation/semantic-path.service.spec.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/semantic-path.service.spec.ts
@@ -1,4 +1,3 @@
-import * as AngularCore from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { RouteConfig } from '../routes-config';
@@ -48,33 +47,6 @@ describe('SemanticPathService', () => {
 
   describe('transform', () => {
     describe(`, when commands contain 'route' property,`, () => {
-      // tslint:disable-next-line:max-line-length
-      it('should console.warn in non-production environment when no configured path matches all its parameters to given object using parameter names mapping ', () => {
-        spyOn(console, 'warn');
-        spyOn(routingConfigService, 'getRouteConfig').and.returnValue({
-          paths: ['path/:param1'],
-        });
-        service.transform({
-          cxRoute: 'test',
-          params: { param2: 'value2' },
-        });
-        expect(console.warn).toHaveBeenCalledTimes(1);
-      });
-
-      // tslint:disable-next-line:max-line-length
-      it('should NOT console.warn in production environment when no configured path matches all its parameters to given object using parameter names mapping ', () => {
-        spyOnProperty(AngularCore, 'isDevMode').and.returnValue(() => false);
-        spyOn(console, 'warn');
-        spyOn(routingConfigService, 'getRouteConfig').and.returnValue({
-          paths: ['path/:param1'],
-        });
-        service.transform({
-          cxRoute: 'test',
-          params: { param2: 'value2' },
-        });
-        expect(console.warn).not.toHaveBeenCalled();
-      });
-
       it('should return absolute path', () => {
         spyOn(routingConfigService, 'getRouteConfig').and.returnValue({
           paths: ['path/:param1'],

--- a/projects/core/src/routing/configurable-routes/url-translation/semantic-path.service.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/semantic-path.service.ts
@@ -1,9 +1,9 @@
-import { Injectable, isDevMode } from '@angular/core';
-import { UrlParsingService } from './url-parsing.service';
-import { RouteConfig, ParamsMapping } from '../routes-config';
-import { getParamName, isParam } from './path-utils';
-import { UrlCommandRoute, UrlCommands, UrlCommand } from './url-command';
+import { Injectable } from '@angular/core';
+import { ParamsMapping, RouteConfig } from '../routes-config';
 import { RoutingConfigService } from '../routing-config.service';
+import { getParamName, isParam } from './path-utils';
+import { UrlCommand, UrlCommandRoute, UrlCommands } from './url-command';
+import { UrlParsingService } from './url-parsing.service';
 
 @Injectable({ providedIn: 'root' })
 export class SemanticPathService {
@@ -140,13 +140,6 @@ export class SemanticPathService {
     );
 
     if (foundPath === undefined || foundPath === null) {
-      this.warn(
-        `No configured path matches all its params to given object. `,
-        `Route config: `,
-        routeConfig,
-        `Params object: `,
-        params
-      );
       return null;
     }
     return foundPath;
@@ -164,11 +157,5 @@ export class SemanticPathService {
       return paramsMapping[paramName] || paramName;
     }
     return paramName;
-  }
-
-  private warn(...args) {
-    if (isDevMode()) {
-      console.warn(...args);
-    }
   }
 }


### PR DESCRIPTION
- drop the console warning when inssuficient params to build URL
- revert workaround from PR https://github.com/SAP/spartacus/pull/9979 (not needed now)

fix #9827