### PR TITLE
fix: render the correct product image format

### DIFF
--- a/projects/storefrontlib/src/cms-components/cart/cart-shared/cart-item/cart-item.component.html
+++ b/projects/storefrontlib/src/cms-components/cart/cart-shared/cart-item/cart-item.component.html
@@ -6,7 +6,10 @@
       cxModal="dismiss"
       tabindex="-1"
     >
-      <cx-media [container]="item.product.images?.PRIMARY"></cx-media>
+      <cx-media
+        [container]="item.product.images?.PRIMARY"
+        format="cartIcon"
+      ></cx-media>
     </a>
   </div>
   <!-- Item Information -->

--- a/projects/storefrontlib/src/cms-components/myaccount/my-interests/my-interests.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/my-interests/my-interests.component.html
@@ -58,7 +58,10 @@
                       { cxRoute: 'product', params: product } | cxUrl
                     "
                   >
-                    <cx-media [container]="product.images?.PRIMARY"></cx-media>
+                    <cx-media
+                      [container]="product.images?.PRIMARY"
+                      format="thumbnail"
+                    ></cx-media>
                   </a>
                 </div>
               </td>

--- a/projects/storefrontlib/src/cms-components/myaccount/order/amend-order/amend-order-items/amend-order-items.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/amend-order/amend-order-items/amend-order-items.component.html
@@ -38,6 +38,7 @@
       <cx-media
         class="col-2"
         [container]="item.product.images?.PRIMARY"
+        format="thumbnail"
       ></cx-media>
 
       <!-- Item Information -->

--- a/projects/storefrontlib/src/cms-components/myaccount/order/return-request-detail/return-request-items/return-request-items.component.html
+++ b/projects/storefrontlib/src/cms-components/myaccount/order/return-request-detail/return-request-items/return-request-items.component.html
@@ -26,6 +26,7 @@
         <div class="col-2 cx-image-container">
           <cx-media
             [container]="returnEntry.orderEntry?.product.images?.PRIMARY"
+            format="thumbnail"
           ></cx-media>
         </div>
         <!-- Item Information -->

--- a/projects/storefrontlib/src/cms-components/navigation/search-box/search-box.component.html
+++ b/projects/storefrontlib/src/cms-components/navigation/search-box/search-box.component.html
@@ -82,6 +82,7 @@
       <cx-media
         *ngIf="config.displayProductImages"
         [container]="product.images?.PRIMARY"
+        format="thumbnail"
         [alt]="product.summary"
       ></cx-media>
       <h4 class="name" [innerHTML]="product.nameHtml"></h4>

--- a/projects/storefrontlib/src/cms-components/product/carousel/product-carousel/product-carousel.component.html
+++ b/projects/storefrontlib/src/cms-components/product/carousel/product-carousel/product-carousel.component.html
@@ -8,7 +8,7 @@
 
 <ng-template #carouselItem let-item="item">
   <a tabindex="0" [routerLink]="{ cxRoute: 'product', params: item } | cxUrl">
-    <cx-media [container]="item.images?.PRIMARY"></cx-media>
+    <cx-media [container]="item.images?.PRIMARY" format="product"></cx-media>
     <h4>
       {{ item.name }}
     </h4>

--- a/projects/storefrontlib/src/cms-components/product/carousel/product-references/product-references.component.html
+++ b/projects/storefrontlib/src/cms-components/product/carousel/product-references/product-references.component.html
@@ -7,7 +7,7 @@
 
 <ng-template #carouselItem let-item="item">
   <a tabindex="0" [routerLink]="{ cxRoute: 'product', params: item } | cxUrl">
-    <cx-media [container]="item.images?.PRIMARY"></cx-media>
+    <cx-media [container]="item.images?.PRIMARY" format="product"></cx-media>
     <h4>{{ item.name }}</h4>
     <div class="price">{{ item.price?.formattedValue }}</div>
   </a>

--- a/projects/storefrontlib/src/cms-components/product/product-images/product-images.component.html
+++ b/projects/storefrontlib/src/cms-components/product/product-images/product-images.component.html
@@ -19,6 +19,7 @@
     tabindex="0"
     (focus)="openImage(item.container)"
     [class.is-active]="isActive(item.container) | async"
+    format="product"
   >
   </cx-media>
 </ng-template>

--- a/projects/storefrontlib/src/cms-components/product/product-list/product-grid-item/product-grid-item.component.html
+++ b/projects/storefrontlib/src/cms-components/product/product-list/product-grid-item/product-grid-item.component.html
@@ -6,6 +6,7 @@
   <cx-media
     class="cx-product-image"
     [container]="product.images?.PRIMARY"
+    format="product"
     [alt]="product.summary"
   ></cx-media>
 </a>

--- a/projects/storefrontlib/src/cms-components/product/product-list/product-list-item/product-list-item.component.html
+++ b/projects/storefrontlib/src/cms-components/product/product-list/product-list-item/product-list-item.component.html
@@ -8,6 +8,7 @@
       <cx-media
         class="cx-product-image"
         [container]="product.images?.PRIMARY"
+        format="product"
         [alt]="product.summary"
       ></cx-media>
     </a>

--- a/projects/storefrontlib/src/cms-components/wish-list/components/wish-list-item/wish-list-item.component.html
+++ b/projects/storefrontlib/src/cms-components/wish-list/components/wish-list-item/wish-list-item.component.html
@@ -5,7 +5,10 @@
       [routerLink]="{ cxRoute: 'product', params: cartEntry.product } | cxUrl"
       tabindex="-1"
     >
-      <cx-media [container]="cartEntry.product.images?.PRIMARY"></cx-media>
+      <cx-media
+        [container]="cartEntry.product.images?.PRIMARY"
+        format="thumbnail"
+      ></cx-media>
     </a>
   </div>
   <!-- Item Information -->

--- a/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
@@ -200,7 +200,7 @@ describe('MediaService', () => {
       });
 
       describe('srcset', () => {
-        it('should return srcset', () => {
+        it('should return all images in srcset', () => {
           expect(
             mediaService.getMedia(mockBestFormatMediaContainer).srcset
           ).toBe(
@@ -208,7 +208,23 @@ describe('MediaService', () => {
           );
         });
 
-        it('should not return srcset for media', () => {
+        it('should return only relevant images in srcset for the given format', () => {
+          expect(
+            mediaService.getMedia(mockBestFormatMediaContainer, 'format400')
+              .srcset
+          ).toBe('base:format-1.url 1w, base:format-400.url 400w');
+        });
+
+        it('should return all formats for unknown format', () => {
+          expect(
+            mediaService.getMedia(mockBestFormatMediaContainer, 'unknown')
+              .srcset
+          ).toBe(
+            'base:format-1.url 1w, base:format-400.url 400w, base:format-600.url 600w'
+          );
+        });
+
+        it('should not return srcset for media without any formats', () => {
           expect(mediaService.getMedia(mockMedia).srcset).toBeFalsy();
         });
       });
@@ -282,10 +298,34 @@ describe('MediaService', () => {
       mediaService = TestBed.inject(MediaService);
     });
 
-    it('should return first media when there is no specific media config', () => {
+    it('should return first available media', () => {
       expect(mediaService.getMedia(mockBestFormatMediaContainer).src).toBe(
         'format-1.url'
       );
+    });
+
+    it('should return first available media for unknown format', () => {
+      expect(
+        mediaService.getMedia(mockBestFormatMediaContainer, 'unknown').src
+      ).toBe('format-1.url');
+    });
+
+    it('should not return srcset for unknown format', () => {
+      expect(
+        mediaService.getMedia(mockBestFormatMediaContainer, 'unknown').srcset
+      ).toBeFalsy();
+    });
+
+    it('should return specific media for given format', () => {
+      expect(
+        mediaService.getMedia(mockBestFormatMediaContainer, 'format600').src
+      ).toBe('format-600.url');
+    });
+
+    it('should not return srcset for given format', () => {
+      expect(
+        mediaService.getMedia(mockBestFormatMediaContainer, 'format600').srcset
+      ).toBeFalsy();
     });
   });
 });

--- a/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
@@ -78,7 +78,7 @@ const mockUrlContainer = {
 };
 
 describe('MediaService', () => {
-  describe('eager loaded config', () => {
+  describe('with eager loaded config', () => {
     let mediaService: MediaService;
 
     beforeEach(() => {
@@ -237,7 +237,7 @@ describe('MediaService', () => {
     });
   });
 
-  describe('lazy loaded config', () => {
+  describe('with lazy loaded config', () => {
     let mediaService: MediaService;
 
     beforeEach(() => {
@@ -262,6 +262,30 @@ describe('MediaService', () => {
           ImageLoadingStrategy.EAGER
         );
       });
+    });
+  });
+
+  describe('without media config', () => {
+    let mediaService: MediaService;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          MediaService,
+          {
+            provide: Config,
+            useValue: {},
+          },
+          { provide: LayoutConfig, useValue: {} },
+        ],
+      });
+      mediaService = TestBed.inject(MediaService);
+    });
+
+    it('should return first media when there is no specific media config', () => {
+      expect(mediaService.getMedia(mockBestFormatMediaContainer).src).toBe(
+        'format-1.url'
+      );
     });
   });
 });

--- a/projects/storefrontlib/src/shared/components/media/media.service.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.ts
@@ -65,7 +65,7 @@ export class MediaService {
     return {
       src: this.resolveAbsoluteUrl(mainMedia?.url),
       alt: alt || mainMedia?.altText,
-      srcset: this.resolveSrcSet(mediaContainer),
+      srcset: this.resolveSrcSet(mediaContainer, format),
     };
   }
 
@@ -146,13 +146,26 @@ export class MediaService {
   /**
    * Returns a set of media for the available media formats. Additionally, the configured media
    * format width is added to the srcset, so that browsers can select the appropriate media.
+   *
+   * The optional maxFormat indicates that only sources till a certain format should be added
+   * to the srcset.
    */
-  protected resolveSrcSet(media: MediaContainer | Image): string {
+  protected resolveSrcSet(
+    media: MediaContainer | Image,
+    maxFormat?: string
+  ): string {
     if (!media) {
       return undefined;
     }
 
-    const srcset = this.sortedFormats.reduce((set, format) => {
+    // Only create srcset images that are smaller than the given `maxFormat` (if any)
+    let formats = this.sortedFormats;
+    const max: number = formats.findIndex((f) => f.code === maxFormat);
+    if (max > -1) {
+      formats = formats.slice(0, max + 1);
+    }
+
+    const srcset = formats.reduce((set, format) => {
       if (!!media[format.code]) {
         if (set) {
           set += ', ';

--- a/projects/storefrontlib/src/shared/components/media/media.service.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.ts
@@ -87,7 +87,7 @@ export class MediaService {
    * benefits.
    */
   protected get sortedFormats(): { code: string; size: MediaFormatSize }[] {
-    if (!this._sortedFormats) {
+    if (!this._sortedFormats && (this.config as MediaConfig)?.mediaFormats) {
       this._sortedFormats = Object.keys(
         (this.config as MediaConfig).mediaFormats
       )
@@ -97,7 +97,7 @@ export class MediaService {
         }))
         .sort((a, b) => (a.size.width > b.size.width ? 1 : -1));
     }
-    return this._sortedFormats;
+    return this._sortedFormats ?? [];
   }
 
   /**
@@ -184,12 +184,14 @@ export class MediaService {
    *
    * The `backend.media.baseUrl` can be used to load media from a different location.
    *
-   * In Commerce Cloud, a differnt location could mean a different "aspect".
+   * In Commerce Cloud, a different location could mean a different "aspect".
+   *
+   * Defaults to empty string in case no config is provided.
    */
   protected getBaseUrl(): string {
     return (
-      (this.config as OccConfig).backend.media.baseUrl ||
-      (this.config as OccConfig).backend.occ.baseUrl ||
+      (this.config as OccConfig).backend?.media?.baseUrl ??
+      (this.config as OccConfig).backend?.occ?.baseUrl ??
       ''
     );
   }

--- a/projects/storefrontstyles/scss/components/misc/spinner/_spinner.scss
+++ b/projects/storefrontstyles/scss/components/misc/spinner/_spinner.scss
@@ -28,6 +28,7 @@
     overflow: hidden;
     animation: load8 var(--cx-spinner-animation-time) infinite linear;
 
+    // @TODO consider merging with the %spinner from the _animation scss
     &::before,
     &:before {
       content: '';
@@ -42,6 +43,13 @@
       border-right-color: var(--cx-spinner-secondary-color);
       border-left-color: var(--cx-spinner-primary-color);
       border-radius: 50%;
+
+      // We prevent pointer events on this pseudo class to avoid any direct mouse
+      // interaction. Mouse interaction with the spinner class affects developer
+      // experience badly, as you can't inspect the actual elements. Also, users
+      // would be blocked to use the context menu to open a link or image in a
+      // new tab.
+      pointer-events: none;
     }
   }
   @keyframes load8 {

--- a/projects/storefrontstyles/scss/cxbase/_animations.scss
+++ b/projects/storefrontstyles/scss/cxbase/_animations.scss
@@ -5,7 +5,7 @@
 }
 
 :root {
-  // spinner size is added to the root so that it can be overriden on individual elements
+  // spinner size is added to the root so that it can be overridden on individual elements
   --cx-spinner-size: 40px;
 }
 
@@ -28,6 +28,13 @@
   // add smooth transition
   opacity: var(--cx-opacity, 0);
   transition: all var(--cx-transition-duration, 0.6s);
+
+  // We prevent pointer events on this pseudo class to avoid any direct mouse
+  // interaction. Mouse interaction with the spinner class affects developer
+  // experience badly, as you can't inspect the actual elements. Also, users
+  // would be blocked to use the context menu to open a link or image in a
+  // new tab.
+  pointer-events: none;
 }
 
 %overlay {


### PR DESCRIPTION
We were previously generating an `img` element with a `srcset` that would have all product image formats. This was fundamentally wrong, and we'd spoil the network by downloading to big images, which impacts performance negatively.

fixes #10009