### PR TITLE
avoid duplicate calls to CPQ

### DIFF
--- a/feature-libs/product/configurators/rulebased/root/interceptor/cpq-configurator-rest.interceptor.ts
+++ b/feature-libs/product/configurators/rulebased/root/interceptor/cpq-configurator-rest.interceptor.ts
@@ -32,7 +32,7 @@ export class CpqConfiguratorRestInterceptor implements HttpInterceptor {
       return next.handle(request);
     }
     return this.cpqAccessStorageService.getCachedCpqAccessData().pipe(
-      take(1), //avoid request being re-executed when token expires
+      take(1), // avoid request being re-executed when token expires
       switchMap((cpqData) => {
         return next
           .handle(this.enrichHeaders(request, cpqData))

--- a/feature-libs/product/configurators/rulebased/root/interceptor/cpq-configurator-rest.interceptor.ts
+++ b/feature-libs/product/configurators/rulebased/root/interceptor/cpq-configurator-rest.interceptor.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { switchMap, tap } from 'rxjs/operators';
+import { switchMap, take, tap } from 'rxjs/operators';
 import { CpqAccessData } from './cpq-access-data.models';
 import { CpqAccessStorageService } from './cpq-access-storage.service';
 
@@ -32,6 +32,7 @@ export class CpqConfiguratorRestInterceptor implements HttpInterceptor {
       return next.handle(request);
     }
     return this.cpqAccessStorageService.getCachedCpqAccessData().pipe(
+      take(1), //avoid request being re-executed when token expires
       switchMap((cpqData) => {
         return next
           .handle(this.enrichHeaders(request, cpqData))


### PR DESCRIPTION
**Test/Repo**:

- login and configure a CPQ product (calls to CPQ are done)
- logout
- login again (no calls to CPQ should happen)