### PR TITLE
SSR Optimization logic should have mechanism to keep cache size under control

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/rendering-cache.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache.spec.ts
@@ -111,3 +111,31 @@ describe('RenderingCache with ttl', () => {
     });
   });
 });
+
+describe('RenderingCache with cacheSize', () => {
+  let renderingCache: RenderingCache;
+
+  beforeEach(() => {
+    renderingCache = new RenderingCache({ cacheSize: 2 });
+  });
+
+  describe('get', () => {
+    it('should drop elements', () => {
+      renderingCache.store('a', null, 'a');
+      renderingCache.store('b', null, 'b');
+      renderingCache.store('c', null, 'c');
+      expect(renderingCache.get('a')).toBeFalsy();
+      expect(renderingCache.get('b')).toBeTruthy();
+    });
+
+    it('should drop oldest elements', () => {
+      renderingCache.store('a', null, 'a');
+      renderingCache.store('b', null, 'b');
+      renderingCache.store('a', null, 'a1');
+      renderingCache.store('c', null, 'c');
+      renderingCache.store('a', null, 'a2');
+      expect(renderingCache.get('a')).toBeTruthy();
+      expect(renderingCache.get('b')).toBeFalsy();
+    });
+  });
+});

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -16,6 +16,18 @@ export interface SsrOptimizationOptions {
   cache?: boolean;
 
   /**
+   * Limit the cache size
+   *
+   * Specified number of entries that will be kept in cache, allows to keep
+   * memory usage under control.
+   *
+   * Can also be use when `cache` option is set to false. It will then limit the
+   * number of renders timeout'ed renders kept in temporary cache, waiting to be
+   * served with next request.
+   */
+  cacheSize?: number;
+
+  /**
    * Limit number of concurrent rendering
    */
   concurrency?: number;

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -22,8 +22,8 @@ export interface SsrOptimizationOptions {
    * memory usage under control.
    *
    * Can also be use when `cache` option is set to false. It will then limit the
-   * number of renders timeout'ed renders kept in temporary cache, waiting to be
-   * served with next request.
+   * number of renders that timeouts and are kept in temporary cache, waiting
+   * to be served with next request.
    */
   cacheSize?: number;
 


### PR DESCRIPTION
Currently in case of timeouts for incorrect URLs or many valid ones that will be issued only once, cache can grow without any limits, which can cause issue on deployments.

Closes #10220