### PR TITLE
fix: stop using explicit homepage label in case of default page

### DIFF
--- a/projects/core/src/occ/adapters/cms/occ-cms-page.adapter.spec.ts
+++ b/projects/core/src/occ/adapters/cms/occ-cms-page.adapter.spec.ts
@@ -6,7 +6,7 @@ import { TestBed } from '@angular/core/testing';
 import { CMS_PAGE_NORMALIZER } from '../../../cms/connectors';
 import { CmsStructureConfigService } from '../../../cms/services';
 import { CmsComponent, PageType } from '../../../model/cms.model';
-import { PageContext } from '../../../routing';
+import { HOME_PAGE_ID, PageContext } from '../../../routing';
 import { ConverterService } from '../../../util/converter.service';
 import { OccEndpointsService } from '../../services/occ-endpoints.service';
 import { OccCmsPageAdapter } from './occ-cms-page.adapter';
@@ -42,9 +42,14 @@ class OccEndpointsServiceMock {
   }
 }
 
-class MockComverterService {
+class MockConverterService {
   pipeable = createSpy().and.returnValue((x) => x);
 }
+
+const homePageContext: PageContext = {
+  id: HOME_PAGE_ID,
+  type: PageType.CONTENT_PAGE,
+};
 
 const context: PageContext = {
   id: 'testPagId',
@@ -71,7 +76,7 @@ describe('OccCmsPageAdapter', () => {
           provide: CmsStructureConfigService,
           useClass: CmsStructureConfigServiceMock,
         },
-        { provide: ConverterService, useClass: MockComverterService },
+        { provide: ConverterService, useClass: MockConverterService },
       ],
     });
     service = TestBed.inject(OccCmsPageAdapter);
@@ -86,8 +91,7 @@ describe('OccCmsPageAdapter', () => {
   describe('Load cms page data', () => {
     it('Should get cms content page data without parameter fields', () => {
       spyOn(endpointsService, 'getUrl').and.returnValue(
-        endpoint +
-          `/pages?fields=DEFAULT&pageType=${context.type}&pageLabelOrId=${context.id}`
+        endpoint + `/pages?pageType=${context.type}&pageLabelOrId=${context.id}`
       );
 
       service.load(context).subscribe((result) => {
@@ -99,14 +103,14 @@ describe('OccCmsPageAdapter', () => {
           req.method === 'GET' &&
           req.url ===
             endpoint +
-              `/pages?fields=DEFAULT&pageType=${context.type}&pageLabelOrId=${context.id}`
+              `/pages?pageType=${context.type}&pageLabelOrId=${context.id}`
         );
       });
 
       expect(endpointsService.getUrl).toHaveBeenCalledWith(
         'pages',
         {},
-        { fields: 'DEFAULT', pageType: context.type, pageLabelOrId: context.id }
+        { pageType: context.type, pageLabelOrId: context.id }
       );
       expect(testRequest.cancelled).toBeFalsy();
       expect(testRequest.request.responseType).toEqual('json');
@@ -142,10 +146,26 @@ describe('OccCmsPageAdapter', () => {
       testRequest.flush(cmsPageData);
     });
 
+    it('Should get home page data without parameters', () => {
+      spyOn(endpointsService, 'getUrl').and.returnValue(endpoint + `/pages`);
+
+      service.load(homePageContext).subscribe((result) => {
+        expect(result).toEqual(cmsPageData);
+      });
+
+      const testRequest = httpMock.expectOne((req) => {
+        return req.method === 'GET' && req.url === endpoint + `/pages`;
+      });
+
+      expect(endpointsService.getUrl).toHaveBeenCalledWith('pages', {}, {});
+      expect(testRequest.cancelled).toBeFalsy();
+      expect(testRequest.request.responseType).toEqual('json');
+      testRequest.flush(cmsPageData);
+    });
+
     it('should get cms product page data', () => {
       spyOn(endpointsService, 'getUrl').and.returnValue(
-        endpoint +
-          `/pages?fields=DEFAULT&pageType=${context1.type}&code=${context1.id}`
+        endpoint + `/pages?pageType=${context1.type}&code=${context1.id}`
       );
       service.load(context1).subscribe((result) => {
         expect(result).toEqual(cmsPageData);
@@ -155,37 +175,33 @@ describe('OccCmsPageAdapter', () => {
         return (
           req.method === 'GET' &&
           req.url ===
-            endpoint +
-              `/pages?fields=DEFAULT&pageType=${context1.type}&code=${context1.id}`
+            endpoint + `/pages?pageType=${context1.type}&code=${context1.id}`
         );
       });
 
       expect(endpointsService.getUrl).toHaveBeenCalledWith(
         'pages',
         {},
-        { fields: 'DEFAULT', pageType: context1.type, code: context1.id }
+        { pageType: context1.type, code: context1.id }
       );
       expect(testRequest.cancelled).toBeFalsy();
       expect(testRequest.request.responseType).toEqual('json');
       testRequest.flush(cmsPageData);
     });
 
-    it('should get cms page data by pageId if PageType is unknow', () => {
+    it('should get cms page data by pageId if PageType is unknown', () => {
       const contextWithoutType: PageContext = {
         id: '123',
       };
       spyOn(endpointsService, 'getUrl').and.returnValue(
-        endpoint + `/pages/${contextWithoutType.id}?fields=DEFAULT`
+        endpoint + `/pages/${contextWithoutType.id}`
       );
       service.load(contextWithoutType).subscribe((result) => {
         expect(result).toEqual(cmsPageData);
       });
 
       const testRequest = httpMock.expectOne((req) => {
-        return (
-          req.method === 'GET' &&
-          req.url === endpoint + '/pages/123?fields=DEFAULT'
-        );
+        return req.method === 'GET' && req.url === endpoint + '/pages/123';
       });
 
       expect(testRequest.cancelled).toBeFalsy();

--- a/projects/core/src/routing/models/page-context.model.ts
+++ b/projects/core/src/routing/models/page-context.model.ts
@@ -6,7 +6,12 @@ import { PageType } from '../../model/cms.model';
  * changing the page id. Therefore, we use a constant to keep track of the page in the
  * store, but are able to ignore the id while querying the backend.
  */
-export const HOME_PAGE_ID = '__HOMEPAGE__';
+export const HOME_PAGE_CONTEXT = '__HOMEPAGE__';
+
+/**
+ * SmartEdit preview page is loaded by previewToken which is added by interceptor
+ */
+export const SMART_EDIT_CONTEXT = 'smartedit-preview';
 
 export class PageContext {
   id: string;

--- a/projects/core/src/routing/models/page-context.model.ts
+++ b/projects/core/src/routing/models/page-context.model.ts
@@ -1,5 +1,13 @@
 import { PageType } from '../../model/cms.model';
 
+/**
+ * The homepage id for the CMS homepage is not required when we query the backend.
+ * CMS business users can have multiple pages, that they might switch quickly without
+ * changing the page id. Therefore, we use a constant to keep track of the page in the
+ * store, but are able to ignore the id while querying the backend.
+ */
+export const HOME_PAGE_ID = '__HOMEPAGE__';
+
 export class PageContext {
   id: string;
   type?: PageType;

--- a/projects/core/src/routing/store/reducers/router.reducer.spec.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.spec.ts
@@ -8,7 +8,7 @@ import {
   StoreRouterConnectingModule,
 } from '@ngrx/router-store';
 import { Store, StoreModule } from '@ngrx/store';
-import { PageContext } from '@spartacus/core';
+import { HOME_PAGE_CONTEXT, PageContext } from '@spartacus/core';
 import { PageType } from '../../../model/cms.model';
 import { RoutingConfig } from '../../configurable-routes/config/routing-config';
 import { ChangeNextPageContext } from '../actions/router.action';
@@ -263,7 +263,7 @@ describe('Router Reducer', () => {
         url: '/',
         queryParams: {},
         params: {},
-        context: { id: '__HOMEPAGE__', type: PageType.CONTENT_PAGE },
+        context: { id: HOME_PAGE_CONTEXT, type: PageType.CONTENT_PAGE },
         cmsRequired: false,
         semanticRoute: SemanticRoutes.HOME,
       });

--- a/projects/core/src/routing/store/reducers/router.reducer.spec.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.spec.ts
@@ -8,12 +8,12 @@ import {
   StoreRouterConnectingModule,
 } from '@ngrx/router-store';
 import { Store, StoreModule } from '@ngrx/store';
+import { PageContext } from '@spartacus/core';
 import { PageType } from '../../../model/cms.model';
 import { RoutingConfig } from '../../configurable-routes/config/routing-config';
+import { ChangeNextPageContext } from '../actions/router.action';
 import { RouterState } from '../routing-state';
 import * as fromReducer from './router.reducer';
-import { ChangeNextPageContext } from '../actions/router.action';
-import { PageContext } from '@spartacus/core';
 
 @Component({
   selector: 'cx-test-cmp',
@@ -263,7 +263,7 @@ describe('Router Reducer', () => {
         url: '/',
         queryParams: {},
         params: {},
-        context: { id: 'homepage', type: PageType.CONTENT_PAGE },
+        context: { id: '__HOMEPAGE__', type: PageType.CONTENT_PAGE },
         cmsRequired: false,
         semanticRoute: SemanticRoutes.HOME,
       });

--- a/projects/core/src/routing/store/reducers/router.reducer.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.ts
@@ -5,7 +5,10 @@ import { ActionReducerMap } from '@ngrx/store';
 import { PageType } from '../../../model/cms.model';
 import { RoutingConfigService } from '../../configurable-routes/routing-config.service';
 import { CmsActivatedRouteSnapshot } from '../../models/cms-route';
-import { HOME_PAGE_ID, PageContext } from '../../models/page-context.model';
+import {
+  HOME_PAGE_CONTEXT,
+  PageContext,
+} from '../../models/page-context.model';
 import { CHANGE_NEXT_PAGE_CONTEXT } from '../actions/router.action';
 import {
   ActivatedRouterStateSnapshot,
@@ -170,7 +173,10 @@ export class CustomSerializer
           context = {
             // We like URLs to be driven by the backend, the CMS actually returns the homepage
             // if no page label is given. Our logic however requires an id. undefined doesn't work.
-            id: HOME_PAGE_ID,
+            id: HOME_PAGE_CONTEXT,
+
+            // We currently need to support a hardcoded page type, since the internal store uses the page
+            // type to store the content.
             type: PageType.CONTENT_PAGE,
           };
         }

--- a/projects/core/src/routing/store/reducers/router.reducer.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.ts
@@ -5,13 +5,13 @@ import { ActionReducerMap } from '@ngrx/store';
 import { PageType } from '../../../model/cms.model';
 import { RoutingConfigService } from '../../configurable-routes/routing-config.service';
 import { CmsActivatedRouteSnapshot } from '../../models/cms-route';
-import { PageContext } from '../../models/page-context.model';
+import { HOME_PAGE_ID, PageContext } from '../../models/page-context.model';
+import { CHANGE_NEXT_PAGE_CONTEXT } from '../actions/router.action';
 import {
   ActivatedRouterStateSnapshot,
   RouterState,
   State,
 } from '../routing-state';
-import { CHANGE_NEXT_PAGE_CONTEXT } from '../actions/router.action';
 
 export const initialState: RouterState = {
   navigationId: 0,
@@ -168,7 +168,9 @@ export class CustomSerializer
           };
         } else {
           context = {
-            id: 'homepage',
+            // We like URLs to be driven by the backend, the CMS actually returns the homepage
+            // if no page label is given. Our logic however requires an id. undefined doesn't work.
+            id: HOME_PAGE_ID,
             type: PageType.CONTENT_PAGE,
           };
         }

--- a/projects/core/src/routing/store/reducers/router.reducer.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.ts
@@ -8,6 +8,7 @@ import { CmsActivatedRouteSnapshot } from '../../models/cms-route';
 import {
   HOME_PAGE_CONTEXT,
   PageContext,
+  SMART_EDIT_CONTEXT,
 } from '../../models/page-context.model';
 import { CHANGE_NEXT_PAGE_CONTEXT } from '../actions/router.action';
 import {
@@ -149,7 +150,7 @@ export class CustomSerializer
     // we give smartedit preview page a PageContext
     if (state.url.length > 0 && state.url[0].path === 'cx-preview') {
       context = {
-        id: 'smartedit-preview',
+        id: SMART_EDIT_CONTEXT,
         type: PageType.CONTENT_PAGE,
       };
     } else {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -409,12 +409,14 @@ export function viewOrderHistoryWithCheapProduct(
 }
 
 export function waitForPage(page: string, alias: string): string {
+  // homepage is not explicitly being asked as it's driven by the backend.
+  const endpoint = page === 'homepage' ? `*` : `*${page}*`;
   cy.server();
   cy.route(
     'GET',
     `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
       'BASE_SITE'
-    )}/cms/pages?*${page}*`
+    )}/cms/pages${endpoint}`
   ).as(alias);
   return alias;
 }


### PR DESCRIPTION
Spartacus has loaded the homepage with an explicit `homepage` label. This conflicts with the behaviour of the CMS, where the homepage can switch from one to another by making an explicit selection. There's no need to bind this to a specific page label. 

fixes #6746