### PR TITLE
chore: temporarily skip failing b2b regression tests

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/my-company/budgets.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/my-company/budgets.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { budgetConfig } from '../../../../helpers/b2b/my-company/config/budget.config';
-import { testMyCompanyFeatureFromConfig } from '../../../../helpers/b2b/my-company/my-company.utils';
+// import { budgetConfig } from '../../../../helpers/b2b/my-company/config/budget.config';
+// import { testMyCompanyFeatureFromConfig } from '../../../../helpers/b2b/my-company/my-company.utils';
 
-testMyCompanyFeatureFromConfig(budgetConfig);
+// testMyCompanyFeatureFromConfig(budgetConfig);

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/my-company/units.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/my-company/units.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { unitConfig } from '../../../../helpers/b2b/my-company/config/unit';
-import { testMyCompanyFeatureFromConfig } from '../../../../helpers/b2b/my-company/my-company.utils';
+// import { unitConfig } from '../../../../helpers/b2b/my-company/config/unit';
+// import { testMyCompanyFeatureFromConfig } from '../../../../helpers/b2b/my-company/my-company.utils';
 
-testMyCompanyFeatureFromConfig(unitConfig);
+// testMyCompanyFeatureFromConfig(unitConfig);

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/my-company/user-groups.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/my-company/user-groups.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { userGroupConfig } from '../../../../helpers/b2b/my-company/config/user-group';
-import { testMyCompanyFeatureFromConfig } from '../../../../helpers/b2b/my-company/my-company.utils';
+// import { userGroupConfig } from '../../../../helpers/b2b/my-company/config/user-group';
+// import { testMyCompanyFeatureFromConfig } from '../../../../helpers/b2b/my-company/my-company.utils';
 
-testMyCompanyFeatureFromConfig(userGroupConfig);
+// testMyCompanyFeatureFromConfig(userGroupConfig);

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/my-company/users.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/my-company/users.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { userConfig } from '../../../../helpers/b2b/my-company/config/user';
-import { testMyCompanyFeatureFromConfig } from '../../../../helpers/b2b/my-company/my-company.utils';
+// import { userConfig } from '../../../../helpers/b2b/my-company/config/user';
+// import { testMyCompanyFeatureFromConfig } from '../../../../helpers/b2b/my-company/my-company.utils';
 
-testMyCompanyFeatureFromConfig(userConfig);
+// testMyCompanyFeatureFromConfig(userConfig);

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/replenishment/b2b-replenishment-checkout-flow.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/replenishment/b2b-replenishment-checkout-flow.e2e-spec.ts
@@ -8,7 +8,7 @@ import {
   recurrencePeriod,
 } from '../../../../sample-data/b2b-checkout';
 
-context('B2B - Replenishment Checkout flow', () => {
+context.skip('B2B - Replenishment Checkout flow', () => {
   for (const [key, replenishment] of Object.entries(recurrencePeriod)) {
     describe(key, () => {
       before(() => {


### PR DESCRIPTION
Skipping e2e tests for:
- whole my-company (except cost-centers and permissions, which should be fixed in PR https://github.com/SAP/spartacus/pull/10237/files)
- replenishment checkout flow

closes #10271