### PR TITLE
fix: getStable API for ConfigInitializerService (#10425)

### DIFF
--- a/projects/core/src/config/config-initializer/config-initializer.service.spec.ts
+++ b/projects/core/src/config/config-initializer/config-initializer.service.spec.ts
@@ -3,6 +3,8 @@ import { TestBed } from '@angular/core/testing';
 import { ConfigInitializerService } from './config-initializer.service';
 import { Config, ConfigInitializer, RootConfig } from '@spartacus/core';
 import { CONFIG_INITIALIZER_FORROOT_GUARD } from './config-initializer';
+import { tap } from 'rxjs/operators';
+import { forkJoin } from 'rxjs';
 
 const MockConfig = {
   test: 'test',
@@ -64,6 +66,44 @@ describe('ConfigInitializerService', () => {
       expect(config.scope2.nested).toBeTruthy();
     });
 
+    describe('getStable should return correct config for scope', () => {
+      it('scope1', (done) => {
+        service.getStable('scope1').subscribe((config) => {
+          expect(config.scope1).toEqual('final');
+          done();
+        });
+      });
+
+      it('scope2', (done) => {
+        service.getStable('scope2').subscribe((config) => {
+          expect(config.scope2).toEqual({ nested: true });
+          done();
+        });
+      });
+
+      it('scope2.nested', (done) => {
+        service.getStable('scope2.nested').subscribe((config) => {
+          expect(config.scope2).toEqual({ nested: true });
+          done();
+        });
+      });
+
+      it('scope2.nested.even.more', (done) => {
+        service.getStable('scope2.nested.even.more').subscribe((config) => {
+          expect(config.scope2).toEqual({ nested: true });
+          done();
+        });
+      });
+
+      it('scope1, scope2', (done) => {
+        service.getStable('scope1', 'scope2').subscribe((config) => {
+          expect(config.scope1).toEqual('final');
+          expect(config.scope2).toEqual({ nested: true });
+          done();
+        });
+      });
+    });
+
     describe('getConfigStable should return correct config for scope', () => {
       it('scope1', async () => {
         const config = await service.getStableConfig('scope1');
@@ -89,6 +129,27 @@ describe('ConfigInitializerService', () => {
         const config = await service.getStableConfig('scope1', 'scope2');
         expect(config.scope1).toEqual('final');
         expect(config.scope2).toEqual({ nested: true });
+      });
+    });
+
+    it('getStable should fulfil gradually', (done) => {
+      const results = [];
+
+      const scope2 = service
+        .getStable('scope2')
+        .pipe(tap(() => results.push('scope2')));
+
+      const stable = service
+        .getStable()
+        .pipe(tap(() => results.push('stable')));
+
+      const scope1 = service
+        .getStable('scope1')
+        .pipe(tap(() => results.push('scope1')));
+
+      forkJoin([scope2, stable, scope1]).subscribe(() => {
+        expect(results).toEqual(['scope1', 'scope2', 'stable']);
+        done();
       });
     });
 

--- a/projects/core/src/config/config-initializer/config-initializer.service.ts
+++ b/projects/core/src/config/config-initializer/config-initializer.service.ts
@@ -3,10 +3,11 @@ import {
   CONFIG_INITIALIZER_FORROOT_GUARD,
   ConfigInitializer,
 } from './config-initializer';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { filter, mapTo, take } from 'rxjs/operators';
 import { deepMerge } from '../utils/deep-merge';
 import { Config, RootConfig } from '../config-tokens';
+import { of } from 'rxjs/internal/observable/of';
 
 /**
  * Provides support for CONFIG_INITIALIZERS
@@ -47,20 +48,24 @@ export class ConfigInitializerService {
    *
    * @param scopes String describing parts of the config we want to be sure are stable
    */
-  async getStableConfig(...scopes: string[]): Promise<any> {
+  getStable(...scopes: string[]): Observable<any> {
     if (this.isStable) {
-      return this.config;
+      return of(this.config);
     }
-    return this.ongoingScopes$
-      .pipe(
-        filter(
-          (ongoingScopes) =>
-            ongoingScopes && this.areReady(scopes, ongoingScopes)
-        ),
-        take(1),
-        mapTo(this.config)
-      )
-      .toPromise();
+    return this.ongoingScopes$.pipe(
+      filter(
+        (ongoingScopes) => ongoingScopes && this.areReady(scopes, ongoingScopes)
+      ),
+      take(1),
+      mapTo(this.config)
+    );
+  }
+
+  /**
+   * @deprecated since 3.0, use getStable() instead
+   */
+  async getStableConfig(...scopes: string[]): Promise<any> {
+    return this.getStable(...scopes).toPromise();
   }
 
   /**

--- a/projects/storefrontlib/src/cms-structure/services/feature-modules.service.spec.ts
+++ b/projects/storefrontlib/src/cms-structure/services/feature-modules.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@spartacus/core';
 import { InjectionToken, NgModule } from '@angular/core';
 import { take } from 'rxjs/operators';
+import { of } from 'rxjs/internal/observable/of';
 
 const mockCmsConfig: CmsConfig = {
   featureModules: {
@@ -27,8 +28,8 @@ const mockCmsConfig: CmsConfig = {
 
 class MockConfigInitializerService
   implements Partial<ConfigInitializerService> {
-  async getStableConfig() {
-    return mockCmsConfig;
+  getStable() {
+    return of(mockCmsConfig);
   }
 }
 

--- a/projects/storefrontlib/src/cms-structure/services/feature-modules.service.ts
+++ b/projects/storefrontlib/src/cms-structure/services/feature-modules.service.ts
@@ -53,22 +53,20 @@ export class FeatureModulesService implements OnDestroy {
     this.initFeatureMap();
   }
 
-  private async initFeatureMap(): Promise<void> {
-    const config: CmsConfig = await this.configInitializer.getStableConfig(
-      'featureModules'
-    );
+  private initFeatureMap(): void {
+    this.configInitializer.getStable('featureModules').subscribe((config) => {
+      this.featureModulesConfig = config.featureModules ?? {};
 
-    this.featureModulesConfig = config.featureModules ?? {};
-
-    for (const [featureName, featureConfig] of Object.entries(
-      this.featureModulesConfig
-    )) {
-      if (featureConfig?.module && featureConfig?.cmsComponents?.length) {
-        for (const component of featureConfig.cmsComponents) {
-          this.componentFeatureMap.set(component, featureName);
+      for (const [featureName, featureConfig] of Object.entries(
+        this.featureModulesConfig
+      )) {
+        if (featureConfig?.module && featureConfig?.cmsComponents?.length) {
+          for (const component of featureConfig.cmsComponents) {
+            this.componentFeatureMap.set(component, featureName);
+          }
         }
       }
-    }
+    });
   }
 
   /**


### PR DESCRIPTION
Backport of #10425 for 3.0.x

We are aiming to have consistent API and favor Observables over Promises.

This is also helpful in fixing some asynchronous issues, as observables can return results synchronously if available.

Closes #10421