### PR TITLE
fix: show global message when no customerId provided on session start

### DIFF
--- a/projects/assets/src/translations/en/asm.ts
+++ b/projects/assets/src/translations/en/asm.ts
@@ -38,5 +38,9 @@ export const asm = {
       agentLoggedInError:
         'Cannot login as user when there is an active CS agent session. Please either emulate user or logout CS agent.',
     },
+    error: {
+      noCustomerId:
+        'No customerId found for selected user. Session cannot be started.',
+    },
   },
 };

--- a/projects/storefrontlib/src/cms-components/asm/asm-main-ui/asm-main-ui.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/asm/asm-main-ui/asm-main-ui.component.spec.ts
@@ -85,6 +85,7 @@ class MockCustomerEmulationComponent {}
 
 class MockGlobalMessageService implements Partial<GlobalMessageService> {
   remove() {}
+  add() {}
 }
 
 class MockRoutingService implements Partial<RoutingService> {
@@ -197,6 +198,18 @@ describe('AsmMainUiComponent', () => {
     expect(
       csAgentAuthService.startCustomerEmulationSession
     ).toHaveBeenCalledWith(testCustomerId);
+  });
+
+  it('should not call authService.startCustomerEmulationSession() when customerId is undefined', () => {
+    spyOn(csAgentAuthService, 'startCustomerEmulationSession').and.stub();
+    spyOn(globalMessageService, 'add').and.stub();
+
+    component.startCustomerEmulationSession({ customerId: undefined });
+
+    expect(globalMessageService.add).toHaveBeenCalled();
+    expect(
+      csAgentAuthService.startCustomerEmulationSession
+    ).not.toHaveBeenCalled();
   });
 
   it('should display the login form by default and when the collapse state is false', () => {

--- a/projects/storefrontlib/src/cms-components/asm/asm-main-ui/asm-main-ui.component.ts
+++ b/projects/storefrontlib/src/cms-components/asm/asm-main-ui/asm-main-ui.component.ts
@@ -90,8 +90,15 @@ export class AsmMainUiComponent implements OnInit {
   }
 
   startCustomerEmulationSession({ customerId }: { customerId: string }): void {
-    this.csAgentAuthService.startCustomerEmulationSession(customerId);
-    this.startingCustomerSession = true;
+    if (customerId) {
+      this.csAgentAuthService.startCustomerEmulationSession(customerId);
+      this.startingCustomerSession = true;
+    } else {
+      this.globalMessageService.add(
+        { key: 'asm.error.noCustomerId' },
+        GlobalMessageType.MSG_TYPE_ERROR
+      );
+    }
   }
 
   hideUi(): void {


### PR DESCRIPTION
Closes: #10244