### PR TITLE
feat: Expose core style capabilities

### DIFF
--- a/extra-webpack.config.js
+++ b/extra-webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const path = require('path');
 
 const keyPrefix = 'SPARTACUS_';
 
@@ -18,4 +19,9 @@ module.exports = {
       'build.process.env': env,
     }),
   ],
+  resolve: {
+    alias: {
+      '@spartacus/styles': path.join(__dirname, 'projects/storefrontstyles'),
+    },
+  },
 };

--- a/projects/storefrontapp/src/styles.scss
+++ b/projects/storefrontapp/src/styles.scss
@@ -1,6 +1,4 @@
-// Spartacus Application styles
-
 // Always bump to the latest (breaking) styles during development.
 $useLatestStyles: true;
 
-@import 'storefrontstyles/index';
+@import '@spartacus/styles';

--- a/projects/storefrontstyles/_index.scss
+++ b/projects/storefrontstyles/_index.scss
@@ -1,3 +1,4 @@
+@import 'scss/core';
 @import 'scss/app';
 @import 'scss/root';
 @import 'scss/page-template';

--- a/projects/storefrontstyles/scss/_core.scss
+++ b/projects/storefrontstyles/scss/_core.scss
@@ -1,0 +1,4 @@
+@import 'versioning';
+@import 'functions';
+@import 'mixins';
+@import 'theme';

--- a/projects/storefrontstyles/scss/app.scss
+++ b/projects/storefrontstyles/scss/app.scss
@@ -1,15 +1,7 @@
-// provide non-breaking versioning in the style layer
-@import 'versioning';
-
-//Functions and mixins
-@import 'functions';
-@import 'mixins';
-//Bring in the theme
-@import 'theme';
 //Fonts must be added separate from the theme
 @import 'fonts';
 
-//Bootsrap modules (these are things we are NOT changing at all)
+// Bootstrap modules (these are things we are NOT changing at all)
 @import '~bootstrap/scss/reboot';
 @import '~bootstrap/scss/type';
 @import '~bootstrap/scss/grid';
@@ -24,7 +16,7 @@
 // new
 @import 'cxbase/index';
 
-//bootsrap enhancements (these are things we ARE changing)
+//bootstrap enhancements (these are things we ARE changing)
 @import 'cxbase/blocks/buttons';
 @import 'cxbase/blocks/forms';
 @import 'cxbase/blocks/modal';


### PR DESCRIPTION
To unblock feature libraries to reuse core style capabillities we introduce a core scss file that holds the basic variables, mixins and functions for other libraries to use. 

closes #10441