### PR TITLE
fix: Handle missing `occ.baseUrl` in `AuthConfigService` (#10437)

### DIFF
--- a/projects/core/src/auth/user-auth/config/base-url-config-validator.spec.ts
+++ b/projects/core/src/auth/user-auth/config/base-url-config-validator.spec.ts
@@ -1,0 +1,47 @@
+import { OccConfig } from '../../../occ/config/occ-config';
+import { AuthConfig } from './auth-config';
+import { baseUrlConfigValidator } from './base-url-config-validator';
+
+describe('baseUrlConfigValidator', () => {
+  it('should warn when occ and auth baseUrl is not set', () => {
+    const config: OccConfig & AuthConfig = {
+      backend: {},
+      authentication: {},
+    };
+    expect(baseUrlConfigValidator(config)).toBeTruthy();
+  });
+
+  it('should not warn when auth baseUrl is set', () => {
+    const config: OccConfig & AuthConfig = {
+      backend: {},
+      authentication: {
+        baseUrl: 'http://authserver.com',
+      },
+    };
+    expect(baseUrlConfigValidator(config)).toBeFalsy();
+  });
+
+  it('should not warn when occ baseUrl is set', () => {
+    const config: OccConfig & AuthConfig = {
+      backend: {
+        occ: {
+          baseUrl: 'http://baseurl.com',
+        },
+      },
+      authentication: {},
+    };
+    expect(baseUrlConfigValidator(config)).toBeFalsy();
+  });
+
+  it('should not warn when requireHttps option is set to false', () => {
+    const config: OccConfig & AuthConfig = {
+      backend: {},
+      authentication: {
+        OAuthLibConfig: {
+          requireHttps: false,
+        },
+      },
+    };
+    expect(baseUrlConfigValidator(config)).toBeFalsy();
+  });
+});

--- a/projects/core/src/auth/user-auth/config/base-url-config-validator.ts
+++ b/projects/core/src/auth/user-auth/config/base-url-config-validator.ts
@@ -1,0 +1,13 @@
+import { OccConfig } from '../../../occ/config/occ-config';
+import { AuthConfig } from './auth-config';
+
+export function baseUrlConfigValidator(config: OccConfig & AuthConfig) {
+  if (
+    typeof config?.authentication?.baseUrl === 'undefined' &&
+    typeof config?.backend?.occ?.baseUrl === 'undefined' &&
+    // Don't show warning when user tries to work around the issue.
+    config?.authentication?.OAuthLibConfig?.requireHttps !== false
+  ) {
+    return 'Authentication might not work correctly without setting either authentication.baseUrl or backend.occ.baseUrl configuration option! Workaround: To support relative urls in angular-oauth2-oidc library you can try setting authentication.OAuthLibConfig.requireHttps to false.';
+  }
+}

--- a/projects/core/src/auth/user-auth/services/auth-config.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/auth-config.service.spec.ts
@@ -32,6 +32,7 @@ const mockOccConfig: OccConfig = {
 describe('AuthConfigService', () => {
   let service: AuthConfigService;
   let authConfig: AuthConfig;
+  let occConfig: OccConfig;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -44,13 +45,14 @@ describe('AuthConfigService', () => {
         },
         {
           provide: OccConfig,
-          useValue: mockOccConfig,
+          useValue: JSON.parse(JSON.stringify(mockOccConfig)),
         },
       ],
     });
 
     service = TestBed.inject(AuthConfigService);
     authConfig = TestBed.inject(AuthConfig);
+    occConfig = TestBed.inject(OccConfig);
   });
 
   it('should inject service', () => {
@@ -77,6 +79,12 @@ describe('AuthConfigService', () => {
     it('should return baseUrl based on occ baseUrl, when auth baseUrl is not provided', () => {
       authConfig.authentication.baseUrl = undefined;
       expect(service.getBaseUrl()).toEqual('occBaseUrl/authorizationserver');
+    });
+
+    it('should return relative url when both occ baseUrl and auth baseUrl are not provided', () => {
+      authConfig.authentication.baseUrl = undefined;
+      occConfig.backend = undefined;
+      expect(service.getBaseUrl()).toEqual('/authorizationserver');
     });
   });
 

--- a/projects/core/src/auth/user-auth/services/auth-config.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-config.service.ts
@@ -18,12 +18,19 @@ export class AuthConfigService {
   ) {}
 
   /**
+   * Utility to make access to authentication config easier.
+   */
+  private get config(): AuthConfig['authentication'] {
+    return this.authConfig?.authentication ?? {};
+  }
+
+  /**
    * Get client_id
    *
    * @return client_id
    */
   public getClientId(): string {
-    return this.authConfig.authentication.client_id ?? '';
+    return this.config.client_id ?? '';
   }
 
   /**
@@ -32,7 +39,7 @@ export class AuthConfigService {
    * @return client_secret
    */
   public getClientSecret(): string {
-    return this.authConfig.authentication.client_secret ?? '';
+    return this.config.client_secret ?? '';
   }
 
   /**
@@ -40,8 +47,8 @@ export class AuthConfigService {
    */
   public getBaseUrl(): string {
     return (
-      this.authConfig.authentication.baseUrl ??
-      this.occConfig.backend.occ.baseUrl + '/authorizationserver'
+      this.config.baseUrl ??
+      (this.occConfig?.backend?.occ?.baseUrl ?? '') + '/authorizationserver'
     );
   }
 
@@ -49,7 +56,7 @@ export class AuthConfigService {
    * Returns endpoint for getting the auth token
    */
   public getTokenEndpoint(): string {
-    const tokenEndpoint = this.authConfig.authentication.tokenEndpoint ?? '';
+    const tokenEndpoint = this.config.tokenEndpoint ?? '';
     return this.prefixEndpoint(tokenEndpoint);
   }
 
@@ -57,7 +64,7 @@ export class AuthConfigService {
    * Returns url for redirect to the authorization server to get token/code
    */
   public getLoginUrl(): string {
-    const loginUrl = this.authConfig.authentication.loginUrl ?? '';
+    const loginUrl = this.config.loginUrl ?? '';
     return this.prefixEndpoint(loginUrl);
   }
 
@@ -65,7 +72,7 @@ export class AuthConfigService {
    * Returns endpoint for token revocation (both access and refresh token).
    */
   public getRevokeEndpoint(): string {
-    const revokeEndpoint = this.authConfig.authentication.revokeEndpoint ?? '';
+    const revokeEndpoint = this.config.revokeEndpoint ?? '';
     return this.prefixEndpoint(revokeEndpoint);
   }
 
@@ -73,7 +80,7 @@ export class AuthConfigService {
    * Returns logout url to redirect to on logout.
    */
   public getLogoutUrl(): string {
-    const logoutUrl = this.authConfig.authentication.logoutUrl ?? '';
+    const logoutUrl = this.config.logoutUrl ?? '';
     return this.prefixEndpoint(logoutUrl);
   }
 
@@ -81,8 +88,7 @@ export class AuthConfigService {
    * Returns userinfo endpoint of the OAuth server.
    */
   public getUserinfoEndpoint(): string {
-    const userinfoEndpoint =
-      this.authConfig.authentication.userinfoEndpoint ?? '';
+    const userinfoEndpoint = this.config.userinfoEndpoint ?? '';
     return this.prefixEndpoint(userinfoEndpoint);
   }
 
@@ -90,7 +96,7 @@ export class AuthConfigService {
    * Returns configuration specific for the angular-oauth2-oidc library.
    */
   public getOAuthLibConfig(): AuthLibConfig {
-    return this.authConfig.authentication?.OAuthLibConfig ?? {};
+    return this.config.OAuthLibConfig ?? {};
   }
 
   protected prefixEndpoint(endpoint: string): string {
@@ -106,8 +112,7 @@ export class AuthConfigService {
    * Use when you have to perform particular action only in some of the OAuth flow scenarios.
    */
   public getOAuthFlow(): OAuthFlow {
-    const responseType = this.authConfig.authentication?.OAuthLibConfig
-      ?.responseType;
+    const responseType = this.config.OAuthLibConfig?.responseType;
     if (responseType) {
       const types = responseType.split(' ');
       if (types.includes('code')) {

--- a/projects/core/src/auth/user-auth/user-auth.module.ts
+++ b/projects/core/src/auth/user-auth/user-auth.module.ts
@@ -3,6 +3,8 @@ import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { provideDefaultConfig } from '../../config/config-providers';
+import { provideConfigValidator } from '../../config/config-validator/config-validator';
+import { baseUrlConfigValidator } from './config/base-url-config-validator';
 import { defaultAuthConfig } from './config/default-auth-config';
 import { AuthService } from './facade/auth.service';
 import { interceptors } from './http-interceptors/index';
@@ -45,6 +47,7 @@ export class UserAuthModule {
       ngModule: UserAuthModule,
       providers: [
         provideDefaultConfig(defaultAuthConfig),
+        provideConfigValidator(baseUrlConfigValidator),
         ...interceptors,
         {
           provide: OAuthStorage,


### PR DESCRIPTION
Closes #10436