### PR TITLE
workaround: App hangs for invalid URLs

### DIFF
--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { cdcFeature } from '../environments/cdc/cdc.feature';
 import { cdsFeature } from '../environments/cds/cds.feature';
 import { environment } from '../environments/environment';
 import { TestOutletModule } from '../test-outlets/test-outlet.module';
+import { routerFixProvider } from './router-fix';
 
 registerLocaleData(localeDe);
 registerLocaleData(localeJa);
@@ -85,6 +86,7 @@ if (environment.cdc) {
 
     ...devImports,
   ],
+  providers: [routerFixProvider],
 
   bootstrap: [StorefrontComponent],
 })

--- a/projects/storefrontapp/src/app/router-fix.ts
+++ b/projects/storefrontapp/src/app/router-fix.ts
@@ -1,0 +1,44 @@
+import { Injectable, Injector, Provider } from '@angular/core';
+import {
+  NavigationError,
+  Router,
+  ROUTER_CONFIGURATION,
+  ɵangular_packages_router_router_h as RouterInitializer,
+} from '@angular/router';
+import { filter, take } from 'rxjs/operators';
+
+@Injectable()
+export class CustomRouterInitializer extends RouterInitializer {
+  appInitializer(): Promise<any> {
+    const injector: Injector = (this as any).injector;
+    const opts = injector.get(ROUTER_CONFIGURATION);
+
+    if (
+      opts.initialNavigation ===
+      'enabled' /* for Ng11: || opts.initialNavigation === 'enabledBlocking' */
+    ) {
+      let resolve: any;
+      const res = new Promise((r) => (resolve = r));
+
+      injector
+        .get(Router)
+        .events.pipe(
+          // We want to explicitly react on NavigationError event occurs just
+          // after the first navigation start event
+          take(2),
+          filter((event) => event instanceof NavigationError)
+        )
+        .subscribe(() => resolve(false));
+
+      super.appInitializer().then((val) => resolve(val));
+      return res;
+    }
+
+    return super.appInitializer();
+  }
+}
+
+export const routerFixProvider: Provider = {
+  provide: RouterInitializer,
+  useClass: CustomRouterInitializer,
+};


### PR DESCRIPTION
Possible workaround for the #10540 bug, which is caused by an issue in the Angular Router.

Fixes #10540