### PR TITLE
feat: update AttributeOverview interface

### DIFF
--- a/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
+++ b/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
@@ -1,6 +1,11 @@
 import { CommonConfigurator } from '@spartacus/product-configurator/common';
 
 export namespace Configurator {
+  export enum AttributeOverviewType {
+    GENERAL = 'general',
+    BUNDLE = 'bundle',
+  }
+
   export interface Attribute {
     attrCode?: number;
     name: string;
@@ -93,6 +98,8 @@ export namespace Configurator {
   export interface AttributeOverview {
     attribute: string;
     value: string;
+    productCode?: string;
+    type?: AttributeOverviewType;
   }
 
   export interface PriceSummary {

--- a/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
+++ b/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
@@ -1,11 +1,6 @@
 import { CommonConfigurator } from '@spartacus/product-configurator/common';
 
 export namespace Configurator {
-  export enum AttributeOverviewType {
-    GENERAL = 'general',
-    BUNDLE = 'bundle',
-  }
-
   export interface Attribute {
     attrCode?: number;
     name: string;
@@ -194,5 +189,10 @@ export namespace Configurator {
     ATTRIBUTE = 'Attribute',
     ATTRIBUTE_QUANTITY = 'AttributeQuantity',
     VALUE_QUANTITY = 'ValueQuantity',
+  }
+
+  export enum AttributeOverviewType {
+    GENERAL = 'general',
+    BUNDLE = 'bundle',
   }
 }

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.spec.ts
@@ -147,13 +147,14 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
   });
 
   it('should map attribute type GENREAL', () => {
+    attr.values = singleSelectionValues;
     expect(serviceUnderTest['convertAttribute'](attr)[0].type).toEqual(
       Configurator.AttributeOverviewType.GENERAL
     );
   });
 
   it('should map attribute type BUNDLE', () => {
-    attr.isLineItem = true;
+    attr.values = singleSelectionProductValues;
     expect(serviceUnderTest['convertAttribute'](attr)[0].type).toEqual(
       Configurator.AttributeOverviewType.BUNDLE
     );

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.spec.ts
@@ -1,5 +1,6 @@
 import { Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { Configurator } from '../core/model/configurator.model';
 import { CpqConfiguratorOverviewNormalizer } from './cpq-configurator-overview-normalizer';
 import { Cpq } from './cpq.models';
 
@@ -26,15 +27,30 @@ const input: Cpq.Configuration = {
 };
 
 const singleSelectionValues: Cpq.Value[] = [
-  { paV_ID: 1, productSystemId: 'another value', selected: false },
-  { paV_ID: 2, productSystemId: 'selected value', selected: true },
-  { paV_ID: 3, productSystemId: 'yet another value', selected: false },
+  { paV_ID: 1, valueDisplay: 'another value', selected: false },
+  { paV_ID: 2, valueDisplay: 'selected value', selected: true },
+  { paV_ID: 3, valueDisplay: 'yet another value', selected: false },
 ];
 
 const singleSelectionProductValues: Cpq.Value[] = [
-  { paV_ID: 1, productSystemId: 'another product', selected: false },
-  { paV_ID: 2, productSystemId: 'selected product', selected: true },
-  { paV_ID: 3, productSystemId: 'yet another product', selected: false },
+  {
+    paV_ID: 1,
+    valueDisplay: 'another product',
+    productSystemId: 'pCode1',
+    selected: false,
+  },
+  {
+    paV_ID: 2,
+    valueDisplay: 'selected product',
+    productSystemId: 'pCode2',
+    selected: true,
+  },
+  {
+    paV_ID: 3,
+    valueDisplay: 'yet another product',
+    productSystemId: 'pCode3',
+    selected: false,
+  },
 ];
 
 const multiSelectionValues: Cpq.Value[] = [
@@ -45,12 +61,28 @@ const multiSelectionValues: Cpq.Value[] = [
 ];
 
 const multiSelectionProductValues: Cpq.Value[] = [
-  { paV_ID: 1, productSystemId: 'another product', selected: false },
-  { paV_ID: 2, productSystemId: 'selected product', selected: true },
-  { paV_ID: 3, productSystemId: 'yet another product', selected: false },
+  {
+    paV_ID: 1,
+    valueDisplay: 'another product',
+    productSystemId: 'pCode1',
+    selected: false,
+  },
+  {
+    paV_ID: 2,
+    valueDisplay: 'selected product',
+    productSystemId: 'pCode2',
+    selected: true,
+  },
+  {
+    paV_ID: 3,
+    valueDisplay: 'yet another product',
+    productSystemId: 'pCode3',
+    selected: false,
+  },
   {
     paV_ID: 4,
-    productSystemId: 'another selected product',
+    valueDisplay: 'another selected product',
+    productSystemId: 'pCode4',
     selected: true,
   },
 ];
@@ -101,69 +133,103 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
   });
 
   it('should map attribute name', () => {
-    expect(serviceUnderTest['convertAttribute'](attr).attribute).toEqual(
+    expect(serviceUnderTest['convertAttribute'](attr)[0].attribute).toEqual(
       ATTR_NAME
+    );
+  });
+
+  it('should map attribute name only for first value', () => {
+    attr.values = multiSelectionValues;
+    attr.displayAs = Cpq.DisplayAs.CHECK_BOX;
+    const ovAttrs = serviceUnderTest['convertAttribute'](attr);
+    expect(ovAttrs[0].attribute).toEqual(ATTR_NAME);
+    expect(ovAttrs[1].attribute).toBeUndefined();
+  });
+
+  it('should map attribute type GENREAL', () => {
+    expect(serviceUnderTest['convertAttribute'](attr)[0].type).toEqual(
+      Configurator.AttributeOverviewType.GENERAL
+    );
+  });
+
+  it('should map attribute type BUNDLE', () => {
+    attr.isLineItem = true;
+    expect(serviceUnderTest['convertAttribute'](attr)[0].type).toEqual(
+      Configurator.AttributeOverviewType.BUNDLE
     );
   });
 
   it('should map user input as attribute value', () => {
     attr.userInput = 'input';
     attr.displayAs = Cpq.DisplayAs.INPUT;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual('input');
+    const ovAttrs = serviceUnderTest['convertAttribute'](attr);
+    expect(ovAttrs.length).toBe(1);
+    expect(ovAttrs[0].value).toEqual('input');
+    expect(ovAttrs[0].productCode).toBeUndefined();
   });
 
   it('should map RB selected value', () => {
     attr.values = singleSelectionValues;
     attr.displayAs = Cpq.DisplayAs.RADIO_BUTTON;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual(
-      'selected value'
-    );
+    const ovAttrs = serviceUnderTest['convertAttribute'](attr);
+    expect(ovAttrs.length).toBe(1);
+    expect(ovAttrs[0].value).toEqual('selected value');
+    expect(ovAttrs[0].productCode).toBeUndefined();
   });
 
   it('should map RB selected product', () => {
     attr.values = singleSelectionProductValues;
     attr.displayAs = Cpq.DisplayAs.RADIO_BUTTON;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual(
-      'selected product'
-    );
+    const ovAttrs = serviceUnderTest['convertAttribute'](attr);
+    expect(ovAttrs.length).toBe(1);
+    expect(ovAttrs[0].value).toEqual('selected product');
+    expect(ovAttrs[0].productCode).toEqual('pCode2');
   });
 
   it('should map ReadOnly selected value', () => {
     attr.values = singleSelectionValues;
     attr.displayAs = Cpq.DisplayAs.READ_ONLY;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual(
-      'selected value'
-    );
+    const ovAttrs = serviceUnderTest['convertAttribute'](attr);
+    expect(ovAttrs.length).toBe(1);
+    expect(ovAttrs[0].value).toEqual('selected value');
+    expect(ovAttrs[0].productCode).toBeUndefined();
   });
 
   it('should map DDLB selected value', () => {
     attr.values = singleSelectionValues;
     attr.displayAs = Cpq.DisplayAs.DROPDOWN;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual(
-      'selected value'
-    );
+    const ovAttrs = serviceUnderTest['convertAttribute'](attr);
+    expect(ovAttrs.length).toBe(1);
+    expect(ovAttrs[0].value).toEqual('selected value');
+    expect(ovAttrs[0].productCode).toBeUndefined();
   });
 
   it('should map CHECK_BOX selected values', () => {
     attr.values = multiSelectionValues;
     attr.displayAs = Cpq.DisplayAs.CHECK_BOX;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual(
-      'selected value, another selected value'
-    );
+    const ovAttrs = serviceUnderTest['convertAttribute'](attr);
+    expect(ovAttrs.length).toBe(2);
+    expect(ovAttrs[0].value).toEqual('selected value');
+    expect(ovAttrs[1].value).toEqual('another selected value');
+    expect(ovAttrs[0].productCode).toBeUndefined();
+    expect(ovAttrs[1].productCode).toBeUndefined();
   });
 
   it('should map CHECK_BOX selected products', () => {
     attr.values = multiSelectionProductValues;
     attr.displayAs = Cpq.DisplayAs.CHECK_BOX;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual(
-      'selected product, another selected product'
-    );
+    const ovAttrs = serviceUnderTest['convertAttribute'](attr);
+    expect(ovAttrs.length).toBe(2);
+    expect(ovAttrs[0].value).toEqual('selected product');
+    expect(ovAttrs[1].value).toEqual('another selected product');
+    expect(ovAttrs[0].productCode).toEqual('pCode2');
+    expect(ovAttrs[1].productCode).toEqual('pCode4');
   });
 
   it('should map LIST_BOX as not implemented', () => {
     attr.values = multiSelectionValues;
     attr.displayAs = Cpq.DisplayAs.LIST_BOX;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual(
+    expect(serviceUnderTest['convertAttribute'](attr)[0].value).toEqual(
       'NOT_IMPLEMENTED'
     );
   });
@@ -171,7 +237,7 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
   it('should map LIST_BOX_MULTI as not implemented', () => {
     attr.values = multiSelectionValues;
     attr.displayAs = Cpq.DisplayAs.LIST_BOX_MULTI;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual(
+    expect(serviceUnderTest['convertAttribute'](attr)[0].value).toEqual(
       'NOT_IMPLEMENTED'
     );
   });
@@ -179,7 +245,7 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
   it('should map AUTO_COMPLETE_CUSTOM as not implemented', () => {
     attr.values = multiSelectionValues;
     attr.displayAs = Cpq.DisplayAs.AUTO_COMPLETE_CUSTOM;
-    expect(serviceUnderTest['convertAttribute'](attr).value).toEqual(
+    expect(serviceUnderTest['convertAttribute'](attr)[0].value).toEqual(
       'NOT_IMPLEMENTED'
     );
   });

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.ts
@@ -22,57 +22,71 @@ export class CpqConfiguratorOverviewNormalizer
   }
 
   protected convertTab(tab: Cpq.Tab): Configurator.GroupOverview {
+    let ovAttributes = [];
+    tab.attributes?.forEach((attr) => {
+      ovAttributes = ovAttributes.concat(this.convertAttribute(attr));
+    });
+
     return {
       id: tab.id.toString(),
       groupDescription: tab.name,
-      attributes: tab.attributes?.flatMap((attr) =>
-        this.convertAttribute(attr)
-      ),
+      attributes: ovAttributes,
     };
   }
 
   protected convertAttribute(
     attr: Cpq.Attribute
-  ): Configurator.AttributeOverview {
-    return {
-      attribute: attr.name,
-      value: this.convertAttributeValue(attr),
-    };
+  ): Configurator.AttributeOverview[] {
+    const ovAttr: Configurator.AttributeOverview[] = [];
+    this.convertAttributeValue(attr).forEach((ovValue) => {
+      ovAttr.push({
+        attribute: undefined,
+        value: ovValue.value,
+        productCode: ovValue.productCode,
+        type: attr.isLineItem
+          ? Configurator.AttributeOverviewType.BUNDLE
+          : Configurator.AttributeOverviewType.GENERAL,
+      });
+    });
+    if (ovAttr.length > 0) {
+      ovAttr[0].attribute = attr.name;
+    }
+    return ovAttr;
   }
 
-  protected convertAttributeValue(attr: Cpq.Attribute): string {
-    let ovValue;
+  protected convertAttributeValue(
+    attr: Cpq.Attribute
+  ): { value: string; productCode?: string }[] {
+    const ovValues: { value: string; productCode?: string }[] = [];
     switch (attr.displayAs) {
       case Cpq.DisplayAs.INPUT:
-        ovValue = attr.userInput;
+        ovValues.push({ value: attr.userInput });
         break;
       case Cpq.DisplayAs.RADIO_BUTTON:
       case Cpq.DisplayAs.READ_ONLY:
       case Cpq.DisplayAs.DROPDOWN:
-        ovValue = this.getProductOrDisplayValue(
-          attr.values?.find((val) => val.selected)
-        );
+        const selectedValue = attr.values?.find((val) => val.selected);
+        if (selectedValue) {
+          ovValues.push({
+            value: selectedValue.valueDisplay,
+            productCode: selectedValue.productSystemId,
+          });
+        }
         break;
       case Cpq.DisplayAs.CHECK_BOX:
-        const OV_VALUE_SEP = ', ';
         attr.values
           ?.filter((val) => val.selected)
-          ?.forEach((val) => {
-            ovValue = ovValue
-              ? ovValue + OV_VALUE_SEP + this.getProductOrDisplayValue(val)
-              : this.getProductOrDisplayValue(val);
+          ?.forEach((valueSelected) => {
+            ovValues.push({
+              value: valueSelected.valueDisplay,
+              productCode: valueSelected.productSystemId,
+            });
           });
         break;
       default:
-        ovValue = 'NOT_IMPLEMENTED';
+        ovValues.push({ value: 'NOT_IMPLEMENTED' });
     }
-    return ovValue;
-  }
-
-  protected getProductOrDisplayValue(selectedValue: Cpq.Value): any {
-    return selectedValue?.productSystemId
-      ? selectedValue?.productSystemId
-      : selectedValue?.valueDisplay;
+    return ovValues;
   }
 
   protected calculateTotalNumberOfIssues(source: Cpq.Configuration): number {

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.ts
@@ -67,26 +67,29 @@ export class CpqConfiguratorOverviewNormalizer
       case Cpq.DisplayAs.DROPDOWN:
         const selectedValue = attr.values?.find((val) => val.selected);
         if (selectedValue) {
-          ovValues.push({
-            value: selectedValue.valueDisplay,
-            productCode: selectedValue.productSystemId,
-          });
+          ovValues.push(this.extractOvValue(selectedValue));
         }
         break;
       case Cpq.DisplayAs.CHECK_BOX:
         attr.values
           ?.filter((val) => val.selected)
           ?.forEach((valueSelected) => {
-            ovValues.push({
-              value: valueSelected.valueDisplay,
-              productCode: valueSelected.productSystemId,
-            });
+            ovValues.push(this.extractOvValue(valueSelected));
           });
         break;
       default:
         ovValues.push({ value: 'NOT_IMPLEMENTED' });
     }
     return ovValues;
+  }
+
+  protected extractOvValue(
+    valueSelected: Cpq.Value
+  ): { value: string; productCode?: string } {
+    return {
+      value: valueSelected.valueDisplay,
+      productCode: valueSelected.productSystemId,
+    };
   }
 
   protected calculateTotalNumberOfIssues(source: Cpq.Configuration): number {

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.ts
@@ -43,7 +43,7 @@ export class CpqConfiguratorOverviewNormalizer
         attribute: undefined,
         value: ovValue.value,
         productCode: ovValue.productCode,
-        type: attr.isLineItem
+        type: ovValue.productCode
           ? Configurator.AttributeOverviewType.BUNDLE
           : Configurator.AttributeOverviewType.GENERAL,
       });


### PR DESCRIPTION
[GH-10479] Prepare overview model with bundle data 
enhance overview model with productCode and and overviewType required for bundles.
existing normalizer logic adapted for multi value attributes. Instead of creating one attribute with comma separated values, for each value a new overview attribute is created, which is the intended proper modelling for multivalued attributes on the OV page.
