### PR TITLE
Feature/gh 10350 move routing

### DIFF
--- a/feature-libs/product-configurator/rulebased/root/default-rulebased-routing-config.ts
+++ b/feature-libs/product-configurator/rulebased/root/default-rulebased-routing-config.ts
@@ -12,6 +12,15 @@ export const defaultRulebasedRoutingConfig: RoutingConfig = {
           'configure-overview/vc/:ownerType/entityKey/:entityKey',
         ],
       },
+      configureCLOUDCPQCONFIGURATOR: {
+        paths: ['configure/cpq/:ownerType/entityKey/:entityKey'],
+      },
+      configureOverviewCLOUDCPQCONFIGURATOR: {
+        paths: [
+          'configure-overview/cpq/:ownerType/entityKey/:entityKey/displayOnly/:displayOnly',
+          'configure-overview/cpq/:ownerType/entityKey/:entityKey',
+        ],
+      },
     },
   },
 };

--- a/projects/storefrontlib/src/cms-structure/routing/default-routing-config.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/default-routing-config.ts
@@ -73,15 +73,6 @@ export const defaultStorefrontRoutesConfig: RoutesConfig = {
     paths: ['my-account/coupon/claim/:couponCode'],
     paramsMapping: { couponCode: 'code' },
   },
-  configureCLOUDCPQCONFIGURATOR: {
-    paths: ['configure/cpq/:ownerType/entityKey/:entityKey'],
-  },
-  configureOverviewCLOUDCPQCONFIGURATOR: {
-    paths: [
-      'configure-overview/cpq/:ownerType/entityKey/:entityKey/displayOnly/:displayOnly',
-      'configure-overview/cpq/:ownerType/entityKey/:entityKey',
-    ],
-  },
   replenishmentOrders: {
     paths: ['my-account/my-replenishments'],
   },


### PR DESCRIPTION
[GH-10350] moves default routing for CPQ configurator from storefront lib to rulebased-configurator module. As the necessary infrastructure for this was already created  when this was done for the variant configurator, this change is rather trivial.