### PR TITLE
fix: absolute media url starting with double slash

### DIFF
--- a/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.spec.ts
@@ -72,6 +72,9 @@ const mockUrlContainer = {
   absolute: {
     url: 'http://absolute.jpg',
   },
+  doubleSlash: {
+    url: '//absolute.jpg',
+  },
   relative: {
     url: 'relative.jpg',
   },
@@ -234,6 +237,12 @@ describe('MediaService', () => {
       it('should avoid baseUrl if absolute image is provided', () => {
         expect(mediaService.getMedia(mockUrlContainer, 'absolute').src).toBe(
           'http://absolute.jpg'
+        );
+      });
+
+      it('should threat image url start with double slash as absolute URL', () => {
+        expect(mediaService.getMedia(mockUrlContainer, 'doubleSlash').src).toBe(
+          '//absolute.jpg'
         );
       });
 

--- a/projects/storefrontlib/src/shared/components/media/media.service.ts
+++ b/projects/storefrontlib/src/shared/components/media/media.service.ts
@@ -183,12 +183,14 @@ export class MediaService {
   /**
    * Resolves the absolute URL for the given url. In most cases, this URL represents
    * the relative URL on the backend. In that case, we prefix the url with the baseUrl.
+   *
+   * When we have receive an absolute URL, we return the URL as-is. An absolute URL might also
+   * start with double slash, which is used to resolve media cross from http and https.
    */
   protected resolveAbsoluteUrl(url: string): string {
-    if (!url) {
-      return null;
-    }
-    return url.startsWith('http') ? url : this.getBaseUrl() + url;
+    return !url || url.startsWith('http') || url.startsWith('//')
+      ? url
+      : this.getBaseUrl() + url;
   }
 
   /**


### PR DESCRIPTION
When media URLs start with a double slash (to accommodate usage cross http and https), these are considered absolute URLs. 

fixes #10711 