### PR TITLE
fix: avoid sharing i18next instance in between SSR requests (for 2.0.x) 

### DIFF
--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -1,11 +1,12 @@
 import { HttpClient } from '@angular/common/http';
-import i18next, { InitOptions } from 'i18next';
+import globalI18next, { i18n, InitOptions } from 'i18next';
 import i18nextXhrBackend from 'i18next-xhr-backend';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
 import { TranslationResources } from '../translation-resources';
 
 export function i18nextInit(
+  i18next: i18n,
   configInit: ConfigInitializerService,
   languageService: LanguageService,
   httpClient: HttpClient,
@@ -13,6 +14,10 @@ export function i18nextInit(
 ): () => Promise<any> {
   return () =>
     configInit.getStableConfig('i18n').then((config) => {
+      // SPIKE TODO REMOVE:
+      window['globalI18next'] = globalI18next;
+      window['i18next'] = i18next;
+
       let i18nextConfig: InitOptions = {
         ns: [], // don't preload any namespaces
         fallbackLng: config.i18n.fallbackLang,
@@ -37,13 +42,16 @@ export function i18nextInit(
       return i18next.init(i18nextConfig, () => {
         // Don't use i18next's 'resources' config key for adding static translations,
         // because it will disable loading chunks from backend. We add resources here, in the init's callback.
-        i18nextAddTranslations(config.i18n.resources);
-        syncI18nextWithSiteContext(languageService);
+        i18nextAddTranslations(i18next, config.i18n.resources);
+        syncI18nextWithSiteContext(i18next, languageService);
       });
     });
 }
 
-export function i18nextAddTranslations(resources: TranslationResources = {}) {
+export function i18nextAddTranslations(
+  i18next: i18n,
+  resources: TranslationResources = {}
+) {
   Object.keys(resources).forEach((lang) => {
     Object.keys(resources[lang]).forEach((chunkName) => {
       i18next.addResourceBundle(
@@ -57,7 +65,10 @@ export function i18nextAddTranslations(resources: TranslationResources = {}) {
   });
 }
 
-export function syncI18nextWithSiteContext(language: LanguageService) {
+export function syncI18nextWithSiteContext(
+  i18next: i18n,
+  language: LanguageService
+) {
   // always update language of i18next on site context (language) change
   language.getActive().subscribe((lang) => i18next.changeLanguage(lang));
 }

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, OnDestroy } from '@angular/core';
-import globalI18next, { i18n, InitOptions } from 'i18next';
+import { i18n, InitOptions } from 'i18next';
 import i18nextXhrBackend from 'i18next-xhr-backend';
 import { Subscription } from 'rxjs';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
@@ -17,10 +17,6 @@ export function i18nextInit(
 ): () => Promise<any> {
   return () =>
     configInit.getStableConfig('i18n').then((config) => {
-      // SPIKE TODO REMOVE:
-      window['globalI18next'] = globalI18next;
-      window['i18next'] = i18next;
-
       let i18nextConfig: InitOptions = {
         ns: [], // don't preload any namespaces
         fallbackLng: config.i18n.fallbackLang,

--- a/projects/core/src/i18n/i18next/i18next-instance.ts
+++ b/projects/core/src/i18n/i18next/i18next-instance.ts
@@ -1,0 +1,16 @@
+import { InjectionToken } from '@angular/core';
+import i18next, { i18n } from 'i18next';
+
+/**
+ * The instance of i18next.
+ *
+ * Each SSR request gets its own instance of i18next.
+ *
+ * The reference to the static global instance of `i18next` (`import i18next from 'i18next`)
+ * should not be used anywhere else, because otherwise it would be shared in between all SSR requests
+ * and can cause concurrency issues.
+ */
+export const I18NEXT_INSTANCE = new InjectionToken<i18n>('I18NEXT_INSTANCE', {
+  providedIn: 'root',
+  factory: () => i18next.createInstance(),
+});

--- a/projects/core/src/i18n/i18next/i18next-instance.ts
+++ b/projects/core/src/i18n/i18next/i18next-instance.ts
@@ -1,5 +1,5 @@
 import { InjectionToken } from '@angular/core';
-import i18next, { i18n } from 'i18next';
+import { i18n } from 'i18next';
 
 /**
  * The instance of i18next.
@@ -10,7 +10,4 @@ import i18next, { i18n } from 'i18next';
  * should not be used anywhere else, because otherwise it would be shared in between all SSR requests
  * and can cause concurrency issues.
  */
-export const I18NEXT_INSTANCE = new InjectionToken<i18n>('I18NEXT_INSTANCE', {
-  providedIn: 'root',
-  factory: () => i18next.createInstance(),
-});
+export const I18NEXT_INSTANCE = new InjectionToken<i18n>('I18NEXT_INSTANCE');

--- a/projects/core/src/i18n/i18next/i18next-instance.ts
+++ b/projects/core/src/i18n/i18next/i18next-instance.ts
@@ -1,5 +1,5 @@
 import { InjectionToken } from '@angular/core';
-import { i18n } from 'i18next';
+import i18next, { i18n } from 'i18next';
 
 /**
  * The instance of i18next.
@@ -10,4 +10,7 @@ import { i18n } from 'i18next';
  * should not be used anywhere else, because otherwise it would be shared in between all SSR requests
  * and can cause concurrency issues.
  */
-export const I18NEXT_INSTANCE = new InjectionToken<i18n>('I18NEXT_INSTANCE');
+export const I18NEXT_INSTANCE = new InjectionToken<i18n>('I18NEXT_INSTANCE', {
+  providedIn: 'root',
+  factory: () => i18next.createInstance(),
+});

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -4,12 +4,14 @@ import { ConfigInitializerService } from '../../config/config-initializer/config
 import { LanguageService } from '../../site-context/facade/language.service';
 import { SERVER_REQUEST_ORIGIN } from '../../ssr/ssr.providers';
 import { i18nextInit } from './i18next-init';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 
 export const i18nextProviders: Provider[] = [
   {
     provide: APP_INITIALIZER,
     useFactory: i18nextInit,
     deps: [
+      I18NEXT_INSTANCE,
       ConfigInitializerService,
       LanguageService,
       HttpClient,

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -1,10 +1,17 @@
 import { HttpClient } from '@angular/common/http';
 import { APP_INITIALIZER, Optional, Provider } from '@angular/core';
+import i18next, { i18n } from 'i18next';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
 import { SERVER_REQUEST_ORIGIN } from '../../ssr/ssr.providers';
 import { i18nextInit, SiteContextI18nextSynchronizer } from './i18next-init';
 import { I18NEXT_INSTANCE } from './i18next-instance';
+
+export function createI18nextInstance(): i18n {
+  // the global `i18next` instance should be used once - only to create
+  // a fresh i18next instance per application bootstrap
+  return i18next.createInstance();
+}
 
 export const i18nextProviders: Provider[] = [
   {
@@ -19,5 +26,9 @@ export const i18nextProviders: Provider[] = [
       SiteContextI18nextSynchronizer,
     ],
     multi: true,
+  },
+  {
+    provide: I18NEXT_INSTANCE,
+    useFactory: createI18nextInstance,
   },
 ];

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -3,7 +3,7 @@ import { APP_INITIALIZER, Optional, Provider } from '@angular/core';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
 import { SERVER_REQUEST_ORIGIN } from '../../ssr/ssr.providers';
-import { i18nextInit } from './i18next-init';
+import { i18nextInit, SiteContextI18nextSynchronizer } from './i18next-init';
 import { I18NEXT_INSTANCE } from './i18next-instance';
 
 export const i18nextProviders: Provider[] = [
@@ -16,6 +16,7 @@ export const i18nextProviders: Provider[] = [
       LanguageService,
       HttpClient,
       [new Optional(), SERVER_REQUEST_ORIGIN],
+      SiteContextI18nextSynchronizer,
     ],
     multi: true,
   },

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -1,17 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { APP_INITIALIZER, Optional, Provider } from '@angular/core';
-import i18next, { i18n } from 'i18next';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
 import { SERVER_REQUEST_ORIGIN } from '../../ssr/ssr.providers';
 import { i18nextInit, SiteContextI18nextSynchronizer } from './i18next-init';
 import { I18NEXT_INSTANCE } from './i18next-instance';
-
-export function createI18nextInstance(): i18n {
-  // the global `i18next` instance should be used once - only to create
-  // a fresh i18next instance per application bootstrap
-  return i18next.createInstance();
-}
 
 export const i18nextProviders: Provider[] = [
   {
@@ -26,9 +19,5 @@ export const i18nextProviders: Provider[] = [
       SiteContextI18nextSynchronizer,
     ],
     multi: true,
-  },
-  {
-    provide: I18NEXT_INSTANCE,
-    useFactory: createI18nextInstance,
   },
 ];

--- a/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
@@ -1,6 +1,6 @@
 import * as AngularCore from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { i18n } from 'i18next';
+import i18nextGlobal, { i18n } from 'i18next';
 import { first, take } from 'rxjs/operators';
 import { I18nConfig } from '../config/i18n-config';
 import { TranslationChunkService } from '../translation-chunk.service';
@@ -29,6 +29,7 @@ describe('I18nextTranslationService', () => {
           provide: TranslationChunkService,
           useValue: mockTranslationChunk,
         },
+        { provide: I18NEXT_INSTANCE, useValue: i18nextGlobal },
         I18nextTranslationService,
       ],
     });

--- a/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
@@ -1,9 +1,10 @@
 import * as AngularCore from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import i18next from 'i18next';
+import { i18n } from 'i18next';
 import { first, take } from 'rxjs/operators';
 import { I18nConfig } from '../config/i18n-config';
 import { TranslationChunkService } from '../translation-chunk.service';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 import { I18nextTranslationService } from './i18next-translation.service';
 
 const testKey = 'testKey';
@@ -12,6 +13,7 @@ const nonBreakingSpace = String.fromCharCode(160);
 
 describe('I18nextTranslationService', () => {
   let service: I18nextTranslationService;
+  let i18next: i18n;
 
   beforeEach(() => {
     const mockTranslationChunk = {
@@ -32,6 +34,7 @@ describe('I18nextTranslationService', () => {
     });
 
     service = TestBed.inject(I18nextTranslationService);
+    i18next = TestBed.inject(I18NEXT_INSTANCE);
   });
 
   describe('loadChunks', () => {

--- a/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
@@ -1,6 +1,6 @@
 import * as AngularCore from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import i18nextGlobal, { i18n } from 'i18next';
+import { i18n } from 'i18next';
 import { first, take } from 'rxjs/operators';
 import { I18nConfig } from '../config/i18n-config';
 import { TranslationChunkService } from '../translation-chunk.service';
@@ -28,10 +28,6 @@ describe('I18nextTranslationService', () => {
         {
           provide: TranslationChunkService,
           useValue: mockTranslationChunk,
-        },
-        {
-          provide: I18NEXT_INSTANCE,
-          useFactory: () => i18nextGlobal.createInstance(),
         },
         I18nextTranslationService,
       ],
@@ -80,9 +76,7 @@ describe('I18nextTranslationService', () => {
 
     describe(', when key does NOT exist,', () => {
       beforeEach(() => {
-        debugger;
         spyOn(i18next, 'exists').and.returnValue(false);
-        debugger;
         spyOn(i18next, 'loadNamespaces').and.returnValue(new Promise(() => {}));
       });
 

--- a/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
@@ -29,7 +29,10 @@ describe('I18nextTranslationService', () => {
           provide: TranslationChunkService,
           useValue: mockTranslationChunk,
         },
-        { provide: I18NEXT_INSTANCE, useValue: i18nextGlobal },
+        {
+          provide: I18NEXT_INSTANCE,
+          useFactory: () => i18nextGlobal.createInstance(),
+        },
         I18nextTranslationService,
       ],
     });
@@ -50,10 +53,13 @@ describe('I18nextTranslationService', () => {
   });
 
   describe('translate', () => {
+    beforeEach(() => {
+      i18next.isInitialized = true;
+    });
+
     describe(', when key exists,', () => {
       beforeEach(() => {
         spyOn(i18next, 'exists').and.returnValue(true);
-        i18next.isInitialized = true;
       });
 
       it('should emit result of i18next.t', () => {
@@ -74,7 +80,9 @@ describe('I18nextTranslationService', () => {
 
     describe(', when key does NOT exist,', () => {
       beforeEach(() => {
+        debugger;
         spyOn(i18next, 'exists').and.returnValue(false);
+        debugger;
         spyOn(i18next, 'loadNamespaces').and.returnValue(new Promise(() => {}));
       });
 

--- a/projects/core/src/i18n/i18next/i18next-translation.service.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.ts
@@ -1,19 +1,36 @@
-import { Injectable, isDevMode } from '@angular/core';
-import i18next from 'i18next';
+import { Inject, Injectable, isDevMode } from '@angular/core';
+import i18next_global_instance, { i18n } from 'i18next';
 import { Observable } from 'rxjs';
 import { I18nConfig } from '../config/i18n-config';
 import { TranslationChunkService } from '../translation-chunk.service';
 import { TranslationService } from '../translation.service';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 
 @Injectable({ providedIn: 'root' })
 export class I18nextTranslationService implements TranslationService {
   private readonly NON_BREAKING_SPACE = String.fromCharCode(160);
   protected readonly NAMESPACE_SEPARATOR = ':';
 
+  /**
+   * @deprecated use instead the constructor variant with `I18NEXT_INSTANCE` token as the 3rd parameter.
+   */
+  constructor(config: I18nConfig, translationChunk: TranslationChunkService);
+  constructor(
+    config: I18nConfig,
+    translationChunk: TranslationChunkService,
+    // tslint:disable-next-line: unified-signatures
+    i18next?: i18n
+  );
   constructor(
     protected config: I18nConfig,
-    protected translationChunk: TranslationChunkService
-  ) {}
+    protected translationChunk: TranslationChunkService,
+    @Inject(I18NEXT_INSTANCE) protected i18next?: i18n
+  ) {
+    /**
+     * @deprecated TODO: remove the line below. The fallback `i18next_global_instance` should not be used anymore. @see I18NEXT_INSTANCE
+     */
+    this.i18next = this.i18next || i18next_global_instance;
+  }
 
   translate(
     key: string,
@@ -32,34 +49,34 @@ export class I18nextTranslationService implements TranslationService {
 
     return new Observable<string>((subscriber) => {
       const translate = () => {
-        if (!i18next.isInitialized) {
+        if (!this.i18next.isInitialized) {
           return;
         }
-        if (i18next.exists(namespacedKey, options)) {
-          subscriber.next(i18next.t(namespacedKey, options));
+        if (this.i18next.exists(namespacedKey, options)) {
+          subscriber.next(this.i18next.t(namespacedKey, options));
         } else {
           if (whitespaceUntilLoaded) {
             subscriber.next(this.NON_BREAKING_SPACE);
           }
-          i18next.loadNamespaces(chunkName, () => {
-            if (!i18next.exists(namespacedKey, options)) {
+          this.i18next.loadNamespaces(chunkName, () => {
+            if (!this.i18next.exists(namespacedKey, options)) {
               this.reportMissingKey(key, chunkName);
               subscriber.next(this.getFallbackValue(namespacedKey));
             } else {
-              subscriber.next(i18next.t(namespacedKey, options));
+              subscriber.next(this.i18next.t(namespacedKey, options));
             }
           });
         }
       };
 
       translate();
-      i18next.on('languageChanged', translate);
-      return () => i18next.off('languageChanged', translate);
+      this.i18next.on('languageChanged', translate);
+      return () => this.i18next.off('languageChanged', translate);
     });
   }
 
   loadChunks(chunkNames: string | string[]): Promise<any> {
-    return i18next.loadNamespaces(chunkNames);
+    return this.i18next.loadNamespaces(chunkNames);
   }
 
   /**

--- a/projects/core/src/i18n/i18next/i18next-translation.service.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, isDevMode } from '@angular/core';
-import i18next_global_instance, { i18n } from 'i18next';
+import { i18n } from 'i18next';
 import { Observable } from 'rxjs';
 import { I18nConfig } from '../config/i18n-config';
 import { TranslationChunkService } from '../translation-chunk.service';
@@ -11,26 +11,11 @@ export class I18nextTranslationService implements TranslationService {
   private readonly NON_BREAKING_SPACE = String.fromCharCode(160);
   protected readonly NAMESPACE_SEPARATOR = ':';
 
-  /**
-   * @deprecated use instead the constructor variant with `I18NEXT_INSTANCE` token as the 3rd parameter.
-   */
-  constructor(config: I18nConfig, translationChunk: TranslationChunkService);
-  constructor(
-    config: I18nConfig,
-    translationChunk: TranslationChunkService,
-    // tslint:disable-next-line: unified-signatures
-    i18next?: i18n
-  );
   constructor(
     protected config: I18nConfig,
     protected translationChunk: TranslationChunkService,
-    @Inject(I18NEXT_INSTANCE) protected i18next?: i18n
-  ) {
-    /**
-     * @deprecated TODO: remove the line below. The fallback `i18next_global_instance` should not be used anymore. @see I18NEXT_INSTANCE
-     */
-    this.i18next = this.i18next || i18next_global_instance;
-  }
+    @Inject(I18NEXT_INSTANCE) protected i18next: i18n
+  ) {}
 
   translate(
     key: string,


### PR DESCRIPTION
The i18next global instance as shared in between all SSR requests. This was buggy, i.e. when 2 requests are made at the same time for different acitive langauges. Now we fix it, by creating a fresh instance for each SSR request (for each app bootstrap).

close #8100