### PR TITLE
fix: add missing route config for cost center

### DIFF
--- a/feature-libs/organization/administration/components/cost-center/cost-center.config.ts
+++ b/feature-libs/organization/administration/components/cost-center/cost-center.config.ts
@@ -32,6 +32,9 @@ const paramsMapping: ParamsMapping = {
 export const costCenterRoutingConfig: RoutingConfig = {
   routing: {
     routes: {
+      orgCostCenters: {
+        paths: ['/organization/cost-centers'],
+      },
       orgCostCenterCreate: {
         paths: ['organization/cost-centers/create'],
       },


### PR DESCRIPTION
closes: #10618 