### PR TITLE
fix: avoid sharing i18next instance in between SSR requests (for 3.0.x)

### DIFF
--- a/projects/core/src/i18n/i18next/i18next-instance.ts
+++ b/projects/core/src/i18n/i18next/i18next-instance.ts
@@ -1,0 +1,16 @@
+import { InjectionToken } from '@angular/core';
+import i18next, { i18n } from 'i18next';
+
+/**
+ * The instance of i18next.
+ *
+ * Each SSR request gets its own instance of i18next.
+ *
+ * The reference to the static global instance of `i18next` (`import i18next from 'i18next`)
+ * should not be used anywhere else, because otherwise it would be shared in between all SSR requests
+ * and can cause concurrency issues.
+ */
+export const I18NEXT_INSTANCE = new InjectionToken<i18n>('I18NEXT_INSTANCE', {
+  providedIn: 'root',
+  factory: () => i18next.createInstance(),
+});

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -3,17 +3,20 @@ import { APP_INITIALIZER, Optional, Provider } from '@angular/core';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { LanguageService } from '../../site-context/facade/language.service';
 import { SERVER_REQUEST_ORIGIN } from '../../util/ssr.tokens';
-import { i18nextInit } from './i18next-init';
+import { i18nextInit, SiteContextI18nextSynchronizer } from './i18next-init';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 
 export const i18nextProviders: Provider[] = [
   {
     provide: APP_INITIALIZER,
     useFactory: i18nextInit,
     deps: [
+      I18NEXT_INSTANCE,
       ConfigInitializerService,
       LanguageService,
       HttpClient,
       [new Optional(), SERVER_REQUEST_ORIGIN],
+      SiteContextI18nextSynchronizer,
     ],
     multi: true,
   },

--- a/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.spec.ts
@@ -1,9 +1,10 @@
 import * as AngularCore from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import i18next from 'i18next';
+import { i18n } from 'i18next';
 import { first, take } from 'rxjs/operators';
 import { I18nConfig } from '../config/i18n-config';
 import { TranslationChunkService } from '../translation-chunk.service';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 import { I18nextTranslationService } from './i18next-translation.service';
 
 const testKey = 'testKey';
@@ -12,6 +13,7 @@ const nonBreakingSpace = String.fromCharCode(160);
 
 describe('I18nextTranslationService', () => {
   let service: I18nextTranslationService;
+  let i18next: i18n;
 
   beforeEach(() => {
     const mockTranslationChunk = {
@@ -32,6 +34,7 @@ describe('I18nextTranslationService', () => {
     });
 
     service = TestBed.inject(I18nextTranslationService);
+    i18next = TestBed.inject(I18NEXT_INSTANCE);
   });
 
   describe('loadChunks', () => {
@@ -46,10 +49,13 @@ describe('I18nextTranslationService', () => {
   });
 
   describe('translate', () => {
+    beforeEach(() => {
+      i18next.isInitialized = true;
+    });
+
     describe(', when key exists,', () => {
       beforeEach(() => {
         spyOn(i18next, 'exists').and.returnValue(true);
-        i18next.isInitialized = true;
       });
 
       it('should emit result of i18next.t', () => {

--- a/projects/core/src/i18n/i18next/i18next-translation.service.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, isDevMode } from '@angular/core';
-import i18next from 'i18next';
+import { Inject, Injectable, isDevMode } from '@angular/core';
+import { i18n } from 'i18next';
 import { Observable } from 'rxjs';
 import { I18nConfig } from '../config/i18n-config';
 import { TranslationChunkService } from '../translation-chunk.service';
 import { TranslationService } from '../translation.service';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 
 @Injectable({ providedIn: 'root' })
 export class I18nextTranslationService implements TranslationService {
@@ -12,7 +13,8 @@ export class I18nextTranslationService implements TranslationService {
 
   constructor(
     protected config: I18nConfig,
-    protected translationChunk: TranslationChunkService
+    protected translationChunk: TranslationChunkService,
+    @Inject(I18NEXT_INSTANCE) protected i18next: i18n
   ) {}
 
   translate(
@@ -32,34 +34,34 @@ export class I18nextTranslationService implements TranslationService {
 
     return new Observable<string>((subscriber) => {
       const translate = () => {
-        if (!i18next.isInitialized) {
+        if (!this.i18next.isInitialized) {
           return;
         }
-        if (i18next.exists(namespacedKey, options)) {
-          subscriber.next(i18next.t(namespacedKey, options));
+        if (this.i18next.exists(namespacedKey, options)) {
+          subscriber.next(this.i18next.t(namespacedKey, options));
         } else {
           if (whitespaceUntilLoaded) {
             subscriber.next(this.NON_BREAKING_SPACE);
           }
-          i18next.loadNamespaces(chunkName, () => {
-            if (!i18next.exists(namespacedKey, options)) {
+          this.i18next.loadNamespaces(chunkName, () => {
+            if (!this.i18next.exists(namespacedKey, options)) {
               this.reportMissingKey(key, chunkName);
               subscriber.next(this.getFallbackValue(namespacedKey));
             } else {
-              subscriber.next(i18next.t(namespacedKey, options));
+              subscriber.next(this.i18next.t(namespacedKey, options));
             }
           });
         }
       };
 
       translate();
-      i18next.on('languageChanged', translate);
-      return () => i18next.off('languageChanged', translate);
+      this.i18next.on('languageChanged', translate);
+      return () => this.i18next.off('languageChanged', translate);
     });
   }
 
   loadChunks(chunkNames: string | string[]): Promise<any> {
-    return i18next.loadNamespaces(chunkNames);
+    return this.i18next.loadNamespaces(chunkNames);
   }
 
   /**


### PR DESCRIPTION
The i18next global instance was shared in between all SSR requests. This was buggy, i.e. when 2 requests are made at the same time for different acitive langauges. Now we fix it, by creating a fresh instance for each SSR request (for each app bootstrap).

backport to 3.0.x

close #8100