### PR TITLE
fix: remove unnecessary s in cost center config

### DIFF
--- a/feature-libs/organization/administration/components/cost-center/cost-center.config.ts
+++ b/feature-libs/organization/administration/components/cost-center/cost-center.config.ts
@@ -32,7 +32,7 @@ const paramsMapping: ParamsMapping = {
 export const costCenterRoutingConfig: RoutingConfig = {
   routing: {
     routes: {
-      orgCostCenters: {
+      orgCostCenter: {
         paths: ['/organization/cost-centers'],
       },
       orgCostCenterCreate: {


### PR DESCRIPTION
Closes #10618