### PR TITLE
fix: Wait in AnonymousConsentsInterceptor for the initialization of the user id [for 3.1.x]

### DIFF
--- a/projects/core/src/anonymous-consents/http-interceptors/anonymous-consents-interceptor.spec.ts
+++ b/projects/core/src/anonymous-consents/http-interceptors/anonymous-consents-interceptor.spec.ts
@@ -9,7 +9,7 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Observable, of, Subscription } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { AuthService } from '../../auth/index';
 import {
@@ -264,16 +264,13 @@ describe('AnonymousConsentsInterceptor', () => {
 
   describe('intercept', () => {
     let http: HttpClient;
-    let sub: Subscription;
 
     beforeEach(() => {
       http = TestBed.inject(HttpClient);
-      sub = new Subscription();
     });
 
     afterEach(() => {
       httpMock.verify();
-      sub.unsubscribe();
     });
 
     describe('when sending a request', () => {
@@ -286,7 +283,7 @@ describe('AnonymousConsentsInterceptor', () => {
           of(false).pipe(delay(DELAY_TIME))
         );
 
-        sub = http.get('/xxx').subscribe();
+        http.get('/xxx').subscribe();
         tick(DELAY_TIME);
         httpMock.expectOne((req) => req.method === 'GET', 'GET');
       }));
@@ -298,7 +295,7 @@ describe('AnonymousConsentsInterceptor', () => {
         );
         spyOn(authService, 'isUserLoggedIn').and.returnValue(of(false));
 
-        sub = http.get('/xxx').subscribe();
+        http.get('/xxx').subscribe();
         tick(DELAY_TIME);
         httpMock.expectOne((req) => req.method === 'GET', 'GET');
       }));
@@ -310,7 +307,7 @@ describe('AnonymousConsentsInterceptor', () => {
         spyOn(authService, 'isUserLoggedIn').and.returnValue(of(false));
         spyOn<any>(interceptor, handleRequestMethod).and.callThrough();
 
-        sub = http.get('/xxx').subscribe();
+        http.get('/xxx').subscribe();
 
         httpMock.expectOne((req) => req.method === 'GET', 'GET');
         expect(interceptor[handleRequestMethod]).toHaveBeenCalled();

--- a/projects/core/src/anonymous-consents/http-interceptors/anonymous-consents-interceptor.ts
+++ b/projects/core/src/anonymous-consents/http-interceptors/anonymous-consents-interceptor.ts
@@ -6,8 +6,8 @@ import {
   HttpResponse,
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { switchMap, take, tap, withLatestFrom } from 'rxjs/operators';
+import { combineLatest, Observable } from 'rxjs';
+import { switchMap, take, tap } from 'rxjs/operators';
 import { AuthService } from '../../auth/index';
 import {
   AnonymousConsent,
@@ -31,8 +31,10 @@ export class AnonymousConsentsInterceptor implements HttpInterceptor {
     request: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
-    return this.anonymousConsentsService.getConsents().pipe(
-      withLatestFrom(this.authService.isUserLoggedIn()),
+    return combineLatest([
+      this.anonymousConsentsService.getConsents(),
+      this.authService.isUserLoggedIn(),
+    ]).pipe(
       take(1),
       switchMap(([consents, isUserLoggedIn]) => {
         if (!this.isOccUrl(request.url)) {


### PR DESCRIPTION
### Backport https://github.com/SAP/spartacus/pull/11114 of to 3.1.x

This bug prevented the render of SSR and the first render of CSR app (when the consents were not initialized yet in the local storage), when sites auto-config was enabled.

The consecutive renders of CSR app worked OK (after refresh), because the retrieved consents from storage caused a second emission of `getConsents()` ( when the user id was already initialized), so `withLatestFrom` finally could emit a value.

Now we fix it, by changing `withLatestFrom` to `combineLatest`. Thanks to that we wait for the initialization of the user id, even when the consents observable already emmited only once before.

closes #11108