### PR TITLE
fix: update storeFinder on context change (GH-10302)

### DIFF
--- a/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.ts
+++ b/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { GeoPoint } from '@spartacus/core';
 import { Observable } from 'rxjs';
@@ -7,13 +7,14 @@ import { StoreFinderService } from '@spartacus/storefinder/core';
 @Component({
   selector: 'cx-store-finder-grid',
   templateUrl: './store-finder-grid.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class StoreFinderGridComponent implements OnInit, OnDestroy {
-  locations$: any;
-  isLoading$: Observable<boolean>;
+export class StoreFinderGridComponent implements OnInit {
   defaultLocation: GeoPoint;
   country: string;
   region: string;
+  locations$: any;
+  isLoading$: Observable<boolean>;
 
   constructor(
     private storeFinderService: StoreFinderService,
@@ -21,21 +22,15 @@ export class StoreFinderGridComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.isLoading$ = this.storeFinderService.getViewAllStoresLoading();
-    this.locations$ = this.storeFinderService.getViewAllStoresEntities();
+    this.isLoading$ = this.storeFinderService.getStoresLoading();
+    this.locations$ = this.storeFinderService.getFindStoresEntities();
     this.defaultLocation = {};
-
-    if (this.route.snapshot.params.country) {
-      this.storeFinderService.findStoresAction(
-        '',
-        {
-          pageSize: -1,
-        },
-        undefined,
-        this.route.snapshot.params.country
-      );
-    }
+    this.findStores();
   }
 
-  ngOnDestroy() {}
+  protected findStores(): void {
+    if (this.route.snapshot.params.country) {
+      this.storeFinderService.callFindStoresAction(this.route.snapshot.params);
+    }
+  }
 }

--- a/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.spec.ts
@@ -8,15 +8,18 @@ import {
 } from '@spartacus/core';
 import { StoreFinderStoreComponent } from './store-finder-store.component';
 import { ICON_TYPE, SpinnerModule } from '@spartacus/storefront';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { StoreFinderService } from '@spartacus/storefinder/core';
+import createSpy = jasmine.createSpy;
 
-const mockStoreFinderService = {
-  getStoresLoading: jasmine.createSpy(),
-  getFindStoresEntities: jasmine.createSpy().and.returnValue(of(Observable)),
-  viewStoreById: jasmine.createSpy().and.returnValue(of(Observable)),
-};
+class MockStoreFinderService implements Partial<StoreFinderService> {
+  getStoresLoading = createSpy('getStoresLoading');
+  getFindStoresEntities = createSpy('getFindStoresEntities').and.returnValue(
+    of()
+  );
+  viewStoreById = createSpy('viewStoreById');
+}
 
 @Component({
   selector: 'cx-icon',
@@ -62,7 +65,7 @@ describe('StoreFinderStoreComponent', () => {
           { provide: RoutingService, useValue: { go: jasmine.createSpy() } },
           {
             provide: StoreFinderService,
-            useValue: mockStoreFinderService,
+            useClass: MockStoreFinderService,
           },
           {
             provide: ActivatedRoute,

--- a/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.spec.ts
@@ -4,12 +4,16 @@ import { I18nTestingModule } from '@spartacus/core';
 import { StoreFinderStoresCountComponent } from './store-finder-stores-count.component';
 import { SpinnerModule } from '@spartacus/storefront';
 import { StoreFinderService } from '@spartacus/storefinder/core';
+import { of } from 'rxjs';
+import createSpy = jasmine.createSpy;
 
-const mockStoreFinderService = {
-  viewAllStores: jasmine.createSpy(),
-  getViewAllStoresEntities: jasmine.createSpy(),
-  getViewAllStoresLoading: jasmine.createSpy(),
-};
+class MockStoreFinderService implements Partial<StoreFinderService> {
+  viewAllStores = createSpy('viewAllStores');
+  getViewAllStoresEntities = createSpy(
+    'getViewAllStoresEntities'
+  ).and.returnValue(of());
+  getViewAllStoresLoading = createSpy('getViewAllStoresLoading');
+}
 
 describe('StoreFinderStoresCountComponent', () => {
   let component: StoreFinderStoresCountComponent;
@@ -23,7 +27,7 @@ describe('StoreFinderStoresCountComponent', () => {
         providers: [
           {
             provide: StoreFinderService,
-            useValue: mockStoreFinderService,
+            useClass: MockStoreFinderService,
           },
         ],
       }).compileComponents();

--- a/feature-libs/storefinder/core/facade/store-data.service.ts
+++ b/feature-libs/storefinder/core/facade/store-data.service.ts
@@ -21,7 +21,7 @@ export class StoreDataService {
    * @param location store location
    */
   getStoreLatitude(location: PointOfService): number {
-    return location.geoPoint.latitude;
+    return location?.geoPoint?.latitude;
   }
 
   /**
@@ -29,7 +29,7 @@ export class StoreDataService {
    * @param location store location
    */
   getStoreLongitude(location: PointOfService): number {
-    return location.geoPoint.longitude;
+    return location?.geoPoint?.longitude;
   }
 
   /**
@@ -80,7 +80,16 @@ export class StoreDataService {
   protected getSchedule(location: PointOfService, date: Date): any {
     const weekday = this.weekDays[date.getDay()];
     return location.openingHours.weekDayOpeningList.find(
-      (weekDayOpeningListItem) => weekDayOpeningListItem.weekDay === weekday
+      (weekDayOpeningListItem) =>
+        weekDayOpeningListItem.weekDay ===
+          date.toLocaleString(window.sessionStorage.language, {
+            weekday: 'short',
+          }) ||
+        weekDayOpeningListItem.weekDay ===
+          date.toLocaleString(window.sessionStorage.language, {
+            weekday: 'long',
+          }) ||
+        weekDayOpeningListItem.weekDay === weekday
     );
   }
 }

--- a/feature-libs/storefinder/core/facade/store-finder.service.ts
+++ b/feature-libs/storefinder/core/facade/store-finder.service.ts
@@ -1,13 +1,9 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, OnDestroy, PLATFORM_ID } from '@angular/core';
 import { Action, select, Store } from '@ngrx/store';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { StoreFinderActions } from '../store/actions/index';
 import { StoreFinderSelectors } from '../store/selectors/index';
-import {
-  FindStoresState,
-  StateWithStoreFinder,
-  ViewAllStoresState,
-} from '../store/store-finder-state';
+import { StateWithStoreFinder } from '../store/store-finder-state';
 import {
   GeoPoint,
   GlobalMessageService,
@@ -16,19 +12,49 @@ import {
   SearchConfig,
   WindowRef,
 } from '@spartacus/core';
+import { StoreEntities } from '../model';
+import { filter, map, withLatestFrom } from 'rxjs/operators';
+import { isPlatformBrowser } from '@angular/common';
 
 @Injectable({
   providedIn: 'root',
 })
-export class StoreFinderService {
+export class StoreFinderService implements OnDestroy {
   private geolocationWatchId: number = null;
+  protected subscription = new Subscription();
+
+  constructor(
+    store: Store<StateWithStoreFinder>,
+    winRef: WindowRef,
+    globalMessageService: GlobalMessageService,
+    routingService: RoutingService
+  );
+
+  /**
+   * @deprecated since version 3.1
+   * Use constructor(protected store: Store<StateWithStoreFinder>, protected winRef: WindowRef, protected globalMessageService: GlobalMessageService,
+   * protected routingService: RoutingService @Inject(PLATFORM_ID) protected platformId: any); instead
+   */
+  // TODO(#11093): Remove deprecated constructors
+
+  constructor(
+    store: Store<StateWithStoreFinder>,
+    winRef: WindowRef,
+    globalMessageService: GlobalMessageService,
+    routingService: RoutingService,
+    // tslint:disable-next-line: unified-signatures
+    platformId: any
+  );
 
   constructor(
     protected store: Store<StateWithStoreFinder>,
     protected winRef: WindowRef,
     protected globalMessageService: GlobalMessageService,
-    protected routingService: RoutingService
-  ) {}
+    protected routingService: RoutingService,
+    @Inject(PLATFORM_ID) protected platformId?: any
+  ) {
+    this.reloadStoreEntitiesOnContextChange();
+  }
 
   /**
    * Returns boolean observable for store's loading state
@@ -38,10 +64,20 @@ export class StoreFinderService {
   }
 
   /**
+   * Returns boolean observable for store's success state
+   */
+  getStoresLoaded(): Observable<boolean> {
+    return this.store.pipe(select(StoreFinderSelectors.getStoresSuccess));
+  }
+
+  /**
    * Returns observable for store's entities
    */
-  getFindStoresEntities(): Observable<FindStoresState> {
-    return this.store.pipe(select(StoreFinderSelectors.getFindStoresEntities));
+  getFindStoresEntities(): Observable<StoreEntities> {
+    return this.store.pipe(
+      select(StoreFinderSelectors.getFindStoresEntities),
+      map((data) => data.findStoresEntities)
+    );
   }
 
   /**
@@ -56,9 +92,10 @@ export class StoreFinderService {
   /**
    * Returns observable for view all store's entities
    */
-  getViewAllStoresEntities(): Observable<ViewAllStoresState> {
+  getViewAllStoresEntities(): Observable<StoreEntities> {
     return this.store.pipe(
-      select(StoreFinderSelectors.getViewAllStoresEntities)
+      select(StoreFinderSelectors.getViewAllStoresEntities),
+      map((data) => data.viewAllStoresEntities)
     );
   }
 
@@ -144,5 +181,53 @@ export class StoreFinderService {
       this.geolocationWatchId = null;
     }
     this.store.dispatch(callbackAction);
+  }
+
+  private isEmpty(store: StoreEntities): boolean {
+    return (
+      !store || (typeof store === 'object' && Object.keys(store).length === 0)
+    );
+  }
+
+  /**
+   * Reload store data when store entities are empty because of the context change
+   */
+  protected reloadStoreEntitiesOnContextChange(): void {
+    if (isPlatformBrowser(this.platformId) || !this.platformId) {
+      this.subscription = this.getFindStoresEntities()
+        .pipe(
+          filter((data) => this.isEmpty(data)),
+          withLatestFrom(
+            this.getStoresLoading(),
+            this.getStoresLoaded(),
+            this.routingService.getParams()
+          )
+        )
+        .subscribe(([, loading, loaded, routeParams]) => {
+          if (!loading && !loaded) {
+            if (routeParams.country && !routeParams.store) {
+              this.callFindStoresAction(routeParams);
+            }
+            if (routeParams.store) {
+              this.viewStoreById(routeParams.store);
+            }
+          }
+        });
+    }
+  }
+
+  callFindStoresAction(routeParams: { [key: string]: string }): void {
+    this.findStoresAction(
+      '',
+      {
+        pageSize: -1,
+      },
+      undefined,
+      routeParams.country
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscription?.unsubscribe();
   }
 }

--- a/feature-libs/storefinder/core/service/google-map-renderer.service.ts
+++ b/feature-libs/storefinder/core/service/google-map-renderer.service.ts
@@ -29,17 +29,18 @@ export class GoogleMapRendererService {
     locations: any[],
     selectMarkerHandler?: Function
   ): void {
-    if (this.googleMap === null) {
-      this.externalJsFileLoader.load(
-        this.config.googleMaps.apiUrl,
-        { key: this.config.googleMaps.apiKey },
-        () => {
-          this.drawMap(mapElement, locations, selectMarkerHandler);
-        }
-      );
-    } else {
-      this.drawMap(mapElement, locations, selectMarkerHandler);
-    }
+    if (Object.entries(locations[Object.keys(locations)[0]]).length > 0)
+      if (this.googleMap === null) {
+        this.externalJsFileLoader.load(
+          this.config.googleMaps.apiUrl,
+          { key: this.config.googleMaps.apiKey },
+          () => {
+            this.drawMap(mapElement, locations, selectMarkerHandler);
+          }
+        );
+      } else {
+        this.drawMap(mapElement, locations, selectMarkerHandler);
+      }
   }
 
   /**

--- a/feature-libs/storefinder/core/store/actions/view-all-stores.action.spec.ts
+++ b/feature-libs/storefinder/core/store/actions/view-all-stores.action.spec.ts
@@ -39,4 +39,13 @@ describe('View All Stores Actions', () => {
       });
     });
   });
+
+  describe('Clear Store Finder Data Action', () => {
+    it('should creat ClearStoreFinderData action', () => {
+      const action = new StoreFinderActions.ClearStoreFinderData();
+      expect({ ...action }).toEqual({
+        type: StoreFinderActions.CLEAR_STORE_FINDER_DATA,
+      });
+    });
+  });
 });

--- a/feature-libs/storefinder/core/store/actions/view-all-stores.action.ts
+++ b/feature-libs/storefinder/core/store/actions/view-all-stores.action.ts
@@ -1,9 +1,11 @@
 import { STORE_FINDER_DATA } from '../store-finder-state';
 import { StateUtils } from '@spartacus/core';
+import { Action } from '@ngrx/store';
 
 export const VIEW_ALL_STORES = '[StoreFinder] View All Stores';
 export const VIEW_ALL_STORES_FAIL = '[StoreFinder] View All Stores Fail';
 export const VIEW_ALL_STORES_SUCCESS = '[StoreFinder] View All Stores Success';
+export const CLEAR_STORE_FINDER_DATA = '[StoreFinder] Clear Data';
 
 export class ViewAllStores extends StateUtils.LoaderLoadAction {
   readonly type = VIEW_ALL_STORES;
@@ -26,7 +28,12 @@ export class ViewAllStoresSuccess extends StateUtils.LoaderSuccessAction {
   }
 }
 
+export class ClearStoreFinderData implements Action {
+  readonly type = CLEAR_STORE_FINDER_DATA;
+}
+
 export type ViewAllStoresAction =
   | ViewAllStores
   | ViewAllStoresFail
-  | ViewAllStoresSuccess;
+  | ViewAllStoresSuccess
+  | ClearStoreFinderData;

--- a/feature-libs/storefinder/core/store/effects/view-all-stores.effect.spec.ts
+++ b/feature-libs/storefinder/core/store/effects/view-all-stores.effect.spec.ts
@@ -7,7 +7,7 @@ import { StoreFinderConnector } from '../../connectors/store-finder.connector';
 import { StoreFinderActions } from '../actions/index';
 import * as fromEffects from './view-all-stores.effect';
 import createSpy = jasmine.createSpy;
-import { OccConfig } from '@spartacus/core';
+import { OccConfig, SiteContextActions } from '@spartacus/core';
 import { StoreCount } from '../../model/store-finder.model';
 
 const mockOccModuleConfig: OccConfig = {
@@ -59,6 +59,42 @@ describe('ViewAllStores Effects', () => {
       const expected = cold('-b', { b: completion });
 
       expect(effects.viewAllStores$).toBeObservable(expected);
+    });
+    it('should return search result on clear store finder data', () => {
+      const action = new StoreFinderActions.ClearStoreFinderData();
+      const completion = new StoreFinderActions.ViewAllStoresSuccess(
+        storesCountResult
+      );
+      actions$ = hot('-a', { a: action });
+      const expected = cold('-b', { b: completion });
+
+      expect(effects.viewAllStores$).toBeObservable(expected);
+    });
+  });
+  describe('clearStoreFinderData$', () => {
+    it('should clear store finder data on language change', () => {
+      const action = new SiteContextActions.LanguageChange({
+        previous: 'previous',
+        current: 'current',
+      });
+      const completion = new StoreFinderActions.ClearStoreFinderData();
+
+      actions$ = hot('-a', { a: action });
+      const expected = cold('-b', { b: completion });
+
+      expect(effects.clearStoreFinderData$).toBeObservable(expected);
+    });
+    it('should clear store finder data on currency change', () => {
+      const action = new SiteContextActions.CurrencyChange({
+        previous: 'previous',
+        current: 'current',
+      });
+      const completion = new StoreFinderActions.ClearStoreFinderData();
+
+      actions$ = hot('-a', { a: action });
+      const expected = cold('-b', { b: completion });
+
+      expect(effects.clearStoreFinderData$).toBeObservable(expected);
     });
   });
 });

--- a/feature-libs/storefinder/core/store/effects/view-all-stores.effect.ts
+++ b/feature-libs/storefinder/core/store/effects/view-all-stores.effect.ts
@@ -4,7 +4,7 @@ import { Observable, of } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { StoreFinderConnector } from '../../connectors/store-finder.connector';
 import { StoreFinderActions } from '../actions/index';
-import { normalizeHttpError } from '@spartacus/core';
+import { normalizeHttpError, SiteContextActions } from '@spartacus/core';
 
 @Injectable()
 export class ViewAllStoresEffect {
@@ -18,7 +18,10 @@ export class ViewAllStoresEffect {
     | StoreFinderActions.ViewAllStoresSuccess
     | StoreFinderActions.ViewAllStoresFail
   > = this.actions$.pipe(
-    ofType(StoreFinderActions.VIEW_ALL_STORES),
+    ofType(
+      StoreFinderActions.VIEW_ALL_STORES,
+      StoreFinderActions.CLEAR_STORE_FINDER_DATA
+    ),
     switchMap(() => {
       return this.storeFinderConnector.getCounts().pipe(
         map((data) => {
@@ -31,6 +34,19 @@ export class ViewAllStoresEffect {
           )
         )
       );
+    })
+  );
+
+  @Effect()
+  clearStoreFinderData$: Observable<
+    StoreFinderActions.ClearStoreFinderData
+  > = this.actions$.pipe(
+    ofType(
+      SiteContextActions.LANGUAGE_CHANGE,
+      SiteContextActions.CURRENCY_CHANGE
+    ),
+    map(() => {
+      return new StoreFinderActions.ClearStoreFinderData();
     })
   );
 }

--- a/feature-libs/storefinder/core/store/reducers/find-stores.reducer.spec.ts
+++ b/feature-libs/storefinder/core/store/reducers/find-stores.reducer.spec.ts
@@ -7,7 +7,7 @@ describe('Find Stores Reducer', () => {
     it('should return the default state', () => {
       const { initialState } = fromReducers;
       const action = {} as any;
-      const state = fromReducers.reducer(undefined, action);
+      const state = fromReducers.findStoresReducer(undefined, action);
 
       expect(state).toBe(initialState);
     });
@@ -23,9 +23,12 @@ describe('Find Stores Reducer', () => {
         searchConfig,
       });
 
-      const loadingState = fromReducers.reducer(initialState, loadAction);
+      const loadingState = fromReducers.findStoresReducer(
+        initialState,
+        loadAction
+      );
       const resultAction = new StoreFinderActions.FindStoresSuccess(results);
-      const state = fromReducers.reducer(loadingState, resultAction);
+      const state = fromReducers.findStoresReducer(loadingState, resultAction);
 
       expect(state.findStoresEntities).toEqual(results);
     });
@@ -39,10 +42,12 @@ describe('Find Stores Reducer', () => {
         storeId: 'testId',
       });
 
-      const loadingState = fromReducers.reducer(initialState, loadAction);
+      const loadingState = fromReducers.findStoresReducer(
+        initialState,
+        loadAction
+      );
       const resultAction = new StoreFinderActions.FindStoreByIdSuccess(results);
-      const state = fromReducers.reducer(loadingState, resultAction);
-
+      const state = fromReducers.findStoresReducer(loadingState, resultAction);
       expect(state.findStoresEntities).toEqual(results);
     });
   });

--- a/feature-libs/storefinder/core/store/reducers/find-stores.reducer.ts
+++ b/feature-libs/storefinder/core/store/reducers/find-stores.reducer.ts
@@ -5,7 +5,7 @@ export const initialState: FindStoresState = {
   findStoresEntities: {},
 };
 
-export function reducer(
+export function findStoresReducer(
   state = initialState,
   action: StoreFinderActions.FindStoresAction
 ): FindStoresState {

--- a/feature-libs/storefinder/core/store/reducers/index.ts
+++ b/feature-libs/storefinder/core/store/reducers/index.ts
@@ -1,13 +1,24 @@
-import { ActionReducerMap, MetaReducer } from '@ngrx/store';
+import {
+  Action,
+  ActionReducer,
+  ActionReducerMap,
+  MetaReducer,
+} from '@ngrx/store';
 
 import { InjectionToken, Provider } from '@angular/core';
 import { StoresState, STORE_FINDER_DATA } from '../store-finder-state';
-import { StateUtils } from '@spartacus/core';
+import { SiteContextActions, StateUtils } from '@spartacus/core';
+import { StoreFinderActions } from '../actions';
+import { findStoresReducer } from './find-stores.reducer';
+import { viewAllStoresReducer } from './view-all-stores.reducer';
 
 export function getReducers(): ActionReducerMap<StoresState> {
   return {
-    findStores: StateUtils.loaderReducer(STORE_FINDER_DATA),
-    viewAllStores: StateUtils.loaderReducer(STORE_FINDER_DATA),
+    findStores: StateUtils.loaderReducer(STORE_FINDER_DATA, findStoresReducer),
+    viewAllStores: StateUtils.loaderReducer(
+      STORE_FINDER_DATA,
+      viewAllStoresReducer
+    ),
   };
 }
 
@@ -20,4 +31,18 @@ export const reducerProvider: Provider = {
   useFactory: getReducers,
 };
 
-export const metaReducers: MetaReducer<any>[] = [];
+export function clearStoreFinderState(
+  reducer: ActionReducer<StoresState, Action>
+): ActionReducer<StoresState, Action> {
+  return function (state, action) {
+    if (action.type === SiteContextActions.LANGUAGE_CHANGE) {
+      state = undefined;
+    }
+    if (action.type === StoreFinderActions.CLEAR_STORE_FINDER_DATA) {
+      state = undefined;
+    }
+    return reducer(state, action);
+  };
+}
+
+export const metaReducers: MetaReducer<any>[] = [clearStoreFinderState];

--- a/feature-libs/storefinder/core/store/reducers/view-all-stores.reducer.spec.ts
+++ b/feature-libs/storefinder/core/store/reducers/view-all-stores.reducer.spec.ts
@@ -6,7 +6,7 @@ describe('View All Stores Reducer', () => {
     it('should return the default state', () => {
       const { initialState } = fromReducers;
       const action = {} as any;
-      const state = fromReducers.reducer(undefined, action);
+      const state = fromReducers.viewAllStoresReducer(undefined, action);
 
       expect(state).toBe(initialState);
     });
@@ -18,9 +18,15 @@ describe('View All Stores Reducer', () => {
       const { initialState } = fromReducers;
       const loadAction = new StoreFinderActions.ViewAllStores();
 
-      const loadingState = fromReducers.reducer(initialState, loadAction);
+      const loadingState = fromReducers.viewAllStoresReducer(
+        initialState,
+        loadAction
+      );
       const resultAction = new StoreFinderActions.ViewAllStoresSuccess(results);
-      const state = fromReducers.reducer(loadingState, resultAction);
+      const state = fromReducers.viewAllStoresReducer(
+        loadingState,
+        resultAction
+      );
 
       expect(state.viewAllStoresEntities).toEqual(results);
     });

--- a/feature-libs/storefinder/core/store/reducers/view-all-stores.reducer.ts
+++ b/feature-libs/storefinder/core/store/reducers/view-all-stores.reducer.ts
@@ -5,7 +5,7 @@ export const initialState: ViewAllStoresState = {
   viewAllStoresEntities: {},
 };
 
-export function reducer(
+export function viewAllStoresReducer(
   state = initialState,
   action: StoreFinderActions.ViewAllStoresAction
 ): ViewAllStoresState {

--- a/feature-libs/storefinder/core/store/selectors/find-stores.selectors.spec.ts
+++ b/feature-libs/storefinder/core/store/selectors/find-stores.selectors.spec.ts
@@ -33,8 +33,7 @@ describe('FindStores Selectors', () => {
       let result;
       store
         .pipe(select(StoreFinderSelectors.getFindStoresEntities))
-        .subscribe((value) => (result = value));
-
+        .subscribe((value) => (result = value.findStoresEntities));
       store.dispatch(new StoreFinderActions.FindStores({ queryText: 'test' }));
       store.dispatch(new StoreFinderActions.FindStoresSuccess(searchResult));
 
@@ -52,6 +51,23 @@ describe('FindStores Selectors', () => {
       expect(result).toEqual(false);
 
       store.dispatch(new StoreFinderActions.FindStores({ queryText: '' }));
+
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('getStoresSuccess', () => {
+    it('should return isLoaded flag', () => {
+      let result: boolean;
+      store
+        .pipe(select(StoreFinderSelectors.getStoresSuccess))
+        .subscribe((value) => (result = value));
+
+      expect(result).toEqual(false);
+
+      store.dispatch(
+        new StoreFinderActions.FindStoresSuccess({ queryText: '' })
+      );
 
       expect(result).toEqual(true);
     });

--- a/feature-libs/storefinder/core/store/selectors/find-stores.selectors.ts
+++ b/feature-libs/storefinder/core/store/selectors/find-stores.selectors.ts
@@ -28,3 +28,10 @@ export const getStoresLoading: MemoizedSelector<
 > = createSelector(getFindStoresState, (state) =>
   StateUtils.loaderLoadingSelector(state)
 );
+
+export const getStoresSuccess: MemoizedSelector<
+  StateWithStoreFinder,
+  boolean
+> = createSelector(getFindStoresState, (state) =>
+  StateUtils.loaderSuccessSelector(state)
+);

--- a/feature-libs/storefinder/core/store/selectors/view-all-stores.selectors.spec.ts
+++ b/feature-libs/storefinder/core/store/selectors/view-all-stores.selectors.spec.ts
@@ -35,7 +35,7 @@ describe('ViewAllStores Selectors', () => {
       let result;
       store
         .pipe(select(StoreFinderSelectors.getViewAllStoresEntities))
-        .subscribe((value) => (result = value))
+        .subscribe((value) => (result = value.viewAllStoresEntities))
         .unsubscribe();
 
       expect(result).toEqual(searchResult);

--- a/feature-libs/storefinder/core/store/store-finder-store.module.ts
+++ b/feature-libs/storefinder/core/store/store-finder-store.module.ts
@@ -4,14 +4,16 @@ import { CommonModule } from '@angular/common';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 
-import { reducerProvider, reducerToken } from './reducers/index';
+import { reducerProvider, reducerToken, metaReducers } from './reducers/index';
 import { effects } from './effects/index';
 import { STORE_FINDER_FEATURE } from './store-finder-state';
 
 @NgModule({
   imports: [
     CommonModule,
-    StoreModule.forFeature(STORE_FINDER_FEATURE, reducerToken),
+    StoreModule.forFeature(STORE_FINDER_FEATURE, reducerToken, {
+      metaReducers,
+    }),
     EffectsModule.forFeature(effects),
   ],
   providers: [reducerProvider],


### PR DESCRIPTION
closes #10302 

* GH-10302 fix opening hours for other languages

* GH-10302 feat: Reset the store on language change

* feat: Add unit tests

* GH-10302 Move reload logic to facade

* feat: Call subscription when storeEntities are empty

Subscription in store-finder.service is called on language/curreny change only instead of service initialization.
Fixed logic for calling renderMap.
Added changeDetection and changed findStores to protected in store-finder-grid.copmonent

* test: add unit tests for store finder service (GH-10302)

Added new test cases for reloadStoreEntitiesOnContextChange in store finder service.
Fixed broken unit tests.
Added a check in google-map-renderer service.
Added constructor deprecation in store finder service.
Removed unnecessary unit tests.

* refactor: Update unit tests

Added method and parameter types.
Updated declaration of mockService class.

* refactor: update package.json

* refactor: remove breaking changes (GH-10302)

closes #10302
Removed findStoreEntitiesById from storeFinderState to avoid breaking changes.
Moved map to service from component to avoid breaking change.

* refactor: remove blank line

* refactor: change type of reducer