### PR TITLE
fix: Add missing serializers for occ-adapters (#10617)

### DIFF
--- a/feature-libs/organization/administration/core/connectors/b2b-user/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/b2b-user/converters.ts
@@ -1,13 +1,13 @@
 import { InjectionToken } from '@angular/core';
-import { Converter, B2BUser, EntitiesModel, Occ } from '@spartacus/core';
+import { Converter, B2BUser, EntitiesModel } from '@spartacus/core';
 
 export const B2B_USER_NORMALIZER = new InjectionToken<Converter<any, B2BUser>>(
   'B2BUserNormalizer'
 );
 
-export const B2B_USER_SERIALIZER = new InjectionToken<
-  Converter<any, Occ.B2BUser>
->('B2BUserSerializer');
+export const B2B_USER_SERIALIZER = new InjectionToken<Converter<B2BUser, any>>(
+  'B2BUserSerializer'
+);
 
 export const B2B_USERS_NORMALIZER = new InjectionToken<
   Converter<any, EntitiesModel<B2BUser>>

--- a/feature-libs/organization/administration/core/connectors/budget/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/budget/converters.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core';
 import { Budget } from '../../model/budget.model';
-import { Converter, EntitiesModel, Occ } from '@spartacus/core';
+import { Converter, EntitiesModel } from '@spartacus/core';
 
 export const BUDGET_NORMALIZER = new InjectionToken<Converter<any, Budget>>(
   'BudgetNormalizer'
@@ -9,6 +9,6 @@ export const BUDGETS_NORMALIZER = new InjectionToken<
   Converter<any, EntitiesModel<Budget>>
 >('BudgetsListNormalizer');
 
-export const BUDGET_SERIALIZER = new InjectionToken<Converter<any, Occ.Budget>>(
+export const BUDGET_SERIALIZER = new InjectionToken<Converter<Budget, any>>(
   'BudgetSerializer'
 );

--- a/feature-libs/organization/administration/core/connectors/org-unit/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/org-unit/converters.ts
@@ -14,6 +14,10 @@ export const B2BUNIT_NORMALIZER = new InjectionToken<Converter<any, B2BUnit>>(
   'B2BUnitNormalizer'
 );
 
+export const B2BUNIT_SERIALIZER = new InjectionToken<Converter<B2BUnit, any>>(
+  'B2BUnitSerializer'
+);
+
 export const B2BUNIT_APPROVAL_PROCESSES_NORMALIZER = new InjectionToken<
   Converter<any, B2BApprovalProcess[]>
 >('B2BUnitApprovalProcessNormalizer');

--- a/feature-libs/organization/administration/core/connectors/permission/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/permission/converters.ts
@@ -21,3 +21,7 @@ export const PERMISSION_TYPE_NORMALIZER = new InjectionToken<
 export const PERMISSION_TYPES_NORMALIZER = new InjectionToken<
   Converter<any, OrderApprovalPermissionType[]>
 >('PermissionTypesListNormalizer');
+
+export const PERMISSION_SERIALIZER = new InjectionToken<
+  Converter<Permission, any>
+>('PermissionSerializer');

--- a/feature-libs/organization/administration/core/connectors/user-group/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/user-group/converters.ts
@@ -5,6 +5,11 @@ import { UserGroup } from '../../model/user-group.model';
 export const USER_GROUP_NORMALIZER = new InjectionToken<
   Converter<any, UserGroup>
 >('UserGroupNormalizer');
+
+export const USER_GROUP_SERIALIZER = new InjectionToken<
+  Converter<UserGroup, any>
+>('UserGroupSerializer');
+
 export const USER_GROUPS_NORMALIZER = new InjectionToken<
   Converter<any, EntitiesModel<UserGroup>>
 >('UserGroupListNormalizer');

--- a/feature-libs/organization/administration/occ/adapters/occ-org-unit.adapter.spec.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-org-unit.adapter.spec.ts
@@ -7,6 +7,7 @@ import {
   Address,
   ADDRESS_LIST_NORMALIZER,
   ADDRESS_NORMALIZER,
+  ADDRESS_SERIALIZER,
   ConverterService,
   OccEndpointsService,
   SearchConfig,
@@ -16,6 +17,7 @@ import {
   B2BUNIT_NODE_LIST_NORMALIZER,
   B2BUNIT_NODE_NORMALIZER,
   B2BUNIT_NORMALIZER,
+  B2BUNIT_SERIALIZER,
   B2B_USERS_NORMALIZER,
 } from '@spartacus/organization/administration/core';
 import { OccOrgUnitAdapter } from './occ-org-unit.adapter';
@@ -60,6 +62,7 @@ describe('OccOrgUnitAdapter', () => {
     service = TestBed.inject(OccOrgUnitAdapter);
     httpMock = TestBed.inject(HttpTestingController);
     spyOn(converterService, 'pipeable').and.callThrough();
+    spyOn(converterService, 'convert').and.callThrough();
   });
 
   afterEach(() => {
@@ -121,6 +124,10 @@ describe('OccOrgUnitAdapter', () => {
   describe('update orgUnit', () => {
     it('should update orgUnit', () => {
       service.update(userId, orgUnitId, orgUnit).subscribe();
+      expect(converterService.convert).toHaveBeenCalledWith(
+        orgUnit,
+        B2BUNIT_SERIALIZER
+      );
       const mockReq = httpMock.expectOne(
         (req) =>
           req.method === 'PATCH' &&
@@ -251,6 +258,10 @@ describe('OccOrgUnitAdapter', () => {
   describe('create address', () => {
     it('should create address', () => {
       service.createAddress(userId, orgUnitId, address).subscribe();
+      expect(converterService.convert).toHaveBeenCalledWith(
+        address,
+        ADDRESS_SERIALIZER
+      );
       const mockReq = httpMock.expectOne(
         (req) =>
           req.method === 'POST' &&
@@ -269,6 +280,10 @@ describe('OccOrgUnitAdapter', () => {
   describe('update address', () => {
     it('should update address', () => {
       service.updateAddress(userId, orgUnitId, addressId, address).subscribe();
+      expect(converterService.convert).toHaveBeenCalledWith(
+        address,
+        ADDRESS_SERIALIZER
+      );
       const mockReq = httpMock.expectOne(
         (req) => req.method === 'PATCH' && req.url === 'orgUnitsAddress'
       );

--- a/feature-libs/organization/administration/occ/adapters/occ-org-unit.adapter.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-org-unit.adapter.ts
@@ -4,6 +4,7 @@ import {
   Address,
   ADDRESS_LIST_NORMALIZER,
   ADDRESS_NORMALIZER,
+  ADDRESS_SERIALIZER,
   B2BApprovalProcess,
   B2BUnit,
   B2BUser,
@@ -19,6 +20,7 @@ import {
   B2BUNIT_NODE_LIST_NORMALIZER,
   B2BUNIT_NODE_NORMALIZER,
   B2BUNIT_NORMALIZER,
+  B2BUNIT_SERIALIZER,
   B2B_USERS_NORMALIZER,
   OrgUnitAdapter,
 } from '@spartacus/organization/administration/core';
@@ -49,6 +51,7 @@ export class OccOrgUnitAdapter implements OrgUnitAdapter {
     orgUnitId: string,
     orgUnit: B2BUnit
   ): Observable<B2BUnit> {
+    orgUnit = this.converter.convert(orgUnit, B2BUNIT_SERIALIZER);
     return this.http
       .patch<Occ.B2BUnit>(this.getOrgUnitEndpoint(userId, orgUnitId), orgUnit)
       .pipe(this.converter.pipeable(B2BUNIT_NORMALIZER));
@@ -145,6 +148,7 @@ export class OccOrgUnitAdapter implements OrgUnitAdapter {
     orgUnitId: string,
     address: Address
   ): Observable<Address> {
+    address = this.converter.convert(address, ADDRESS_SERIALIZER);
     return this.http
       .post<Occ.Address>(this.getAddressesEndpoint(userId, orgUnitId), address)
       .pipe(this.converter.pipeable(ADDRESS_NORMALIZER));
@@ -156,6 +160,7 @@ export class OccOrgUnitAdapter implements OrgUnitAdapter {
     addressId: string,
     address: Address
   ): Observable<Address> {
+    address = this.converter.convert(address, ADDRESS_SERIALIZER);
     return this.http
       .patch<Occ.Address>(
         this.getAddressEndpoint(userId, orgUnitId, addressId),

--- a/feature-libs/organization/administration/occ/adapters/occ-permission.adapter.spec.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-permission.adapter.spec.ts
@@ -7,6 +7,7 @@ import { ConverterService, OccEndpointsService } from '@spartacus/core';
 import {
   PERMISSIONS_NORMALIZER,
   PERMISSION_NORMALIZER,
+  PERMISSION_SERIALIZER,
 } from '@spartacus/organization/administration/core';
 import { OccPermissionAdapter } from './occ-permission.adapter';
 
@@ -47,6 +48,7 @@ describe('OccPermissionAdapter', () => {
     service = TestBed.inject(OccPermissionAdapter);
     httpMock = TestBed.inject(HttpTestingController);
     spyOn(converterService, 'pipeable').and.callThrough();
+    spyOn(converterService, 'convert').and.callThrough();
   });
 
   afterEach(() => {
@@ -92,6 +94,10 @@ describe('OccPermissionAdapter', () => {
   describe('create permission', () => {
     it('should create permission', () => {
       service.create(userId, permission).subscribe();
+      expect(converterService.convert).toHaveBeenCalledWith(
+        permission,
+        PERMISSION_SERIALIZER
+      );
       const mockReq = httpMock.expectOne(
         (req) =>
           req.method === 'POST' &&
@@ -112,6 +118,11 @@ describe('OccPermissionAdapter', () => {
       service
         .update(userId, orderApprovalPermissionCode, permission)
         .subscribe();
+      expect(converterService.convert).toHaveBeenCalledWith(
+        permission,
+        PERMISSION_SERIALIZER
+      );
+
       const mockReq = httpMock.expectOne(
         (req) =>
           req.method === 'PATCH' &&

--- a/feature-libs/organization/administration/occ/adapters/occ-permission.adapter.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-permission.adapter.ts
@@ -14,6 +14,7 @@ import {
   PERMISSIONS_NORMALIZER,
   PERMISSION_NORMALIZER,
   PERMISSION_TYPES_NORMALIZER,
+  PERMISSION_SERIALIZER,
 } from '@spartacus/organization/administration/core';
 import { Observable } from 'rxjs';
 
@@ -41,6 +42,7 @@ export class OccPermissionAdapter implements PermissionAdapter {
   }
 
   create(userId: string, permission: Permission): Observable<Permission> {
+    permission = this.converter.convert(permission, PERMISSION_SERIALIZER);
     return this.http
       .post<Occ.Permission>(this.getPermissionsEndpoint(userId), permission)
       .pipe(this.converter.pipeable(PERMISSION_NORMALIZER));
@@ -51,6 +53,7 @@ export class OccPermissionAdapter implements PermissionAdapter {
     permissionCode: string,
     permission: Permission
   ): Observable<Permission> {
+    permission = this.converter.convert(permission, PERMISSION_SERIALIZER);
     return this.http
       .patch<Occ.Permission>(
         this.getPermissionEndpoint(userId, permissionCode),

--- a/feature-libs/organization/administration/occ/adapters/occ-user-group.adapter.spec.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-user-group.adapter.spec.ts
@@ -10,6 +10,7 @@ import {
   PERMISSIONS_NORMALIZER,
   USER_GROUPS_NORMALIZER,
   USER_GROUP_NORMALIZER,
+  USER_GROUP_SERIALIZER,
 } from '@spartacus/organization/administration/core';
 import { OccUserGroupAdapter } from './occ-user-group.adapter';
 
@@ -61,6 +62,7 @@ describe('OccUserGroupAdapter', () => {
       HttpTestingController as Type<HttpTestingController>
     );
     spyOn(converterService, 'pipeable').and.callThrough();
+    spyOn(converterService, 'convert').and.callThrough();
   });
 
   afterEach(() => {
@@ -104,6 +106,10 @@ describe('OccUserGroupAdapter', () => {
   describe('create userGroup', () => {
     it('should create userGroup', () => {
       service.create(userId, userGroup).subscribe();
+      expect(converterService.convert).toHaveBeenCalledWith(
+        userGroup,
+        USER_GROUP_SERIALIZER
+      );
       const mockReq = httpMock.expectOne(
         (req) =>
           req.method === 'POST' &&
@@ -122,6 +128,10 @@ describe('OccUserGroupAdapter', () => {
   describe('update userGroup', () => {
     it('should update userGroup', () => {
       service.update(userId, userGroupId, userGroup).subscribe();
+      expect(converterService.convert).toHaveBeenCalledWith(
+        userGroup,
+        USER_GROUP_SERIALIZER
+      );
       const mockReq = httpMock.expectOne(
         (req) =>
           req.method === 'PATCH' &&

--- a/feature-libs/organization/administration/occ/adapters/occ-user-group.adapter.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-user-group.adapter.ts
@@ -16,6 +16,7 @@ import {
   UserGroupAdapter,
   USER_GROUPS_NORMALIZER,
   USER_GROUP_NORMALIZER,
+  USER_GROUP_SERIALIZER,
 } from '@spartacus/organization/administration/core';
 import { Observable } from 'rxjs';
 
@@ -67,6 +68,7 @@ export class OccUserGroupAdapter implements UserGroupAdapter {
   }
 
   create(userId: string, userGroup: UserGroup): Observable<UserGroup> {
+    userGroup = this.converter.convert(userGroup, USER_GROUP_SERIALIZER);
     return this.http
       .post<Occ.OrgUnitUserGroup>(this.getUserGroupsEndpoint(userId), userGroup)
       .pipe(this.converter.pipeable(USER_GROUP_NORMALIZER));
@@ -85,6 +87,7 @@ export class OccUserGroupAdapter implements UserGroupAdapter {
     userGroupId: string,
     userGroup: UserGroup
   ): Observable<UserGroup> {
+    userGroup = this.converter.convert(userGroup, USER_GROUP_SERIALIZER);
     return this.http
       .patch<Occ.OrgUnitUserGroup>(
         this.getUserGroupEndpoint(userId, userGroupId),


### PR DESCRIPTION
* GH-10617 Add missing serializer token for organization

* GH-10617 Update unit tests

* refactor: Update unit test

* unify types for serializers

* Update feature-libs/organization/administration/core/connectors/org-unit/converters.ts

Co-authored-by: Michał Gruca <pucek9@gmail.com>

* Update feature-libs/organization/administration/core/connectors/user-group/converters.ts

Co-authored-by: Michał Gruca <pucek9@gmail.com>

* Update feature-libs/organization/administration/core/connectors/permission/converters.ts

Co-authored-by: Michał Gruca <pucek9@gmail.com>

* test: mark unit and checkout as guest e2e tests as flaky

* test: remove flaky from units and checkout as guest

* Trigger build

Co-authored-by: Michał Gruca <pucek9@gmail.com>