### PR TITLE
test: Support running only specified viewport e2e

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress.ci.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.ci.json
@@ -16,6 +16,7 @@
     "OCC_PREFIX": "/occ/v2",
     "OCC_PREFIX_USER_ENDPOINT": "users",
     "OCC_PREFIX_ORDER_ENDPOINT": "orders",
-    "BASE_SITE": "electronics-spa"
+    "BASE_SITE": "electronics-spa",
+    "VIEWPORT": "desktop"
   }
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/viewport-context.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/viewport-context.ts
@@ -31,9 +31,14 @@ export function viewportContext(
   viewportList: Viewports[],
   callback: () => unknown
 ) {
-  const viewports = viewportConfigs.filter((conf) =>
-    viewportList.includes(conf.viewport)
-  );
+  // When we set `CYPRESS_VIEWPORT` with one of the viewport name value we only want to run tests in this viewport.
+  // eg. with `CYPRESS_VIEWPORT="desktop" tests will be run only in desktop viewport size
+  const viewportFromConfig = Cypress.env('VIEWPORT');
+  const viewports = viewportConfigs
+    .filter((conf) => viewportList.includes(conf.viewport))
+    .filter((conf) =>
+      viewportFromConfig ? conf.viewport === viewportFromConfig : true
+    );
   viewports.forEach((viewport: Viewport) => {
     context(
       `${capitalize(viewport.viewport)}`,


### PR DESCRIPTION
Further improvement for #11163 that won't overload CI (we will be able to pick if we want to run tests in all defined viewports or just in a single one).

To run only mobile viewport tests set `CYPRESS_VIEWPORT="mobile"`.