### PR TITLE
Feature/gh 11110 avoid change group after attribute update

### DIFF
--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-rest.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-rest.service.spec.ts
@@ -20,6 +20,7 @@ import { Cpq } from './cpq.models';
 
 const productCode = 'CONF_LAPTOP';
 const tabId = '2';
+const tabIdUpdatedAttribute = '1';
 const configId = '1234-56-7890';
 
 const configCreatedResponse: Cpq.ConfigurationCreatedResponseData = {
@@ -92,12 +93,14 @@ const updateAttribute: Cpq.UpdateAttribute = {
   changeAttributeValue: {
     attributeValueIds: attrValueId,
   },
+  tabId: tabIdUpdatedAttribute,
 };
 const updateValue: Cpq.UpdateValue = {
   configurationId: configId,
   standardAttributeCode: attrCode,
   attributeValueId: attrValueId,
   quantity: 5,
+  tabId: tabIdUpdatedAttribute,
 };
 
 describe('CpqConfiguratorRestService', () => {
@@ -280,7 +283,7 @@ describe('CpqConfiguratorRestService', () => {
       );
     });
     mockReq.flush(configUpdateResponse);
-    mockDisplayConfig();
+    mockDisplayConfigWithTabId(tabIdUpdatedAttribute);
   });
 
   it('should call serializer, update value quantity and call normalizer', () => {
@@ -306,7 +309,7 @@ describe('CpqConfiguratorRestService', () => {
       );
     });
     mockReq.flush(configUpdateResponse);
-    mockDisplayConfig();
+    mockDisplayConfigWithTabId(tabIdUpdatedAttribute);
   });
 
   function mockDisplayConfig(response?: Cpq.Configuration) {

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-rest.service.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-rest.service.ts
@@ -146,7 +146,10 @@ export class CpqConfiguratorRestService {
     );
     return this.callUpdateAttribute(updateAttribute).pipe(
       switchMap(() => {
-        return this.callConfigurationDisplay(configuration.configId).pipe(
+        return this.callConfigurationDisplay(
+          configuration.configId,
+          updateAttribute.tabId
+        ).pipe(
           this.converterService.pipeable(CPQ_CONFIGURATOR_NORMALIZER),
           map((resultConfiguration) => {
             return {
@@ -172,7 +175,10 @@ export class CpqConfiguratorRestService {
     );
     return this.callUpdateValue(updateValue).pipe(
       switchMap(() => {
-        return this.callConfigurationDisplay(configuration.configId).pipe(
+        return this.callConfigurationDisplay(
+          configuration.configId,
+          updateValue.tabId
+        ).pipe(
           this.converterService.pipeable(CPQ_CONFIGURATOR_NORMALIZER),
           map((resultConfiguration) => {
             return {

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-serializer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-serializer.spec.ts
@@ -16,6 +16,7 @@ const userInput = '123';
 const expectedValueIdsMulti = 'ValueCode1,ValueCode3,';
 const expectedValueIdsMultiNoSelection = ',';
 const expectedProcessedSingleValueNoValue = ',';
+const firstGroupId = '1';
 
 const firstAttribute: Configurator.Attribute = {
   attrCode: attrCodeFirst,
@@ -23,6 +24,7 @@ const firstAttribute: Configurator.Attribute = {
   uiType: Configurator.UiType.RADIOBUTTON,
   selectedSingleValue: selectedSingleValue,
   quantity: 5,
+  groupId: firstGroupId,
 };
 
 const attributeRB: Configurator.Attribute = {
@@ -322,6 +324,7 @@ describe('CpqConfiguratorSerializer', () => {
       selectedSingleValue
     );
     expect(updateAttribute.changeAttributeValue.userInput).toBeUndefined();
+    expect(updateAttribute.tabId).toBe(firstGroupId);
   });
 
   it('should convert quantity changes', () => {
@@ -332,5 +335,6 @@ describe('CpqConfiguratorSerializer', () => {
     expect(updateValues.changeAttributeValue.quantity).toBe(5);
     expect(updateValues.changeAttributeValue.attributeValueIds).toBeUndefined();
     expect(updateValues.changeAttributeValue.userInput).toBeUndefined();
+    expect(updateValues.tabId).toBe(firstGroupId);
   });
 });

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-serializer.ts
@@ -29,6 +29,7 @@ export class CpqConfiguratorSerializer
       configurationId: configId,
       standardAttributeCode: attribute.attrCode.toString(),
       changeAttributeValue: { quantity: attribute.quantity },
+      tabId: attribute.groupId,
     };
     return updateAttribute;
   }
@@ -47,6 +48,7 @@ export class CpqConfiguratorSerializer
       configurationId: configurationId,
       standardAttributeCode: attribute.attrCode.toString(),
       changeAttributeValue: {},
+      tabId: attribute.groupId,
     };
 
     if (

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-value-serializer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-value-serializer.spec.ts
@@ -8,6 +8,7 @@ const configId = '1';
 const attrCode = 222;
 const attributeName = '9999';
 const valueCode = 'abc';
+const groupIdOfChangedAttribute = '1';
 
 const configuration: Configurator.Configuration = {
   configId: configId,
@@ -18,6 +19,7 @@ const configuration: Configurator.Configuration = {
           attrCode: attrCode,
           name: attributeName,
           values: [{ valueCode: valueCode, quantity: 5 }],
+          groupId: groupIdOfChangedAttribute,
         },
       ],
     },
@@ -45,5 +47,6 @@ describe('CpqConfiguratorValueSerializer', () => {
     expect(updateValue.standardAttributeCode).toBe(attrCode.toString());
     expect(updateValue.attributeValueId).toBe(valueCode);
     expect(updateValue.quantity).toBe(5);
+    expect(updateValue.tabId).toBe(groupIdOfChangedAttribute);
   });
 });

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-value-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-value-serializer.ts
@@ -33,6 +33,7 @@ export class CpqConfiguratorValueSerializer
       standardAttributeCode: attribute.attrCode.toString(),
       attributeValueId: value.valueCode,
       quantity: value.quantity,
+      tabId: attribute.groupId,
     };
 
     return updateAttribute;

--- a/feature-libs/product-configurator/rulebased/cpq/cpq.models.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq.models.ts
@@ -90,6 +90,7 @@ export namespace Cpq {
     configurationId: string;
     standardAttributeCode: string;
     changeAttributeValue: ChangeAttributeValue;
+    tabId: string;
   }
 
   /**
@@ -110,6 +111,7 @@ export namespace Cpq {
     standardAttributeCode: string;
     attributeValueId: string;
     quantity: number;
+    tabId: string;
   }
 
   /**


### PR DESCRIPTION
To avoid undesired group change after an attribute update, we call CPQ API display/tab instead of display.