### PR TITLE
Events for the user lib

### DIFF
--- a/feature-libs/user/account/core/facade/user-account.service.ts
+++ b/feature-libs/user/account/core/facade/user-account.service.ts
@@ -1,19 +1,30 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { select, Store } from '@ngrx/store';
-import { UserIdService } from '@spartacus/core';
-import { Observable } from 'rxjs';
+import { EventService, UserIdService } from '@spartacus/core';
+import { Observable, Subscription } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { User, UserAccountFacade } from '@spartacus/user/account/root';
 import { UserAccountActions } from '../store/actions/index';
 import { UserAccountSelectors } from '../store/selectors/index';
 import { StateWithUserAccount } from '../store/user-account.state';
+import { UserAccountChangedEvent } from '@spartacus/user/account/events';
 
 @Injectable()
-export class UserAccountService implements UserAccountFacade {
+export class UserAccountService implements UserAccountFacade, OnDestroy {
+  eventSubscription: Subscription;
+
   constructor(
     protected store: Store<StateWithUserAccount>,
-    protected userIdService: UserIdService
-  ) {}
+    protected userIdService: UserIdService,
+    protected eventService: EventService
+  ) {
+    this.eventSubscription = this.eventService
+      .get(UserAccountChangedEvent)
+      .subscribe(() => {
+        // reload on user account changed event
+        this.load();
+      });
+  }
 
   /**
    * Returns the current user.
@@ -37,5 +48,9 @@ export class UserAccountService implements UserAccountFacade {
       .subscribe((userId) =>
         this.store.dispatch(new UserAccountActions.LoadUserAccount(userId))
       );
+  }
+
+  ngOnDestroy(): void {
+    this.eventSubscription.unsubscribe();
   }
 }

--- a/feature-libs/user/account/events/index.ts
+++ b/feature-libs/user/account/events/index.ts
@@ -1,0 +1,1 @@
+export * from './user-account-events';

--- a/feature-libs/user/account/events/ng-package.json
+++ b/feature-libs/user/account/events/ng-package.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "./public_api.ts",
+    "umdModuleIds": {
+      "@spartacus/core": "core"
+    }
+  }
+}

--- a/feature-libs/user/account/events/public_api.ts
+++ b/feature-libs/user/account/events/public_api.ts
@@ -1,0 +1,1 @@
+export * from './index';

--- a/feature-libs/user/account/events/user-account-events.ts
+++ b/feature-libs/user/account/events/user-account-events.ts
@@ -1,0 +1,10 @@
+import { User } from '@spartacus/user/account/root';
+import { CxEvent } from '@spartacus/core';
+
+export abstract class UserAccountEvent extends CxEvent {
+  user: User;
+}
+
+export class UserAccountChangedEvent extends UserAccountEvent {
+  static readonly type = 'UserAccountChangedEvent';
+}

--- a/feature-libs/user/profile/core/store/effects/update-profile.effect.ts
+++ b/feature-libs/user/profile/core/store/effects/update-profile.effect.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { normalizeHttpError } from '@spartacus/core';
+import { EventService, normalizeHttpError } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
-import { catchError, concatMap, map } from 'rxjs/operators';
+import { catchError, concatMap, map, tap } from 'rxjs/operators';
 import { UserProfileConnector } from '../../connectors/user-profile.connector';
 import { UserProfileActions } from '../actions/index';
+import { UserAccountChangedEvent } from '@spartacus/user/account/events';
 
 @Injectable()
 export class UpdateProfileEffects {
@@ -20,6 +21,12 @@ export class UpdateProfileEffects {
         map(
           () => new UserProfileActions.UpdateUserProfileSuccess(payload.details)
         ),
+        tap(() => {
+          this.eventService.dispatch(
+            { user: payload.details },
+            UserAccountChangedEvent
+          );
+        }),
         catchError((error) =>
           of(
             new UserProfileActions.UpdateUserProfileFail(
@@ -33,6 +40,7 @@ export class UpdateProfileEffects {
 
   constructor(
     private actions$: Actions,
-    private userProfileConnector: UserProfileConnector
+    private userProfileConnector: UserProfileConnector,
+    private eventService: EventService
   ) {}
 }

--- a/projects/storefrontapp/tsconfig.app.prod.json
+++ b/projects/storefrontapp/tsconfig.app.prod.json
@@ -72,6 +72,7 @@
       "@spartacus/user/account/assets": ["dist/user/account/assets"],
       "@spartacus/user/account/components": ["dist/user/account/components"],
       "@spartacus/user/account/core": ["dist/user/account/core"],
+      "@spartacus/user/account/events": ["dist/user/account/events"],
       "@spartacus/user/account": ["dist/user/account"],
       "@spartacus/user/account/occ": ["dist/user/account/occ"],
       "@spartacus/user/account/root": ["dist/user/account/root"],

--- a/projects/storefrontapp/tsconfig.server.json
+++ b/projects/storefrontapp/tsconfig.server.json
@@ -108,6 +108,9 @@
       "@spartacus/user/account/core": [
         "../../feature-libs/user/account/core/public_api"
       ],
+      "@spartacus/user/account/events": [
+        "../../feature-libs/user/account/events/public_api"
+      ],
       "@spartacus/user/account": ["../../feature-libs/user/account/public_api"],
       "@spartacus/user/account/occ": [
         "../../feature-libs/user/account/occ/public_api"

--- a/projects/storefrontapp/tsconfig.server.prod.json
+++ b/projects/storefrontapp/tsconfig.server.prod.json
@@ -77,6 +77,7 @@
         "../../dist/user/account/components"
       ],
       "@spartacus/user/account/core": ["../../dist/user/account/core"],
+      "@spartacus/user/account/events": ["../../dist/user/account/events"],
       "@spartacus/user/account": ["../../dist/user/account"],
       "@spartacus/user/account/occ": ["../../dist/user/account/occ"],
       "@spartacus/user/account/root": ["../../dist/user/account/root"],

--- a/tsconfig.compodoc.json
+++ b/tsconfig.compodoc.json
@@ -140,6 +140,9 @@
       "@spartacus/user/account/core": [
         "feature-libs/user/account/core/public_api"
       ],
+      "@spartacus/user/account/events": [
+        "feature-libs/user/account/events/public_api"
+      ],
       "@spartacus/user/account": [
         "feature-libs/user/account/public_api"
       ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -144,6 +144,9 @@
       "@spartacus/user/account/core": [
         "feature-libs/user/account/core/public_api"
       ],
+      "@spartacus/user/account/events": [
+        "feature-libs/user/account/events/public_api"
+      ],
       "@spartacus/user/account": [
         "feature-libs/user/account/public_api"
       ],


### PR DESCRIPTION
Exposing `UserAccountChangedEvent` used to keep fresh user account data if changed outside of the library.