### PR TITLE
fix: Storefront Component is no exported from BaseStorefrontModule

### DIFF
--- a/projects/storefrontlib/src/base-storefront.module.ts
+++ b/projects/storefrontlib/src/base-storefront.module.ts
@@ -13,9 +13,9 @@ import { SkipLinkModule } from './layout/a11y/skip-link/skip-link.module';
 import { KeyboardFocusModule } from './layout/a11y/keyboard-focus/keyboard-focus.module';
 import { MediaModule } from './shared/components/media/media.module';
 import { BaseCoreModule } from '@spartacus/core';
+import { StorefrontComponentModule } from './layout/main/storefront-component.module';
 
 @NgModule({
-  declarations: [],
   imports: [
     BaseCoreModule.forRoot(),
     RouterModule,
@@ -32,7 +32,8 @@ import { BaseCoreModule } from '@spartacus/core';
     RoutingModule.forRoot(),
     MediaModule.forRoot(),
     OutletModule.forRoot(),
+    StorefrontComponentModule,
   ],
-  exports: [LayoutModule],
+  exports: [LayoutModule, StorefrontComponentModule],
 })
 export class BaseStorefrontModule {}

--- a/projects/storefrontlib/src/layout/main/main.module.ts
+++ b/projects/storefrontlib/src/layout/main/main.module.ts
@@ -1,40 +1,22 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { RouterModule } from '@angular/router';
 import { FeaturesConfigModule } from '@spartacus/core';
-import { GlobalMessageComponentModule } from '../../cms-components/misc/global-message/global-message.module';
-import { OutletRefModule } from '../../cms-structure/outlet/outlet-ref/outlet-ref.module';
-import { OutletModule } from '../../cms-structure/outlet/outlet.module';
-import { PageLayoutModule } from '../../cms-structure/page/page-layout/page-layout.module';
-import { PageSlotModule } from '../../cms-structure/page/slot/page-slot.module';
 import { PwaModule } from '../../cms-structure/pwa/pwa.module';
 import { SeoModule } from '../../cms-structure/seo/seo.module';
 import { AnonymousConsentsDialogModule } from '../../shared/components/anonymous-consents-dialog/anonymous-consents-dialog.module';
-import { KeyboardFocusModule } from '../a11y/keyboard-focus/keyboard-focus.module';
-import { SkipLinkModule } from '../a11y/skip-link/skip-link.module';
-import { StorefrontComponent } from './storefront.component';
+import { StorefrontComponentModule } from './storefront-component.module';
 
 /**
- * @deprecated since 3.1, see https://sap.github.io/spartacus-docs/getting-started/reference-app-structure
+ * @deprecated since 3.1, see https://sap.github.io/spartacus-docs/reference-app-structure
  */
 @NgModule({
   imports: [
-    CommonModule,
-    RouterModule,
-    GlobalMessageComponentModule,
-    OutletModule,
-    OutletRefModule,
     PwaModule,
-    PageLayoutModule,
     SeoModule,
-    PageSlotModule,
     AnonymousConsentsDialogModule,
     FeaturesConfigModule,
 
-    SkipLinkModule,
-    KeyboardFocusModule,
+    StorefrontComponentModule,
   ],
-  declarations: [StorefrontComponent],
-  exports: [StorefrontComponent],
+  exports: [StorefrontComponentModule],
 })
 export class MainModule {}

--- a/projects/storefrontlib/src/layout/main/storefront-component.module.ts
+++ b/projects/storefrontlib/src/layout/main/storefront-component.module.ts
@@ -1,0 +1,28 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { GlobalMessageComponentModule } from '../../cms-components/misc/global-message/global-message.module';
+import { OutletRefModule } from '../../cms-structure/outlet/outlet-ref/outlet-ref.module';
+import { OutletModule } from '../../cms-structure/outlet/outlet.module';
+import { PageLayoutModule } from '../../cms-structure/page/page-layout/page-layout.module';
+import { PageSlotModule } from '../../cms-structure/page/slot/page-slot.module';
+import { StorefrontComponent } from './storefront.component';
+import { KeyboardFocusModule } from '../a11y/keyboard-focus/keyboard-focus.module';
+import { SkipLinkModule } from '../a11y/skip-link/skip-link.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    GlobalMessageComponentModule,
+    OutletModule,
+    OutletRefModule,
+    PageLayoutModule,
+    PageSlotModule,
+    KeyboardFocusModule,
+    SkipLinkModule,
+  ],
+  declarations: [StorefrontComponent],
+  exports: [StorefrontComponent],
+})
+export class StorefrontComponentModule {}

--- a/projects/storefrontlib/src/recipes/storefront-foundation.module.ts
+++ b/projects/storefrontlib/src/recipes/storefront-foundation.module.ts
@@ -27,7 +27,7 @@ import { PageEventModule } from '../events/page/page-event.module';
 import { ProductPageEventModule } from '../events/product/product-page-event.module';
 
 /**
- * @deprecated since 3.1, see https://sap.github.io/spartacus-docs/getting-started/reference-app-structure
+ * @deprecated since 3.1, see https://sap.github.io/spartacus-docs/reference-app-structure
  */
 @NgModule({
   imports: [

--- a/projects/storefrontlib/src/recipes/storefront.module.ts
+++ b/projects/storefrontlib/src/recipes/storefront.module.ts
@@ -18,7 +18,7 @@ import { StorefrontConfig } from '../storefront-config';
 import { StorefrontFoundationModule } from './storefront-foundation.module';
 
 /**
- * @deprecated since 3.1, see https://sap.github.io/spartacus-docs/getting-started/reference-app-structure
+ * @deprecated since 3.1, see https://sap.github.io/spartacus-docs/reference-app-structure
  */
 @NgModule({
   imports: [


### PR DESCRIPTION
Backport of #11371 to 3.1.x

Closes #11368