### PR TITLE
chore: update peer deps bumper (tracking) + release template missing lib (product)

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -83,6 +83,7 @@ To keep track of spartacussampledata releases, we keep a `latest` branch on each
     - [ ] `npm run release:organization:with-changelog` (needed since `3.0.0-next.1`)
     - [ ] `npm run release:storefinder:with-changelog` (needed since `3.0.0-rc.0`)
     - [ ] `npm run release:tracking:with-changelog` (needed since `3.2.0-next.0`)
+    - [ ] `npm run release:product:with-changelog` (needed since `3.2.0-next.1`)
     - [ ] `npm run release:smartedit:with-changelog` (needed since `3.2.0-next.0`)
     - [ ] `npm run release:qualtrics:with-changelog` (needed since `3.1.0-next.0`)
     - [ ] `npm run release:product-configurator:with-changelog` (needed since `3.1.0-next.0`)

--- a/feature-libs/tracking/.release-it.json
+++ b/feature-libs/tracking/.release-it.json
@@ -23,7 +23,10 @@
       "out": [
         {
           "file": "package.json",
-          "path": ["peerDependencies.@spartacus/core"]
+          "path": [
+            "peerDependencies.@spartacus/core",
+            "peerDependencies.@spartacus/schematics"
+          ]
         }
       ]
     }


### PR DESCRIPTION
closes #11392 