### PR TITLE
fix: Don't set logout page as redirect after login

### DIFF
--- a/projects/storefrontlib/src/cms-components/user/logout/logout.guard.spec.ts
+++ b/projects/storefrontlib/src/cms-components/user/logout/logout.guard.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
+  AuthRedirectService,
   AuthService,
   CmsService,
   ProtectedRoutesService,
@@ -37,11 +38,16 @@ class MockProtectedRoutesService implements Partial<ProtectedRoutesService> {
   }
 }
 
+class MockAuthRedirectService implements Partial<AuthRedirectService> {
+  reportNotAuthGuard() {}
+}
+
 describe('LogoutGuard', () => {
   let logoutGuard: LogoutGuard;
   let authService: AuthService;
   let protectedRoutesService: ProtectedRoutesService;
   let cmsService: CmsService;
+  let authRedirectService: AuthRedirectService;
 
   let zone: NgZone;
   let router: Router;
@@ -83,6 +89,7 @@ describe('LogoutGuard', () => {
           provide: ProtectedRoutesService,
           useClass: MockProtectedRoutesService,
         },
+        { provide: AuthRedirectService, useClass: MockAuthRedirectService },
         SemanticPathService,
       ],
     });
@@ -92,11 +99,20 @@ describe('LogoutGuard', () => {
     cmsService = TestBed.inject(CmsService);
     protectedRoutesService = TestBed.inject(ProtectedRoutesService);
     zone = TestBed.inject(NgZone);
+    authRedirectService = TestBed.inject(AuthRedirectService);
   });
 
   describe('When user is authorized,', () => {
     beforeEach(() => {
       spyOn(authService, 'coreLogout').and.callThrough();
+    });
+
+    it('should report with reportNotAuthGuard to AuthRedirectService', () => {
+      spyOn(authRedirectService, 'reportNotAuthGuard').and.callThrough();
+
+      logoutGuard.canActivate();
+
+      expect(authRedirectService.reportNotAuthGuard).toHaveBeenCalled();
     });
 
     it('should logout and clear user state', async () => {

--- a/projects/storefrontlib/src/cms-components/user/logout/logout.guard.ts
+++ b/projects/storefrontlib/src/cms-components/user/logout/logout.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router, UrlTree } from '@angular/router';
 import {
+  AuthRedirectService,
   AuthService,
   CmsService,
   PageType,
@@ -26,10 +27,15 @@ export class LogoutGuard implements CanActivate {
     protected cms: CmsService,
     protected semanticPathService: SemanticPathService,
     protected protectedRoutes: ProtectedRoutesService,
-    protected router: Router
+    protected router: Router,
+    // TODO(#11380): Make service required
+    protected authRedirectService?: AuthRedirectService
   ) {}
 
   canActivate(): Observable<boolean | UrlTree> {
+    // TODO(#11380): Remove the optional chaining
+    // Logout route should never be remembered as a redirect url after login (that would cause logout right after login).
+    this.authRedirectService?.reportNotAuthGuard();
     /**
      * First we want to complete logout process before redirecting to logout page
      * We want to avoid errors like `token is no longer valid`

--- a/projects/storefrontlib/src/cms-structure/routing/default-routing-config.ts
+++ b/projects/storefrontlib/src/cms-structure/routing/default-routing-config.ts
@@ -10,7 +10,7 @@ export const defaultStorefrontRoutesConfig: RoutesConfig = {
   register: { paths: ['login/register'], protected: false },
   forgotPassword: { paths: ['login/forgot-password'], protected: false },
   resetPassword: { paths: ['login/pw/change'], protected: false },
-  logout: { paths: ['logout'] },
+  logout: { paths: ['logout'], protected: false },
   checkoutLogin: { paths: ['checkout-login'] },
 
   checkout: { paths: ['checkout'] },


### PR DESCRIPTION
Backport of #11381

Closes #11226

BREAKING CHANGE: Logout route is no longer protected by default config