### PR TITLE
fix: Defer removing of product bound configuration (GH-11540)

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.spec.ts
@@ -292,12 +292,12 @@ describe('ConfigAddToCartButtonComponent', () => {
       );
     });
 
-    it('should remove 2 configurations in case configuration has not yet been added and we are on configuration page', () => {
+    it('should remove one configuration (cart bound) in case configuration has not yet been added and we are on configuration page', () => {
       ensureProductBound();
       component.onAddToCart(mockProductConfiguration, mockRouterData);
       expect(
         configuratorCommonsService.removeConfiguration
-      ).toHaveBeenCalledTimes(2);
+      ).toHaveBeenCalledTimes(1);
     });
 
     it('should display addToCart message in case configuration has not been added yet', () => {
@@ -319,11 +319,11 @@ describe('ConfigAddToCartButtonComponent', () => {
       expect(routingService.go).toHaveBeenCalledWith('cart');
     });
 
-    it('should remove 2 configurations in case configuration has not yet been added and process was triggered from overview', () => {
+    it('should remove one (cart bound) configurations in case configuration has not yet been added and process was triggered from overview', () => {
       performAddToCartOnOverview();
       expect(
         configuratorCommonsService.removeConfiguration
-      ).toHaveBeenCalledTimes(2);
+      ).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
@@ -203,11 +203,17 @@ export class ConfiguratorAddToCartButtonComponent {
                 isOverview,
                 true
               );
-              // we clean up both the product related configuration (no longer needed)
-              // and the cart entry related configuration, as we might have a configuration
-              // for the same cart entry number stored already.
+
+              // we clean up the cart entry related configuration, as we might have a
+              // configuration for the same cart entry number stored already.
               // (Cart entries might have been deleted)
-              this.configuratorCommonsService.removeConfiguration(owner);
+
+              // we do not clean up the product bound configuration yet, as existing
+              // observables would instantly trigger a re-create.
+              // Cleaning up this obsolete product bound configuration will only happen
+              // when a new config form requests a new observable for a product bound
+              // configuration
+
               this.configuratorCommonsService.removeConfiguration(
                 configWithNextOwner.nextOwner
               );

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-commons.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-commons.service.spec.ts
@@ -68,6 +68,11 @@ let productConfiguration: Configurator.Configuration = {
   configId: CONFIG_ID,
 };
 
+const productConfigurationProductBoundObsolete: Configurator.Configuration = {
+  configId: CONFIG_ID,
+  nextOwner: OWNER_CART_ENTRY,
+};
+
 const productConfigurationChanged: Configurator.Configuration = {
   configId: CONFIG_ID,
 };
@@ -511,6 +516,30 @@ describe('ConfiguratorCommonsService', () => {
           done();
         })
         .unsubscribe();
+    });
+  });
+
+  describe('removeObsoleteProductBoundConfiguration', () => {
+    it('should not dispatch any action if the configuration does not carry a next owner', () => {
+      spyOn(store, 'dispatch').and.callThrough();
+      spyOnProperty(ngrxStore, 'select').and.returnValue(() => () =>
+        of(productConfiguration)
+      );
+      serviceUnderTest['removeObsoleteProductBoundConfiguration'](
+        OWNER_PRODUCT
+      );
+      expect(store.dispatch).toHaveBeenCalledTimes(0);
+    });
+
+    it('should dispatch the remove action if the configuration carries a next owner', () => {
+      spyOn(store, 'dispatch').and.callThrough();
+      spyOnProperty(ngrxStore, 'select').and.returnValue(() => () =>
+        of(productConfigurationProductBoundObsolete)
+      );
+      serviceUnderTest['removeObsoleteProductBoundConfiguration'](
+        OWNER_PRODUCT
+      );
+      expect(store.dispatch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-commons.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-commons.service.ts
@@ -207,17 +207,34 @@ export class ConfiguratorCommonsService {
       )
     );
   }
+  protected removeObsoleteProductBoundConfiguration(
+    owner: CommonConfigurator.Owner
+  ): void {
+    this.store
+      .pipe(
+        select(ConfiguratorSelectors.getConfigurationFactory(owner.key)),
+        take(1)
+      )
+      .subscribe((configuration) => {
+        if (
+          this.configuratorUtils.isConfigurationCreated(configuration) &&
+          configuration.nextOwner
+        ) {
+          this.removeConfiguration(owner);
+        }
+      });
+  }
 
   protected getOrCreateConfigurationForProduct(
     owner: CommonConfigurator.Owner
   ): Observable<Configurator.Configuration> {
+    this.removeObsoleteProductBoundConfiguration(owner);
     return this.store.pipe(
       select(
         ConfiguratorSelectors.getConfigurationProcessLoaderStateFactory(
           owner.key
         )
       ),
-
       tap((configurationState) => {
         if (
           !this.configuratorUtils.isConfigurationCreated(

--- a/feature-libs/product-configurator/rulebased/core/state/reducers/configurator.reducer.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/reducers/configurator.reducer.ts
@@ -68,6 +68,10 @@ export function configuratorReducer(
       content.nextOwner = {
         type: CommonConfigurator.OwnerType.CART_ENTRY,
         id: action.payload.cartEntryNo,
+        key:
+          CommonConfigurator.OwnerType.CART_ENTRY +
+          '/' +
+          action.payload.cartEntryNo,
       };
       const result = {
         ...state,


### PR DESCRIPTION
During the addToCart process, the product bound configuration was removed too early,
leading existing observers to re-create a configuration in the backend. 
This caused 2 un-needed OCC calls.
Removal of the (obsolete) product bound configuration is now done only when the 
next interactive configuration starts.

Closes GH-11540