### PR TITLE
GH-11579 Show attribute label in OV page

### DIFF
--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-normalizer.ts
@@ -154,9 +154,7 @@ export class CpqConfiguratorNormalizer
       attrCode: sourceAttribute.stdAttrCode,
       name: sourceAttribute.pA_ID.toString(),
       description: sourceAttribute.description,
-      label: sourceAttribute.label
-        ? sourceAttribute.label
-        : sourceAttribute.name,
+      label: this.cpqUtilitiesService.retrieveAttributeLabel(sourceAttribute),
       required: sourceAttribute.required,
       isLineItem: sourceAttribute.isLineItem,
       uiType: this.convertAttributeType(sourceAttribute),

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-overview-normalizer.ts
@@ -69,7 +69,9 @@ export class CpqConfiguratorOverviewNormalizer
         ...ovValue,
         type: attributeOverviewType,
       });
-      ovAttr[index].attribute = attr.name;
+      ovAttr[index].attribute = this.cpqUtilitiesService.retrieveAttributeLabel(
+        attr
+      );
     });
     return ovAttr;
   }

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-utilities.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-utilities.service.spec.ts
@@ -440,4 +440,37 @@ describe('CpqConfiguratorUtilitiesService', () => {
       cpqConfiguratorUtilitiesService.preparePriceSummary(cpqConfiguration)
     ).toEqual(expectedPriceSummary);
   });
+
+  it('should retrieve attribute label', () => {
+    const attribute: Cpq.Attribute = {
+      pA_ID: 1,
+      stdAttrCode: 2,
+      label: 'label',
+      name: 'name',
+    };
+    expect(
+      cpqConfiguratorUtilitiesService.retrieveAttributeLabel(attribute)
+    ).toBe('label');
+  });
+
+  it('should retrieve attribute name if no label available', () => {
+    const attribute: Cpq.Attribute = {
+      pA_ID: 1,
+      stdAttrCode: 2,
+      name: 'name',
+    };
+    expect(
+      cpqConfiguratorUtilitiesService.retrieveAttributeLabel(attribute)
+    ).toBe('name');
+  });
+
+  it('should retrieve empty string if neither attribute label nor attribute name are available', () => {
+    const attribute: Cpq.Attribute = {
+      pA_ID: 1,
+      stdAttrCode: 2,
+    };
+    expect(
+      cpqConfiguratorUtilitiesService.retrieveAttributeLabel(attribute)
+    ).toBe('');
+  });
 });

--- a/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-utilities.service.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/cpq-configurator-utilities.service.ts
@@ -248,4 +248,17 @@ export class CpqConfiguratorUtilitiesService {
   hasAnyProducts(attributeValues: Cpq.Value[]): boolean {
     return attributeValues.some((value: Cpq.Value) => value?.productSystemId);
   }
+
+  /**
+   * Retrieve attribute label
+   * @param attribute CPQ Attribute
+   * @returns attribute label
+   */
+  retrieveAttributeLabel(attribute: Cpq.Attribute): string {
+    return attribute.label
+      ? attribute.label
+      : attribute.name
+      ? attribute.name
+      : '';
+  }
 }


### PR DESCRIPTION
Show attribute label (instead of the attribute name) in the overview page like it is done in the configuration page