### PR TITLE
test: Saved carts accessibility e2e and happy path

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/b2b/tabbing-order.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/b2b/tabbing-order.config.ts
@@ -1,4 +1,5 @@
 import * as orderApprovalSampleData from '../../../sample-data/b2b-order-approval';
+import * as savedCartSampleData from '../../../sample-data/b2b-saved-cart';
 import { TabbingOrderConfig, TabbingOrderTypes } from '../tabbing-order.model';
 
 const paymentTypeRadio = {
@@ -296,5 +297,90 @@ export const tabbingOrderConfig: TabbingOrderConfig = {
     { value: 'Day(s)', type: TabbingOrderTypes.SELECT },
     { type: TabbingOrderTypes.GENERIC_INPUT },
     ...acceptAndSubmitOrder,
+  ],
+  cart: [
+    {
+      value: 'Saved Carts',
+      type: TabbingOrderTypes.LINK,
+    },
+    {
+      value: 'Save Cart For Later',
+      type: TabbingOrderTypes.LINK,
+    },
+    {
+      value: savedCartSampleData.products[0].name,
+      type: TabbingOrderTypes.LINK,
+    },
+    { type: TabbingOrderTypes.GENERIC_INPUT },
+    { value: 'Remove', type: TabbingOrderTypes.LINK },
+    {
+      value: 'Proceed to Checkout',
+      type: TabbingOrderTypes.BUTTON,
+    },
+    {
+      value: 'couponCode',
+      type: TabbingOrderTypes.FORM_FIELD,
+    },
+    {
+      value: 'Apply',
+      type: TabbingOrderTypes.BUTTON,
+    },
+  ],
+  savedCartModal: [
+    {
+      type: TabbingOrderTypes.CX_ICON,
+    },
+    {
+      type: TabbingOrderTypes.GENERIC_INPUT,
+    },
+    {
+      type: TabbingOrderTypes.TEXT_AREA,
+    },
+    {
+      value: 'Cancel',
+      type: TabbingOrderTypes.BUTTON,
+    },
+    {
+      value: 'Save',
+      type: TabbingOrderTypes.BUTTON,
+    },
+  ],
+  savedCartListing: [
+    {
+      type: TabbingOrderTypes.LINK,
+    },
+    {
+      type: TabbingOrderTypes.LINK,
+    },
+    {
+      type: TabbingOrderTypes.LINK,
+    },
+
+    {
+      value: '1',
+      type: TabbingOrderTypes.LINK,
+    },
+
+    {
+      value: '$35.00',
+      type: TabbingOrderTypes.LINK,
+    },
+    {
+      value: 'Make Cart Active',
+      type: TabbingOrderTypes.LINK,
+    },
+  ],
+  savedCartDetails: [
+    {
+      type: TabbingOrderTypes.CX_ICON,
+    },
+    {
+      value: 'Cordless screwdriver 2436',
+      type: TabbingOrderTypes.LINK,
+    },
+    { type: TabbingOrderTypes.GENERIC_INPUT },
+    { value: 'Remove', type: TabbingOrderTypes.LINK },
+    { value: 'Delete Saved Cart', type: TabbingOrderTypes.BUTTON },
+    { value: 'Make cart active', type: TabbingOrderTypes.BUTTON },
   ],
 };

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order.model.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order.model.ts
@@ -29,4 +29,5 @@ export enum TabbingOrderTypes {
   H3 = 'h3',
   CX_PRODUCT_VIEW = 'cxProductView',
   INDEX_OF_ELEMENT = 'indexOfElement',
+  TEXT_AREA = 'textarea',
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-saved-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-saved-cart.ts
@@ -1,0 +1,585 @@
+import { tabbingOrderConfig as config } from '../../helpers/accessibility/b2b/tabbing-order.config';
+import * as alerts from '../../helpers/global-message';
+import * as sampleData from '../../sample-data/b2b-saved-cart';
+import { SampleProduct } from '../../sample-data/checkout-flow';
+import { verifyTabbingOrder as tabbingOrder } from '../accessibility/tabbing-order';
+import { waitForPage } from '../checkout-flow';
+import { loginB2bUser as login } from './b2b-checkout';
+
+export const SAVE_CART_ENDPOINT_ALIAS = 'saveCart';
+export const GET_ALL_SAVED_CART_ENDPOINT_ALIAS = 'getAllSavedCart';
+export const RESTORE_SAVED_CART_ENDPOINT_ALIAS = 'restoreCart';
+export const GET_SAVED_CART_ENDPOINT_ALIAS = 'getSavedCart';
+export const DELETE_CART_ENDPOINT = 'deleteCart';
+
+export function verifyCartPageTabbingOrder() {
+  addProductToCart(sampleData.products[0], 1);
+
+  cy.get(
+    'cx-cart-item-list cx-item-counter input[type=number]:not([disabled])'
+  ); // wait until counter is accessible
+
+  tabbingOrder('cx-page-layout.CartPageTemplate', config.cart);
+}
+
+export function verifyModalTabbingOrder() {
+  cy.get(
+    'cx-cart-item-list cx-item-counter input[type=number]:not([disabled])'
+  ); // wait until counter is accessible
+
+  clickSavedCartButtonsFromCartPage(1);
+
+  cy.get('cx-saved-cart-form-dialog').within(() => {
+    cy.get('[formcontrolname="name"]').type(
+      sampleData.savedActiveCartForm[1].name
+    );
+    cy.get('[formcontrolname="description"]').type(
+      sampleData.savedActiveCartForm[1].description
+    );
+  });
+
+  tabbingOrder('cx-saved-cart-form-dialog', config.savedCartModal);
+}
+
+export function verifyListingTabbingOrder() {
+  // page rendering
+  cy.wait(1000);
+  tabbingOrder('cx-page-layout.AccountPageTemplate', config.savedCartListing);
+}
+
+export function verifyDetailsTabbingOrder() {
+  // page rendering
+  cy.wait(1000);
+  tabbingOrder('cx-page-layout.AccountPageTemplate', config.savedCartDetails);
+}
+
+export function interceptSaveCartEndpoint(cartCode: string) {
+  cy.intercept(
+    'PATCH',
+    `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
+      'BASE_SITE'
+    )}/users/current/carts/${cartCode}/save?*`
+  ).as(SAVE_CART_ENDPOINT_ALIAS);
+
+  return SAVE_CART_ENDPOINT_ALIAS;
+}
+
+export function interceptGetAllSavedCartEndpoint() {
+  cy.intercept(
+    'GET',
+    `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
+      'BASE_SITE'
+    )}/users/current/carts?savedCartsOnly=true*`
+  ).as(GET_ALL_SAVED_CART_ENDPOINT_ALIAS);
+
+  return GET_ALL_SAVED_CART_ENDPOINT_ALIAS;
+}
+
+export function interceptRestoreSavedCartEndpoint(cartCode: string) {
+  cy.intercept(
+    'PATCH',
+    `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
+      'BASE_SITE'
+    )}/users/current/carts/${cartCode}/restoresavedcart?*`
+  ).as(RESTORE_SAVED_CART_ENDPOINT_ALIAS);
+
+  return RESTORE_SAVED_CART_ENDPOINT_ALIAS;
+}
+
+export function interceptGetSavedCartEndpoint(cartCode: string) {
+  cy.intercept(
+    'GET',
+    `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
+      'BASE_SITE'
+    )}/users/current/carts/${cartCode}/savedcart?*`
+  ).as(GET_SAVED_CART_ENDPOINT_ALIAS);
+
+  return GET_SAVED_CART_ENDPOINT_ALIAS;
+}
+
+export function interceptDeleteCartEndpoint(cartCode: string) {
+  cy.intercept(
+    'DELETE',
+    `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
+      'BASE_SITE'
+    )}/users/current/carts/${cartCode}?*`
+  ).as(DELETE_CART_ENDPOINT);
+
+  return DELETE_CART_ENDPOINT;
+}
+
+export function visitCartPage() {
+  const alias = waitForPage('/cart', 'cartPage');
+
+  cy.visit(`/cart`);
+  cy.wait(`@${alias}`).its('status').should('eq', 200);
+}
+
+export function visitSavedCartListingPage() {
+  const getAllSavedCartAlias = interceptGetAllSavedCartEndpoint();
+  const savedCartListingPageAlias = waitForPage(
+    '/my-account/saved-carts',
+    'savedCartListPage'
+  );
+
+  cy.visit(`/my-account/saved-carts`);
+  cy.wait(`@${savedCartListingPageAlias}`).its('status').should('eq', 200);
+  cy.wait(`@${getAllSavedCartAlias}`)
+    .its('response.statusCode')
+    .should('eq', 200);
+}
+
+export function visitSavedCartDetailsPage(cartCode: string) {
+  const getSavedCartAlias = interceptGetSavedCartEndpoint(cartCode);
+
+  const savedCartDetailsPageAlias = waitForPage(
+    `/my-account/saved-cart/${cartCode}`,
+    'savedCartDetailsPage'
+  );
+
+  cy.visit(`/my-account/saved-cart/${cartCode}`);
+  cy.wait(`@${savedCartDetailsPageAlias}`).its('status').should('eq', 200);
+  cy.wait(`@${getSavedCartAlias}`).its('response.statusCode').should('eq', 200);
+}
+
+export function loginB2bUser() {
+  login();
+}
+
+export function addProductToCart(product: SampleProduct, quantity: number) {
+  const alis = waitForPage(`code=${product.code}`, 'getProductPage');
+
+  cy.visit(`/product/${product.code}`);
+
+  cy.wait(`@${alis}`).its('status').should('eq', 200);
+
+  cy.get('cx-item-counter input').type(`{selectall}${quantity.toString()}`);
+  cy.get('cx-add-to-cart')
+    .findByText(/Add To Cart/i)
+    .click();
+  cy.get('cx-added-to-cart-dialog').within(() => {
+    cy.get('.cx-name .cx-link').should('contain', product.name);
+    cy.findByText(/view cart/i).click();
+  });
+}
+
+export function clickSavedCartButtonsFromCartPage(position: number) {
+  // 0 = Saved Carts 'link' button
+  // 1 = Save Cart For Later 'link' button
+  cy.get(`cx-add-to-saved-cart button`).eq(position).should('exist').click();
+}
+
+export function waitForCartPageData(product: SampleProduct) {
+  cy.window()
+    .then((win) => JSON.parse(win.localStorage.getItem('spartacus⚿⚿auth')))
+    .then(({ token }) => {
+      cy.requireProductAddedToCart(token, product);
+    });
+}
+
+export function waitForSavedCartListingPageData(product: SampleProduct) {
+  cy.window()
+    .then((win) => JSON.parse(win.localStorage.getItem('spartacus⚿⚿auth')))
+    .then(({ token }) => {
+      cy.requireSavedCart(token, product);
+    });
+}
+
+export function waitForSavedCartDetailsPageData(product: SampleProduct) {
+  cy.window()
+    .then((win) => JSON.parse(win.localStorage.getItem('spartacus⚿⚿auth')))
+    .then(({ token }) => {
+      cy.requireSavedCart(token, product).then((cart) => {
+        visitSavedCartDetailsPage(cart.code);
+      });
+    });
+}
+
+export function saveActiveCart() {
+  clickSavedCartButtonsFromCartPage(1);
+
+  cy.window()
+    .then((win) =>
+      JSON.parse(win.localStorage.getItem('spartacus⚿powertools-spa⚿cart'))
+    )
+    .then(({ active }) => {
+      const alias = interceptSaveCartEndpoint(active);
+
+      // open modal to save the cart
+
+      cy.get('cx-saved-cart-form-dialog').within(() => {
+        cy.get('[formcontrolname="name"]').type(
+          sampleData.savedActiveCartForm[0].name
+        );
+        cy.get('[formcontrolname="description"]').type(
+          sampleData.savedActiveCartForm[0].description
+        );
+
+        cy.get('button[aria-label="Save"]').click();
+      });
+
+      cy.wait(`@${alias}`).its('response.statusCode').should('eq', 200);
+
+      alerts
+        .getSuccessAlert()
+        .should(
+          'contain',
+          `Your cart items have been succesfully saved for later in the "${sampleData.savedActiveCartForm[0].name}" cart`
+        );
+
+      cy.get('cx-paragraph').should('contain', 'Your shopping cart is empty');
+
+      // assert the cart was saved in the listing page
+      verifyActiveCartWasSaved(active);
+    });
+}
+
+export function verifyActiveCartWasSaved(cartCode: string) {
+  const getAllSavedCartAlias = interceptGetAllSavedCartEndpoint();
+
+  cy.selectUserMenuOption({
+    option: 'Saved Carts',
+  });
+
+  cy.wait(`@${getAllSavedCartAlias}`)
+    .its('response.statusCode')
+    .should('eq', 200);
+
+  cy.get(`@${getAllSavedCartAlias}`).should((xhr) => {
+    const body = xhr.response.body;
+
+    expect(body.carts).to.have.length(1);
+
+    expect(body.carts[0].code).to.equal(cartCode);
+    expect(body.carts[0].name).to.equal(sampleData.savedActiveCartForm[0].name);
+    expect(body.carts[0].description).to.equal(
+      sampleData.savedActiveCartForm[0].description
+    );
+  });
+
+  cy.get(
+    'cx-saved-cart-list .cx-saved-cart-list-cart-name > .cx-saved-cart-list-value'
+  ).should('contain', sampleData.savedActiveCartForm[0].name);
+
+  cy.get(
+    'cx-saved-cart-list .cx-saved-cart-list-cart-id > .cx-saved-cart-list-value'
+  ).should('contain', cartCode);
+
+  cy.get(
+    'cx-saved-cart-list .cx-saved-cart-list-quantity > .cx-saved-cart-list-value'
+  ).should('contain', sampleData.savedCarts.carts[0].totalUnitCount);
+
+  cy.get(
+    'cx-saved-cart-list .cx-saved-cart-list-total > .cx-saved-cart-list-value'
+  ).should('contain', sampleData.savedCarts.carts[0].totalPrice.formattedValue);
+}
+
+export function verifyMiniCartQuantity(quantity: number) {
+  cy.get('cx-mini-cart .count').should('contain', quantity);
+}
+
+export function verifyCartDetails(cart: any) {
+  cy.get('cx-cart-item-list')
+    .contains('cx-cart-item', cart.entries[0].product.code)
+    .within(() => {
+      cy.get('.cx-name').should('contain', cart.entries[0].product.name);
+    });
+}
+
+export function restoreCart(
+  product: SampleProduct,
+  savedCartForm: any,
+  isEmptyCart: boolean = false
+) {
+  cy.window()
+    .then((win) => JSON.parse(win.localStorage.getItem('spartacus⚿⚿auth')))
+    .then(({ token }) => {
+      cy.requireSavedCart(token, product, savedCartForm).then((cart) => {
+        visitSavedCartListingPage();
+
+        if (isEmptyCart) {
+          verifyMiniCartQuantity(0);
+        } else {
+          verifyMiniCartQuantity(1);
+        }
+
+        // asserts the cart matches what is shown in the table
+
+        cy.get(
+          'cx-saved-cart-list .cx-saved-cart-list-cart-name > .cx-saved-cart-list-value'
+        ).should('contain', cart.code);
+
+        cy.get(
+          'cx-saved-cart-list .cx-saved-cart-list-cart-id > .cx-saved-cart-list-value'
+        ).should('contain', cart.code);
+
+        cy.get(
+          'cx-saved-cart-list .cx-saved-cart-list-quantity > .cx-saved-cart-list-value'
+        ).should('contain', sampleData.savedCarts.carts[0].totalUnitCount);
+
+        cy.get(
+          'cx-saved-cart-list .cx-saved-cart-list-total > .cx-saved-cart-list-value'
+        ).should(
+          'contain',
+          sampleData.savedCarts.carts[0].totalPrice.formattedValue
+        );
+
+        const restoreSavedCartAlias = interceptRestoreSavedCartEndpoint(
+          cart.code
+        );
+
+        //get the previous active cart before it gets replaced
+        //maybe there's a better way
+        cy.window()
+          .then((win) =>
+            JSON.parse(
+              win.localStorage.getItem('spartacus⚿powertools-spa⚿cart')
+            )
+          )
+          .then(({ active }) => {
+            cy.get('cx-saved-cart-list button:first').should('exist').click();
+
+            cy.wait(`@${restoreSavedCartAlias}`)
+              .its('response.statusCode')
+              .should('eq', 200);
+
+            if (isEmptyCart) {
+              alerts
+                .getSuccessAlert()
+                .should(
+                  'contain',
+                  `Existing cart is activated by ${cart.code} successfully`
+                );
+            } else {
+              alerts
+                .getSuccessAlert()
+                .should(
+                  'contain',
+                  `Existing cart is activated by ${cart.code} successfully. Your previous items were saved in a cart ${active}.`
+                );
+            }
+          });
+
+        verifyMiniCartQuantity(1);
+
+        // assert that the cart was properly swapped / made active
+        visitCartPage();
+
+        cy.get('.cart-details-wrapper .cx-total').should(
+          'contain',
+          `Cart #${cart.code}`
+        );
+
+        verifyCartDetails(cart);
+      });
+    });
+}
+
+export function updateSavedCartAndDelete(
+  product: SampleProduct,
+  savedCartForm: any,
+  deleteEntry: boolean = false
+) {
+  cy.window()
+    .then((win) => JSON.parse(win.localStorage.getItem('spartacus⚿⚿auth')))
+    .then(({ token }) => {
+      cy.requireSavedCart(token, product, savedCartForm).then((cart) => {
+        visitSavedCartDetailsPage(cart.code);
+
+        // assert some cart details
+        verifyCartDetails(cart);
+
+        // asserts the name and description is the current one
+        cy.get('cx-saved-cart-detail-overview .cx-card-title')
+          .parent()
+          .find('.cx-card-label')
+          .should('contain', savedCartForm.name);
+
+        cy.get('cx-truncate-text-popover .cx-action-link')
+          .should('contain', 'more')
+          .click();
+
+        cy.get('cx-popover').within(() => {
+          cy.get(' .popover-body').should('contain', savedCartForm.description);
+          cy.get('button[class="close"]').click();
+        });
+
+        // open modal to update name and description
+        cy.get('cx-saved-cart-detail-overview .cx-edit-cart').click();
+
+        const updatedSavedCartAlias = interceptSaveCartEndpoint(cart.code);
+
+        cy.get('cx-saved-cart-form-dialog').within(() => {
+          cy.get('[formcontrolname="name"]').type(`
+          {selectall}${sampleData.savedActiveCartForm[4].name}`);
+          cy.get('[formcontrolname="description"]').type(`
+          {selectall}${sampleData.savedActiveCartForm[4].description}`);
+
+          cy.get('button[aria-label="Save"]').click();
+        });
+
+        cy.wait(`@${updatedSavedCartAlias}`)
+          .its('response.statusCode')
+          .should('eq', 200);
+
+        // asserts the name and description was updated to the new one
+        cy.get('cx-saved-cart-detail-overview .cx-card-title')
+          .parent()
+          .find('.cx-card-label')
+          .should('contain', sampleData.savedActiveCartForm[4].name);
+
+        cy.get('cx-saved-cart-detail-overview .cx-card-title')
+          .parent()
+          .find('cx-truncate-text-popover')
+          .should('contain', sampleData.savedActiveCartForm[4].description);
+
+        alerts.getSuccessAlert().should('contain', `Cart Edited Successfully`);
+
+        // open modal to delete cart or delete cart from removing the last entry product
+
+        const getAllSavedCartAlias = interceptGetAllSavedCartEndpoint();
+        const deleteCartAlias = interceptDeleteCartEndpoint(cart.code);
+
+        if (deleteEntry) {
+          cy.get(
+            'cx-saved-cart-detail-items cx-cart-item .cx-action-link'
+          ).click();
+        } else {
+          cy.get('cx-saved-cart-detail-action .btn-action').click();
+
+          cy.get('cx-saved-cart-form-dialog').within(() => {
+            cy.get('.cx-saved-cart-value').should(
+              'contain',
+              sampleData.savedActiveCartForm[4].name
+            );
+            cy.get('.cx-saved-cart-value').should(
+              'contain',
+              sampleData.savedActiveCartForm[4].description
+            );
+
+            cy.get('button[aria-label="delete"]').click();
+          });
+        }
+
+        cy.wait(`@${deleteCartAlias}`)
+          .its('response.statusCode')
+          .should('eq', 200);
+        cy.wait(`@${getAllSavedCartAlias}`)
+          .its('response.statusCode')
+          .should('eq', 200);
+
+        alerts.getSuccessAlert().should('contain', `Cart Deleted Successfully`);
+
+        cy.get('cx-saved-cart-list .cx-saved-cart-list-no-saved-carts').should(
+          'contain',
+          'No Saved Carts Found'
+        );
+      });
+    });
+}
+
+export function updateSavedCartAndRestore(
+  product: SampleProduct,
+  savedCartForm: any
+) {
+  cy.window()
+    .then((win) => JSON.parse(win.localStorage.getItem('spartacus⚿⚿auth')))
+    .then(({ token }) => {
+      cy.requireSavedCart(token, product, savedCartForm).then((cart) => {
+        visitSavedCartDetailsPage(cart.code);
+
+        // assert that there's active cart with no entries
+        verifyMiniCartQuantity(0);
+
+        // assert some cart details
+        verifyCartDetails(cart);
+
+        // asserts the name and description is the current one
+        cy.get('cx-saved-cart-detail-overview .cx-card-title')
+          .parent()
+          .find('.cx-card-label')
+          .should('contain', savedCartForm.name);
+
+        cy.get('cx-truncate-text-popover .cx-action-link')
+          .should('contain', 'more')
+          .click();
+
+        cy.get('cx-popover').within(() => {
+          cy.get(' .popover-body').should('contain', savedCartForm.description);
+          cy.get('button[class="close"]').click();
+        });
+
+        // open modal to update name and description
+        cy.get('cx-saved-cart-detail-overview .cx-edit-cart').click();
+
+        const updatedSavedCartAlias = interceptSaveCartEndpoint(cart.code);
+
+        cy.get('cx-saved-cart-form-dialog').within(() => {
+          cy.get('[formcontrolname="name"]').type(`
+          {selectall}${sampleData.savedActiveCartForm[4].name}`);
+          cy.get('[formcontrolname="description"]').type(`
+          {selectall}${sampleData.savedActiveCartForm[4].description}`);
+
+          cy.get('button[aria-label="Save"]').click();
+        });
+
+        cy.wait(`@${updatedSavedCartAlias}`)
+          .its('response.statusCode')
+          .should('eq', 200);
+
+        // asserts the name and description was updated to the new one
+        cy.get('cx-saved-cart-detail-overview .cx-card-title')
+          .parent()
+          .find('.cx-card-label')
+          .should('contain', sampleData.savedActiveCartForm[4].name);
+
+        cy.get('cx-saved-cart-detail-overview .cx-card-title')
+          .parent()
+          .find('cx-truncate-text-popover')
+          .should('contain', sampleData.savedActiveCartForm[4].description);
+
+        alerts.getSuccessAlert().should('contain', `Cart Edited Successfully`);
+
+        // restore saved cart
+        const restoreSavedCartAlias = interceptRestoreSavedCartEndpoint(
+          cart.code
+        );
+        const getAllSavedCartAlias = interceptGetAllSavedCartEndpoint();
+
+        cy.get('cx-saved-cart-detail-action .btn-primary').click();
+
+        cy.wait(`@${restoreSavedCartAlias}`)
+          .its('response.statusCode')
+          .should('eq', 200);
+
+        alerts
+          .getSuccessAlert()
+          .should(
+            'contain',
+            `Existing cart is activated by ${cart.code} successfully`
+          );
+
+        cy.wait(`@${getAllSavedCartAlias}`)
+          .its('response.statusCode')
+          .should('eq', 200);
+
+        cy.get('cx-saved-cart-list .cx-saved-cart-list-no-saved-carts').should(
+          'contain',
+          'No Saved Carts Found'
+        );
+
+        // assert that restored cart became active cart
+        verifyMiniCartQuantity(1);
+
+        // assert that it is now in the cart page
+        visitCartPage();
+
+        cy.get('.cart-details-wrapper .cx-total').should(
+          'contain',
+          `Cart #${cart.code}`
+        );
+
+        verifyCartDetails(cart);
+      });
+    });
+}

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/saved-cart/b2b-saved-cart.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/saved-cart/b2b-saved-cart.e2e-spec.ts
@@ -1,0 +1,161 @@
+import * as savedCart from '../../../../helpers/b2b/b2b-saved-cart';
+import { viewportContext } from '../../../../helpers/viewport-context';
+import * as sampleData from '../../../../sample-data/b2b-saved-cart';
+
+context('B2B - Saved Cart', () => {
+  viewportContext(['mobile', 'desktop'], () => {
+    before(() => {
+      cy.window().then((win) => win.sessionStorage.clear());
+      cy.window().then((win) => win.localStorage.clear());
+      cy.clearLocalStorageMemory();
+    });
+
+    describe('Accessibility - keyboarding', () => {
+      describe('Cart page', () => {
+        it('should conform to tabbing order', () => {
+          savedCart.verifyCartPageTabbingOrder();
+        });
+      });
+
+      describe('Modal', () => {
+        before(() => {
+          savedCart.loginB2bUser();
+          savedCart.waitForCartPageData(sampleData.products[1]);
+          savedCart.visitCartPage();
+        });
+
+        it('should conform to tabbing order', () => {
+          savedCart.verifyModalTabbingOrder();
+        });
+      });
+
+      describe('Saved Cart Listing Page', () => {
+        before(() => {
+          savedCart.loginB2bUser();
+          savedCart.waitForSavedCartListingPageData(sampleData.products[0]);
+          savedCart.visitSavedCartListingPage();
+        });
+
+        it('should conform to tabbing order', () => {
+          savedCart.verifyListingTabbingOrder();
+        });
+      });
+
+      describe('Saved Cart Details Page', () => {
+        before(() => {
+          savedCart.loginB2bUser();
+          savedCart.waitForSavedCartDetailsPageData(sampleData.products[0]);
+        });
+
+        it('should conform to tabbing order', () => {
+          savedCart.verifyDetailsTabbingOrder();
+        });
+      });
+    });
+
+    describe('Restricted pages to anonymous user', () => {
+      afterEach(() => {
+        cy.location('pathname').should('contain', '/login');
+      });
+
+      it('should redirect to login page when trying to visit the saved cart "listing" page through url', () => {
+        cy.visit(`/my-account/saved-carts`);
+      });
+
+      it('should redirect to login page when trying to visit the saved cart "details" page through url', () => {
+        cy.visit(`/my-account/saved-cart/${sampleData.MOCK_ACTIVE_CART_CODE}`);
+      });
+    });
+
+    describe('Cart page', () => {
+      describe('Anonymous user', () => {
+        beforeEach(() => {
+          savedCart.addProductToCart(sampleData.products[0], 2);
+        });
+
+        afterEach(() => {
+          cy.location('pathname').should('contain', '/login');
+        });
+
+        it('should redirect to login page when clicking "Saved Cart"', () => {
+          savedCart.clickSavedCartButtonsFromCartPage(0);
+        });
+
+        it('should redirect to login page when clicking "Save Cart For Later"', () => {
+          savedCart.clickSavedCartButtonsFromCartPage(1);
+        });
+      });
+
+      describe('Logged in user', () => {
+        beforeEach(() => {
+          savedCart.loginB2bUser();
+          savedCart.waitForCartPageData(sampleData.products[1]);
+          savedCart.visitCartPage();
+        });
+
+        it('should be able to visit the saved cart listing page', () => {
+          savedCart.clickSavedCartButtonsFromCartPage(0);
+          cy.location('pathname').should('contain', '/my-account/saved-carts');
+        });
+
+        it('should be able to save the active cart and view it in the listing page', () => {
+          savedCart.saveActiveCart();
+        });
+      });
+    });
+
+    describe('Saved Cart Listing Page', () => {
+      beforeEach(() => {
+        savedCart.loginB2bUser();
+      });
+
+      it('should make cart active and not swap cart when active cart is empty', () => {
+        savedCart.restoreCart(
+          sampleData.products[1],
+          sampleData.savedActiveCartForm[2],
+          true
+        );
+      });
+
+      it('should make cart active and swap cart when active cart has entries', () => {
+        savedCart.waitForCartPageData(sampleData.products[2]);
+        savedCart.visitCartPage();
+
+        savedCart.verifyCartDetails(sampleData.savedCarts.carts[1]);
+
+        savedCart.restoreCart(
+          sampleData.products[1],
+          sampleData.savedActiveCartForm[2]
+        );
+      });
+    });
+
+    describe('Saved Cart Details Page', () => {
+      beforeEach(() => {
+        savedCart.loginB2bUser();
+      });
+
+      it('should update saved cart name and description, and delete it from the modal', () => {
+        savedCart.updateSavedCartAndDelete(
+          sampleData.products[1],
+          sampleData.savedActiveCartForm[3]
+        );
+      });
+
+      it('should update saved cart name and description, and delete it from 0 entries', () => {
+        savedCart.updateSavedCartAndDelete(
+          sampleData.products[1],
+          sampleData.savedActiveCartForm[0],
+          true
+        );
+      });
+
+      it('should update saved cart name and description, and restore it', () => {
+        savedCart.updateSavedCartAndRestore(
+          sampleData.products[1],
+          sampleData.savedActiveCartForm[0]
+        );
+      });
+    });
+  });
+});

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-saved-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-saved-cart.ts
@@ -1,0 +1,245 @@
+import { b2bProduct } from './b2b-checkout';
+
+export const CURRENT_USER_ID = 'current';
+export const MOCK_ACTIVE_CART_CODE = '00000001';
+
+export const products = [
+  b2bProduct,
+  {
+    name: 'Measuring beakers',
+    code: '2217258',
+  },
+  {
+    name: '6 Inch Nylon Cable Ties 100-Pack',
+    code: '1128763',
+  },
+];
+
+export const savedActiveCartForm = [
+  {
+    name: 'test1',
+    description:
+      'lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum',
+  },
+  { name: 'test2accessibility', description: 'test' },
+  // to return default name and description from backend
+  { name: '', description: '' },
+  {
+    name: 'test3',
+    description:
+      'lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum',
+  },
+  {
+    name: 'test4 updated',
+    description: 'updated body',
+  },
+];
+
+export const savedCarts = {
+  carts: [
+    {
+      entries: [
+        {
+          basePrice: {
+            formattedValue: '$4.50',
+            value: 4.5,
+          },
+          cancellableQuantity: 0,
+          configurationInfos: [],
+          entryNumber: 0,
+          product: {
+            availableForPickup: false,
+            baseOptions: [],
+            categories: [
+              {
+                code: '1358',
+                name: 'Measuring & Layout Tools',
+              },
+              {
+                code: 'brand_912',
+                name: 'Hama',
+              },
+            ],
+            code: '2217258',
+            configurable: false,
+            images: [
+              {
+                altText: 'Measuring beakers',
+                format: 'zoom',
+                imageType: 'PRIMARY',
+                url:
+                  '/medias/?context=bWFzdGVyfGltYWdlc3wzNjg4N3xpbWFnZS9qcGVnfGltYWdlcy9oMzMvaDQ3Lzg3OTY4Njc2OTA1MjYuanBnfGQ1MGM5YzMxMzIwOTNhOGZiMDdhMzRiMzc3ZGVlNmE4ZTY3YWRiZTkyODA1N2Q3ZDVhYjM4MTNiZTU0YzhjNTc',
+              },
+              {
+                altText: 'Measuring beakers',
+                format: 'product',
+                imageType: 'PRIMARY',
+                url:
+                  '/medias/?context=bWFzdGVyfGltYWdlc3wxMzk0M3xpbWFnZS9qcGVnfGltYWdlcy9oY2QvaDE2Lzg3OTY4OTQ5NTM1MDIuanBnfGE5ZTYyNjY4YjZhYjcxNzNkNWQ0OTNkN2Y1NjM5MjljNjdlMzlkNDc3ODQ1NjhjZjI2NGY4ZDFiZTBmYWY5MTU',
+              },
+              {
+                altText: 'Measuring beakers',
+                format: 'thumbnail',
+                imageType: 'PRIMARY',
+                url:
+                  '/medias/?context=bWFzdGVyfGltYWdlc3wyMzc4fGltYWdlL2pwZWd8aW1hZ2VzL2gzMS9oZDkvODc5NjkyMjIxNjQ3OC5qcGd8OTg5OGE5OTFjNDE0M2FhMDU1ZjJiZjgxY2NkNzlmYTExYmI5YTRmZTI3MTZmMzlmNjBjZTVjNmQ2NTFiMzAyMQ',
+              },
+              {
+                altText: 'Measuring beakers',
+                format: 'cartIcon',
+                imageType: 'PRIMARY',
+                url:
+                  '/medias/?context=bWFzdGVyfGltYWdlc3wxNDc2fGltYWdlL2pwZWd8aW1hZ2VzL2g3NC9oOTYvODc5Njk0OTQ3OTQ1NC5qcGd8MDkxODQ4MWQ1Y2UzZjljYzU5NDdmN2RlNjNmY2I0MTc3MzFkMDRkNjk4YmJjNWI4NzNlODZlMDg3NDdmOTQ1MQ',
+              },
+            ],
+            manufacturer: 'Hama',
+            name: 'Measuring beakers',
+            purchasable: true,
+            stock: {
+              isValueRounded: false,
+              stockLevel: 168,
+              stockLevelStatus: 'inStock',
+            },
+            url:
+              '/Open-Catalogue/Tools/Measuring-%26-Layout-Tools/Measuring-beakers/p/2217258',
+          },
+          quantity: 1,
+          returnableQuantity: 0,
+          statusSummaryList: [],
+          totalPrice: {
+            currencyIso: 'USD',
+            formattedValue: '$4.50',
+            value: 4.5,
+          },
+          updateable: true,
+        },
+      ],
+      guid: '2d486162-87f8-4ab8-bd07-b69d70f4e471',
+      totalItems: 1,
+      totalPrice: {
+        currencyIso: 'USD',
+        formattedValue: '$4.50',
+        priceType: 'BUY',
+        value: 4.5,
+      },
+      totalPriceWithTax: {
+        currencyIso: 'USD',
+        formattedValue: '$4.50',
+        priceType: 'BUY',
+        value: 4.5,
+      },
+      totalTax: {
+        currencyIso: 'USD',
+        formattedValue: '$0.00',
+        priceType: 'BUY',
+        value: 0.0,
+      },
+      description: savedActiveCartForm[0].description,
+      name: savedActiveCartForm[0].name,
+      saveTime: '2021-03-22T21:42:23+0000',
+      totalUnitCount: 1,
+    },
+    {
+      entries: [
+        {
+          basePrice: {
+            formattedValue: '$16.00',
+            value: 16,
+          },
+          cancellableQuantity: 0,
+          configurationInfos: [],
+          entryNumber: 0,
+          product: {
+            availableForPickup: false,
+            baseOptions: [],
+            categories: [
+              {
+                code: '1358',
+                name: 'Measuring & Layout Tools',
+              },
+              {
+                code: 'brand_1518',
+                name: 'StarTech.com',
+              },
+            ],
+            code: '1128763',
+            configurable: false,
+            images: [
+              {
+                altText: '6 Inch Nylon Cable Ties 100-Pack',
+                format: 'zoom',
+                imageType: 'PRIMARY',
+                url:
+                  '/medias/?context=bWFzdGVyfGltYWdlc3wyNzc3OHxpbWFnZS9qcGVnfGltYWdlcy9oOTEvaGJhLzg3OTY4NjI3NzUzMjYuanBnfGE3NTA4NjIyN2FhNmYyMjI3Nzk4YTU5NjE0ZWVjOWUwOGM2MzdhMDljMjA5MjM1N2Q0ZDc5MDg4OTVlYzU3ODI',
+              },
+              {
+                altText: '6 Inch Nylon Cable Ties 100-Pack',
+                format: 'product',
+                imageType: 'PRIMARY',
+                url:
+                  '/medias/?context=bWFzdGVyfGltYWdlc3wxMDk3MnxpbWFnZS9qcGVnfGltYWdlcy9oMDMvaGZmLzg3OTY4OTAwMzgzMDIuanBnfGIwMWMzMTg5ODU4ZDMwZjU2MjA4ODMyMjlkMzA4NTBjZDZiMjMxM2RmOTU2MzJlYWZjMjVhYTgwOGRiMjBiMzc',
+              },
+              {
+                altText: '6 Inch Nylon Cable Ties 100-Pack',
+                format: 'thumbnail',
+                imageType: 'PRIMARY',
+                url:
+                  '/medias/?context=bWFzdGVyfGltYWdlc3wxOTYzfGltYWdlL2pwZWd8aW1hZ2VzL2hmZi9oYzUvODc5NjkxNzMwMTI3OC5qcGd8ODMzMGVkOWU2MTg5ZTg0NGI2ZjRjYTEzYzFiODJhMGYyNzg2ODA4MzA3M2U2ZTE2NWZhMWFmNTk1Mjg5ODBmYQ',
+              },
+              {
+                altText: '6 Inch Nylon Cable Ties 100-Pack',
+                format: 'cartIcon',
+                imageType: 'PRIMARY',
+                url:
+                  '/medias/?context=bWFzdGVyfGltYWdlc3wxMjQwfGltYWdlL2pwZWd8aW1hZ2VzL2gyYS9oYTMvODc5Njk0NDU2NDI1NC5qcGd8ODI3NjA2NjhiOTNiNDYxOTMxMzdiNjIxMmFmNjFiZGUxMWVkMmQ5ZDA3ZGU4YmU2Mzg0MzcxNDRjMDJmNzdjMQ',
+              },
+            ],
+            manufacturer: 'StarTech.com',
+            name: '6 Inch Nylon Cable Ties 100-Pack',
+            purchasable: true,
+            stock: {
+              isValueRounded: false,
+              stockLevel: 122,
+              stockLevelStatus: 'inStock',
+            },
+            url:
+              '/Open-Catalogue/Tools/Measuring-%26-Layout-Tools/6-Inch-Nylon-Cable-Ties-100-Pack/p/1128763',
+          },
+          quantity: 1,
+          returnableQuantity: 0,
+          statusSummaryList: [],
+          totalPrice: {
+            currencyIso: 'USD',
+            formattedValue: '$16.00',
+            value: 16,
+          },
+          updateable: true,
+        },
+      ],
+      guid: 'ca9b4d35-7d9e-4a52-b87c-bb44575c7ae2',
+      totalItems: 1,
+      totalPrice: {
+        currencyIso: 'USD',
+        formattedValue: '$16.00',
+        priceType: 'BUY',
+        value: 16,
+      },
+      totalPriceWithTax: {
+        currencyIso: 'USD',
+        formattedValue: '$16.00',
+        priceType: 'BUY',
+        value: 16,
+      },
+      totalTax: {
+        currencyIso: 'USD',
+        formattedValue: '$0.00',
+        priceType: 'BUY',
+        value: 0,
+      },
+      description: '-',
+      name: '00002708',
+      saveTime: '2021-03-23T00:50:08+0000',
+      totalUnitCount: 1,
+    },
+  ],
+};

--- a/projects/storefrontapp-e2e-cypress/cypress/support/commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/commands.ts
@@ -12,6 +12,7 @@ import './require-logged-in.commands';
 import './require-payment-done.commands';
 import './require-placed-order.commands';
 import './require-product-added-to-cart.commands';
+import './require-saved-carts.commands';
 import './require-shipping-address-added.commands';
 import './require-shipping-method-selected.commands';
 import './select-user-menu-option.commands';

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-saved-carts.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-saved-carts.commands.ts
@@ -1,0 +1,62 @@
+import { b2bProduct } from '../sample-data/b2b-checkout';
+import { savedActiveCartForm } from '../sample-data/b2b-saved-cart';
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       *  Returns Saved Cart Object.
+       *
+       * @memberof Cypress.Chainable
+       *
+       * @example
+        ```
+        cy.requireSavedCart(auth);
+        ```
+       */
+      requireSavedCart: (
+        auth: {},
+        productData?: {},
+        savedCartForm?: {}
+      ) => Cypress.Chainable<any>;
+    }
+  }
+}
+
+Cypress.Commands.add(
+  'requireSavedCart',
+  (auth, productData = b2bProduct, savedCartForm = savedActiveCartForm[2]) => {
+    function saveCart(cartCode: string) {
+      return cy.request({
+        method: 'PATCH',
+        url: `${Cypress.env('API_URL')}/${Cypress.env(
+          'OCC_PREFIX'
+        )}/${Cypress.env(
+          'BASE_SITE'
+        )}/users/current/carts/${cartCode}/save?saveCartName=${
+          savedCartForm.name
+        }&saveCartDescription=${savedCartForm.description}`,
+        headers: {
+          Authorization: `bearer ${auth.access_token}`,
+        },
+      });
+    }
+
+    cy.requireProductAddedToCart(auth, productData).then((cart) => {
+      saveCart(cart.cartId).then((response) => {
+        Cypress.log({
+          name: 'requireSavedCart',
+          displayName: 'Save cart (require)',
+          message: [`🛒 Successfully saved a cart`],
+          consoleProps: () => {
+            return {
+              'Cart ID': cart.cartId,
+              'Saved Cart Data': response.body,
+            };
+          },
+        });
+        cy.wrap(response.body.savedCartData);
+      });
+    });
+  }
+);


### PR DESCRIPTION
closes GH-9201
closes GH-9202


- tested against dev3 (has latest sample data, but with the saved cart cms components)
- b2b = true
- don't forget to update appropriate cypress.json (depends how you run the command to open/run cypress)

`REASON why the b2b check is failing is due to the fact that the sample data was not up to date in the backend for the CI running the b2b instance`

<img width="333" alt="Screen Shot 2021-03-23 at 12 12 56 AM" src="https://user-images.githubusercontent.com/29099466/112091923-cb642980-8b6c-11eb-925e-3915cefea764.png">
