### PR TITLE
persist focus for product card

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.html
@@ -20,9 +20,7 @@
           </p>
           <ng-template #withLink>
             <a
-              [cxFocus]="{
-                key: productCardOptions?.productBoundValue?.productSystemId
-              }"
+              [cxFocus]="focusConfig"
               [routerLink]="{ cxRoute: 'product', params: product } | cxUrl"
               class="cx-link"
               cxModal="dismiss"
@@ -80,9 +78,7 @@
                 productCardOptions?.hideRemoveButton ||
                 (loading$ | async)
               "
-              [cxFocus]="{
-                key: productCardOptions?.productBoundValue?.productSystemId
-              }"
+              [cxFocus]="focusConfig"
             >
               {{ 'configurator.button.remove' | cxTranslate }}
             </button>
@@ -93,9 +89,7 @@
                 [disabled]="
                   productCardOptions?.disableAllButtons || (loading$ | async)
                 "
-                [cxFocus]="{
-                  key: productCardOptions?.productBoundValue?.productSystemId
-                }"
+                [cxFocus]="focusConfig"
               >
                 {{ 'configurator.button.add' | cxTranslate }}
               </button>
@@ -112,9 +106,7 @@
                 !productCardOptions?.productBoundValue?.selected;
                 else deselect
               "
-              [cxFocus]="{
-                key: productCardOptions?.productBoundValue?.productSystemId
-              }"
+              [cxFocus]="focusConfig"
             >
               {{ 'configurator.button.select' | cxTranslate }}
             </button>
@@ -133,9 +125,7 @@
                   [disabled]="
                     productCardOptions?.hideRemoveButton || (loading$ | async)
                   "
-                  [cxFocus]="{
-                    key: productCardOptions?.productBoundValue?.productSystemId
-                  }"
+                  [cxFocus]="focusConfig"
                 >
                   {{ 'configurator.button.deselect' | cxTranslate }}
                 </button>

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.html
@@ -20,6 +20,9 @@
           </p>
           <ng-template #withLink>
             <a
+              [cxFocus]="{
+                key: productCardOptions?.productBoundValue?.productSystemId
+              }"
               [routerLink]="{ cxRoute: 'product', params: product } | cxUrl"
               class="cx-link"
               cxModal="dismiss"
@@ -77,6 +80,9 @@
                 productCardOptions?.hideRemoveButton ||
                 (loading$ | async)
               "
+              [cxFocus]="{
+                key: productCardOptions?.productBoundValue?.productSystemId
+              }"
             >
               {{ 'configurator.button.remove' | cxTranslate }}
             </button>
@@ -87,6 +93,9 @@
                 [disabled]="
                   productCardOptions?.disableAllButtons || (loading$ | async)
                 "
+                [cxFocus]="{
+                  key: productCardOptions?.productBoundValue?.productSystemId
+                }"
               >
                 {{ 'configurator.button.add' | cxTranslate }}
               </button>
@@ -103,6 +112,9 @@
                 !productCardOptions?.productBoundValue?.selected;
                 else deselect
               "
+              [cxFocus]="{
+                key: productCardOptions?.productBoundValue?.productSystemId
+              }"
             >
               {{ 'configurator.button.select' | cxTranslate }}
             </button>
@@ -121,6 +133,9 @@
                   [disabled]="
                     productCardOptions?.hideRemoveButton || (loading$ | async)
                   "
+                  [cxFocus]="{
+                    key: productCardOptions?.productBoundValue?.productSystemId
+                  }"
                 >
                   {{ 'configurator.button.deselect' | cxTranslate }}
                 </button>

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.spec.ts
@@ -181,6 +181,7 @@ describe('ConfiguratorAttributeProductCardComponent', () => {
       productBoundValue: value,
       singleDropdown: false,
       withQuantity: true,
+      attributeId: 123,
     };
 
     spyOn(component, 'onHandleDeselect').and.callThrough();
@@ -192,6 +193,15 @@ describe('ConfiguratorAttributeProductCardComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('create a focus config with key', () => {
+    expect(component.focusConfig.key).toContain(
+      component.productCardOptions.attributeId.toString()
+    );
+    const valueCode =
+      component.productCardOptions.productBoundValue?.valueCode ?? 'noCode';
+    expect(component.focusConfig.key).toContain(valueCode);
   });
 
   it('should indicate loading state when fetching product data', () => {

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.ts
@@ -32,6 +32,7 @@ export interface ConfiguratorAttributeProductCardComponentOptions {
   singleDropdown?: boolean;
   withQuantity?: boolean;
   loading$?: Observable<boolean>;
+  attributeId?: number;
 }
 
 @Component({
@@ -77,6 +78,16 @@ export class ConfiguratorAttributeProductCardComponent implements OnInit {
       this.productCardOptions?.productBoundValue?.selected &&
       this.productCardOptions?.multiSelect
     );
+  }
+
+  get focusConfig() {
+    return {
+      key:
+        this.productCardOptions.attributeId +
+        '--' +
+        this.productCardOptions.productBoundValue?.valueCode +
+        '--focus',
+    };
   }
 
   onHandleSelect(): void {

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.ts
@@ -32,7 +32,7 @@ export interface ConfiguratorAttributeProductCardComponentOptions {
   singleDropdown?: boolean;
   withQuantity?: boolean;
   loading$?: Observable<boolean>;
-  attributeId?: number;
+  attributeId: number;
 }
 
 @Component({

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { I18nModule, UrlModule } from '@spartacus/core';
-import { MediaModule } from '@spartacus/storefront';
+import { KeyboardFocusModule, MediaModule } from '@spartacus/storefront';
 import { ConfiguratorPriceModule } from '../../price/configurator-price.module';
 import { ConfiguratorShowMoreModule } from '../../show-more/configurator-show-more.module';
 import { ConfiguratorAttributeQuantityModule } from '../quantity/configurator-attribute-quantity.module';
@@ -24,6 +24,7 @@ import { ConfiguratorAttributeProductCardComponent } from './configurator-attrib
     ReactiveFormsModule,
     MediaModule,
     ConfiguratorPriceModule,
+    KeyboardFocusModule,
   ],
 })
 export class ConfiguratorAttributeProductCardModule {}

--- a/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { Config, I18nModule, provideDefaultConfig } from '@spartacus/core';
-import { ItemCounterModule } from '@spartacus/storefront';
+import { ItemCounterModule, KeyboardFocusModule } from '@spartacus/storefront';
 import {
   ConfiguratorUISettings,
   DefaultConfiguratorUISettings,
@@ -12,7 +12,7 @@ import { ConfiguratorAttributeQuantityComponent } from './configurator-attribute
   declarations: [ConfiguratorAttributeQuantityComponent],
   entryComponents: [ConfiguratorAttributeQuantityComponent],
   exports: [ConfiguratorAttributeQuantityComponent],
-  imports: [CommonModule, I18nModule, ItemCounterModule],
+  imports: [CommonModule, I18nModule, ItemCounterModule, KeyboardFocusModule],
   providers: [
     provideDefaultConfig(DefaultConfiguratorUISettings),
     { provide: ConfiguratorUISettings, useExisting: Config },

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.ts
@@ -263,6 +263,7 @@ export class ConfiguratorAttributeMultiSelectionBundleComponent
       multiSelect: true,
       withQuantity: this.withQuantity,
       loading$: this.loading$,
+      attributeId: this.attribute.attrCode,
     };
   }
 

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.ts
@@ -141,6 +141,7 @@ export class ConfiguratorAttributeSingleSelectionBundleDropdownComponent
       singleDropdown: true,
       withQuantity: false,
       loading$: this.loading$,
+      attributeId: this.attribute.attrCode,
     };
   }
 

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.ts
@@ -138,6 +138,8 @@ export class ConfiguratorAttributeSingleSelectionBundleComponent extends Configu
     return {
       hideRemoveButton: this.attribute.required,
       productBoundValue: value,
+      loading$: this.loading$,
+      attributeId: this.attribute.attrCode,
     };
   }
 


### PR DESCRIPTION
will restore focus to the the current button or the replaced button in case of add/remove or restore the focus to the product link, in case button disappears (e.g. for mandatory attributes).