### PR TITLE
make configurator UISettings in constructor optional

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
@@ -38,7 +38,7 @@ export class ConfiguratorAttributeInputFieldComponent
    * In case no config is injected, or when the debounce time is not configured at all,
    * this value will be used as fallback.
    */
-  public readonly FALLBACK_DEBOUNCE_TIME = 500;
+  private readonly FALLBACK_DEBOUNCE_TIME = 500;
 
   /**
    * @param {ConfiguratorUISettings} config Optional configuration for debounce time,

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
@@ -44,6 +44,14 @@ export class ConfiguratorAttributeInputFieldComponent
    * @param {ConfiguratorUISettings} config Optional configuration for debounce time,
    * if omitted {@link FALLBACK_DEBOUNCE_TIME} is used instead.
    */
+  // TODO(#11681): make config a required dependency
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  constructor(config: ConfiguratorUISettings);
+  /**
+   * @deprecated  since 3.3
+   */
+  constructor();
+
   constructor(protected config?: ConfiguratorUISettings) {
     super();
   }

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
@@ -34,7 +34,17 @@ export class ConfiguratorAttributeInputFieldComponent
 
   @Output() inputChange = new EventEmitter<ConfigFormUpdateEvent>();
 
-  constructor(protected config: ConfiguratorUISettings) {
+  /**
+   * In case no config is injected, or when the debounce time is not configured at all,
+   * this value will be used as fallback.
+   */
+  public readonly FALLBACK_DEBOUNCE_TIME = 500;
+
+  /**
+   * @param {ConfiguratorUISettings} config Optional configuration for debounce time,
+   * if omitted {@link FALLBACK_DEBOUNCE_TIME} is used instead.
+   */
+  constructor(protected config?: ConfiguratorUISettings) {
     super();
   }
 
@@ -51,7 +61,10 @@ export class ConfiguratorAttributeInputFieldComponent
     this.sub = this.attributeInputForm.valueChanges
       .pipe(
         debounce(() =>
-          timer(this.config.rulebasedConfigurator.inputDebounceTime)
+          timer(
+            this.config?.rulebasedConfigurator.inputDebounceTime ??
+              this.FALLBACK_DEBOUNCE_TIME
+          )
         )
       )
       .subscribe(() => this.onChange());

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
@@ -40,13 +40,14 @@ export class ConfiguratorAttributeInputFieldComponent
    */
   private readonly FALLBACK_DEBOUNCE_TIME = 500;
 
+  // TODO(#11681): make config a required dependency
   /**
    * @param {ConfiguratorUISettings} config Optional configuration for debounce time,
    * if omitted {@link FALLBACK_DEBOUNCE_TIME} is used instead.
    */
-  // TODO(#11681): make config a required dependency
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   constructor(config: ConfiguratorUISettings);
+
   /**
    * @deprecated  since 3.3
    */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.spec.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Directive,
-  Input,
-  Pipe,
-  PipeTransform,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Pipe, PipeTransform } from '@angular/core';
 import {
   ComponentFixture,
   fakeAsync,
@@ -30,15 +24,7 @@ class MockTranslateUrlPipe implements PipeTransform {
   transform(): any {}
 }
 
-@Directive({
-  selector: '[cxFocus]',
-})
-export class MockFocusDirective {
-  @Input('cxFocus') protected config: string;
-}
-
-const DEBOUNCE_TIME =
-  DefaultConfiguratorUISettings.rulebasedConfigurator.inputDebounceTime;
+let DEBOUNCE_TIME: number;
 
 function checkForValidationMessage(
   component: ConfiguratorAttributeNumericInputFieldComponent,
@@ -73,7 +59,6 @@ describe('ConfigAttributeNumericInputFieldComponent', () => {
         declarations: [
           ConfiguratorAttributeNumericInputFieldComponent,
           MockTranslateUrlPipe,
-          MockFocusDirective,
         ],
         imports: [ReactiveFormsModule],
         providers: [
@@ -111,6 +96,9 @@ describe('ConfigAttributeNumericInputFieldComponent', () => {
     fixture.detectChanges();
     htmlElem = fixture.nativeElement;
     spyOn(component.inputChange, 'emit');
+    DEBOUNCE_TIME =
+      DefaultConfiguratorUISettings.rulebasedConfigurator.inputDebounceTime ??
+      component['FALLBACK_DEBOUNCE_TIME'];
   });
 
   function checkForValidity(
@@ -196,6 +184,16 @@ describe('ConfigAttributeNumericInputFieldComponent', () => {
   it('should delay emit inputValue for debounce period', fakeAsync(() => {
     component.attributeInputForm.setValue('123');
     fixture.detectChanges();
+    expect(component.inputChange.emit).not.toHaveBeenCalled();
+    tick(DEBOUNCE_TIME);
+    expect(component.inputChange.emit).toHaveBeenCalled();
+  }));
+
+  it('should delay emit inputValue for debounce period with fallback config', fakeAsync(() => {
+    component['config'] = undefined;
+    component.attributeInputForm.setValue('123');
+    fixture.detectChanges();
+    tick(1); //in case undefined is passed as debounce time it will fire almost immediately
     expect(component.inputChange.emit).not.toHaveBeenCalled();
     tick(DEBOUNCE_TIME);
     expect(component.inputChange.emit).toHaveBeenCalled();

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.ts
@@ -44,17 +44,19 @@ export class ConfiguratorAttributeNumericInputFieldComponent
    */
   private readonly FALLBACK_DEBOUNCE_TIME = 500;
 
+  // TODO(#11681): make config a required dependency
   /**
    * @param {ConfiguratorAttributeNumericInputFieldService} configAttributeNumericInputFieldService Serive for numeric formatting and validation.
    * @param {ConfiguratorUISettings} config Optional configuration for debounce time,
    * if omitted {@link FALLBACK_DEBOUNCE_TIME} is used instead.
    */
-  // TODO(#11681): make config a required dependency
-  // eslint-disable-next-line @typescript-eslint/unified-signatures
   constructor(
+    // eslint-disable-next-line @typescript-eslint/unified-signatures
     configAttributeNumericInputFieldService: ConfiguratorAttributeNumericInputFieldService,
+    // eslint-disable-next-line @typescript-eslint/unified-signatures
     config?: ConfiguratorUISettings
   );
+
   /**
    * @deprecated  since 3.3
    */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.ts
@@ -38,9 +38,20 @@ export class ConfiguratorAttributeNumericInputFieldComponent
   @Output() inputChange = new EventEmitter<ConfigFormUpdateEvent>();
   sub: any;
 
+  /**
+   * In case no config is injected, or when the debounce time is not configured at all,
+   * this value will be used as fallback.
+   */
+  private readonly FALLBACK_DEBOUNCE_TIME = 500;
+
+  /**
+   * @param {ConfiguratorAttributeNumericInputFieldService} configAttributeNumericInputFieldService Serive for numeric formatting and validation.
+   * @param {ConfiguratorUISettings} config Optional configuration for debounce time,
+   * if omitted {@link FALLBACK_DEBOUNCE_TIME} is used instead.
+   */
   constructor(
     protected configAttributeNumericInputFieldService: ConfiguratorAttributeNumericInputFieldService,
-    protected config: ConfiguratorUISettings
+    protected config?: ConfiguratorUISettings
   ) {
     super();
   }
@@ -82,7 +93,10 @@ export class ConfiguratorAttributeNumericInputFieldComponent
     this.sub = this.attributeInputForm.valueChanges
       .pipe(
         debounce(() =>
-          timer(this.config.rulebasedConfigurator.inputDebounceTime)
+          timer(
+            this.config?.rulebasedConfigurator.inputDebounceTime ??
+              this.FALLBACK_DEBOUNCE_TIME
+          )
         )
       )
       .subscribe(() => this.onChange());

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.ts
@@ -49,6 +49,19 @@ export class ConfiguratorAttributeNumericInputFieldComponent
    * @param {ConfiguratorUISettings} config Optional configuration for debounce time,
    * if omitted {@link FALLBACK_DEBOUNCE_TIME} is used instead.
    */
+  // TODO(#11681): make config a required dependency
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  constructor(
+    configAttributeNumericInputFieldService: ConfiguratorAttributeNumericInputFieldService,
+    config?: ConfiguratorUISettings
+  );
+  /**
+   * @deprecated  since 3.3
+   */
+  constructor(
+    configAttributeNumericInputFieldService: ConfiguratorAttributeNumericInputFieldService
+  );
+
   constructor(
     protected configAttributeNumericInputFieldService: ConfiguratorAttributeNumericInputFieldService,
     protected config?: ConfiguratorUISettings


### PR DESCRIPTION
PS: also removed the mockedFocus Directive from the test, as it is obviously not required, but caused a strict mode issue in the test.