### PR TITLE
style: Adding blue outline to the modal buttons to explicitly show the focus

### DIFF
--- a/feature-libs/cart/_index.scss
+++ b/feature-libs/cart/_index.scss
@@ -4,4 +4,12 @@
 @import '~bootstrap/scss/variables';
 @import '~bootstrap/scss/_mixins';
 
+@mixin visible-focus {
+  outline-style: solid;
+  outline-color: var(--cx-color-visual-focus);
+  outline-width: var(--cx-visual-focus-width, 2px);
+  outline-offset: 4px;
+  transition: none;
+}
+
 @import './saved-cart/index';

--- a/feature-libs/cart/saved-cart/styles/_add-to-saved-cart.scss
+++ b/feature-libs/cart/saved-cart/styles/_add-to-saved-cart.scss
@@ -24,4 +24,10 @@ cx-add-to-saved-cart {
       justify-content: flex-end;
     }
   }
+
+  button {
+    &:focus {
+      @include visible-focus();
+    }
+  }
 }

--- a/feature-libs/cart/saved-cart/styles/_saved-cart-form-dialog.scss
+++ b/feature-libs/cart/saved-cart/styles/_saved-cart-form-dialog.scss
@@ -67,6 +67,10 @@ cx-saved-cart-form-dialog {
           &:last-child {
             margin-inline-start: 0.5rem;
           }
+
+          &:focus {
+            @include visible-focus();
+          }
         }
       }
     }


### PR DESCRIPTION
closes https://github.com/SAP/spartacus/issues/11775

Do note that it was accessible and that there's no trap as mentioned in the issue.

What was wrong though is that visually, it did not show a blue outline or show that the 'save' button was focused.
This PR addresses the statement above.