### PR TITLE
style: fix long names for saved carts in the modal and overview component

### DIFF
--- a/feature-libs/cart/saved-cart/styles/_saved-cart-details-overview.scss
+++ b/feature-libs/cart/saved-cart/styles/_saved-cart-details-overview.scss
@@ -51,6 +51,7 @@ cx-saved-cart-details-overview {
         .cx-edit-container {
           display: flex;
           justify-content: space-between;
+          word-break: break-word;
 
           .cx-edit-cart {
             height: 100%;

--- a/feature-libs/cart/saved-cart/styles/_saved-cart-form-dialog.scss
+++ b/feature-libs/cart/saved-cart/styles/_saved-cart-form-dialog.scss
@@ -35,6 +35,7 @@ cx-saved-cart-form-dialog {
 
             .cx-saved-cart-value {
               font-weight: bold;
+              word-break: break-word;
             }
           }
 


### PR DESCRIPTION
closes GH-11787


<img width="1109" alt="Screen Shot 2021-04-01 at 3 38 52 PM" src="https://user-images.githubusercontent.com/29099466/113345418-6a70ea00-9300-11eb-8b74-da8867596ef2.png">
<img width="499" alt="Screen Shot 2021-04-01 at 3 38 58 PM" src="https://user-images.githubusercontent.com/29099466/113345422-6b098080-9300-11eb-9680-4be14a68e612.png">
