### PR TITLE
Feature/fusion 1721

### DIFF
--- a/projects/storefrontlib/src/cms-components/user/login/login.component.html
+++ b/projects/storefrontlib/src/cms-components/user/login/login.component.html
@@ -6,6 +6,9 @@
 </ng-container>
 
 <ng-template #login>
+  <div class="headerLinks">
+    <cx-page-slot position="HeaderLinks"></cx-page-slot>
+  </div>
   <a role="link" [routerLink]="{ cxRoute: 'login' } | cxUrl">{{
     'miniLogin.signInRegister' | cxTranslate
   }}</a>

--- a/projects/storefrontlib/src/cms-components/user/login/login.component.html
+++ b/projects/storefrontlib/src/cms-components/user/login/login.component.html
@@ -8,8 +8,8 @@
 <ng-template #login>
   <div class="headerLinks">
     <cx-page-slot position="HeaderLinks"></cx-page-slot>
+    <a role="link" [routerLink]="{ cxRoute: 'login' } | cxUrl">{{
+      'miniLogin.signInRegister' | cxTranslate
+    }}</a>
   </div>
-  <a role="link" [routerLink]="{ cxRoute: 'login' } | cxUrl">{{
-    'miniLogin.signInRegister' | cxTranslate
-  }}</a>
 </ng-template>

--- a/projects/storefrontstyles/scss/components/user/login/_login.scss
+++ b/projects/storefrontstyles/scss/components/user/login/_login.scss
@@ -18,4 +18,13 @@
       @include type();
     }
   }
+  
+  .headerLinks{
+    float: left;
+  }
+  .login{
+    margin-left: 10px; 
+    float: right;
+  }
+
 }

--- a/projects/storefrontstyles/scss/components/user/login/_login.scss
+++ b/projects/storefrontstyles/scss/components/user/login/_login.scss
@@ -20,11 +20,8 @@
   }
   
   .headerLinks{
-    float: left;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 10px;
   }
-  .login{
-    margin-left: 10px; 
-    float: right;
-  }
-
 }

--- a/projects/storefrontstyles/scss/components/user/login/_login.scss
+++ b/projects/storefrontstyles/scss/components/user/login/_login.scss
@@ -18,7 +18,7 @@
       @include type();
     }
   }
-  
+
   .headerLinks {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/projects/storefrontstyles/scss/components/user/login/_login.scss
+++ b/projects/storefrontstyles/scss/components/user/login/_login.scss
@@ -19,7 +19,7 @@
     }
   }
   
-  .headerLinks{
+  .headerLinks {
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-gap: 10px;


### PR DESCRIPTION
Introducing the HeaderLinks Slot to load any CMS Component for the user. Here the CMS Component "Gigya Raas Component for Organisation Registration" is added to the slot in the backoffice which is loaded on the Homepage UI. If the user does not wish to use the gigya raas component then it will not be loaded in the slot instead they can use this slot to load any component of their choice or leave it empty.
I have added the styling info to ensure both Sign In / Register option and "Register Organisation" option are on the same level as to give the user similar look and feel as with the previous commerce UI.