### PR TITLE
fix: B2B tests that breaks the pipeline

### DIFF
--- a/feature-libs/cart/saved-cart/core/services/saved-cart.service.ts
+++ b/feature-libs/cart/saved-cart/core/services/saved-cart.service.ts
@@ -43,7 +43,6 @@ export class SavedCartService {
     protected multiCartService: MultiCartService,
     protected eventService: EventService
   ) {}
-  // test pr
 
   /**
    * Loads a single saved cart

--- a/feature-libs/cart/saved-cart/core/services/saved-cart.service.ts
+++ b/feature-libs/cart/saved-cart/core/services/saved-cart.service.ts
@@ -43,6 +43,7 @@ export class SavedCartService {
     protected multiCartService: MultiCartService,
     protected eventService: EventService
   ) {}
+  // test pr
 
   /**
    * Loads a single saved cart

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/shared-users.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/shared-users.ts
@@ -11,12 +11,12 @@ export const standardUser: AccountData = {
 };
 
 export const myCompanyAdminUser: AccountData = {
-  user: 'linda.wolf@rustic-hw.com',
+  user: 'powertools.admin@ydev.hybris.com',
   registrationData: {
-    firstName: 'Linda',
-    lastName: 'Wolf',
+    firstName: 'Powertools',
+    lastName: 'Admin Test User',
     titleCode: '',
-    password: 'pw4all',
-    email: 'linda.wolf@rustic-hw.com',
+    password: 'Password123.',
+    email: 'powertools.admin@ydev.hybris.com',
   },
 };


### PR DESCRIPTION
test to fix the broken b2b e2es that relies on the admin account.

- using a b2b 'new' admin user specifically for e2e testing



Password mismatch may still happen, but I believe changing the user to an 'e2e' admin user is better than using Linda. Reason being, some may still be using the CI server directly + using the current admin account (Linda).
