### PR TITLE
fix: Improper typing for decorateExpressEngine

### DIFF
--- a/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
+++ b/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
@@ -49,7 +49,7 @@ export class NgExpressEngineDecorator {
    */
   static get(
     ngExpressEngine: NgExpressEngine,
-    optimizationOptions?: SsrOptimizationOptions
+    optimizationOptions?: SsrOptimizationOptions | null
   ): NgExpressEngine {
     const result = decorateExpressEngine(ngExpressEngine, optimizationOptions);
     return result;
@@ -58,7 +58,7 @@ export class NgExpressEngineDecorator {
 
 export function decorateExpressEngine(
   ngExpressEngine: NgExpressEngine,
-  optimizationOptions: SsrOptimizationOptions = {
+  optimizationOptions: SsrOptimizationOptions | null = {
     concurrency: 20,
     timeout: 3000,
   }


### PR DESCRIPTION
Backport of #11858 to 3.2 maintenance branch.

Closes #11857