### PR TITLE
chore: Fix release-it configurations after release

### DIFF
--- a/feature-libs/tracking/.release-it.json
+++ b/feature-libs/tracking/.release-it.json
@@ -10,7 +10,7 @@
     "publishPath": "./../../dist/tracking"
   },
   "hooks": {
-    "after:version:bump": "cd ../.. && ng build tracking --prod"
+    "after:version:bump": "cd ../.. && yarn build:tracking"
   },
   "github": {
     "release": true,

--- a/feature-libs/user/.release-it.json
+++ b/feature-libs/user/.release-it.json
@@ -26,7 +26,8 @@
           "path": [
             "peerDependencies.@spartacus/core",
             "peerDependencies.@spartacus/storefront",
-            "peerDependencies.@spartacus/styles"
+            "peerDependencies.@spartacus/styles",
+            "peerDependencies.@spartacus/schematics"
           ]
         }
       ]


### PR DESCRIPTION
During 3.2.0-rc.1 I found couple of misconfiguration in .release-it files.