### PR TITLE
fix: import sub-modules from sub-entry points, but not from relative paths

### DIFF
--- a/feature-libs/cart/import-export/core/import-export-core.module.ts
+++ b/feature-libs/cart/import-export/core/import-export-core.module.ts
@@ -1,31 +1,13 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { provideDefaultConfig } from '@spartacus/core';
+import { defaultImportExportConfig } from './config/default-import-export-config';
 
-@NgModule({
-  providers: [
-    // TODO: Avoid using duplicated config #11931
-    provideDefaultConfig({
-      importExport: {
-        fileValidity: {
-          maxSize: 1,
-          allowedExtensions: [
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-            'application/vnd.ms-excel',
-            'text/csv',
-          ],
-          checkEmptyFile: true,
-        },
-        file: {
-          separator: ',',
-        },
-      },
-    }),
-  ],
-})
+@NgModule({})
 export class ImportExportCoreModule {
   static forRoot(): ModuleWithProviders<ImportExportCoreModule> {
     return {
       ngModule: ImportExportCoreModule,
+      providers: [provideDefaultConfig(defaultImportExportConfig)],
     };
   }
 }

--- a/feature-libs/cart/import-export/core/public_api.ts
+++ b/feature-libs/cart/import-export/core/public_api.ts
@@ -1,3 +1,4 @@
-export * from './services/index';
 export * from './config/index';
+export * from './import-export-core.module';
 export * from './model/index';
+export * from './services/index';

--- a/feature-libs/cart/import-export/import-export.module.ts
+++ b/feature-libs/cart/import-export/import-export.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
-import { ImportExportCoreModule } from './core/import-export-core.module';
-import { ExportEntriesModule } from './components/export-entries/export-entries.module';
+import { ExportEntriesModule } from '@spartacus/cart/import-export/components';
+import { ImportExportCoreModule } from '@spartacus/cart/import-export/core';
 
 @NgModule({
   imports: [ImportExportCoreModule.forRoot(), ExportEntriesModule],


### PR DESCRIPTION
Imported sub-modules from sub-entry points, but not from relative paths. This fixes the compilation error - duplicate generation of the d.ts files in `dist/cart/import-export/core`

Btw. moved providing the default config to the `forRoot()` method

closes #11931