### PR TITLE
test: Fix cart e2e flakiness

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress.json
+++ b/projects/storefrontapp-e2e-cypress/cypress.json
@@ -12,6 +12,7 @@
     "API_URL": "https://40.76.109.9:9002",
     "BASE_SITE": "electronics-spa",
     "BASE_LANG": "en",
+    "BASE_CURRENCY": "USD",
     "OCC_PREFIX": "/occ/v2",
     "OCC_PREFIX_USER_ENDPOINT": "users",
     "OCC_PREFIX_ORDER_ENDPOINT": "orders"

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/cart.ts
@@ -174,6 +174,7 @@ export function checkBasicCart() {
   removeCartItem(products[0]);
 
   cy.wait('@refresh_cart');
+  cy.get('cx-cart-item').should('have.length', 1);
 
   removeCartItem(products[4]);
 
@@ -276,9 +277,7 @@ export function removeAllItemsFromCart() {
 export function removeCartItem(product) {
   registerDeleteCartItemRoute();
 
-  getCartItem(product.name).within(() => {
-    cy.findByText('Remove').click();
-  });
+  getCartItem(product.name).findByText('Remove').click();
 
   cy.wait('@delete_cart_item');
 }


### PR DESCRIPTION
Cart e2e is currently the test that is marked as the "flaky" in dashboard and it's fail rate causes too much retries in pipelines.

This PR fixes the flaky behaviour for the 2 worst cases
![image](https://user-images.githubusercontent.com/6259079/115355178-b3f37d00-a1ba-11eb-9c0b-160bc8392478.png)



**Problem was caused by the lack of knowledge of cypress retry-ability:**
In spec we grabbed element in loading state and tried to click the disabled remove button.
Instead we should have waited for the loading state to end and then grab the element to remove.