### PR TITLE
chore: Allow CDC CI to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
   - script:
     name: "E2E tests for B2C, 4th job"
     <<: *defaults
-  - script: "export CYPRESS_CONFIG=cypress.ci.cdc.json && export SPA_ENV='cdc' && ./ci-scripts/e2e-cypress.sh -s cdc"
+  - script: "export CYPRESS_CONFIG=cypress.ci.cdc.json && export SPA_ENV='cdc' && ./ci-scripts/e2e-cypress.sh -s cdc || exit 0"
     name: "E2E tests for CDC"
 addons:
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ jobs:
     <<: *defaults
   - script: "export CYPRESS_CONFIG=cypress.ci.cdc.json && export SPA_ENV='cdc' && ./ci-scripts/e2e-cypress.sh -s cdc"
     name: "E2E tests for CDC"
-    allow_failures:
-      if: 1 = 1
 addons:
   chrome: stable
   sonarcloud:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ jobs:
     <<: *defaults
   - script: "export CYPRESS_CONFIG=cypress.ci.cdc.json && export SPA_ENV='cdc' && ./ci-scripts/e2e-cypress.sh -s cdc"
     name: "E2E tests for CDC"
+    allow_failures:
+      if: 1 = 1
 addons:
   chrome: stable
   sonarcloud:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "e2e:run:ci:flaky": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:ci:flaky",
     "e2e:run:ci:cds": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:ci:cds",
     "e2e:run:ci:product-configuration": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:product-configuration",
-    "e2e:run:ci:cdc": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:ci:cdc",
+    "e2e:run:ci:cdc": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:ci:cdc || exit 0",
     "generate:changelog": "ts-node ./scripts/changelog.ts",
     "generate:docs": "npx @compodoc/compodoc -p tsconfig.compodoc.json && ./scripts/zip-docs.sh",
     "generate:publish:docs": "yarn generate:docs && yarn publish:docs",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "e2e:run:ci:flaky": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:ci:flaky",
     "e2e:run:ci:cds": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:ci:cds",
     "e2e:run:ci:product-configuration": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:product-configuration",
-    "e2e:run:ci:cdc": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:ci:cdc || exit 0",
+    "e2e:run:ci:cdc": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:ci:cdc",
     "generate:changelog": "ts-node ./scripts/changelog.ts",
     "generate:docs": "npx @compodoc/compodoc -p tsconfig.compodoc.json && ./scripts/zip-docs.sh",
     "generate:publish:docs": "yarn generate:docs && yarn publish:docs",


### PR DESCRIPTION
We don't have control over CDC servers, but we would like to see it's shape regularly and that's why we run it always in the pipeline.

And for potential problems not blocking us I made this job always passing (we still have visibility through cypress status and cypress comment)