### PR TITLE
test: Stable save-for-later e2e

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/save-for-later/save-for-later.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/save-for-later/save-for-later.e2e-spec.ts
@@ -1,4 +1,7 @@
-import { viewportContext } from '../../../helpers/viewport-context';
+import { login } from '../../../helpers/auth-forms';
+import * as cart from '../../../helpers/cart';
+import * as cartCoupon from '../../../helpers/cart-coupon';
+import { waitForPage } from '../../../helpers/checkout-flow';
 import {
   addProductToCart,
   ItemList,
@@ -10,9 +13,7 @@ import {
   validateProduct,
   verifyMiniCartQty,
 } from '../../../helpers/save-for-later';
-import { waitForPage } from '../../../helpers/checkout-flow';
-import * as cart from '../../../helpers/cart';
-import * as cartCoupon from '../../../helpers/cart-coupon';
+import { viewportContext } from '../../../helpers/viewport-context';
 
 context('Save for later', () => {
   viewportContext(['mobile', 'desktop'], () => {
@@ -33,15 +34,17 @@ context('Save for later', () => {
     context('Re-login customer', () => {
       it('Should save items in saved for later list when logout', () => {
         const alias = waitForPage('/cart', 'cartPage');
-
-        cart.registerCartUser();
-        cart.loginCartUser();
-        addProductToCart(products[2]);
-        moveItem(products[2], ItemList.SaveForLater);
-        validateCart(0, 1);
-        cart.logOutAndEmptyCart();
-        cart.loginCartUser();
-
+        cy.requireLoggedIn().then((account) => {
+          addProductToCart(products[2]);
+          moveItem(products[2], ItemList.SaveForLater);
+          validateCart(0, 1);
+          cart.logOutAndEmptyCart();
+          const loginPage = waitForPage('/login', 'getLoginPage');
+          cy.visit('/login');
+          cy.wait(`@${loginPage}`).its('status').should('eq', 200);
+          login(account.username, account.password);
+          cy.url().should('not.contain', 'login');
+        });
         cy.visit(`/cart`);
         cy.wait(`@${alias}`).its('status').should('eq', 200);
 

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-logged-in.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-logged-in.commands.ts
@@ -17,7 +17,7 @@ declare global {
       requireLoggedIn: (
         user?: AccountData,
         options?: RequireLoggedInDebugOptions
-      ) => Cypress.Chainable<{ username: string }>;
+      ) => Cypress.Chainable<{ username: string; password: string }>;
     }
   }
 }
@@ -126,6 +126,6 @@ Cypress.Commands.add(
       }
     });
 
-    return cy.wrap({ username });
+    return cy.wrap({ username, password: account.registrationData.password });
   }
 );


### PR DESCRIPTION
The save-for-later e2e was recently flaky test on desktop.

From debugging it looks like the problem was caused by reusing the same user in 2 tests (mobile and desktop) and sometimes you had the leftovers in state from previous tests.

In this PR I dropped usage of this single user and in mobile/desktop we generate completely new user that should always have fresh/empty state of carts.