### PR TITLE
GH-12067 adjust cypress test for add configuration directly, checkout…

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configuration.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configuration.ts
@@ -1315,6 +1315,7 @@ export function checkoutB2B(): void {
     .contains('Continue')
     .click()
     .then(() => {
+      cy.wait('@deliveryMode');
       cy.location('pathname').should('contain', '/checkout/delivery-mode');
       cy.get('.cx-checkout-title').should('contain', 'Shipping Method');
       cy.get('cx-delivery-mode').should('be.visible');
@@ -1537,4 +1538,21 @@ export function checkAmountOfBundleItems(
     cy.get('.cx-number-items').should('contain', itemsAmount);
     toggleBundleItems('show');
   });
+}
+
+/**
+ * Verifies the amount of cart entries.
+ *
+ * @param {number} expectedCount - Expected amount of cart entries
+ */
+export function verifyCartCount(expectedCount: number) {
+  cy.log('expectedCount =' + expectedCount);
+  cy.get('cx-mini-cart .count').contains(expectedCount);
+}
+
+/**
+ * Define alias for deliveryMode API call.
+ */
+export function defineDeliveryModeAlias() {
+  cy.intercept('PUT', '**/deliverymode*').as('deliveryMode');
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/vendor/cpq/cpq-configuration.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/vendor/cpq/cpq-configuration.e2e-spec.ts
@@ -428,8 +428,17 @@ context('CPQ Configuration', () => {
         const numberOfCartItems = Number(elem.text());
         cy.log('numberOfCartItems = ' + numberOfCartItems);
         editConfigurationFromCartEntry(numberOfCartItems);
-        checkout();
-        orderHistory();
+        // Checkout
+        configuration.clickOnProceedToCheckoutBtnInCart();
+        configuration.checkoutB2B();
+        // Order historyorderHistory();
+        configuration.selectOrderByOrderNumberAlias(POWERTOOLS);
+        configurationOverview.checkGroupHeaderDisplayed(GRP_CAM_MAIN, 0);
+        configurationOverview.checkAttrDisplayed(
+          'Camera Body',
+          'Canon EOS 80D',
+          0
+        );
       });
     });
   });
@@ -459,7 +468,10 @@ context('CPQ Configuration', () => {
         quantity: '1',
       },
     ];
-    configuration.checkAmountOfBundleItems(cartEntryIndex, 3);
+    configuration.checkAmountOfBundleItems(
+      cartEntryIndex,
+      ovBundleInfos.length
+    );
 
     ovBundleInfos.forEach((line, bundleItemIndex) => {
       configuration.checkBundleItemName(
@@ -515,16 +527,5 @@ context('CPQ Configuration', () => {
 
     configuration.checkAmountOfBundleItems(cartEntryIndex, 4);
     configuration.verifyCartCount(numberOfCartItems);
-  }
-
-  function checkout() {
-    configuration.clickOnProceedToCheckoutBtnInCart();
-    configuration.checkoutB2B();
-  }
-
-  function orderHistory() {
-    configuration.selectOrderByOrderNumberAlias(POWERTOOLS);
-    configurationOverview.checkGroupHeaderDisplayed(GRP_CAM_MAIN, 0);
-    configurationOverview.checkAttrDisplayed('Camera Body', 'Canon EOS 80D', 0);
   }
 });

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/vendor/cpq/cpq-configuration.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/vendor/cpq/cpq-configuration.e2e-spec.ts
@@ -1,4 +1,3 @@
-import * as cart from '../../../helpers/cart';
 import * as configuration from '../../../helpers/product-configuration';
 import * as configurationOverview from '../../../helpers/product-configuration-overview';
 import * as productSearch from '../../../helpers/product-search';
@@ -420,100 +419,112 @@ context('CPQ Configuration', () => {
 
   describe('Configuration Process', () => {
     it('should be able to add a configuration directly to the cart, navigate from the cart back to the configuration and update it, checkout and order', () => {
+      configuration.defineDeliveryModeAlias();
       configuration.goToPDPage(POWERTOOLS, PROD_CODE_CAM);
       configuration.clickOnAddToCartBtnOnPD();
       configuration.clickOnViewCartBtnOnPD();
 
-      type ovBundleInfo = {
-        name: string;
-        price?: string;
-        quantity?: string;
-      };
-      const ovBundleInfos: ovBundleInfo[] = [
-        {
-          name: 'SanDisk Extreme Pro 128GB SDXC',
-          price: '$100.00',
-          quantity: '1',
-        },
-        {
-          name: 'Canon RF 24-105mm f4L IS USM',
-          price: '$1,500.00',
-          quantity: '1',
-        },
-        {
-          name: 'LowePro Streetline SL 140',
-          price: '$110.00',
-          quantity: '1',
-        },
-      ];
-      configuration.checkAmountOfBundleItems(0, 3);
-
-      ovBundleInfos.forEach((line, bundleItemIndex) => {
-        configuration.checkBundleItemName(0, bundleItemIndex, line.name);
-        configuration.checkBundleItemPrice(0, bundleItemIndex, line.price);
-        configuration.checkBundleItemQuantity(
-          0,
-          bundleItemIndex,
-          line.quantity
-        );
+      cy.get('cx-mini-cart .count').then((elem) => {
+        const numberOfCartItems = Number(elem.text());
+        cy.log('numberOfCartItems = ' + numberOfCartItems);
+        editConfigurationFromCartEntry(numberOfCartItems);
+        checkout();
+        orderHistory();
       });
-
-      //We assume the last product in the cart is the one we added
-      configuration.clickOnEditConfigurationLink(
-        configuration.getNumberOfCartItems() - 1
-      );
-
-      configuration.checkAttributeDisplayed(ATTR_CAM_BODY, RADGRP_PROD);
-      configuration.selectAttribute(
-        ATTR_CAM_BODY,
-        RADGRP_PROD,
-        VAL_CAM_BODY_D850
-      );
-      configuration.checkValueSelected(
-        RADGRP_PROD,
-        ATTR_CAM_BODY,
-        VAL_CAM_BODY_D850
-      );
-      configuration.selectAttribute(
-        ATTR_CAM_BODY,
-        RADGRP_PROD,
-        VAL_CAM_BODY_EOS80D
-      );
-      configuration.checkValueSelected(
-        RADGRP_PROD,
-        ATTR_CAM_BODY,
-        VAL_CAM_BODY_EOS80D
-      );
-      configuration.selectAttribute(ATTR_CAM_LEN, CHKBOX_PROD, VAL_CAM_LEN_SI);
-      configuration.checkValueSelected(
-        CHKBOX_PROD,
-        ATTR_CAM_LEN,
-        VAL_CAM_LEN_SI
-      );
-      configuration.clickAddToCartBtn();
-
-      configurationOverview.checkConfigOverviewPageDisplayed();
-      configurationOverview.checkGroupHeaderDisplayed(GRP_CAM_MAIN, 0);
-      configurationOverview.checkAttrDisplayed(
-        'Camera Body',
-        'Canon EOS 80D',
-        0
-      );
-
-      configurationOverview.checkGroupHeaderDisplayed(GRP_CAM_ACC, 1);
-      configurationOverview.clickContinueToCartBtnOnOP();
-
-      cart.verifyCartNotEmpty();
-
-      configuration.clickOnProceedToCheckoutBtnInCart();
-      configuration.checkoutB2B();
-      configuration.selectOrderByOrderNumberAlias(POWERTOOLS);
-      configurationOverview.checkGroupHeaderDisplayed(GRP_CAM_MAIN, 0);
-      configurationOverview.checkAttrDisplayed(
-        'Camera Body',
-        'Canon EOS 80D',
-        0
-      );
     });
   });
+
+  function editConfigurationFromCartEntry(numberOfCartItems: number) {
+    //We assume the last product in the cart is the one we added
+    const cartEntryIndex: number = numberOfCartItems - 1;
+    type ovBundleInfo = {
+      name: string;
+      price?: string;
+      quantity?: string;
+    };
+    const ovBundleInfos: ovBundleInfo[] = [
+      {
+        name: 'SanDisk Extreme Pro 128GB SDXC',
+        price: '$100.00',
+        quantity: '1',
+      },
+      {
+        name: 'Canon RF 24-105mm f4L IS USM',
+        price: '$1,500.00',
+        quantity: '1',
+      },
+      {
+        name: 'LowePro Streetline SL 140',
+        price: '$110.00',
+        quantity: '1',
+      },
+    ];
+    configuration.checkAmountOfBundleItems(cartEntryIndex, 3);
+
+    ovBundleInfos.forEach((line, bundleItemIndex) => {
+      configuration.checkBundleItemName(
+        cartEntryIndex,
+        bundleItemIndex,
+        line.name
+      );
+      configuration.checkBundleItemPrice(
+        cartEntryIndex,
+        bundleItemIndex,
+        line.price
+      );
+      configuration.checkBundleItemQuantity(
+        cartEntryIndex,
+        bundleItemIndex,
+        line.quantity
+      );
+    });
+
+    configuration.clickOnEditConfigurationLink(cartEntryIndex);
+
+    configuration.checkAttributeDisplayed(ATTR_CAM_BODY, RADGRP_PROD);
+    configuration.selectAttribute(
+      ATTR_CAM_BODY,
+      RADGRP_PROD,
+      VAL_CAM_BODY_D850
+    );
+    configuration.checkValueSelected(
+      RADGRP_PROD,
+      ATTR_CAM_BODY,
+      VAL_CAM_BODY_D850
+    );
+    configuration.selectAttribute(
+      ATTR_CAM_BODY,
+      RADGRP_PROD,
+      VAL_CAM_BODY_EOS80D
+    );
+    configuration.checkValueSelected(
+      RADGRP_PROD,
+      ATTR_CAM_BODY,
+      VAL_CAM_BODY_EOS80D
+    );
+    configuration.selectAttribute(ATTR_CAM_LEN, CHKBOX_PROD, VAL_CAM_LEN_SI);
+    configuration.checkValueSelected(CHKBOX_PROD, ATTR_CAM_LEN, VAL_CAM_LEN_SI);
+    configuration.clickAddToCartBtn();
+
+    configurationOverview.checkConfigOverviewPageDisplayed();
+    configurationOverview.checkGroupHeaderDisplayed(GRP_CAM_MAIN, 0);
+    configurationOverview.checkAttrDisplayed('Camera Body', 'Canon EOS 80D', 0);
+
+    configurationOverview.checkGroupHeaderDisplayed(GRP_CAM_ACC, 1);
+    configurationOverview.clickContinueToCartBtnOnOP();
+
+    configuration.checkAmountOfBundleItems(cartEntryIndex, 4);
+    configuration.verifyCartCount(numberOfCartItems);
+  }
+
+  function checkout() {
+    configuration.clickOnProceedToCheckoutBtnInCart();
+    configuration.checkoutB2B();
+  }
+
+  function orderHistory() {
+    configuration.selectOrderByOrderNumberAlias(POWERTOOLS);
+    configurationOverview.checkGroupHeaderDisplayed(GRP_CAM_MAIN, 0);
+    configurationOverview.checkAttrDisplayed('Camera Body', 'Canon EOS 80D', 0);
+  }
 });


### PR DESCRIPTION
Adjust cypress test for add configuration directly, checkout and order:
identify cart entry correctly; wait for API call during continue to delivery mode in checkout. 