### PR TITLE
chore: add umdModuleIds for product-configurator/assets lib

### DIFF
--- a/feature-libs/product-configurator/common/assets/ng-package.json
+++ b/feature-libs/product-configurator/common/assets/ng-package.json
@@ -1,6 +1,9 @@
 {
   "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
-    "entryFile": "./public_api.ts"
+    "entryFile": "./public_api.ts",
+    "umdModuleIds": {
+      "@spartacus/core": "core"
+    }
   }
 }


### PR DESCRIPTION
closes #12244