### PR TITLE
chore: add umdModuleIds for product-configurator/assets lib (backport 3.3)

### DIFF
--- a/feature-libs/product-configurator/common/assets/ng-package.json
+++ b/feature-libs/product-configurator/common/assets/ng-package.json
@@ -1,6 +1,9 @@
 {
   "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
-    "entryFile": "./public_api.ts"
+    "entryFile": "./public_api.ts",
+    "umdModuleIds": {
+      "@spartacus/core": "core"
+    }
   }
 }


### PR DESCRIPTION
backport of https://github.com/SAP/spartacus/pull/12245 to 3.3

closes #12244