### PR TITLE
chore: Fix config for CDS release-it

### DIFF
--- a/integration-libs/cds/.release-it.json
+++ b/integration-libs/cds/.release-it.json
@@ -25,6 +25,7 @@
           "file": "package.json",
           "path": [
             "peerDependencies.@spartacus/core",
+            "peerDependencies.@spartacus/schematics",
             "peerDependencies.@spartacus/storefront"
           ]
         }


### PR DESCRIPTION
We forgot to include CDS schematics peerDeps to bump list