### PR TITLE
PoC: persist langauge splitted into 2 URL segments

### DIFF
--- a/projects/core/src/site-context/index.ts
+++ b/projects/core/src/site-context/index.ts
@@ -4,6 +4,7 @@ export * from './events/index';
 export * from './facade/index';
 export * from './providers/index';
 export * from './services/site-context-params.service';
+export * from './services/site-context-url-serializer';
 export { SiteContextModule } from './site-context.module';
 export * from './store/actions/index';
 export * from './store/selectors/index';

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -13,12 +13,21 @@ import { StoreModule } from '@ngrx/store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { translationChunksConfig, translations } from '@spartacus/assets';
 import {
+  BaseSiteService,
+  BASE_SITE_CONTEXT_ID,
   ConfigModule,
+  ContextServiceMap,
+  CurrencyService,
+  CURRENCY_CONTEXT_ID,
   FeaturesConfig,
   I18nConfig,
+  LanguageService,
+  LANGUAGE_CONTEXT_ID,
   OccConfig,
   provideConfig,
   RoutingConfig,
+  SiteContextConfig,
+  SiteContextUrlSerializer,
   TestConfigModule,
 } from '@spartacus/core';
 import { configuratorTranslations } from '@spartacus/product-configurator/common/assets';
@@ -28,6 +37,8 @@ import { StorefrontComponent } from '@spartacus/storefront';
 import { environment } from '../environments/environment';
 import { TestOutletModule } from '../test-outlets/test-outlet.module';
 import { AppRoutingModule } from './app-routing.module';
+import { CustomContextService } from './custom-context.service';
+import { CustomSiteContextUrlSerializer } from './custom-site-context-url-serializer';
 import { SpartacusModule } from './spartacus/spartacus.module';
 
 registerLocaleData(localeDe);
@@ -61,6 +72,15 @@ const ruleBasedFeatureConfiguration = environment.cpq
   ? ruleBasedCpqFeatureConfiguration
   : ruleBasedVcFeatureConfiguration;
 // PRODUCT CONFIGURATOR END
+
+export function serviceMapFactory() {
+  return {
+    [LANGUAGE_CONTEXT_ID]: LanguageService,
+    [CURRENCY_CONTEXT_ID]: CurrencyService,
+    [BASE_SITE_CONTEXT_ID]: BaseSiteService,
+    custom: CustomContextService,
+  };
+}
 
 @NgModule({
   imports: [
@@ -98,6 +118,21 @@ const ruleBasedFeatureConfiguration = environment.cpq
     ...devImports,
   ],
   providers: [
+    {
+      provide: ContextServiceMap,
+      useFactory: serviceMapFactory,
+    },
+    {
+      provide: SiteContextUrlSerializer,
+      useExisting: CustomSiteContextUrlSerializer,
+    },
+    provideConfig(<SiteContextConfig>{
+      context: {
+        urlParameters: ['baseSite', 'custom', 'currency'],
+        custom: ['e/n', 'd/e', 'j/a', 'z/h'],
+      },
+    }),
+
     provideConfig(<OccConfig>{
       backend: {
         occ: {

--- a/projects/storefrontapp/src/app/custom-context.service.ts
+++ b/projects/storefrontapp/src/app/custom-context.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { LanguageService, SiteContext } from '@spartacus/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+/**
+ * Puts slash in between 2 letters of lang iso code
+ */
+export function languageToCustom(lang: string): string {
+  return lang && lang.split('').join('/');
+}
+
+/**
+ * Removes slash from between 2 letters and maps the result to lang iso code
+ */
+export function customToLanguage(custom: string): string {
+  return custom && custom.replace('/', '');
+}
+
+@Injectable({ providedIn: 'root' })
+export class CustomContextService implements SiteContext<string> {
+  constructor(protected langService: LanguageService) {}
+
+  getActive(): Observable<string> {
+    return this.langService.getActive().pipe(map(languageToCustom));
+  }
+
+  setActive(custom: string): void {
+    this.langService.setActive(customToLanguage(custom));
+  }
+
+  getAll(): Observable<string[]> {
+    return this.langService
+      .getAll()
+      .pipe(
+        map((languages) =>
+          languages.map((lang) => languageToCustom(lang.isocode))
+        )
+      );
+  }
+}

--- a/projects/storefrontapp/src/app/custom-site-context-url-serializer.ts
+++ b/projects/storefrontapp/src/app/custom-site-context-url-serializer.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import { UrlTree } from '@angular/router';
+import { SiteContextUrlSerializer } from '@spartacus/core';
+
+export interface ParamValuesMap {
+  [name: string]: string;
+}
+
+export interface UrlTreeWithSiteContext extends UrlTree {
+  siteContext?: ParamValuesMap;
+}
+
+const UrlSplit = /(^[^#?]*)(.*)/; // used to split url into path and query/fragment parts
+
+@Injectable({ providedIn: 'root' })
+export class CustomSiteContextUrlSerializer extends SiteContextUrlSerializer {
+  urlExtractContextParameters(
+    url: string
+  ): { url: string; params: ParamValuesMap } {
+    let [, urlPart, queryPart] = url.match(UrlSplit);
+
+    const urlEncodingParameters = this['urlEncodingParameters'];
+    const siteContextParamsService = this['siteContextParams'];
+
+    const segments = urlPart.split('/');
+    if (segments[0] === '') {
+      segments.shift();
+    }
+    const params = {};
+
+    let paramId = 0;
+    let segmentId = 0;
+    while (
+      paramId < urlEncodingParameters.length &&
+      segmentId < segments.length
+    ) {
+      const paramName = urlEncodingParameters[paramId];
+      const paramValues = siteContextParamsService.getParamValues(paramName);
+
+      let segmentValue;
+      if (paramName === 'custom') {
+        // Consume 2 segments at one time for the context 'custom'
+
+        // if the 2nd segment doesn't exist, end recognition
+        if (segmentId + 1 > segments.length) {
+          break;
+        }
+
+        const segment1 = segments[segmentId];
+        const segment2 = segments[segmentId + 1];
+        segmentValue = `${segment1}/${segment2}`;
+      } else {
+        // Consume one segment for one context, by default
+        segmentValue = segments[segmentId];
+      }
+
+      if (paramValues.includes(segmentValue)) {
+        params[paramName] = segmentValue;
+        segmentId++;
+
+        if (paramName === 'custom') {
+          // We consumed 2 segments, so need to move the "cursor" to yet next position:
+          segmentId++;
+        }
+      }
+      paramId++;
+    }
+
+    url = segments.slice(segmentId).join('/') + queryPart;
+    return { url, params };
+  }
+}


### PR DESCRIPTION
This PoC PR is only for demo purposes (don't merge to develop). It's a show case how to split the language site context into 2 parts and store them in 2 separate URL segments (i.e. `/e/n/ -> en`, `/d/e/ -> de`).

By analogy, this example can be tweaked to store the language (being a full locale) as 2 separate URL segments (i.e. `/ch/de -> de_CH`). See feature request https://github.com/SAP/spartacus/issues/11549

Please note that `SiteContextUrlSerializer` is in private API yet (as the time of writing ~3.3 RC), so to import it you'll need a [workaround](https://stackoverflow.com/a/66871920/11734692). But we have plans to expose it the next minor in https://github.com/SAP/spartacus/pull/12298.