### PR TITLE
fix: Provide breakpoint service as mandatory dependency (#12310)

### DIFF
--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
@@ -144,7 +144,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
   describe('bundle info for cart entry', () => {
     it('should not be displayed if model provides empty array', () => {
       mockCartItemContext.item$.next({
-        statusSummaryList: null,
+        statusSummaryList: undefined,
         configurationInfos: [
           {
             configuratorType: 'ANOTHERCPQCONFIGURATOR',
@@ -163,7 +163,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
 
     it('should be displayed if model provides a success entry', () => {
       mockCartItemContext.item$.next({
-        statusSummaryList: null,
+        statusSummaryList: undefined,
         configurationInfos: [
           {
             configurationLabel: 'Color',
@@ -185,7 +185,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
 
     it('should be displayed if model provides a warning entry', () => {
       mockCartItemContext.item$.next({
-        statusSummaryList: null,
+        statusSummaryList: undefined,
         configurationInfos: [
           {
             configurationLabel: 'Pricing',
@@ -310,7 +310,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
     describe('with line item information', () => {
       beforeEach(() => {
         mockCartItemContext.item$.next({
-          statusSummaryList: null,
+          statusSummaryList: undefined,
           configurationInfos: configurationInfos,
           product: {
             configurable: true,
@@ -383,7 +383,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
     describe('cart entry bundle info with price and quantity', () => {
       beforeEach(() => {
         mockCartItemContext.item$.next({
-          statusSummaryList: null,
+          statusSummaryList: undefined,
           configurationInfos: [
             {
               configurationLabel: 'Canon ABC',
@@ -524,7 +524,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
     describe('cart entry bundle info with only quantity', () => {
       beforeEach(() => {
         mockCartItemContext.item$.next({
-          statusSummaryList: null,
+          statusSummaryList: undefined,
           configurationInfos: [
             {
               configurationLabel: 'Canon ABC',

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
@@ -24,7 +24,7 @@ export class ConfiguratorCartEntryBundleInfoComponent {
   constructor(
     protected commonConfigUtilsService: CommonConfiguratorUtilsService,
     protected configCartEntryBundleInfoService: ConfiguratorCartEntryBundleInfoService,
-    protected breakpointService?: BreakpointService,
+    protected breakpointService: BreakpointService,
     // TODO(#10946): make CartItemContext a required dependency and drop fallbacks to `?? EMPTY`.
     @Optional() protected cartItemContext?: CartItemContext
   ) {}


### PR DESCRIPTION
This fix injects the breakpoint service as mandatory dependency into configurator-cart-entry-bundle-info.component.ts