### PR TITLE
fix: Check availability of config form before setting focus (#12342)

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/service/configurator-storefront-utils.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/service/configurator-storefront-utils.service.spec.ts
@@ -1,3 +1,4 @@
+import { Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FormControl } from '@angular/forms';
 import { CommonConfigurator } from '@spartacus/product-configurator/common';
@@ -29,6 +30,9 @@ describe('ConfigUtilsService', () => {
     type: CommonConfigurator.OwnerType.PRODUCT,
   };
 
+  let keyboardFocusService: KeyboardFocusService;
+  let querySelectorOriginal: any;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -43,6 +47,14 @@ describe('ConfigUtilsService', () => {
       ],
     });
     classUnderTest = TestBed.inject(ConfiguratorStorefrontUtilsService);
+    keyboardFocusService = TestBed.inject(
+      KeyboardFocusService as Type<KeyboardFocusService>
+    );
+    querySelectorOriginal = document.querySelector;
+  });
+
+  afterEach(() => {
+    document.querySelector = querySelectorOriginal;
   });
 
   it('should be created', () => {
@@ -109,5 +121,33 @@ describe('ConfigUtilsService', () => {
     expect(values[0].selected).toBe(true);
     expect(values[1].name).toBe(attribute.values[1].name);
     expect(values[1].selected).toBe(false);
+  });
+
+  describe('focusFirstAttribute', () => {
+    it('should not delegate to keyboardFocusService if we did not provide that', () => {
+      classUnderTest['keyboardFocusService'] = undefined;
+      spyOn(keyboardFocusService, 'findFocusable').and.stub();
+      classUnderTest.focusFirstAttribute();
+      expect(keyboardFocusService.findFocusable).toHaveBeenCalledTimes(0);
+    });
+
+    it('should delegate to focus service', () => {
+      const theElement = document.createElement('form');
+      document.querySelector = jasmine
+        .createSpy('HTML Element')
+        .and.returnValue(theElement);
+      spyOn(keyboardFocusService, 'findFocusable').and.returnValue([]);
+      classUnderTest.focusFirstAttribute();
+      expect(keyboardFocusService.findFocusable).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not delegate to focus service if form is not available', () => {
+      document.querySelector = jasmine
+        .createSpy('HTML Element')
+        .and.returnValue(null);
+      spyOn(keyboardFocusService, 'findFocusable').and.returnValue([]);
+      classUnderTest.focusFirstAttribute();
+      expect(keyboardFocusService.findFocusable).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/feature-libs/product-configurator/rulebased/components/service/configurator-storefront-utils.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/service/configurator-storefront-utils.service.ts
@@ -116,14 +116,16 @@ export class ConfiguratorStorefrontUtilsService {
   focusFirstAttribute(): void {
     if (this.keyboardFocusService) {
       if (isPlatformBrowser(this.platformId)) {
-        const form: HTMLElement = document.querySelector(
+        const form: HTMLElement | null = document.querySelector(
           'cx-configurator-form'
         );
-        const focusedElements: HTMLElement[] = this.keyboardFocusService.findFocusable(
-          form
-        );
-        if (focusedElements && focusedElements.length > 1) {
-          focusedElements[0]?.focus();
+        if (form) {
+          const focusableElements: HTMLElement[] = this.keyboardFocusService.findFocusable(
+            form
+          );
+          if (focusableElements && focusableElements.length > 0) {
+            focusableElements[0].focus();
+          }
         }
       }
     }


### PR DESCRIPTION
When the focus was set on previous/next navigation, the interactive configuration form was sometimes already teared down. This led to an error message in the console

Closes #12341