### PR TITLE
chore: Support node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "SAP, Spartacus team",
   "engines": {
-    "node": ">=12 <16"
+    "node": ">=12 <17"
   },
   "scripts": {
     "build": "env-cmd --no-override -e dev,b2c,$SPA_ENV ng build storefrontapp --prod",


### PR DESCRIPTION
Support active node 16 version in Spartacus

Backport of #12357