### PR TITLE
chore: bump missing feature level config and styles level to 3.3 [for 3.3.x]

### DIFF
--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -138,7 +138,7 @@ const ruleBasedFeatureConfiguration = environment.cpq
     }),
     provideConfig(<FeaturesConfig>{
       features: {
-        level: '3.2',
+        level: '3.3',
       },
     }),
   ],

--- a/projects/storefrontstyles/scss/_versioning.scss
+++ b/projects/storefrontstyles/scss/_versioning.scss
@@ -22,7 +22,7 @@
 // Indicates the current major/minor version, which is used to avoid breaking changes.
 // Any CSS added later than this version is omitted by default, unless the `$useLatestStyles`
 // or `$styleVersion` are enabled.
-$_fullVersion: 3.2;
+$_fullVersion: 3.3;
 
 // The _global_ major version. Any (left over) styles from previous stable versions
 // are processed to the final CSS.


### PR DESCRIPTION
closes #12480
backport of PR #12482 to 3.3.x