### PR TITLE
fix: Popover close button ('x') is not aligned properly for dir="rtl" (GH-11614)

### DIFF
--- a/projects/storefrontstyles/scss/components/misc/popover/_popover.scss
+++ b/projects/storefrontstyles/scss/components/misc/popover/_popover.scss
@@ -193,5 +193,9 @@
     margin-top: -5px;
     margin-inline-end: -5px;
     font-size: 1rem;
+
+    html[dir='rtl'] & {
+      float: left;
+    }
   }
 }


### PR DESCRIPTION
closes #11614 