### PR TITLE
fix: Missing translation and text escaping off the button in storefinder list (GH-12422)

### DIFF
--- a/feature-libs/storefinder/assets/translations/en/store-finder.ts
+++ b/feature-libs/storefinder/assets/translations/en/store-finder.ts
@@ -2,6 +2,7 @@ export const storeFinder = {
   storeFinder: {
     openUntil: 'Open until',
     closed: 'Closed',
+    clickBack: 'Back',
     call: 'Call',
     getDirections: 'Get Directions',
     listView: 'List View',

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.html
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.html
@@ -8,7 +8,7 @@
       </div>
       <div class="col-md-2 text-left cx-back-wrapper">
         <button
-          class="btn btn-block btn-action"
+          class="btn btn-block btn-action cx-back"
           *ngIf="isDetailsModeVisible"
           (click)="hideStoreDetails()"
         >

--- a/feature-libs/storefinder/styles/components/_store-finder-list.scss
+++ b/feature-libs/storefinder/styles/components/_store-finder-list.scss
@@ -104,12 +104,10 @@
   }
 
   .cx-back {
-    margin-top: 0.5rem;
-    cursor: pointer;
     font-weight: 600;
-
-    &:hover {
-      color: var(--cx-color-primary);
-    }
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 85vw;
   }
 }


### PR DESCRIPTION
closes #12422