### PR TITLE
fix: Navigate to OV after addToCart even when cart is empty (#12689)

### DIFF
--- a/feature-libs/product-configurator/common/core/model/common-configurator.model.ts
+++ b/feature-libs/product-configurator/common/core/model/common-configurator.model.ts
@@ -15,7 +15,7 @@ export namespace CommonConfigurator {
      * Business identifier of the owner.
      * Can be a product code, a cart entry number, or an order code with order entry number
      */
-    id?: string;
+    id: string;
     /**
      * Configurator type. Derived from the cxRoute
      */

--- a/feature-libs/product-configurator/common/shared/utils/common-configurator-utils.service.spec.ts
+++ b/feature-libs/product-configurator/common/shared/utils/common-configurator-utils.service.spec.ts
@@ -104,27 +104,6 @@ describe('CommonConfiguratorUtilsService', () => {
     }).toThrow();
   });
 
-  it('should throw an error if for owner type PRODUCT if no product code is present', () => {
-    owner.type = CommonConfigurator.OwnerType.PRODUCT;
-    expect(function () {
-      classUnderTest.setOwnerKey(owner);
-    }).toThrow();
-  });
-
-  it('should throw an error if for owner type CART_ENTRY no cart entry link is present', () => {
-    owner.type = CommonConfigurator.OwnerType.CART_ENTRY;
-    expect(function () {
-      classUnderTest.setOwnerKey(owner);
-    }).toThrow();
-  });
-
-  it('should throw an error if for owner type ORDER_ENTRY no order entry link is present', () => {
-    owner.type = CommonConfigurator.OwnerType.ORDER_ENTRY;
-    expect(function () {
-      classUnderTest.setOwnerKey(owner);
-    }).toThrow();
-  });
-
   it('should compose an owner ID from 2 attributes', () => {
     expect(classUnderTest.getComposedOwnerId(documentId, entryNumber)).toBe(
       documentId + '+' + entryNumber

--- a/feature-libs/product-configurator/common/shared/utils/configurator-model-utils.spec.ts
+++ b/feature-libs/product-configurator/common/shared/utils/configurator-model-utils.spec.ts
@@ -12,11 +12,32 @@ describe('ConfiguratorModelUtils', () => {
     ).toBe(CommonConfigurator.OwnerType.PRODUCT + '/' + PRODUCT_CODE);
   });
 
+  it('should throw error if owner id is not present when creating an owner key', () => {
+    expect(function () {
+      ConfiguratorModelUtils.getOwnerKey(
+        CommonConfigurator.OwnerType.PRODUCT,
+        undefined
+      );
+    }).toThrow();
+    expect(function () {
+      ConfiguratorModelUtils.getOwnerKey(
+        CommonConfigurator.OwnerType.CART_ENTRY,
+        undefined
+      );
+    }).toThrow();
+    expect(function () {
+      ConfiguratorModelUtils.getOwnerKey(
+        CommonConfigurator.OwnerType.ORDER_ENTRY,
+        undefined
+      );
+    }).toThrow();
+  });
+
   it('should create initial owner with only key defined', () => {
     const owner = ConfiguratorModelUtils.createInitialOwner();
     expect(owner.key).toBe('INITIAL');
     expect(owner.type).toBeUndefined();
-    expect(owner.id).toBeUndefined();
+    expect(owner.id).toBe('INITIAL');
   });
 
   it('should create owner from attributes', () => {

--- a/feature-libs/product-configurator/common/shared/utils/configurator-model-utils.ts
+++ b/feature-libs/product-configurator/common/shared/utils/configurator-model-utils.ts
@@ -36,7 +36,7 @@ export class ConfiguratorModelUtils {
    * @returns Initial owner
    */
   static createInitialOwner(): CommonConfigurator.Owner {
-    return { key: 'INITIAL', configuratorType: 'INITIAL' };
+    return { key: 'INITIAL', configuratorType: 'INITIAL', id: 'INITIAL' };
   }
 
   /**

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
@@ -6,6 +6,7 @@ import {
 } from '@spartacus/core';
 import {
   CommonConfigurator,
+  ConfiguratorModelUtils,
   ConfiguratorRouter,
   ConfiguratorRouterExtractorService,
 } from '@spartacus/product-configurator/common';
@@ -152,11 +153,13 @@ export class ConfiguratorAddToCartButtonComponent {
       routerData.owner.type === CommonConfigurator.OwnerType.CART_ENTRY;
     const owner = configuration.owner;
 
-    this.configuratorGroupsService.setGroupStatusVisited(
-      configuration.owner,
-      configuration.interactionState.currentGroup
-    );
-
+    const currentGroup = configuration.interactionState.currentGroup;
+    if (currentGroup) {
+      this.configuratorGroupsService.setGroupStatusVisited(
+        configuration.owner,
+        currentGroup
+      );
+    }
     this.container$
       .pipe(
         filter((cont) => !cont.hasPendingChanges),
@@ -173,7 +176,7 @@ export class ConfiguratorAddToCartButtonComponent {
             owner,
             false,
             isOverview,
-            configuration.isCartEntryUpdateRequired
+            configuration.isCartEntryUpdateRequired ?? false
           );
           if (configuration.isCartEntryUpdateRequired) {
             this.configuratorCommonsService.removeConfiguration(owner);
@@ -195,9 +198,14 @@ export class ConfiguratorAddToCartButtonComponent {
               take(1)
             )
             .subscribe((configWithNextOwner) => {
+              //See preceeding filter operator: configWithNextOwner.nextOwner is always defined here
+              const nextOwner =
+                configWithNextOwner.nextOwner ??
+                ConfiguratorModelUtils.createInitialOwner();
+
               this.performNavigation(
                 configuratorType,
-                configWithNextOwner.nextOwner,
+                nextOwner,
                 true,
                 isOverview,
                 true
@@ -213,9 +221,7 @@ export class ConfiguratorAddToCartButtonComponent {
               // when a new config form requests a new observable for a product bound
               // configuration
 
-              this.configuratorCommonsService.removeConfiguration(
-                configWithNextOwner.nextOwner
-              );
+              this.configuratorCommonsService.removeConfiguration(nextOwner);
             });
         }
       });

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-cart.effect.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-cart.effect.spec.ts
@@ -30,10 +30,9 @@ const productCode = 'CONF_LAPTOP';
 const configId = '1234-56-7890';
 const groupId = 'GROUP-1';
 const cartId = 'CART-1234';
-const cartEntryNumber = '1';
 const userId = 'theUser';
 const quantity = 1;
-const entryNumber = 47;
+const entryNumber = 0;
 const emptyStatus = '';
 const errorResponse: HttpErrorResponse = new HttpErrorResponse({
   error: 'notFound',
@@ -159,16 +158,16 @@ describe('ConfiguratorCartEffect', () => {
       );
       const addOwnerAction = new ConfiguratorActions.AddNextOwner({
         ownerKey: productConfiguration.owner.key,
-        cartEntryNo: cartEntryNumber,
+        cartEntryNo: entryNumber.toString(),
       });
 
       const setNextOwnerAction = new ConfiguratorActions.SetNextOwnerCartEntry({
         configuration: productConfiguration,
-        cartEntryNo: cartEntryNumber,
+        cartEntryNo: entryNumber.toString(),
       });
       const newCartEntryOwner = ConfiguratorModelUtils.createOwner(
         CommonConfigurator.OwnerType.CART_ENTRY,
-        cartEntryNumber
+        entryNumber.toString()
       );
 
       const setInteractionStateAction = new ConfiguratorActions.SetInteractionState(

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-cart.effect.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-cart.effect.ts
@@ -40,7 +40,7 @@ export class ConfiguratorCartEffects {
       return this.configuratorCommonsConnector.addToCart(payload).pipe(
         switchMap((entry: CartModification) => {
           const entryNumber = entry.entry?.entryNumber;
-          if (!entryNumber) {
+          if (entryNumber === undefined) {
             throw Error(ERROR_MESSAGE_NO_ENTRY_NUMBER_FOUND);
           } else {
             return [

--- a/feature-libs/product-configurator/rulebased/cpq/occ/converters/occ-configurator-cpq-add-to-cart-serializer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/converters/occ-configurator-cpq-add-to-cart-serializer.spec.ts
@@ -20,7 +20,11 @@ describe('OccConfiguratorCpqAddToCartSerializer', () => {
     productCode: PRODUCT_CODE,
     quantity: QUANTITY,
     configId: CONFIG_ID,
-    owner: { key: 'A', configuratorType: ConfiguratorType.CPQ },
+    owner: {
+      key: 'A',
+      id: PRODUCT_CODE,
+      configuratorType: ConfiguratorType.CPQ,
+    },
   };
 
   const targetParameters: OccCpqConfigurator.AddToCartParameters = {

--- a/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-rest.adapter.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-rest.adapter.spec.ts
@@ -175,6 +175,7 @@ describe('CpqConfiguratorRestAdapter', () => {
     adapterUnderTest
       .createConfiguration({
         key: owner.key,
+        id: owner.id,
         configuratorType: ConfiguratorType.CPQ,
       })
       .subscribe(


### PR DESCRIPTION
When the user clicked addToCart on the configuration and the cart was empty, the system did not navigate to the OV page.

Closes #12688