### PR TITLE
feat: include the semantic route into the scoring of page meta resolvers

### DIFF
--- a/projects/core/src/cms/page/page-meta.resolver.ts
+++ b/projects/core/src/cms/page/page-meta.resolver.ts
@@ -1,6 +1,6 @@
 import { PageType } from '../../model/cms.model';
-import { Page } from '../model/page.model';
 import { Applicable } from '../../util/applicable';
+import { Page } from '../model/page.model';
 
 /**
  * Abstract class that can be used to resolve meta data for specific pages.
@@ -15,11 +15,14 @@ export abstract class PageMetaResolver implements Applicable {
   /** The page template is used to score the (non)matching page template */
   pageTemplate: string;
 
+  /** The semantic route is used to score the (non)matching page template */
+  semanticRoute?: string;
+
   /**
    * Returns the matching score for a resolver class, based on
    * the page type and page template.
    */
-  getScore(page: Page): number {
+  getScore(page: Page, semanticRoute?: string): number {
     let score = 0;
     if (this.pageType) {
       score += page.type === this.pageType ? 1 : -1;
@@ -27,14 +30,18 @@ export abstract class PageMetaResolver implements Applicable {
     if (this.pageTemplate) {
       score += page.template === this.pageTemplate ? 1 : -1;
     }
+    if (this.semanticRoute) {
+      score += semanticRoute === this.semanticRoute ? 1 : -1;
+    }
+
     return score;
   }
 
-  hasMatch(page: Page): boolean {
-    return this.getScore(page) > 0;
+  hasMatch(page: Page, semanticRoute?: string): boolean {
+    return this.getScore(page, semanticRoute) > 0;
   }
 
-  getPriority(page: Page): number {
-    return this.getScore(page);
+  getPriority(page: Page, semanticRoute?: string): number {
+    return this.getScore(page, semanticRoute);
   }
 }


### PR DESCRIPTION
TODO:
- [ ] proper testing (create an example PageMetaResolver leveraging semanticRoute)
- [ ] add unit tests
- [ ] clean up of `console.debug()`
- [ ] make RoutingService a required dependency
   - [ ] add migrations for it

Note: undefined is a valid value of the semanticRoute . semanticRoute for the current route is undefined, when there is no routing config for the current URL. It's the case of a CMS content page's URL, that is referenced only via links defined in CMS (in CMS link components defined by the content manager), but not in Spartacus. 

closes #12581