### PR TITLE
speed up 'ng serve' by using use the default development configuration

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -104,6 +104,14 @@
               "buildOptimizer": true,
               "serviceWorker": false,
               "tsConfig": "projects/storefrontapp/tsconfig.app.prod.json"
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true
             }
           }
         },
@@ -119,7 +127,8 @@
             "development": {
               "browserTarget": "storefrontapp:build:development"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         },
         "test": {
           "builder": "@angular-devkit/build-angular:karma",


### PR DESCRIPTION
In ng12 the default configuration for the build is production. Because `ng serve` reuses the configuration options from `ng build`, it happens that `ng serve` runs also in production mode by default.

To fix it, Angular 12 generates in fresh apps the angular.json containing explicit `development` configuration, marked there as default.

So I copied this default configuration for `ng serve` from a fresh angular 12 app to our angular.json

By the way, the compiled chunks are now back named:
![image](https://user-images.githubusercontent.com/4001059/123801183-54b49600-d8ea-11eb-9851-f688e9706153.png)
