### PR TITLE
chore: Change version check to be an error

### DIFF
--- a/tools/config/manage-dependencies.ts
+++ b/tools/config/manage-dependencies.ts
@@ -29,7 +29,6 @@ import {
   reportProgress,
   Repository,
   success,
-  warning,
 } from './index';
 
 // ------------ Utilities ------------
@@ -1138,7 +1137,7 @@ function updateDependenciesVersions(
     }
     if (breakingErrors.length > 0) {
       errorsFound = true;
-      warning(pathToPackageJson, breakingErrors, [
+      error(pathToPackageJson, breakingErrors, [
         `All external dependencies should have the same version as in the root \`${chalk.bold(
           PACKAGE_JSON
         )}\`.`,


### PR DESCRIPTION
With 4.0 we updated all peerDependencies to match what we use. 

With that, we can now enforce the same versions in peerDependencies from the version of the package from the root package.json.