### PR TITLE
chore: Convert missed --prod flags

### DIFF
--- a/core-libs/setup/.release-it.json
+++ b/core-libs/setup/.release-it.json
@@ -10,7 +10,7 @@
     "publishPath": "./../../dist/setup"
   },
   "hooks": {
-    "after:version:bump": "cd ../.. && ng build setup --prod"
+    "after:version:bump": "cd ../.. && ng build setup --configuration production"
   },
   "github": {
     "release": true,

--- a/docs/libs/creating-lib.md
+++ b/docs/libs/creating-lib.md
@@ -225,7 +225,7 @@ The following files should be modified:
 Add the following scripts:
 
 ```json
-"build:asm": "yarn --cwd feature-libs/asm run build:schematics && ng build asm --prod",
+"build:asm": "yarn --cwd feature-libs/asm run build:schematics && ng build asm --configuration production",
 "release:asm:with-changelog": "cd feature-libs/asm && release-it && cd ../..",
 ```
 
@@ -252,7 +252,7 @@ Add `- [ ] `npm run release:TODO::with-changelog` (needed since `x.x.x`)` under 
     "publishPath": "./../../dist/TODO:"
   },
   "hooks": {
-    "after:version:bump": "cd ../.. && ng build TODO: --prod"
+    "after:version:bump": "cd ../.. && ng build TODO: --configuration production"
   },
   "github": {
     "release": true,
@@ -339,7 +339,7 @@ Don't forget to:
 
 - run the tests for the generated library - `ng test <lib-name> --code-coverage`. In case of a library with multiple entry points, make sure to check the code-coverage report generated in the `coverage/my-account/lcov-report/index.html`
 - build the generated library _with Ivy enabled_ - `ng build <lib-name>`
-- build the generated library (without Ivy) - `ng build <lib-name> --prod`
+- build the generated library (without Ivy) - `ng build <lib-name> --configuration production`
 - build the production-ready shell app with the included generated library (import a dummy service from the generated service):
   - `yarn build:libs` (build all the libs)
   - `yarn build`

--- a/projects/assets/package.json
+++ b/projects/assets/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/projects/assets",
   "scripts": {
-    "build": "ng build assets --prod && yarn generate:translations:ts-2-json",
+    "build": "ng build assets --configuration production && yarn generate:translations:ts-2-json",
     "generate:translations:properties-2-ts": "ts-node ./generate-translations-properties-2-ts && cd ../.. && npx prettier \"./projects/assets/src/translations/**/*.ts\" --write",
     "generate:translations:ts-2-json": "ts-node ./generate-translations-ts-2-json",
     "generate:translations:ts-2-properties": "ts-node ./generate-translations-ts-2-properties"

--- a/projects/core/.release-it.json
+++ b/projects/core/.release-it.json
@@ -10,7 +10,7 @@
     "publishPath": "./../../dist/core"
   },
   "hooks": {
-    "after:version:bump": "cd ../.. && ng build core --prod"
+    "after:version:bump": "cd ../.. && ng build core --configuration production"
   },
   "github": {
     "release": true,

--- a/projects/storefrontlib/.release-it.json
+++ b/projects/storefrontlib/.release-it.json
@@ -10,7 +10,7 @@
     "publishPath": "./../../dist/storefrontlib"
   },
   "hooks": {
-    "after:version:bump": "cd ../.. && ng build storefrontlib --prod"
+    "after:version:bump": "cd ../.. && ng build storefrontlib --configuration production"
   },
   "github": {
     "release": true,


### PR DESCRIPTION
We missed a few `--prod` flags when updating that after ng 12 update.