### PR TITLE
chore: improve 4.0 migrations - part 3 [backport to 4.0.x]

### DIFF
--- a/docs/migration/4_0.md
+++ b/docs/migration/4_0.md
@@ -618,6 +618,7 @@ There is a new method: `getScheduleReplenishmentOrderEndpoint`.
 
 ### CheckoutModule
 The `CheckoutModule` from `@spartacus/core` became `CheckoutCoreModule` in `@spartacus/checkout/core`.  `CheckoutCoreModule` from `@spartacus/checkout/core` fills a similar role as the previous `CheckoutModule` from `@spartacus/core`.  One exception is providing the `CheckoutCartInterceptor`, which is now done in `CheckoutRootModule` from `@spartacus/checkout/root` instead.
+(Note: The new `CheckoutCoreModule` doesn't have the method `forRoot()` - please just import `CheckoutCoreModule` instead.)
 
 There is still a `CheckoutModule` in `@spartacus/checkout`.  While its name is the same as the previous module from `@spartacus/core`,  his role is different.  It imports other new checkout lib modules: `CheckoutComponentsModule`, `CheckoutCoreModule`, `CheckoutOccModule`.  The new module naming changes might seem confusing at first sight, but the choice of the new names were made to align with the feature libs module naming convention in Spartacus.
 
@@ -986,6 +987,8 @@ The display of the guest checkout button relies on the presence of the `forced` 
 
 - `AsmModule` was removed from storefrontlib, and renamed AsmComponentsModule. Use @spartacus/asm/components instead.
 - `AsmModule` was removed from core, and renamed AsmCoreModule. Use @spartacus/asm/core. instead.
+- `AsmOccModule` was removed from core. Use @spartacus/asm/occ instead.
+- `OccAsmAdapter` was removed from core. Use @spartacus/asm/occ instead.
 - `AsmConfig` was removed from core. Use @spartacus/asm/core.
 - `AsmAdapter` was removed. Use @spartacus/asm/core instead.
 - `AsmConnector` was removed. Use @spartacus/asm/core instead.

--- a/projects/schematics/src/migrations/4_0/rename-symbol/rename-symbol.ts
+++ b/projects/schematics/src/migrations/4_0/rename-symbol/rename-symbol.ts
@@ -9,6 +9,7 @@ import {
   ASM_CONNECTOR,
   ASM_FEATURE,
   ASM_MODULE,
+  ASM_OCC_MODULE,
   ASM_SELECTORS,
   ASM_SERVICE,
   ASM_STATE,
@@ -34,6 +35,7 @@ import {
   LOGIN_MODULE,
   LOGIN_REGISTER_COMPONENT,
   LOGIN_REGISTER_MODULE,
+  OCC_ASM_ADAPTER,
   PERMISSION_ROUTING_CONFIG,
   PERSONALIZATION_ACTION,
   PERSONALIZATION_CONFIG,
@@ -165,6 +167,18 @@ export const RENAMED_SYMBOLS_DATA: RenamedSymbol[] = [
     previousImportPath: SPARTACUS_STOREFRONTLIB,
     newNode: 'AsmComponentsModule',
     newImportPath: `${SPARTACUS_ASM}/components`,
+  },
+  // projects/core/src/occ/adapters/asm/asm-occ.module.ts
+  {
+    previousNode: ASM_OCC_MODULE,
+    previousImportPath: SPARTACUS_CORE,
+    newImportPath: `${SPARTACUS_ASM}/occ`,
+  },
+  // projects/core/src/occ/adapters/asm/occ-asm.adapter.ts
+  {
+    previousNode: OCC_ASM_ADAPTER,
+    previousImportPath: SPARTACUS_CORE,
+    newImportPath: `${SPARTACUS_ASM}/occ`,
   },
   // projects/core/src/asm/config/asm-config.ts
   {

--- a/projects/schematics/src/migrations/mechanism/methods-and-properties-deprecations/methods-and-properties-deprecations_spec.ts
+++ b/projects/schematics/src/migrations/mechanism/methods-and-properties-deprecations/methods-and-properties-deprecations_spec.ts
@@ -155,6 +155,21 @@ const CMS_COMPONENT_ACTIONS_TEST_CLASS = `
     }
 `;
 
+const CMS_COMPONENT_ACTIONS_TEST_TWO_CLASSES = `
+    import { CmsActions } from '@spartacus/core';
+    export class Test1 {
+      loadCmsComponent(): void {
+        console.log(new CmsActions.LoadCmsComponent('xxx'));
+      }
+    }
+
+    export class Test2 {
+      loadCmsComponent(): void {
+        console.log(new CmsActions.LoadCmsComponent('yyy'));
+      }
+    }
+`;
+
 describe('updateCmsComponentState migration', () => {
   let host: TempScopedNodeJsSyncHost;
   let appTree = Tree.empty() as UnitTestTree;
@@ -340,5 +355,18 @@ describe('updateCmsComponentState migration', () => {
       content.match(cmsGetComponentFromPageRegex) || []
     ).length;
     expect(cmsGetComponentFromPageRegexOccurrences).toEqual(1);
+  });
+
+  it('should add comments to more than one class in the same file', async () => {
+    writeFile(host, '/src/index.ts', CMS_COMPONENT_ACTIONS_TEST_TWO_CLASSES);
+
+    await runMigration(appTree, schematicRunner, MIGRATION_SCRIPT_NAME);
+
+    const content = appTree.readContent('/src/index.ts');
+
+    const spartacusToDoRegex = new RegExp(`^// TODO:Spartacus`, 'gm');
+    const spartacusToDoOccurrences = (content.match(spartacusToDoRegex) || [])
+      .length;
+    expect(spartacusToDoOccurrences).toEqual(2);
   });
 });

--- a/projects/schematics/src/migrations/migrations.json
+++ b/projects/schematics/src/migrations/migrations.json
@@ -18,7 +18,7 @@
     "migration-v3-methods-and-properties-deprecations-04": {
       "version": "3.2.0-next.2",
       "factory": "./3_0/methods-and-properties-deprecations/methods-and-properties-deprecations#migrate",
-      "description": "Comment about usage of remove public methods or properties"
+      "description": "Comment about usage of removed public methods or properties"
     },
     "migration-v3-removed-public-api-deprecation-05": {
       "version": "3.2.0-next.2",
@@ -59,7 +59,7 @@
     "02-migration-v4-methods-and-properties-deprecations": {
       "version": "4.0.0-rc.0",
       "factory": "./4_0/methods-and-properties-deprecations/methods-and-properties-deprecations#migrate",
-      "description": "Comment about usage of remove public methods or properties"
+      "description": "Comment about usage of removed public methods or properties"
     },
     "03-migration-v4-constructor-deprecations": {
       "version": "4.0.0-rc.0",

--- a/projects/schematics/src/migrations/test/migrations-test.json
+++ b/projects/schematics/src/migrations/test/migrations-test.json
@@ -3,7 +3,7 @@
     "migration-v2-methods-and-properties-deprecations-02": {
       "version": "2.1.0-next.1",
       "factory": "./methods-and-properties-deprecations/methods-and-properties-deprecations#migrate",
-      "description": "Comment about usage of remove public methods or properties"
+      "description": "Comment about usage of removed public methods or properties"
     },
     "migration-v2-constructor-deprecations-03": {
       "version": "2.1.0-next.1",

--- a/projects/schematics/src/shared/constants.ts
+++ b/projects/schematics/src/shared/constants.ts
@@ -621,6 +621,8 @@ export const CSAGENT_TOKEN_DATA = 'CSAGENT_TOKEN_DATA';
 export const CUSTOMER_SUPPORT_AGENT_TOKEN_INTERCEPTOR =
   'CustomerSupportAgentTokenInterceptor ';
 export const ASM_MODULE = 'AsmModule';
+export const ASM_OCC_MODULE = 'AsmOccModule';
+export const OCC_ASM_ADAPTER = 'OccAsmAdapter';
 export const ASM_CONFIG = 'AsmConfig';
 export const ASM_ADAPTER = 'AsmAdapter';
 export const ASM_CONNECTOR = 'AsmConnector';

--- a/projects/schematics/src/shared/utils/file-utils.ts
+++ b/projects/schematics/src/shared/utils/file-utils.ts
@@ -1066,27 +1066,28 @@ export function insertCommentAboveIdentifier(
   comment: string,
   identifierType = ts.SyntaxKind.Identifier
 ): Change[] {
-  const classNode = getSourceNodes(source).find(
-    (node) => node.kind === ts.SyntaxKind.ClassDeclaration
-  );
-  if (!classNode) {
-    return [new NoopChange()];
-  }
-
-  const identifierNodes = findNodes(classNode, identifierType).filter(
-    (node) => node.getText() === identifierName
-  );
-
   const changes: InsertChange[] = [];
-  identifierNodes.forEach((n) =>
-    changes.push(
-      new InsertChange(
-        sourcePath,
-        getLineStartFromTSFile(source, n.getStart()),
-        `${comment}`
+
+  getSourceNodes(source).forEach((node) => {
+    if (node.kind !== ts.SyntaxKind.ClassDeclaration) {
+      return;
+    }
+
+    const identifierNodes = findNodes(node, identifierType).filter(
+      (node) => node.getText() === identifierName
+    );
+
+    identifierNodes.forEach((n) =>
+      changes.push(
+        new InsertChange(
+          sourcePath,
+          getLineStartFromTSFile(source, n.getStart()),
+          `${comment}`
+        )
       )
-    )
-  );
+    );
+  });
+
   return changes;
 }
 


### PR DESCRIPTION
backport of https://github.com/SAP/spartacus/pull/13207