### PR TITLE
test: fix added-to-cart-modal e2e [release/4.0.x only]

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/added-to-cart-modal.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/added-to-cart-modal.e2e-spec.ts
@@ -84,7 +84,7 @@ describe('Added to cart modal', () => {
 
     it('adding different products to cart', () => {
       cy.onMobile(() => {
-        cy.get('cx-searchbox div.search').click();
+        cy.get('cx-searchbox button.search').click();
       });
 
       // search for new product and select it, and add to cart


### PR DESCRIPTION
`added-to-cart-modal e2e` is failing on `release/4.0.x` branch due to a typo in the e2e selector `div.search`. It should be `button.search` instead.

The issue appears because the original commit in develop https://github.com/SAP/spartacus/pull/12952/files#diff-455284f6af20d91c666e945e97512af33c1bc0985899f53eb795ab5707a41140R87
differs in one line with the backport commit https://github.com/SAP/spartacus/pull/13169/files#diff-455284f6af20d91c666e945e97512af33c1bc0985899f53eb795ab5707a41140R87