### PR TITLE
fix: selected options price for CPQ products is shown even when there…

### DIFF
--- a/feature-libs/product-configurator/rulebased/cpq/rest/converters/cpq-configurator-normalizer-utils.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/converters/cpq-configurator-normalizer-utils.service.spec.ts
@@ -417,6 +417,37 @@ describe('CpqConfiguratorNormalizerUtilsService', () => {
     ).toEqual(expectedPriceSummary);
   });
 
+  it('should convert price summary when no base price is 0', () => {
+    const cpqConfiguration: Cpq.Configuration = {
+      productSystemId: 'productSystemId',
+      currencyISOCode: 'USD',
+      currencySign: '$',
+      responder: { totalPrice: '$3333.33', baseProductPrice: '0.00' },
+    };
+    const expectedPriceSummary: Configurator.PriceSummary = {
+      currentTotal: {
+        currencyIso: 'USD',
+        formattedValue: '$3,333.33',
+        value: 3333.33,
+      },
+      basePrice: {
+        currencyIso: 'USD',
+        formattedValue: '$0.00',
+        value: 0,
+      },
+      selectedOptions: {
+        currencyIso: 'USD',
+        formattedValue: '$3,333.33',
+        value: 3333.33,
+      },
+    };
+    expect(
+      cpqConfiguratorNormalizerUtilsService.convertPriceSummary(
+        cpqConfiguration
+      )
+    ).toEqual(expectedPriceSummary);
+  });
+
   it('should convert price summary when no total price exists', () => {
     const cpqConfiguration: Cpq.Configuration = {
       productSystemId: 'productSystemId',

--- a/feature-libs/product-configurator/rulebased/cpq/rest/converters/cpq-configurator-normalizer-utils.service.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/converters/cpq-configurator-normalizer-utils.service.ts
@@ -219,7 +219,7 @@ export class CpqConfiguratorNormalizerUtilsService {
         this.formatPriceForLocale(basePrice, this.getLanguage());
         priceSummary.basePrice = basePrice;
       }
-      if (priceSummary.currentTotal?.value && priceSummary.basePrice?.value) {
+      if (priceSummary.currentTotal && priceSummary.basePrice) {
         const selectedOptionsPrice: Configurator.PriceDetails = {
           currencyIso: currency,
           value: priceSummary.currentTotal.value - priceSummary.basePrice.value,


### PR DESCRIPTION
… is no base price (#13176)

Selected Options price will be always calculated correctly including the case when a CPQ product has no Base price.

Closes #13140