### PR TITLE
fix: Prevent undefined auth header

### DIFF
--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
@@ -133,7 +133,7 @@ describe('AuthHttpHeaderService', () => {
         access_token: `old_token`,
         refresh_token: 'ref_token',
       } as AuthToken);
-      const handler = (a) => of(a);
+      const handler = (a: any) => of(a);
       spyOn(oAuthLibWrapperService, 'refreshToken').and.callFake(() => {
         token.next({
           access_token: `new_token`,
@@ -159,7 +159,7 @@ describe('AuthHttpHeaderService', () => {
     });
 
     it('should invoke expired refresh token handler when there is no refresh token', () => {
-      const handler = (a) => of(a);
+      const handler = jasmine.createSpy('handler', (a: any) => of(a));
       spyOn(oAuthLibWrapperService, 'refreshToken').and.callThrough();
       spyOn(service, 'handleExpiredRefreshToken').and.stub();
       spyOn(authStorageService, 'getToken').and.returnValue(
@@ -172,8 +172,12 @@ describe('AuthHttpHeaderService', () => {
           new HttpRequest('GET', 'some-server/occ/cart'),
           { handle: handler } as HttpHandler
         )
-        .subscribe()
-        .unsubscribe();
+        .subscribe({
+          complete: () => {
+            // check that we didn't created new requests
+            expect(handler).not.toHaveBeenCalled();
+          },
+        });
       expect(oAuthLibWrapperService.refreshToken).not.toHaveBeenCalled();
       expect(service.handleExpiredRefreshToken).toHaveBeenCalled();
     });

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
@@ -1,7 +1,7 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { filter, switchMap, take, tap } from 'rxjs/operators';
+import { EMPTY, Observable } from 'rxjs';
+import { filter, map, switchMap, take, tap } from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
 import { OccEndpointsService } from '../../../occ/services/occ-endpoints.service';
@@ -56,13 +56,13 @@ export class AuthHttpHeaderService {
     return url.includes(this.occEndpoints.getBaseUrl());
   }
 
-  protected getAuthorizationHeader(request: HttpRequest<any>): string {
+  protected getAuthorizationHeader(request: HttpRequest<any>): string | null {
     const rawValue = request.headers.get('Authorization');
     return rawValue;
   }
 
   protected createAuthorizationHeader(): { Authorization: string } | {} {
-    let token;
+    let token: AuthToken | undefined;
     this.authStorageService
       .getToken()
       .subscribe((tok) => (token = tok))
@@ -84,8 +84,10 @@ export class AuthHttpHeaderService {
     next: HttpHandler
   ): Observable<HttpEvent<AuthToken>> {
     return this.handleExpiredToken().pipe(
-      switchMap((token: AuthToken) => {
-        return next.handle(this.createNewRequestWithNewToken(request, token));
+      switchMap((token) => {
+        return token
+          ? next.handle(this.createNewRequestWithNewToken(request, token))
+          : EMPTY;
       })
     );
   }
@@ -124,11 +126,11 @@ export class AuthHttpHeaderService {
    *
    * @return observable which omits new access_token. (Warn: might never emit!).
    */
-  protected handleExpiredToken(): Observable<AuthToken> {
+  protected handleExpiredToken(): Observable<AuthToken | undefined> {
     const stream = this.authStorageService.getToken();
     let oldToken: AuthToken;
     return stream.pipe(
-      tap((token: AuthToken) => {
+      tap((token) => {
         if (token.access_token && token.refresh_token && !oldToken) {
           this.oAuthLibWrapperService.refreshToken();
         } else if (!token.refresh_token) {
@@ -136,9 +138,8 @@ export class AuthHttpHeaderService {
         }
         oldToken = oldToken || token;
       }),
-      filter(
-        (token: AuthToken) => oldToken.access_token !== token.access_token
-      ),
+      filter((token) => oldToken.access_token !== token.access_token),
+      map((token) => (token?.access_token ? token : undefined)),
       take(1)
     );
   }


### PR DESCRIPTION
This fix won't retry requests when we don't have new token (logout scenario).

Steps to reproduce:
- go to the storefront
- login
- refresh the page (to lose refresh token)
- wait for the access token to expire and then try to invoke some occ request (eg. checkout) or if you can't wait alter the access token in localStorage and refresh

Behavior before the fix:
- you would notice that the request that failed is later retries with the Authorization header set to `bearer undefined`

Current behavior:
- request is not retried at all (no point to retry the request for the user as user is now logged out)