### PR TITLE
fix: Access token refresh flow

### DIFF
--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
@@ -1,7 +1,8 @@
 import { HttpHandler, HttpHeaders, HttpRequest } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject, of, queueScheduler } from 'rxjs';
+import { TokenResponse } from 'angular-oauth2-oidc';
+import { BehaviorSubject, EMPTY, Observable, of, queueScheduler } from 'rxjs';
 import { observeOn, take } from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
@@ -27,7 +28,9 @@ class MockAuthStorageService implements Partial<AuthStorageService> {
 }
 
 class MockOAuthLibWrapperService implements Partial<OAuthLibWrapperService> {
-  refreshToken() {}
+  refreshToken(): Observable<TokenResponse> {
+    return EMPTY;
+  }
 }
 
 class MockRoutingService implements Partial<RoutingService> {
@@ -139,6 +142,7 @@ describe('AuthHttpHeaderService', () => {
           access_token: `new_token`,
           refresh_token: 'ref_token',
         } as AuthToken);
+        return EMPTY;
       });
       spyOn(authStorageService, 'getToken').and.returnValue(
         token.asObservable().pipe(observeOn(queueScheduler))

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
@@ -19,6 +19,11 @@ import { OAuthLibWrapperService } from './oauth-lib-wrapper.service';
   providedIn: 'root',
 })
 export class AuthHttpHeaderService {
+  /**
+   * Indicates whether the access token is being refreshed
+   */
+  protected refreshInProgress = false;
+
   constructor(
     protected authService: AuthService,
     protected authStorageService: AuthStorageService,
@@ -129,8 +134,16 @@ export class AuthHttpHeaderService {
     let oldToken: AuthToken;
     return stream.pipe(
       tap((token: AuthToken) => {
-        if (token.access_token && token.refresh_token && !oldToken) {
-          this.oAuthLibWrapperService.refreshToken();
+        if (
+          token.access_token &&
+          token.refresh_token &&
+          !oldToken &&
+          !this.refreshInProgress
+        ) {
+          this.refreshInProgress = true;
+          this.oAuthLibWrapperService
+            .refreshToken()
+            .subscribe({ complete: () => (this.refreshInProgress = false) });
         } else if (!token.refresh_token) {
           this.handleExpiredRefreshToken();
         }

--- a/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
+++ b/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { OAuthService, TokenResponse } from 'angular-oauth2-oidc';
+import { from, Observable } from 'rxjs';
 import { WindowRef } from '../../../window/window-ref';
 import { AuthConfigService } from './auth-config.service';
 
@@ -62,8 +63,8 @@ export class OAuthLibWrapperService {
   /**
    * Refresh access_token.
    */
-  refreshToken(): void {
-    this.oAuthService.refreshToken();
+  refreshToken(): Observable<TokenResponse> {
+    return from(this.oAuthService.refreshToken());
   }
 
   /**


### PR DESCRIPTION
The goal of this PR is to issue only one token request to refresh an access token. This is relevant for cases when there are multiple requests being fired simultaneously after the access token expired.