### PR TITLE
fix: Fix OnNavigateFocusService with SSR v2

### DIFF
--- a/projects/storefrontlib/src/layout/a11y/keyboard-focus/on-navigate/on-navigate-focus.service.ts
+++ b/projects/storefrontlib/src/layout/a11y/keyboard-focus/on-navigate/on-navigate-focus.service.ts
@@ -1,11 +1,11 @@
+import { DOCUMENT } from '@angular/common';
 import { Inject, Injectable, OnDestroy } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
-import { BREAKPOINT } from '../../../config';
 import { BreakpointService } from '../../../../layout/breakpoint/breakpoint.service';
+import { BREAKPOINT } from '../../../config';
 import { KeyboardFocusConfig } from '../config';
-import { DOCUMENT } from '@angular/common';
 
 /**
  * Shared service for keyboard focus features called when the browser navigates.
@@ -33,11 +33,6 @@ export class OnNavigateFocusService implements OnDestroy {
    * Reads configuration and enables features based on flags set.
    */
   initializeWithConfig(): void {
-    // Do not initialize on server-side
-    if (typeof window === 'undefined') {
-      return;
-    }
-
     if (this.config?.keyboardFocus?.enableResetFocusOnNavigate) {
       this.setResetFocusOnNavigate(
         this.config.keyboardFocus.enableResetFocusOnNavigate
@@ -67,11 +62,11 @@ export class OnNavigateFocusService implements OnDestroy {
               .pipe(take(1))
               .subscribe((breakpoint: BREAKPOINT) => {
                 if (enable.includes(breakpoint)) {
-                  this.document.body.focus();
+                  this.document.body.focus?.();
                 }
               });
           } else if (typeof enable === 'boolean') {
-            this.document.body.focus();
+            this.document.body.focus?.();
           }
         });
     }
@@ -93,11 +88,11 @@ export class OnNavigateFocusService implements OnDestroy {
               .pipe(take(1))
               .subscribe((breakpoint: BREAKPOINT) => {
                 if (enable.includes(breakpoint)) {
-                  this.document.body.scrollIntoView();
+                  this.document.body.scrollIntoView?.();
                 }
               });
           } else if (typeof enable === 'boolean') {
-            this.document.body.scrollIntoView();
+            this.document.body.scrollIntoView?.();
           }
         });
     }


### PR DESCRIPTION
In backport #13285 to 3.4.x we added a SSR check to avoid the error caused by the absence of the method `scrollIntoView()` in SSR:
```
ERROR TypeError: (...).scrollIntoView is not a function
```

We didn't want to add a new constructor dependency to avoid a breaking change. So instead of injecting proper PLATFORM_ID or WindowRef, we checked `if (typeof window === 'undefined')`. 

However we realized this solution might not work for customers that mock `window` object in SSR. (Note: we don't recommend modking `window` in SSR, but for some customers it might be needed.)

So this PR removes the window check and gracefully handles the absence of the method `scrollIntoView()`, by adding `?.` check.

The agreed tradeoff is that the subscriptions will run in SSR, although they don't need to. 

closes #13221 