### PR TITLE
fix: Infinite spinner after refresh token expires 2nd time

### DIFF
--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
@@ -1,8 +1,7 @@
 import { HttpHandler, HttpHeaders, HttpRequest } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { TokenResponse } from 'angular-oauth2-oidc';
-import { BehaviorSubject, EMPTY, Observable, of, queueScheduler } from 'rxjs';
+import { BehaviorSubject, EMPTY, of, queueScheduler } from 'rxjs';
 import { observeOn, take } from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
@@ -28,9 +27,7 @@ class MockAuthStorageService implements Partial<AuthStorageService> {
 }
 
 class MockOAuthLibWrapperService implements Partial<OAuthLibWrapperService> {
-  refreshToken(): Observable<TokenResponse> {
-    return EMPTY;
-  }
+  refreshToken(): void {}
 }
 
 class MockRoutingService implements Partial<RoutingService> {

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
@@ -143,15 +143,14 @@ export class AuthHttpHeaderService {
           !this.refreshInProgress
         ) {
           this.refreshInProgress = true;
-          this.oAuthLibWrapperService
-            .refreshToken()
-            .subscribe({ complete: () => (this.refreshInProgress = false) });
+          this.oAuthLibWrapperService.refreshToken();
         } else if (!token.refresh_token) {
           this.handleExpiredRefreshToken();
         }
         oldToken = oldToken || token;
       }),
       filter((token) => oldToken.access_token !== token.access_token),
+      tap(() => (this.refreshInProgress = false)),
       map((token) => (token?.access_token ? token : undefined)),
       take(1)
     );

--- a/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
+++ b/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { OAuthService, TokenResponse } from 'angular-oauth2-oidc';
-import { from, Observable } from 'rxjs';
 import { WindowRef } from '../../../window/window-ref';
 import { AuthConfigService } from './auth-config.service';
 
@@ -63,8 +62,8 @@ export class OAuthLibWrapperService {
   /**
    * Refresh access_token.
    */
-  refreshToken(): Observable<TokenResponse> {
-    return from(this.oAuthService.refreshToken());
+  refreshToken(): void {
+    this.oAuthService.refreshToken();
   }
 
   /**


### PR DESCRIPTION
This PR fixes the infinite spinner after the refresh token expires for the 2nd time.