### PR TITLE
chore: Change root package.json version to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storefrontapp",
-  "version": "4.0.0",
+  "version": "0.0.0",
   "license": "Apache-2.0",
   "author": "SAP, Spartacus team",
   "engines": {


### PR DESCRIPTION
Our root `package.json` version often becomes outdated on our branches including `develop` and `maintenance` branches as package versioning is usually handled automatically by release scripts on a per project/feature basis.

Instead of adding another step to also try and manage the root version, lets set it to `0.0.0`. This helps to indicate that the version number of this file should not be considered.