### PR TITLE
fix: Console error on resolving conflict (#13314)

### DIFF
--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-groups.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-groups.service.spec.ts
@@ -159,11 +159,36 @@ describe('ConfiguratorGroupsService', () => {
         done();
       });
     });
+
     it('should return undefined if menu parent group is not availaible in uiState', (done) => {
       const configurationWoMenuParentGroup = ConfiguratorTestUtils.createConfiguration(
         CONFIG_ID,
         ConfiguratorModelUtils.createInitialOwner()
       );
+      spyOn(configuratorCommonsService, 'getConfiguration').and.returnValue(
+        of(configurationWoMenuParentGroup)
+      );
+      const parentGroup = classUnderTest.getMenuParentGroup(
+        productConfiguration.owner
+      );
+
+      expect(parentGroup).toBeDefined();
+      parentGroup.subscribe((group) => {
+        expect(group).toBeUndefined();
+        done();
+      });
+    });
+
+    it('should return undefined if menu parent group cannot be found', (done) => {
+      const configurationWoMenuParentGroup: Configurator.Configuration = {
+        ...ConfiguratorTestUtils.createConfiguration(
+          CONFIG_ID,
+          ConfiguratorModelUtils.createInitialOwner()
+        ),
+        interactionState: {
+          menuParentGroup: 'Conflict header group that is gone',
+        },
+      };
       spyOn(configuratorCommonsService, 'getConfiguration').and.returnValue(
         of(configurationWoMenuParentGroup)
       );

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-groups.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-groups.service.ts
@@ -112,7 +112,7 @@ export class ConfiguratorGroupsService {
       map((configuration) => {
         const menuParentGroup = configuration.interactionState.menuParentGroup;
         return menuParentGroup
-          ? this.configuratorUtilsService.getGroupById(
+          ? this.configuratorUtilsService.getOptionalGroupById(
               configuration.groups,
               menuParentGroup
             )

--- a/feature-libs/product-configurator/rulebased/core/facade/utils/configurator-utils.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/utils/configurator-utils.service.spec.ts
@@ -6,6 +6,7 @@ import {
   ATTRIBUTE_1_CHECKBOX,
   GROUP_ID_1,
   GROUP_ID_2,
+  GROUP_ID_4,
   productConfiguration,
   subGroupWith2Attributes,
 } from '../../../testing/configurator-test-data';
@@ -131,15 +132,6 @@ describe('ConfiguratorGroupUtilsService', () => {
 
   it('should be created', () => {
     expect(classUnderTest).toBeTruthy();
-  });
-
-  it('should find group from group Id', () => {
-    const group = classUnderTest.getGroupById(
-      productConfiguration.groups,
-      GROUP_ID_2
-    );
-
-    expect(group).toBe(productConfiguration.groups[1]);
   });
 
   it('should find parent group from group', () => {
@@ -361,6 +353,50 @@ describe('ConfiguratorGroupUtilsService', () => {
       expect(() =>
         classUnderTest.getConfigurationFromState(configurationState)
       ).toThrowError();
+    });
+  });
+
+  describe('getOptionalGroupById', () => {
+    it('should find group from group id if present on the root level', () => {
+      const group = classUnderTest.getOptionalGroupById(
+        productConfiguration.groups,
+        GROUP_ID_2
+      );
+      expect(group).toBe(productConfiguration.groups[1]);
+    });
+
+    it('should find group from group id if present as sub group', () => {
+      const group = classUnderTest.getOptionalGroupById(
+        productConfiguration.groups,
+        GROUP_ID_4
+      );
+      expect(group).toBe(subGroupWith2Attributes);
+    });
+
+    it('should return undefined if group cannot be found', () => {
+      const group = classUnderTest.getOptionalGroupById(
+        productConfiguration.groups,
+        'UNKNOWN_ID'
+      );
+      expect(group).toBeUndefined();
+    });
+  });
+
+  describe('getGroupById', () => {
+    it('should find group from group id if present on the root level', () => {
+      const group = classUnderTest.getGroupById(
+        productConfiguration.groups,
+        GROUP_ID_2
+      );
+      expect(group).toBe(productConfiguration.groups[1]);
+    });
+
+    it('should fall back to first group if group cannot be found', () => {
+      const group = classUnderTest.getGroupById(
+        productConfiguration.groups,
+        'UNKNOWN_ID'
+      );
+      expect(group).toBe(productConfiguration.groups[0]);
     });
   });
 });

--- a/feature-libs/product-configurator/rulebased/core/facade/utils/configurator-utils.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/utils/configurator-utils.service.ts
@@ -32,7 +32,16 @@ export class ConfiguratorUtilsService {
       .filter((foundGroup) => foundGroup)
       .pop();
   }
-
+  /**
+   * Finds group identified by its ID, and ensures that we always get a valid group.
+   * If nothing is found in the configuration group list, this methods returns the first group.
+   *
+   * The exceptional case can happen if e.g. an edit in a conflict was done that
+   * resolved the conflict, or if a group vanished due to object dependencies.
+   * @param {Configurator.Group[]} groups - List of groups
+   * @param groupId Group id
+   * @returns {Configurator.Group} - Group identified by its id, if available. Otherwise first group
+   */
   getGroupById(
     groups: Configurator.Group[],
     groupId: string
@@ -42,14 +51,24 @@ export class ConfiguratorUtilsService {
       return currentGroup;
     }
     const groupFound = this.getGroupFromSubGroups(groups, groupId);
+    return groupFound ? groupFound : groups[0];
+  }
 
-    //we can safely assumed that a group exists, as we know the ID belongs to a
-    //group part of the configuration
-    if (groupFound) {
-      return groupFound;
-    } else {
-      throw new Error('Group could not be found ' + groupId);
-    }
+  /**
+   * Finds group identified by its ID. If nothing is found, this
+   * methods returns undefined
+   * @param {Configurator.Group[]} groups - List of groups
+   * @param groupId Group id
+   * @returns {Configurator.Group} - Group identified by its id, if available. Otherwise undefined
+   */
+  getOptionalGroupById(
+    groups: Configurator.Group[],
+    groupId: string
+  ): Configurator.Group | undefined {
+    const currentGroup = groups.find((group) => group.id === groupId);
+    return currentGroup
+      ? currentGroup
+      : this.getGroupFromSubGroups(groups, groupId);
   }
 
   protected getGroupByIdIfPresent(


### PR DESCRIPTION
When a conflict is solved in the respective conflict group on the product configurator page, a console error appears that states that the conflict group, or the conflict header group, cannot be found. In this case often no further navigation is possible within the configurator page.
The bug was introduced with wrong strict mode adjustments.

This fix addresses that, by taking into account that conflict groups will disappear when all conflicts are solved.

Closes #13313