### PR TITLE
fix: prevent style reimport by importing required sub-libraries

### DIFF
--- a/feature-libs/cart/_index.scss
+++ b/feature-libs/cart/_index.scss
@@ -1,4 +1,6 @@
-@import '~@spartacus/styles';
+@import '~@spartacus/styles/scss/core';
+@import '~@spartacus/styles/scss/app';
+@import '~@spartacus/styles/scss/components';
 
 @import '~bootstrap/scss/functions';
 @import '~bootstrap/scss/variables';


### PR DESCRIPTION
… in saved cart feature styles

Fixes https://github.com/SAP/spartacus/issues/12714

Saved Cart feature styles reimport entire style libraries, which takes precedence over style changes made to `src/styles.scss`. As a result, global css variables declared there are being overwritten by library styles.

This fix imports only the required sub-libraries from styles so that the variables are not redeclared.