### PR TITLE
fix: OAuth improvements

### DIFF
--- a/projects/core/src/auth/auth.module.ts
+++ b/projects/core/src/auth/auth.module.ts
@@ -4,7 +4,10 @@ import { ClientAuthModule } from './client-auth/client-auth.module';
 import { UserAuthModule } from './user-auth/user-auth.module';
 
 @NgModule({
-  imports: [CommonModule, ClientAuthModule.forRoot(), UserAuthModule.forRoot()],
+  // ClientAuthModule should always be imported after UserAuthModule because the ClientTokenInterceptor must be imported after the AuthInterceptor.
+  // This way, the ClientTokenInterceptor is the first to handle 401 errors and attempt to refresh the client token.
+  // If the request is not for the client token, the AuthInterceptor handles the refresh.
+  imports: [CommonModule, UserAuthModule.forRoot(), ClientAuthModule.forRoot()],
 })
 export class AuthModule {
   static forRoot(): ModuleWithProviders<AuthModule> {

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpHandler, HttpHeaders, HttpRequest } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject, of, queueScheduler } from 'rxjs';
+import { BehaviorSubject, EMPTY, of, queueScheduler } from 'rxjs';
 import { observeOn, take } from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
@@ -27,7 +27,7 @@ class MockAuthStorageService implements Partial<AuthStorageService> {
 }
 
 class MockOAuthLibWrapperService implements Partial<OAuthLibWrapperService> {
-  refreshToken() {}
+  refreshToken(): void {}
 }
 
 class MockRoutingService implements Partial<RoutingService> {
@@ -133,12 +133,13 @@ describe('AuthHttpHeaderService', () => {
         access_token: `old_token`,
         refresh_token: 'ref_token',
       } as AuthToken);
-      const handler = (a) => of(a);
+      const handler = (a: any) => of(a);
       spyOn(oAuthLibWrapperService, 'refreshToken').and.callFake(() => {
         token.next({
           access_token: `new_token`,
           refresh_token: 'ref_token',
         } as AuthToken);
+        return EMPTY;
       });
       spyOn(authStorageService, 'getToken').and.returnValue(
         token.asObservable().pipe(observeOn(queueScheduler))
@@ -159,7 +160,7 @@ describe('AuthHttpHeaderService', () => {
     });
 
     it('should invoke expired refresh token handler when there is no refresh token', () => {
-      const handler = (a) => of(a);
+      const handler = jasmine.createSpy('handler', (a: any) => of(a));
       spyOn(oAuthLibWrapperService, 'refreshToken').and.callThrough();
       spyOn(service, 'handleExpiredRefreshToken').and.stub();
       spyOn(authStorageService, 'getToken').and.returnValue(
@@ -172,8 +173,12 @@ describe('AuthHttpHeaderService', () => {
           new HttpRequest('GET', 'some-server/occ/cart'),
           { handle: handler } as HttpHandler
         )
-        .subscribe()
-        .unsubscribe();
+        .subscribe({
+          complete: () => {
+            // check that we didn't created new requests
+            expect(handler).not.toHaveBeenCalled();
+          },
+        });
       expect(oAuthLibWrapperService.refreshToken).not.toHaveBeenCalled();
       expect(service.handleExpiredRefreshToken).toHaveBeenCalled();
     });

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
@@ -1,7 +1,7 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { filter, switchMap, take, tap } from 'rxjs/operators';
+import { EMPTY, Observable } from 'rxjs';
+import { filter, map, switchMap, take, tap } from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
 import { OccEndpointsService } from '../../../occ/services/occ-endpoints.service';
@@ -19,6 +19,11 @@ import { OAuthLibWrapperService } from './oauth-lib-wrapper.service';
   providedIn: 'root',
 })
 export class AuthHttpHeaderService {
+  /**
+   * Indicates whether the access token is being refreshed
+   */
+  protected refreshInProgress = false;
+
   constructor(
     protected authService: AuthService,
     protected authStorageService: AuthStorageService,
@@ -56,13 +61,13 @@ export class AuthHttpHeaderService {
     return url.includes(this.occEndpoints.getBaseUrl());
   }
 
-  protected getAuthorizationHeader(request: HttpRequest<any>): string {
+  protected getAuthorizationHeader(request: HttpRequest<any>): string | null {
     const rawValue = request.headers.get('Authorization');
     return rawValue;
   }
 
   protected createAuthorizationHeader(): { Authorization: string } | {} {
-    let token;
+    let token: AuthToken | undefined;
     this.authStorageService
       .getToken()
       .subscribe((tok) => (token = tok))
@@ -84,8 +89,10 @@ export class AuthHttpHeaderService {
     next: HttpHandler
   ): Observable<HttpEvent<AuthToken>> {
     return this.handleExpiredToken().pipe(
-      switchMap((token: AuthToken) => {
-        return next.handle(this.createNewRequestWithNewToken(request, token));
+      switchMap((token) => {
+        return token
+          ? next.handle(this.createNewRequestWithNewToken(request, token))
+          : EMPTY;
       })
     );
   }
@@ -124,21 +131,27 @@ export class AuthHttpHeaderService {
    *
    * @return observable which omits new access_token. (Warn: might never emit!).
    */
-  protected handleExpiredToken(): Observable<AuthToken> {
+  protected handleExpiredToken(): Observable<AuthToken | undefined> {
     const stream = this.authStorageService.getToken();
     let oldToken: AuthToken;
     return stream.pipe(
-      tap((token: AuthToken) => {
-        if (token.access_token && token.refresh_token && !oldToken) {
+      tap((token) => {
+        if (
+          token.access_token &&
+          token.refresh_token &&
+          !oldToken &&
+          !this.refreshInProgress
+        ) {
+          this.refreshInProgress = true;
           this.oAuthLibWrapperService.refreshToken();
         } else if (!token.refresh_token) {
           this.handleExpiredRefreshToken();
         }
         oldToken = oldToken || token;
       }),
-      filter(
-        (token: AuthToken) => oldToken.access_token !== token.access_token
-      ),
+      filter((token) => oldToken.access_token !== token.access_token),
+      tap(() => (this.refreshInProgress = false)),
+      map((token) => (token?.access_token ? token : undefined)),
       take(1)
     );
   }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
@@ -174,6 +174,7 @@ export function checkWishListPersisted(product: TestProduct) {
   cy.selectUserMenuOption({
     option: 'Sign Out',
   });
+  cy.location('pathname').should('equal', '/electronics-spa/en/USD/');
 
   cy.findByText(/Sign in \/ Register/i).click();
 

--- a/projects/storefrontlib/src/cms-components/user/logout/logout.module.ts
+++ b/projects/storefrontlib/src/cms-components/user/logout/logout.module.ts
@@ -13,7 +13,7 @@ import { LogoutGuard } from './logout.guard';
     RouterModule.forChild([
       {
         path: null,
-        canActivate: [CmsPageGuard, LogoutGuard],
+        canActivate: [LogoutGuard, CmsPageGuard],
         component: PageLayoutComponent,
         data: { cxRoute: 'logout' },
       },


### PR DESCRIPTION
Improvements:

- guest checkout access_token handling
- handling access_token expiry when multiple http calls are made - issue only one http request to refresh an access token in cases when there are multiple requests being fired simultaneously after the access token expired.
- not sending `Authorization: bearer undefined` http header
- unable to login after logged after the access token expiration

Backport of #13295