### PR TITLE
feat: use error details of the form control to populate translation params in `FormErrorsComponent`

### DIFF
--- a/projects/storefrontlib/src/shared/components/form/form-errors/form-errors.component.html
+++ b/projects/storefrontlib/src/shared/components/form/form-errors/form-errors.component.html
@@ -1,3 +1,3 @@
-<p *ngFor="let errorName of errors$ | async">
-  {{ prefix + '.' + errorName | cxTranslate: translationParams }}
+<p *ngFor="let error of errorsDetails$ | async">
+  {{ prefix + '.' + error[0] | cxTranslate: getTranslationParams(error[1]) }}
 </p>

--- a/projects/storefrontlib/src/shared/components/form/form-errors/form-errors.component.spec.ts
+++ b/projects/storefrontlib/src/shared/components/form/form-errors/form-errors.component.spec.ts
@@ -81,7 +81,6 @@ describe('FormErrors', () => {
     control.setErrors({});
     component.errors$.subscribe((errors) => {
       returnedErrors = errors;
-      console.log(errors);
     });
 
     expect(returnedErrors).toEqual([]);
@@ -89,7 +88,6 @@ describe('FormErrors', () => {
     control.setErrors(mockError);
     component.errors$.subscribe((errors) => {
       returnedErrors = errors;
-      console.log(errors);
     });
 
     expect(returnedErrors).toEqual([mockErrorName]);

--- a/projects/storefrontlib/src/shared/components/form/form-errors/form-errors.component.ts
+++ b/projects/storefrontlib/src/shared/components/form/form-errors/form-errors.component.ts
@@ -5,11 +5,18 @@ import {
   Input,
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
+import { isObject } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
 /**
- * This component renders form errors.
+ * Renders translated form errors for a given form control, based on its `errors` property.
+ *
+ * The translation key consists of the optional input `prefix`
+ * concatenated with the error key.
+ *
+ * And the translation params object consist of the error details
+ * (if only it's an object) merged with the optional input object `translationParams`.
  */
 @Component({
   selector: 'cx-form-errors',
@@ -18,10 +25,27 @@ import { map, startWith } from 'rxjs/operators';
 })
 export class FormErrorsComponent {
   _control: FormControl;
+
+  /**
+   * @deprecated since 4.1 - use `errorsDetails$` instead, which contains not only
+   *                         the error key, but also the error details
+   */
   errors$: Observable<string[]>;
 
+  /**
+   * Emits an array of errors, each represented by a tuple:
+   * the error key and error details.
+   */
+  errorsDetails$: Observable<Array<[string, string]>>;
+
+  /**
+   * Prefix prepended to the translation key.
+   */
   @Input() prefix = 'formErrors';
 
+  /**
+   * Translation params to enrich the error details object.
+   */
   @Input()
   translationParams: { [key: string]: string };
 
@@ -29,19 +53,34 @@ export class FormErrorsComponent {
   set control(control: FormControl) {
     this._control = control;
 
-    this.errors$ = control?.statusChanges.pipe(
+    this.errorsDetails$ = control?.statusChanges.pipe(
       startWith({}),
       map(() => control.errors || {}),
       map((errors) =>
-        Object.entries(errors)
-          .filter((error) => error[1])
-          .map((error) => error[0])
+        Object.entries(errors).filter(([_key, details]) => details)
       )
+    );
+
+    this.errors$ = this.errorsDetails$.pipe(
+      map((errors) => errors.map(([key, _details]) => key))
     );
   }
 
   get control(): FormControl {
     return this._control;
+  }
+
+  /**
+   * Returns translation params composed of
+   * the argument `errorDetails` (if only is an object) merged with
+   * the component input object `translationParams`.
+   *
+   * In case of a conflicting object key, the value from
+   * `translationParams` takes precedence.
+   */
+  getTranslationParams(errorDetails?: any): object {
+    errorDetails = isObject(errorDetails) ? errorDetails : {};
+    return { ...errorDetails, ...this.translationParams };
   }
 
   @HostBinding('class.control-invalid') get invalid() {


### PR DESCRIPTION
Previously, i18n params were  passed to the component `cx-form-errors` only via the component input `translationParams`, which forces parent components (that own the form) to pass the `translationParams` down the components tree. This was impacting negatively the API of the components in the middle which unnecessarily had to implement the `translationParams` input and pass it down the tree.

This is now avoided as we start using the error details object in the `cx-form-errors`. This error is embedded in the form control (which is already passed down the components tree).

Note: for backward compatibility the `translationParams` input is preserved and takes precedence over the params from the error details.

closes #13375 