### PR TITLE
fix: OAuth improvements

### DIFF
--- a/projects/core/src/auth/auth.module.ts
+++ b/projects/core/src/auth/auth.module.ts
@@ -4,7 +4,10 @@ import { ClientAuthModule } from './client-auth/client-auth.module';
 import { UserAuthModule } from './user-auth/user-auth.module';
 
 @NgModule({
-  imports: [CommonModule, ClientAuthModule.forRoot(), UserAuthModule.forRoot()],
+  // ClientAuthModule should always be imported after UserAuthModule because the ClientTokenInterceptor must be imported after the AuthInterceptor.
+  // This way, the ClientTokenInterceptor is the first to handle 401 errors and attempt to refresh the client token.
+  // If the request is not for the client token, the AuthInterceptor handles the refresh.
+  imports: [CommonModule, UserAuthModule.forRoot(), ClientAuthModule.forRoot()],
 })
 export class AuthModule {
   static forRoot(): ModuleWithProviders<AuthModule> {

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
@@ -1,7 +1,7 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { filter, switchMap, take, tap } from 'rxjs/operators';
+import { EMPTY, Observable } from 'rxjs';
+import { filter, map, switchMap, take, tap } from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
 import { OccEndpointsService } from '../../../occ/services/occ-endpoints.service';
@@ -18,6 +18,11 @@ import { OAuthLibWrapperService } from './oauth-lib-wrapper.service';
   providedIn: 'root',
 })
 export class AuthHttpHeaderService {
+  /**
+   * Indicates whether the access token is being refreshed
+   */
+  protected refreshInProgress = false;
+
   constructor(
     protected authService: AuthService,
     protected authStorageService: AuthStorageService,
@@ -54,13 +59,13 @@ export class AuthHttpHeaderService {
     return url.includes(this.occEndpoints.getBaseEndpoint());
   }
 
-  protected getAuthorizationHeader(request: HttpRequest<any>): string {
+  protected getAuthorizationHeader(request: HttpRequest<any>): string | null {
     const rawValue = request.headers.get('Authorization');
     return rawValue;
   }
 
   protected createAuthorizationHeader(): { Authorization: string } | {} {
-    let token;
+    let token: AuthToken | undefined;
     this.authStorageService
       .getToken()
       .subscribe((tok) => (token = tok))
@@ -82,8 +87,10 @@ export class AuthHttpHeaderService {
     next: HttpHandler
   ): Observable<HttpEvent<AuthToken>> {
     return this.handleExpiredToken().pipe(
-      switchMap((token: AuthToken) => {
-        return next.handle(this.createNewRequestWithNewToken(request, token));
+      switchMap((token) => {
+        return token
+          ? next.handle(this.createNewRequestWithNewToken(request, token))
+          : EMPTY;
       })
     );
   }
@@ -110,21 +117,27 @@ export class AuthHttpHeaderService {
    *
    * @return observable which omits new access_token. (Warn: might never emit!).
    */
-  protected handleExpiredToken(): Observable<AuthToken> {
+  protected handleExpiredToken(): Observable<AuthToken | undefined> {
     const stream = this.authStorageService.getToken();
     let oldToken: AuthToken;
     return stream.pipe(
-      tap((token: AuthToken) => {
-        if (token.access_token && token.refresh_token && !oldToken) {
+      tap((token) => {
+        if (
+          token.access_token &&
+          token.refresh_token &&
+          !oldToken &&
+          !this.refreshInProgress
+        ) {
+          this.refreshInProgress = true;
           this.oAuthLibWrapperService.refreshToken();
         } else if (!token.refresh_token) {
           this.handleExpiredRefreshToken();
         }
         oldToken = oldToken || token;
       }),
-      filter(
-        (token: AuthToken) => oldToken.access_token !== token.access_token
-      ),
+      filter((token) => oldToken.access_token !== token.access_token),
+      tap(() => (this.refreshInProgress = false)),
+      map((token) => (token?.access_token ? token : undefined)),
       take(1)
     );
   }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -196,7 +196,7 @@ export function selectDeliveryMethod() {
     )}/cms/pages?*/checkout/payment-details*`
   ).as('getPaymentPage');
   cy.get('.cx-checkout-title').should('contain', 'Shipping Method');
-  cy.get('#deliveryMode-standard-net').should('be.checked');
+  cy.get('#deliveryMode-standard-gross').should('be.checked');
   cy.get('button.btn-primary').click();
   cy.wait('@getPaymentPage').its('status').should('eq', 200);
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -20,7 +20,7 @@ import {
 export const ELECTRONICS_BASESITE = 'electronics-spa';
 export const ELECTRONICS_CURRENCY = 'USD';
 
-export const ELECTRONICS_DEFAULT_DELIVERY_MODE = 'deliveryMode-standard-net';
+export const ELECTRONICS_DEFAULT_DELIVERY_MODE = 'deliveryMode-standard-gross';
 
 export function visitHomePage(queryStringParams?: string) {
   const homePage = waitForPage('homepage', 'getHomePage');

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/consignment-tracking.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/consignment-tracking.ts
@@ -1,8 +1,8 @@
 import { waitForPage } from './checkout-flow';
 
 export function loginUsingUserWithOrder() {
-  const username = 'test-user-with-orders@ydev.hybris.com';
-  const password = 'Password123.';
+  const username = 'test-user-with-orders@sap.cx.com';
+  const password = 'pw4all';
   cy.login(username, password);
 
   const homePage = waitForPage('homepage', 'getHomePage');

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/login.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/login.ts
@@ -57,7 +57,7 @@ export function loginUser() {
 export function loginWithBadCredentials() {
   const loginPage = waitForPage('/login', 'getLoginPage');
   cy.get(loginLinkSelector).click();
-  cy.wait(`@${loginPage}`).its('status').should('eq', 200);
+  cy.wait(`@${loginPage}`);
 
   login(user.email, 'Password321');
 

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/site-context-selector.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/site-context-selector.ts
@@ -99,7 +99,7 @@ export function addressBookNextStep() {
 }
 
 export function deliveryModeNextStep() {
-  cy.get('cx-delivery-mode #deliveryMode-standard-net').click({
+  cy.get('cx-delivery-mode #deliveryMode-standard-gross').click({
     force: true,
   });
 

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
@@ -176,6 +176,7 @@ export function checkWishListPersisted(product: TestProduct) {
   cy.selectUserMenuOption({
     option: 'Sign Out',
   });
+  cy.location('pathname').should('equal', '/electronics-spa/en/USD/');
 
   cy.findByText(/Sign in \/ Register/i).click();
 

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-checkout.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-checkout.ts
@@ -29,8 +29,8 @@ export const cartWithB2bProduct: SampleCartProduct = {
 };
 
 export const b2bAccountShipToUser: SampleUser = {
-  email: 'powertools-test-user-with-orders@ydev.hybris.com',
-  password: 'Password123.',
+  email: 'powertools-test-user-with-orders@sap.cx.com',
+  password: 'pw4all',
   fullName: 'PunchOut Customer',
   address: {
     city: 'Chicago',

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/checkout-flow.ts
@@ -77,7 +77,7 @@ export const cheapProduct: SampleProduct = {
 export const cart: SampleCartProduct = {
   estimatedShipping: '$11.99',
   total: '$2,623.08',
-  totalAndShipping: '$2,633.07', // $2,623.08 + $9.99
+  totalAndShipping: '$2,635.07', // $2,623.08 + $11.99
 };
 
 export const cartWithCheapProduct: SampleCartProduct = {

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/checkout-flow.ts
@@ -81,9 +81,9 @@ export const cart: SampleCartProduct = {
 };
 
 export const cartWithCheapProduct: SampleCartProduct = {
-  estimatedShipping: '$9.99',
+  estimatedShipping: '$11.99',
   total: '$8.20',
-  totalAndShipping: '$18.19',
+  totalAndShipping: '$20.19',
 };
 
 export const delivery = {

--- a/projects/storefrontlib/src/cms-components/user/logout/logout.module.ts
+++ b/projects/storefrontlib/src/cms-components/user/logout/logout.module.ts
@@ -13,7 +13,7 @@ import { CmsPageGuard } from '../../../cms-structure/guards/cms-page.guard';
     RouterModule.forChild([
       {
         path: null,
-        canActivate: [CmsPageGuard, LogoutGuard],
+        canActivate: [LogoutGuard, CmsPageGuard],
         component: PageLayoutComponent,
         data: { cxRoute: 'logout' },
       },


### PR DESCRIPTION
Improvements:

- guest checkout access_token handling
- handling access_token expiry when multiple http calls are made - issue only one http request to refresh an access token in cases when there are multiple requests being fired simultaneously after the access token expired.
- not sending `Authorization: bearer undefined` http header
- unable to login after logged after the access token expiration

Backport of #13295