### PR TITLE
fix: OAuth improvements

### DIFF
--- a/projects/core/src/auth/auth.module.ts
+++ b/projects/core/src/auth/auth.module.ts
@@ -4,7 +4,10 @@ import { ClientAuthModule } from './client-auth/client-auth.module';
 import { UserAuthModule } from './user-auth/user-auth.module';
 
 @NgModule({
-  imports: [CommonModule, ClientAuthModule.forRoot(), UserAuthModule.forRoot()],
+  // ClientAuthModule should always be imported after UserAuthModule because the ClientTokenInterceptor must be imported after the AuthInterceptor.
+  // This way, the ClientTokenInterceptor is the first to handle 401 errors and attempt to refresh the client token.
+  // If the request is not for the client token, the AuthInterceptor handles the refresh.
+  imports: [CommonModule, UserAuthModule.forRoot(), ClientAuthModule.forRoot()],
 })
 export class AuthModule {
   static forRoot(): ModuleWithProviders<AuthModule> {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
@@ -176,6 +176,7 @@ export function checkWishListPersisted(product: TestProduct) {
   cy.selectUserMenuOption({
     option: 'Sign Out',
   });
+  cy.location('pathname').should('equal', '/electronics-spa/en/USD/');
 
   cy.findByText(/Sign in \/ Register/i).click();
 

--- a/projects/storefrontlib/src/cms-components/user/logout/logout.module.ts
+++ b/projects/storefrontlib/src/cms-components/user/logout/logout.module.ts
@@ -13,7 +13,7 @@ import { CmsPageGuard } from '../../../cms-structure/guards/cms-page.guard';
     RouterModule.forChild([
       {
         path: null,
-        canActivate: [CmsPageGuard, LogoutGuard],
+        canActivate: [LogoutGuard, CmsPageGuard],
         component: PageLayoutComponent,
         data: { cxRoute: 'logout' },
       },


### PR DESCRIPTION
Improvements:

- guest checkout access_token handling
- handling access_token expiry when multiple http calls are made - issue only one http request to refresh an access token in cases when there are multiple requests being fired simultaneously after the access token expired.
- not sending `Authorization: bearer undefined` http header
- unable to login after logged after the access token expiration

Backport of #13295