### PR TITLE
chore: Strict compodoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "e2e:run:ci:product-configuration": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:product-configurator-vc",
     "e2e:run:ci:cdc": "yarn --cwd ./projects/storefrontapp-e2e-cypress run cy:run:ci:cdc",
     "generate:changelog": "ts-node ./scripts/changelog.ts",
-    "generate:docs": "npx @compodoc/compodoc -p tsconfig.compodoc.json && ./scripts/zip-docs.sh",
+    "generate:docs": "npx @compodoc/compodoc@1.1.13 -p tsconfig.compodoc.json && ./scripts/zip-docs.sh",
     "generate:publish:docs": "yarn generate:docs && yarn publish:docs",
     "i18n-lint": "i18n-lint -t \"{{,}}\" projects/storefrontlib/src/**/*.html feature-libs/**/*.html --exclude **/node_modules/**/*.html -a alt,title,placeholder,aria-label",
     "lint": "ng lint",


### PR DESCRIPTION
With version 1.1.14 compodocs couldn't correctly parse some `@link` in our comments.

This PR restricts compodocs version to 1.1.13

To reproduce the problem just try to run `yarn generate:docs` on develop. *Note* Make sure that you don't have any compodoc version cached that would be used instead of the current "latest" -> 1.1.14