### PR TITLE
chore: Release 3.0.5

### DIFF
--- a/core-libs/setup/package.json
+++ b/core-libs/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/setup",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Includes features that makes Spartacus and it's setup easier and streamlined.",
   "homepage": "https://github.com/SAP/spartacus",
   "keywords": [
@@ -19,8 +19,8 @@
     "@angular/common": "^10.1.0",
     "@angular/core": "^10.1.0",
     "rxjs": "^6.6.0",
-    "@spartacus/core": "3.0.4",
-    "@spartacus/storefront": "3.0.4"
+    "@spartacus/core": "3.0.5",
+    "@spartacus/storefront": "3.0.5"
   },
   "optionalDependencies": {
     "@nguniversal/express-engine": "^10.1.0",

--- a/feature-libs/organization/package.json
+++ b/feature-libs/organization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/organization",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Organization library for Spartacus",
   "homepage": "https://github.com/SAP/spartacus",
   "keywords": [
@@ -28,9 +28,9 @@
     "@angular/router": "^10.1.0",
     "bootstrap": "^4.0",
     "rxjs": "^6.6.0",
-    "@spartacus/core": "3.0.4",
-    "@spartacus/storefront": "3.0.4",
-    "@spartacus/schematics": "3.0.4"
+    "@spartacus/core": "3.0.5",
+    "@spartacus/storefront": "3.0.5",
+    "@spartacus/schematics": "3.0.5"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/feature-libs/storefinder/package.json
+++ b/feature-libs/storefinder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/storefinder",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Store finder feature library for Spartacus",
   "homepage": "https://github.com/SAP/spartacus",
   "keywords": [
@@ -27,9 +27,9 @@
     "@angular-devkit/schematics": "^10.1.0",
     "@angular/router": "^10.1.0",
     "rxjs": "^6.6.0",
-    "@spartacus/core": "3.0.4",
-    "@spartacus/storefront": "3.0.4",
-    "@spartacus/schematics": "3.0.4",
+    "@spartacus/core": "3.0.5",
+    "@spartacus/storefront": "3.0.5",
+    "@spartacus/schematics": "3.0.5",
     "@ng-bootstrap/ng-bootstrap": "^7.0.0"
   },
   "devDependencies": {

--- a/integration-libs/cds/package.json
+++ b/integration-libs/cds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/cds",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Context Driven Service library for Spartacus",
   "homepage": "https://github.com/SAP/spartacus",
   "keywords": [
@@ -24,8 +24,8 @@
     "@angular/common": "^10.1.0",
     "@angular/core": "^10.1.0",
     "@angular/router": "^10.1.0",
-    "@spartacus/core": "3.0.4",
-    "@spartacus/storefront": "3.0.4",
+    "@spartacus/core": "3.0.5",
+    "@spartacus/storefront": "3.0.5",
     "rxjs": "^6.6.0"
   }
 }

--- a/projects/assets/package.json
+++ b/projects/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/assets",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/projects/assets",
   "publishConfig": {

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/core",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Spartacus - the core framework",
   "homepage": "https://github.com/SAP/spartacus",
   "keywords": [

--- a/projects/core/src/auth/auth.module.ts
+++ b/projects/core/src/auth/auth.module.ts
@@ -4,7 +4,10 @@ import { ClientAuthModule } from './client-auth/client-auth.module';
 import { UserAuthModule } from './user-auth/user-auth.module';
 
 @NgModule({
-  imports: [CommonModule, ClientAuthModule.forRoot(), UserAuthModule.forRoot()],
+  // ClientAuthModule should always be imported after UserAuthModule because the ClientTokenInterceptor must be imported after the AuthInterceptor.
+  // This way, the ClientTokenInterceptor is the first to handle 401 errors and attempt to refresh the client token.
+  // If the request is not for the client token, the AuthInterceptor handles the refresh.
+  imports: [CommonModule, UserAuthModule.forRoot(), ClientAuthModule.forRoot()],
 })
 export class AuthModule {
   static forRoot(): ModuleWithProviders<AuthModule> {

--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/schematics",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Spartacus schematics",
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/projects/schematics",

--- a/projects/schematics/src/migrations/migrations.json
+++ b/projects/schematics/src/migrations/migrations.json
@@ -47,32 +47,32 @@
     },
 
     "migration-v3-component-deprecations-01": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "factory": "./3_0/component-deprecations/component-deprecations#migrate",
       "description": "Handle deprecated Spartacus components"
     },
     "migration-v3-config-deprecations-02": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "factory": "./3_0/config-deprecations/config-deprecation#migrate",
       "description": "Handle deprecated configuration properties"
     },
     "migration-v3-constructor-deprecations-03": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "factory": "./3_0/constructor-deprecations/constructor-deprecations#migrate",
       "description": "Add or remove constructor parameters"
     },
     "migration-v3-methods-and-properties-deprecations-04": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "factory": "./3_0/methods-and-properties-deprecations/methods-and-properties-deprecations#migrate",
       "description": "Comment about usage of remove public methods or properties"
     },
     "migration-v3-removed-public-api-deprecation-05": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "factory": "./3_0/removed-public-api-deprecations/removed-public-api-deprecation#migrate",
       "description": "Comment about usage of removed public api"
     },
     "migration-v3-css-06": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "factory": "./3_0/css/css#migrate",
       "description": "Handle deprecated CSS"
     },
@@ -87,7 +87,7 @@
       "description": "Add and install additional dependencies"
     },
     "migration-v3-ssr-09": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "factory": "./3_0/ssr/ssr#migrate",
       "description": "Migrate ssr to the new setup"
     }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
@@ -176,6 +176,7 @@ export function checkWishListPersisted(product: TestProduct) {
   cy.selectUserMenuOption({
     option: 'Sign Out',
   });
+  cy.location('pathname').should('equal', '/electronics-spa/en/USD/');
 
   cy.findByText(/Sign in \/ Register/i).click();
 

--- a/projects/storefrontlib/package.json
+++ b/projects/storefrontlib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/storefront",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "homepage": "https://github.com/SAP/spartacus",
   "keywords": [
     "spartacus",
@@ -28,7 +28,7 @@
     "@ng-select/ng-select": "^5.0.9",
     "@ngrx/effects": "^10.0.0",
     "@ngrx/store": "^10.0.0",
-    "@spartacus/core": "3.0.4",
+    "@spartacus/core": "3.0.5",
     "rxjs": "^6.6.0",
     "zone.js": "^0.10.2",
     "ngx-infinite-scroll": "^8.0.0"

--- a/projects/storefrontlib/src/cms-components/user/logout/logout.module.ts
+++ b/projects/storefrontlib/src/cms-components/user/logout/logout.module.ts
@@ -13,7 +13,7 @@ import { CmsPageGuard } from '../../../cms-structure/guards/cms-page.guard';
     RouterModule.forChild([
       {
         path: null,
-        canActivate: [CmsPageGuard, LogoutGuard],
+        canActivate: [LogoutGuard, CmsPageGuard],
         component: PageLayoutComponent,
         data: { cxRoute: 'logout' },
       },

--- a/projects/storefrontstyles/package.json
+++ b/projects/storefrontstyles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/styles",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Style library containing global styles",
   "homepage": "https://github.com/SAP/spartacus",
   "keywords": [


### PR DESCRIPTION
Improvements:

- guest checkout access_token handling
- handling access_token expiry when multiple http calls are made - issue only one http request to refresh an access token in cases when there are multiple requests being fired simultaneously after the access token expired.
- not sending `Authorization: bearer undefined` http header
- unable to login after logged after the access token expiration

Contains backport of #13295 (as we were unable to merge it because of protected branches and e2e failures)

Closes #13404 