### PR TITLE
fix: Session management improvements (#13353)

### DIFF
--- a/feature-libs/asm/root/services/asm-auth-http-header.service.spec.ts
+++ b/feature-libs/asm/root/services/asm-auth-http-header.service.spec.ts
@@ -25,6 +25,7 @@ class MockCsAgentAuthService implements Partial<CsAgentAuthService> {
 }
 
 class MockAuthService implements Partial<AuthService> {
+  setLogoutProgress(_progress: boolean): void {}
   coreLogout() {
     return Promise.resolve();
   }
@@ -147,11 +148,12 @@ describe('AsmAuthHttpHeaderService', () => {
   });
 
   describe('handleExpiredRefreshToken', () => {
-    it('should work the same as in AuthHeaderService when there is normally logged user', () => {
+    it('should work the same as in AuthHeaderService when there is normally logged user', async () => {
       spyOn(authService, 'coreLogout').and.callThrough();
       spyOn(routingService, 'go').and.callThrough();
 
       service.handleExpiredRefreshToken();
+      await Promise.resolve();
 
       expect(authService.coreLogout).toHaveBeenCalled();
       expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'login' });
@@ -165,9 +167,11 @@ describe('AsmAuthHttpHeaderService', () => {
       ).and.returnValue(of(true));
       spyOn(csAgentAuthService, 'logoutCustomerSupportAgent').and.callThrough();
       spyOn(globalMessageService, 'add').and.callThrough();
+      spyOn(authService, 'setLogoutProgress').and.stub();
 
       service.handleExpiredRefreshToken();
 
+      expect(authService.setLogoutProgress).toHaveBeenCalledWith(true);
       expect(authService.coreLogout).not.toHaveBeenCalled();
       expect(csAgentAuthService.logoutCustomerSupportAgent).toHaveBeenCalled();
       expect(globalMessageService.add).toHaveBeenCalledWith(

--- a/feature-libs/asm/root/services/asm-auth-http-header.service.ts
+++ b/feature-libs/asm/root/services/asm-auth-http-header.service.ts
@@ -44,6 +44,18 @@ export class AsmAuthHttpHeaderService extends AuthHttpHeaderService {
   }
 
   /**
+   * Checks if the authorization header should be added to the request
+   *
+   *  @override
+   */
+  public shouldAddAuthorizationHeader(request: HttpRequest<any>): boolean {
+    return (
+      super.shouldAddAuthorizationHeader(request) ||
+      this.isCSAgentTokenRequest(request)
+    );
+  }
+
+  /**
    * @override
    *
    * Checks if particular request should be handled by this service.

--- a/feature-libs/asm/root/services/asm-auth-http-header.service.ts
+++ b/feature-libs/asm/root/services/asm-auth-http-header.service.ts
@@ -4,6 +4,7 @@ import {
   AuthHttpHeaderService,
   AuthService,
   AuthStorageService,
+  AuthToken,
   GlobalMessageService,
   GlobalMessageType,
   InterceptorUtil,
@@ -59,16 +60,19 @@ export class AsmAuthHttpHeaderService extends AuthHttpHeaderService {
    * Adds `Authorization` header to occ and CS agent requests.
    * For CS agent requests also removes the `cx-use-csagent-token` header (to avoid problems with CORS).
    */
-  public alterRequest(request: HttpRequest<any>): HttpRequest<any> {
+  public alterRequest(
+    request: HttpRequest<any>,
+    token?: AuthToken
+  ): HttpRequest<any> {
     const hasAuthorizationHeader = !!this.getAuthorizationHeader(request);
     const isCSAgentRequest = this.isCSAgentTokenRequest(request);
 
-    let req = super.alterRequest(request);
+    let req = super.alterRequest(request, token);
 
     if (!hasAuthorizationHeader && isCSAgentRequest) {
       req = request.clone({
         setHeaders: {
-          ...this.createAuthorizationHeader(),
+          ...this.createAuthorizationHeader(token),
         },
       });
       return InterceptorUtil.removeHeader(
@@ -99,6 +103,7 @@ export class AsmAuthHttpHeaderService extends AuthHttpHeaderService {
       .pipe(take(1))
       .subscribe((csAgentLoggedIn) => {
         if (csAgentLoggedIn) {
+          this.authService.setLogoutProgress(true);
           this.csAgentAuthService.logoutCustomerSupportAgent();
           this.globalMessageService.add(
             {

--- a/projects/core/src/asm/services/asm-auth-http-header.service.spec.ts
+++ b/projects/core/src/asm/services/asm-auth-http-header.service.spec.ts
@@ -145,11 +145,12 @@ describe('AsmAuthHttpHeaderService', () => {
   });
 
   describe('handleExpiredRefreshToken', () => {
-    it('should work the same as in AuthHeaderService when there is normally logged user', () => {
+    it('should work the same as in AuthHeaderService when there is normally logged user', async () => {
       spyOn(authService, 'coreLogout').and.callThrough();
       spyOn(routingService, 'go').and.callThrough();
 
       service.handleExpiredRefreshToken();
+      await Promise.resolve();
 
       expect(authService.coreLogout).toHaveBeenCalled();
       expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'login' });

--- a/projects/core/src/auth/user-auth/facade/auth.service.spec.ts
+++ b/projects/core/src/auth/user-auth/facade/auth.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { Store, StoreModule } from '@ngrx/store';
 import { TokenResponse } from 'angular-oauth2-oidc';
 import { OCC_USER_ID_CURRENT } from 'projects/core/src/occ';
-import { Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { RoutingService } from '../../../routing/facade/routing.service';
 import { AuthToken } from '../models/auth-token.model';
@@ -149,6 +149,9 @@ describe('AuthService', () => {
 
       await service.coreLogout();
 
+      expect(
+        (service.logoutInProgress$ as BehaviorSubject<boolean>).value
+      ).toBeTruthy();
       expect(userIdService.clearUserId).toHaveBeenCalled();
       expect(oAuthLibWrapperService.revokeAndLogout).toHaveBeenCalled();
       expect(store.dispatch).toHaveBeenCalledWith(new AuthActions.Logout());

--- a/projects/core/src/auth/user-auth/facade/auth.service.ts
+++ b/projects/core/src/auth/user-auth/facade/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { OCC_USER_ID_CURRENT } from '../../../occ/utils/occ-constants';
 import { RoutingService } from '../../../routing/facade/routing.service';
@@ -19,6 +19,16 @@ import { UserIdService } from './user-id.service';
   providedIn: 'root',
 })
 export class AuthService {
+  /**
+   * Indicates whether the access token is being refreshed
+   */
+  refreshInProgress$: Observable<boolean> = new BehaviorSubject<boolean>(false);
+
+  /**
+   * Indicates whether the logout is being performed
+   */
+  logoutInProgress$: Observable<boolean> = new BehaviorSubject<boolean>(false);
+
   constructor(
     protected store: Store<StateWithClientAuth>,
     protected userIdService: UserIdService,
@@ -77,6 +87,7 @@ export class AuthService {
    * To perform logout it is best to use `logout` method. Use this method with caution.
    */
   coreLogout(): Promise<void> {
+    this.setLogoutProgress(true);
     this.userIdService.clearUserId();
     return new Promise((resolve) => {
       this.oAuthLibWrapperService.revokeAndLogout().finally(() => {
@@ -101,5 +112,19 @@ export class AuthService {
    */
   logout(): void {
     this.routingService.go({ cxRoute: 'logout' });
+  }
+
+  /**
+   * Start or stop the refresh process
+   */
+  setRefreshProgress(progress: boolean): void {
+    (this.refreshInProgress$ as BehaviorSubject<boolean>).next(progress);
+  }
+
+  /**
+   * Start or stop the logout process
+   */
+  setLogoutProgress(progress: boolean): void {
+    (this.logoutInProgress$ as BehaviorSubject<boolean>).next(progress);
   }
 }

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
@@ -1,7 +1,27 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { EMPTY, Observable } from 'rxjs';
-import { filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { Injectable, OnDestroy } from '@angular/core';
+import {
+  combineLatest,
+  defer,
+  EMPTY,
+  Observable,
+  queueScheduler,
+  Subject,
+  Subscription,
+  using,
+} from 'rxjs';
+import {
+  filter,
+  map,
+  observeOn,
+  pairwise,
+  shareReplay,
+  skipWhile,
+  switchMap,
+  take,
+  tap,
+  withLatestFrom,
+} from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
 import { OccEndpointsService } from '../../../occ/services/occ-endpoints.service';
@@ -17,11 +37,78 @@ import { OAuthLibWrapperService } from './oauth-lib-wrapper.service';
 @Injectable({
   providedIn: 'root',
 })
-export class AuthHttpHeaderService {
+export class AuthHttpHeaderService implements OnDestroy {
   /**
    * Indicates whether the access token is being refreshed
+   *
+   * @deprecated will be removed in the next major. Use `AuthService.refreshInProgress$` instead.
    */
+  // TODO:#13421 - legacy, remove this flag
   protected refreshInProgress = false;
+
+  /**
+   * Starts the refresh of the access token
+   */
+  protected refreshTokenTrigger$ = new Subject<AuthToken>();
+
+  /**
+   * Internal token streams which reads the latest from the storage.
+   * Emits the token or `undefined`
+   */
+  protected token$: Observable<
+    AuthToken | undefined
+  > = this.authStorageService
+    .getToken()
+    .pipe(map((token) => (token?.access_token ? token : undefined)));
+
+  /**
+   * Compares the previous and the new token in order to stop the refresh or logout processes
+   */
+  protected stopProgress$ = this.token$.pipe(
+    // Keeps the previous and the new token
+    pairwise(),
+    tap(([oldToken, newToken]) => {
+      // if we got the new token we know that either the refresh or logout finished
+      if (oldToken?.access_token !== newToken?.access_token) {
+        this.authService.setLogoutProgress(false);
+        this.authService.setRefreshProgress(false);
+      }
+    })
+  );
+
+  /**
+   * Refreshes the token only if currently there's no refresh nor logout in progress.
+   * If the refresh token is not present, it triggers the logout process
+   */
+  protected refreshToken$ = this.refreshTokenTrigger$.pipe(
+    withLatestFrom(
+      this.authService.refreshInProgress$,
+      this.authService.logoutInProgress$
+    ),
+    filter(
+      ([, refreshInProgress, logoutInProgress]) =>
+        !refreshInProgress && !logoutInProgress
+    ),
+    tap(([token]) => {
+      if (token?.refresh_token) {
+        this.oAuthLibWrapperService.refreshToken();
+        this.authService.setRefreshProgress(true);
+      } else {
+        this.handleExpiredRefreshToken();
+      }
+    })
+  );
+
+  /**
+   * Kicks of the process by listening to the new token and refresh token processes.
+   * This token should be used when retrying the failed http request.
+   */
+  protected tokenToRetryRequest$ = using(
+    () => this.refreshToken$.subscribe(),
+    () => this.getStableToken()
+  ).pipe(shareReplay({ refCount: true, bufferSize: 1 }));
+
+  protected subscriptions = new Subscription();
 
   constructor(
     protected authService: AuthService,
@@ -30,7 +117,12 @@ export class AuthHttpHeaderService {
     protected routingService: RoutingService,
     protected occEndpoints: OccEndpointsService,
     protected globalMessageService: GlobalMessageService
-  ) {}
+  ) {
+    // We need to have stopProgress$ stream active for the whole time,
+    // so when the logout finishes we finish it's process.
+    // It could happen when retryToken$ is not active.
+    this.subscriptions.add(this.stopProgress$.subscribe());
+  }
 
   /**
    * Checks if request should be handled by this service (if it's OCC call).
@@ -39,16 +131,25 @@ export class AuthHttpHeaderService {
     return this.isOccUrl(request.url);
   }
 
+  public shouldAddAuthorizationHeader(request: HttpRequest<any>): boolean {
+    const hasAuthorizationHeader = !!this.getAuthorizationHeader(request);
+    const isOccUrl = this.isOccUrl(request.url);
+    return !hasAuthorizationHeader && isOccUrl;
+  }
+
   /**
    * Adds `Authorization` header for OCC calls.
    */
-  public alterRequest(request: HttpRequest<any>): HttpRequest<any> {
+  public alterRequest(
+    request: HttpRequest<any>,
+    token?: AuthToken
+  ): HttpRequest<any> {
     const hasAuthorizationHeader = !!this.getAuthorizationHeader(request);
     const isOccUrl = this.isOccUrl(request.url);
     if (!hasAuthorizationHeader && isOccUrl) {
       return request.clone({
         setHeaders: {
-          ...this.createAuthorizationHeader(),
+          ...this.createAuthorizationHeader(token),
         },
       });
     }
@@ -64,16 +165,25 @@ export class AuthHttpHeaderService {
     return rawValue;
   }
 
-  protected createAuthorizationHeader(): { Authorization: string } | {} {
-    let token: AuthToken | undefined;
-    this.authStorageService
-      .getToken()
-      .subscribe((tok) => (token = tok))
-      .unsubscribe();
-
+  protected createAuthorizationHeader(
+    token?: AuthToken
+  ): { Authorization: string } | {} {
     if (token?.access_token) {
       return {
         Authorization: `${token.token_type || 'Bearer'} ${token.access_token}`,
+      };
+    }
+    let currentToken: AuthToken | undefined;
+    this.authStorageService
+      .getToken()
+      .subscribe((token) => (currentToken = token))
+      .unsubscribe();
+
+    if (currentToken?.access_token) {
+      return {
+        Authorization: `${currentToken.token_type || 'Bearer'} ${
+          currentToken.access_token
+        }`,
       };
     }
     return {};
@@ -84,8 +194,23 @@ export class AuthHttpHeaderService {
    */
   public handleExpiredAccessToken(
     request: HttpRequest<any>,
-    next: HttpHandler
+    next: HttpHandler,
+    // TODO:#13421 make required
+    initialToken?: AuthToken
   ): Observable<HttpEvent<AuthToken>> {
+    // TODO:#13421 remove this if-statement, and just return the stream.
+    if (initialToken) {
+      return this.getValidToken(initialToken).pipe(
+        switchMap((token) =>
+          // we break the stream with EMPTY when we don't have the token. This prevents sending the requests with `Authorization: bearer undefined` header
+          token
+            ? next.handle(this.createNewRequestWithNewToken(request, token))
+            : EMPTY
+        )
+      );
+    }
+
+    // TODO:#13421 legacy - remove in 5.0
     return this.handleExpiredToken().pipe(
       switchMap((token) => {
         return token
@@ -101,21 +226,26 @@ export class AuthHttpHeaderService {
   public handleExpiredRefreshToken(): void {
     // Logout user
     // TODO(#9638): Use logout route when it will support passing redirect url
-    this.authService.coreLogout();
-    this.routingService.go({ cxRoute: 'login' });
-    this.globalMessageService.add(
-      {
-        key: 'httpHandlers.sessionExpired',
-      },
-      GlobalMessageType.MSG_TYPE_ERROR
-    );
+    this.authService.coreLogout().finally(() => {
+      this.routingService.go({ cxRoute: 'login' });
+
+      this.globalMessageService.add(
+        {
+          key: 'httpHandlers.sessionExpired',
+        },
+        GlobalMessageType.MSG_TYPE_ERROR
+      );
+    });
   }
 
+  // TODO:#13421 - remove this method
   /**
    * Attempts to refresh token if possible.
    * If it is not possible calls `handleExpiredRefreshToken`.
    *
    * @return observable which omits new access_token. (Warn: might never emit!).
+   *
+   * @deprecated will be removed in the next major. Use `getValidToken()` instead
    */
   protected handleExpiredToken(): Observable<AuthToken | undefined> {
     const stream = this.authStorageService.getToken();
@@ -136,10 +266,58 @@ export class AuthHttpHeaderService {
         oldToken = oldToken || token;
       }),
       filter((token) => oldToken.access_token !== token.access_token),
-      tap(() => (this.refreshInProgress = false)),
+      tap(() => {
+        this.refreshInProgress = false;
+      }),
       map((token) => (token?.access_token ? token : undefined)),
       take(1)
     );
+  }
+
+  /**
+   * Emits the token or `undefined` only when the refresh or the logout processes are finished.
+   */
+  getStableToken(): Observable<AuthToken | undefined> {
+    return combineLatest([
+      this.token$,
+      this.authService.refreshInProgress$,
+      this.authService.logoutInProgress$,
+    ]).pipe(
+      observeOn(queueScheduler),
+      filter(
+        ([_, refreshInProgress, logoutInProgress]) =>
+          !refreshInProgress && !logoutInProgress
+      ),
+      switchMap(() => this.token$)
+    );
+  }
+
+  /**
+   * Returns a valid access token.
+   * It will attempt to refresh it if the current one expired; emits after the new one is retrieved.
+   */
+  protected getValidToken(
+    requestToken: AuthToken
+  ): Observable<AuthToken | undefined> {
+    return defer(() => {
+      // flag to only refresh token only on first emission
+      let refreshTriggered = false;
+      return this.tokenToRetryRequest$.pipe(
+        tap((token) => {
+          // we want to refresh the access token only when it is old.
+          // this is a guard for the case when there are multiple parallel http calls
+          if (
+            token?.access_token === requestToken?.access_token &&
+            !refreshTriggered
+          ) {
+            this.refreshTokenTrigger$.next(token);
+          }
+          refreshTriggered = true;
+        }),
+        skipWhile((token) => token?.access_token === requestToken.access_token),
+        take(1)
+      );
+    });
   }
 
   protected createNewRequestWithNewToken(
@@ -152,5 +330,9 @@ export class AuthHttpHeaderService {
       },
     });
     return request;
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
   }
 }

--- a/projects/core/src/checkout/store/effects/checkout.effect.spec.ts
+++ b/projects/core/src/checkout/store/effects/checkout.effect.spec.ts
@@ -241,10 +241,16 @@ describe('Checkout effect', () => {
   describe('clearCheckoutDataOnLogout$', () => {
     it('should dispatch clear checkout data action on logout', () => {
       const action = new AuthActions.Logout();
-      const completion = new CheckoutActions.ClearCheckoutData();
+      const completion1 = new CheckoutActions.ClearCheckoutData();
+      const completion2 = new CheckoutActions.ResetLoadSupportedDeliveryModesProcess();
+      const completion3 = new CheckoutActions.ResetLoadPaymentTypesProcess();
 
       actions$ = hot('-a', { a: action });
-      const expected = cold('-b', { b: completion });
+      const expected = cold('-(bcd)', {
+        b: completion1,
+        c: completion2,
+        d: completion3,
+      });
 
       expect(entryEffects.clearCheckoutDataOnLogout$).toBeObservable(expected);
     });

--- a/projects/core/src/checkout/store/effects/checkout.effect.ts
+++ b/projects/core/src/checkout/store/effects/checkout.effect.ts
@@ -170,9 +170,17 @@ export class CheckoutEffects {
   );
 
   @Effect()
-  clearCheckoutDataOnLogout$: Observable<CheckoutActions.ClearCheckoutData> = this.actions$.pipe(
+  clearCheckoutDataOnLogout$: Observable<
+    | CheckoutActions.ClearCheckoutData
+    | CheckoutActions.ResetLoadSupportedDeliveryModesProcess
+    | CheckoutActions.ResetLoadPaymentTypesProcess
+  > = this.actions$.pipe(
     ofType(AuthActions.LOGOUT),
-    map(() => new CheckoutActions.ClearCheckoutData())
+    mergeMap(() => [
+      new CheckoutActions.ClearCheckoutData(),
+      new CheckoutActions.ResetLoadSupportedDeliveryModesProcess(),
+      new CheckoutActions.ResetLoadPaymentTypesProcess(),
+    ])
   );
 
   @Effect()


### PR DESCRIPTION
This PR improves the access and refresh token handling, and the session management in general. On of the key updates are:
- fixed spinner issue when a user logs back in and is redirected to the 2nd or 3rd checkout step
- making the multiple request handling with expired access tokens bullet proof
- decreasing 401 calls to a minimum
- waiting for the logout process to finish before redirecting to the login page
- don't attempt to refresh the token if the logout is in progress