### PR TITLE
fix: Session management improvements (#13353)

### DIFF
--- a/feature-libs/asm/root/services/asm-auth-http-header.service.spec.ts
+++ b/feature-libs/asm/root/services/asm-auth-http-header.service.spec.ts
@@ -26,6 +26,7 @@ class MockCsAgentAuthService implements Partial<CsAgentAuthService> {
 }
 
 class MockAuthService implements Partial<AuthService> {
+  setLogoutProgress(_progress: boolean): void {}
   coreLogout() {
     return Promise.resolve();
   }
@@ -155,11 +156,12 @@ describe('AsmAuthHttpHeaderService', () => {
   });
 
   describe('handleExpiredRefreshToken', () => {
-    it('should work the same as in AuthHeaderService when there is normally logged user', () => {
+    it('should work the same as in AuthHeaderService when there is normally logged user', async () => {
       spyOn(authService, 'coreLogout').and.callThrough();
       spyOn(routingService, 'go').and.callThrough();
 
       service.handleExpiredRefreshToken();
+      await Promise.resolve();
 
       expect(authService.coreLogout).toHaveBeenCalled();
       expect(
@@ -176,9 +178,11 @@ describe('AsmAuthHttpHeaderService', () => {
       ).and.returnValue(of(true));
       spyOn(csAgentAuthService, 'logoutCustomerSupportAgent').and.callThrough();
       spyOn(globalMessageService, 'add').and.callThrough();
+      spyOn(authService, 'setLogoutProgress').and.stub();
 
       service.handleExpiredRefreshToken();
 
+      expect(authService.setLogoutProgress).toHaveBeenCalledWith(true);
       expect(authService.coreLogout).not.toHaveBeenCalled();
       expect(csAgentAuthService.logoutCustomerSupportAgent).toHaveBeenCalled();
       expect(globalMessageService.add).toHaveBeenCalledWith(

--- a/feature-libs/asm/root/services/asm-auth-http-header.service.ts
+++ b/feature-libs/asm/root/services/asm-auth-http-header.service.ts
@@ -5,6 +5,7 @@ import {
   AuthRedirectService,
   AuthService,
   AuthStorageService,
+  AuthToken,
   GlobalMessageService,
   GlobalMessageType,
   InterceptorUtil,
@@ -62,16 +63,19 @@ export class AsmAuthHttpHeaderService extends AuthHttpHeaderService {
    * Adds `Authorization` header to occ and CS agent requests.
    * For CS agent requests also removes the `cx-use-csagent-token` header (to avoid problems with CORS).
    */
-  public alterRequest(request: HttpRequest<any>): HttpRequest<any> {
+  public alterRequest(
+    request: HttpRequest<any>,
+    token?: AuthToken
+  ): HttpRequest<any> {
     const hasAuthorizationHeader = !!this.getAuthorizationHeader(request);
     const isCSAgentRequest = this.isCSAgentTokenRequest(request);
 
-    let req = super.alterRequest(request);
+    let req = super.alterRequest(request, token);
 
     if (!hasAuthorizationHeader && isCSAgentRequest) {
       req = request.clone({
         setHeaders: {
-          ...this.createAuthorizationHeader(),
+          ...this.createAuthorizationHeader(token),
         },
       });
       return InterceptorUtil.removeHeader(
@@ -102,6 +106,7 @@ export class AsmAuthHttpHeaderService extends AuthHttpHeaderService {
       .pipe(take(1))
       .subscribe((csAgentLoggedIn) => {
         if (csAgentLoggedIn) {
+          this.authService.setLogoutProgress(true);
           this.csAgentAuthService.logoutCustomerSupportAgent();
           this.globalMessageService.add(
             {

--- a/feature-libs/asm/root/services/asm-auth-http-header.service.ts
+++ b/feature-libs/asm/root/services/asm-auth-http-header.service.ts
@@ -47,6 +47,18 @@ export class AsmAuthHttpHeaderService extends AuthHttpHeaderService {
   }
 
   /**
+   * Checks if the authorization header should be added to the request
+   *
+   *  @override
+   */
+  public shouldAddAuthorizationHeader(request: HttpRequest<any>): boolean {
+    return (
+      super.shouldAddAuthorizationHeader(request) ||
+      this.isCSAgentTokenRequest(request)
+    );
+  }
+
+  /**
    * @override
    *
    * Checks if particular request should be handled by this service.

--- a/feature-libs/checkout/core/store/effects/checkout.effect.spec.ts
+++ b/feature-libs/checkout/core/store/effects/checkout.effect.spec.ts
@@ -246,10 +246,16 @@ describe('Checkout effect', () => {
   describe('clearCheckoutDataOnLogout$', () => {
     it('should dispatch clear checkout data action on logout', () => {
       const action = new AuthActions.Logout();
-      const completion = new CheckoutActions.ClearCheckoutData();
+      const completion1 = new CheckoutActions.ClearCheckoutData();
+      const completion2 = new CheckoutActions.ResetLoadSupportedDeliveryModesProcess();
+      const completion3 = new CheckoutActions.ResetLoadPaymentTypesProcess();
 
       actions$ = hot('-a', { a: action });
-      const expected = cold('-b', { b: completion });
+      const expected = cold('-(bcd)', {
+        b: completion1,
+        c: completion2,
+        d: completion3,
+      });
 
       expect(entryEffects.clearCheckoutDataOnLogout$).toBeObservable(expected);
     });

--- a/feature-libs/checkout/core/store/effects/checkout.effect.ts
+++ b/feature-libs/checkout/core/store/effects/checkout.effect.ts
@@ -172,9 +172,17 @@ export class CheckoutEffects {
   );
 
   @Effect()
-  clearCheckoutDataOnLogout$: Observable<CheckoutActions.ClearCheckoutData> = this.actions$.pipe(
+  clearCheckoutDataOnLogout$: Observable<
+    | CheckoutActions.ClearCheckoutData
+    | CheckoutActions.ResetLoadSupportedDeliveryModesProcess
+    | CheckoutActions.ResetLoadPaymentTypesProcess
+  > = this.actions$.pipe(
     ofType(AuthActions.LOGOUT),
-    map(() => new CheckoutActions.ClearCheckoutData())
+    mergeMap(() => [
+      new CheckoutActions.ClearCheckoutData(),
+      new CheckoutActions.ResetLoadSupportedDeliveryModesProcess(),
+      new CheckoutActions.ResetLoadPaymentTypesProcess(),
+    ])
   );
 
   @Effect()

--- a/projects/core/src/auth/user-auth/facade/auth.service.spec.ts
+++ b/projects/core/src/auth/user-auth/facade/auth.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { Store, StoreModule } from '@ngrx/store';
 import { TokenResponse } from 'angular-oauth2-oidc';
 import { OCC_USER_ID_CURRENT } from 'projects/core/src/occ';
-import { Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { RoutingService } from '../../../routing/facade/routing.service';
 import { AuthToken } from '../models/auth-token.model';
@@ -149,6 +149,9 @@ describe('AuthService', () => {
 
       await service.coreLogout();
 
+      expect(
+        (service.logoutInProgress$ as BehaviorSubject<boolean>).value
+      ).toBeTruthy();
       expect(userIdService.clearUserId).toHaveBeenCalled();
       expect(oAuthLibWrapperService.revokeAndLogout).toHaveBeenCalled();
       expect(store.dispatch).toHaveBeenCalledWith(new AuthActions.Logout());

--- a/projects/core/src/auth/user-auth/facade/auth.service.ts
+++ b/projects/core/src/auth/user-auth/facade/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { OCC_USER_ID_CURRENT } from '../../../occ/utils/occ-constants';
 import { RoutingService } from '../../../routing/facade/routing.service';
@@ -19,6 +19,16 @@ import { UserIdService } from './user-id.service';
   providedIn: 'root',
 })
 export class AuthService {
+  /**
+   * Indicates whether the access token is being refreshed
+   */
+  refreshInProgress$: Observable<boolean> = new BehaviorSubject<boolean>(false);
+
+  /**
+   * Indicates whether the logout is being performed
+   */
+  logoutInProgress$: Observable<boolean> = new BehaviorSubject<boolean>(false);
+
   constructor(
     protected store: Store<StateWithClientAuth>,
     protected userIdService: UserIdService,
@@ -77,6 +87,7 @@ export class AuthService {
    * To perform logout it is best to use `logout` method. Use this method with caution.
    */
   coreLogout(): Promise<void> {
+    this.setLogoutProgress(true);
     this.userIdService.clearUserId();
     return new Promise((resolve) => {
       this.oAuthLibWrapperService.revokeAndLogout().finally(() => {
@@ -101,5 +112,19 @@ export class AuthService {
    */
   logout(): void {
     this.routingService.go({ cxRoute: 'logout' });
+  }
+
+  /**
+   * Start or stop the refresh process
+   */
+  setRefreshProgress(progress: boolean): void {
+    (this.refreshInProgress$ as BehaviorSubject<boolean>).next(progress);
+  }
+
+  /**
+   * Start or stop the logout process
+   */
+  setLogoutProgress(progress: boolean): void {
+    (this.logoutInProgress$ as BehaviorSubject<boolean>).next(progress);
   }
 }

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpHandler, HttpHeaders, HttpRequest } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject, EMPTY, of, queueScheduler } from 'rxjs';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+import { BehaviorSubject, EMPTY, merge, of, queueScheduler } from 'rxjs';
 import { observeOn, take } from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
@@ -14,15 +14,30 @@ import { AuthRedirectService } from './auth-redirect.service';
 import { AuthStorageService } from './auth-storage.service';
 import { OAuthLibWrapperService } from './oauth-lib-wrapper.service';
 
+const testToken: AuthToken = {
+  access_token: 'acc_token',
+  access_token_stored_at: '123',
+};
+
+const logoutInProgressSubject = new BehaviorSubject<boolean>(false);
+const refreshInProgressSubject = new BehaviorSubject<boolean>(false);
+const getTokenFromStorage = new BehaviorSubject<AuthToken | undefined>(
+  testToken
+);
+
 class MockAuthService implements Partial<AuthService> {
+  logoutInProgress$ = logoutInProgressSubject;
+  refreshInProgress$ = refreshInProgressSubject;
   coreLogout() {
     return Promise.resolve();
   }
+  setLogoutProgress(_progress: boolean): void {}
+  setRefreshProgress(_progress: boolean): void {}
 }
 
 class MockAuthStorageService implements Partial<AuthStorageService> {
   getToken() {
-    return of({ access_token: 'acc_token' } as AuthToken);
+    return getTokenFromStorage.asObservable();
   }
 }
 
@@ -88,6 +103,34 @@ describe('AuthHttpHeaderService', () => {
     expect(service).toBeTruthy();
   });
 
+  describe('shouldAddAuthorizationHeader', () => {
+    it('should return true for occ urls', () => {
+      expect(
+        service.shouldAddAuthorizationHeader(
+          new HttpRequest('GET', 'some-server/occ/cart')
+        )
+      ).toBeTrue();
+    });
+
+    it('should return false for non occ urls', () => {
+      expect(
+        service.shouldAddAuthorizationHeader(
+          new HttpRequest('GET', 'some-server/auth')
+        )
+      ).toBeFalse();
+    });
+
+    it('should return false if request already have Authorization header', () => {
+      expect(
+        service.shouldAddAuthorizationHeader(
+          new HttpRequest('GET', 'some-server/auth', {
+            headers: new HttpHeaders({ Authorization: 'Bearer acc_token' }),
+          })
+        )
+      ).toBeFalse();
+    });
+  });
+
   describe('shouldCatchError', () => {
     it('should return true for occ urls', () => {
       expect(
@@ -110,6 +153,14 @@ describe('AuthHttpHeaderService', () => {
       expect(request.headers.get('Authorization')).toEqual('Bearer acc_token');
     });
 
+    it('should use AuthToken that is passed to this method', () => {
+      const request = service.alterRequest(
+        new HttpRequest('GET', 'some-server/occ/cart'),
+        { access_token: 'new_token' } as AuthToken
+      );
+      expect(request.headers.get('Authorization')).toEqual('Bearer new_token');
+    });
+
     it('should not change Authorization header for occ calls', () => {
       const request = service.alterRequest(
         new HttpRequest('GET', 'some-server/occ/cart', {
@@ -129,16 +180,18 @@ describe('AuthHttpHeaderService', () => {
 
   describe('handleExpiredAccessToken', () => {
     it('should refresh the token and retry the call with new token', (done) => {
-      const token = new BehaviorSubject({
+      const token = new BehaviorSubject<AuthToken>({
         access_token: `old_token`,
+        access_token_stored_at: '123',
         refresh_token: 'ref_token',
-      } as AuthToken);
+      });
       const handler = (a: any) => of(a);
       spyOn(oAuthLibWrapperService, 'refreshToken').and.callFake(() => {
         token.next({
           access_token: `new_token`,
+          access_token_stored_at: '456',
           refresh_token: 'ref_token',
-        } as AuthToken);
+        });
         return EMPTY;
       });
       spyOn(authStorageService, 'getToken').and.returnValue(
@@ -182,15 +235,113 @@ describe('AuthHttpHeaderService', () => {
       expect(oAuthLibWrapperService.refreshToken).not.toHaveBeenCalled();
       expect(service.handleExpiredRefreshToken).toHaveBeenCalled();
     });
+
+    it('should refresh token only once when method is invoked multiple times at the same time', (done) => {
+      const token = new BehaviorSubject<AuthToken>({
+        access_token: `old_token`,
+        access_token_stored_at: '123',
+        refresh_token: 'ref_token',
+      });
+      const handler = (a: any) => of(a);
+      spyOn(oAuthLibWrapperService, 'refreshToken').and.callFake(() => {
+        token.next({
+          access_token: `new_token`,
+          access_token_stored_at: '456',
+          refresh_token: 'ref_token',
+        });
+        return EMPTY;
+      });
+      spyOn(authStorageService, 'getToken').and.returnValue(
+        token.asObservable().pipe(observeOn(queueScheduler))
+      );
+
+      merge(
+        service.handleExpiredAccessToken(
+          new HttpRequest('GET', 'some-server/1/'),
+          { handle: handler } as HttpHandler
+        ),
+        service.handleExpiredAccessToken(
+          new HttpRequest('GET', 'some-server/2/'),
+          { handle: handler } as HttpHandler
+        )
+      ).subscribe((res: any) => {
+        expect(res.headers.get('Authorization')).toEqual('Bearer new_token');
+        expect(res.url).toEqual('some-server/1/');
+        expect(res.method).toEqual('GET');
+        expect(oAuthLibWrapperService.refreshToken).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+
+    // it('should not attempt to refresh the token when there was a logout before the token expired', () => {
+    //   const token: AuthToken = {
+    //     access_token: `token`,
+    //     access_token_stored_at: '123',
+    //   };
+
+    //   logoutInProgressSubject.next(true);
+    //   const handler = jasmine.createSpy('handler', (a: any) => of(a));
+    //   spyOn(oAuthLibWrapperService, 'refreshToken').and.callThrough();
+    //   spyOn(service, 'handleExpiredRefreshToken').and.stub();
+    //   spyOn(authStorageService, 'getToken').and.returnValue(of(token));
+
+    //   service
+    //     .handleExpiredAccessToken(
+    //       new HttpRequest('GET', 'some-server/occ/cart'),
+    //       { handle: handler } as HttpHandler,
+    //       token
+    //     )
+    //     .subscribe({
+    //       complete: () => {
+    //         // check that we didn't created new requests
+    //         expect(handler).not.toHaveBeenCalled();
+    //       },
+    //     });
+    //   expect(oAuthLibWrapperService.refreshToken).not.toHaveBeenCalled();
+
+    //   logoutInProgressSubject.next(false);
+    //   expect(handler).toHaveBeenCalled();
+    // });
+
+    it('should not refresh token when the given token is already different than the token used for failing refresh', (done) => {
+      refreshInProgressSubject.next(false);
+      logoutInProgressSubject.next(false);
+      const initialToken: AuthToken = {
+        access_token: `old_token`,
+        access_token_stored_at: '123',
+      };
+      const handler = (a: any) => of(a);
+      spyOn(oAuthLibWrapperService, 'refreshToken').and.stub();
+
+      service
+        .handleExpiredAccessToken(
+          new HttpRequest('GET', 'some-server/1/'),
+          { handle: handler } as HttpHandler,
+          initialToken
+        )
+        .subscribe((res: any) => {
+          expect(res.headers.get('Authorization')).toEqual(
+            `Bearer ${testToken.access_token}`
+          );
+          expect(res.url).toEqual('some-server/1/');
+          expect(res.method).toEqual('GET');
+          expect(oAuthLibWrapperService.refreshToken).not.toHaveBeenCalled();
+          done();
+        });
+    });
   });
 
   describe('handleExpiredRefreshToken', () => {
-    it('should logout user, save current navigation url, and redirect to login page', () => {
+    it('should logout user, save current navigation url, and redirect to login page', async () => {
+      refreshInProgressSubject.next(false);
+      logoutInProgressSubject.next(false);
       spyOn(authService, 'coreLogout').and.callThrough();
       spyOn(routingService, 'go').and.callThrough();
       spyOn(globalMessageService, 'add').and.callThrough();
 
       service.handleExpiredRefreshToken();
+      // wait for the internal coreLogout() to resolve before assertions
+      await Promise.resolve();
 
       expect(authService.coreLogout).toHaveBeenCalled();
       expect(
@@ -204,5 +355,68 @@ describe('AuthHttpHeaderService', () => {
         GlobalMessageType.MSG_TYPE_ERROR
       );
     });
+  });
+
+  describe('getValidToken', () => {
+    it('should return undefined when token does not have access token', (done) => {
+      getTokenFromStorage.next(undefined);
+
+      service['getValidToken']({
+        access_token: 'xxx',
+        access_token_stored_at: '123',
+      })
+        .pipe(take(1))
+        .subscribe((result) => {
+          expect(result).toBeFalsy();
+          done();
+        });
+    });
+
+    it('should return token when we have access token', (done) => {
+      getTokenFromStorage.next(testToken);
+
+      service['getValidToken']({
+        access_token: 'xxx',
+        access_token_stored_at: '123',
+      })
+        .pipe(take(1))
+        .subscribe((result) => {
+          expect(result).toBeTruthy();
+          expect(result).toEqual(testToken);
+          done();
+        });
+    });
+
+    it('should not emit when logout is in progress', fakeAsync(() => {
+      logoutInProgressSubject.next(true);
+
+      let emitted = false;
+      service['getValidToken']({
+        access_token: 'xxx',
+        access_token_stored_at: '123',
+      })
+        .pipe(take(1))
+        .subscribe(() => {
+          emitted = true;
+        });
+
+      expect(emitted).toBeFalsy();
+    }));
+
+    it('should not emit when refresh is in progress', fakeAsync(() => {
+      refreshInProgressSubject.next(true);
+
+      let emitted = false;
+      service['getValidToken']({
+        access_token: 'xxx',
+        access_token_stored_at: '123',
+      })
+        .pipe(take(1))
+        .subscribe(() => {
+          emitted = true;
+        });
+
+      expect(emitted).toBeFalsy();
+    }));
   });
 });

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpHandler, HttpHeaders, HttpRequest } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { fakeAsync, TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { BehaviorSubject, EMPTY, merge, of, queueScheduler } from 'rxjs';
 import { observeOn, take } from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
@@ -29,15 +29,20 @@ class MockAuthService implements Partial<AuthService> {
   logoutInProgress$ = logoutInProgressSubject;
   refreshInProgress$ = refreshInProgressSubject;
   coreLogout() {
+    this.setLogoutProgress(true);
     return Promise.resolve();
   }
-  setLogoutProgress(_progress: boolean): void {}
-  setRefreshProgress(_progress: boolean): void {}
+  setLogoutProgress(progress: boolean): void {
+    logoutInProgressSubject.next(progress);
+  }
+  setRefreshProgress(progress: boolean): void {
+    refreshInProgressSubject.next(progress);
+  }
 }
 
 class MockAuthStorageService implements Partial<AuthStorageService> {
   getToken() {
-    return getTokenFromStorage.asObservable();
+    return getTokenFromStorage.asObservable().pipe(observeOn(queueScheduler));
   }
 }
 
@@ -67,7 +72,6 @@ describe('AuthHttpHeaderService', () => {
   let service: AuthHttpHeaderService;
   let oAuthLibWrapperService: OAuthLibWrapperService;
   let authService: AuthService;
-  let authStorageService: AuthStorageService;
   let routingService: RoutingService;
   let globalMessageService: GlobalMessageService;
   let authRedirectService: AuthRedirectService;
@@ -95,8 +99,11 @@ describe('AuthHttpHeaderService', () => {
     oAuthLibWrapperService = TestBed.inject(OAuthLibWrapperService);
     routingService = TestBed.inject(RoutingService);
     globalMessageService = TestBed.inject(GlobalMessageService);
-    authStorageService = TestBed.inject(AuthStorageService);
     authRedirectService = TestBed.inject(AuthRedirectService);
+
+    getTokenFromStorage.next(testToken);
+    logoutInProgressSubject.next(false);
+    refreshInProgressSubject.next(false);
   });
 
   it('should be created', () => {
@@ -180,27 +187,26 @@ describe('AuthHttpHeaderService', () => {
 
   describe('handleExpiredAccessToken', () => {
     it('should refresh the token and retry the call with new token', (done) => {
-      const token = new BehaviorSubject<AuthToken>({
+      const initialToken: AuthToken = {
         access_token: `old_token`,
         access_token_stored_at: '123',
         refresh_token: 'ref_token',
-      });
+      };
+      getTokenFromStorage.next(initialToken);
       const handler = (a: any) => of(a);
       spyOn(oAuthLibWrapperService, 'refreshToken').and.callFake(() => {
-        token.next({
+        getTokenFromStorage.next({
           access_token: `new_token`,
           access_token_stored_at: '456',
           refresh_token: 'ref_token',
         });
         return EMPTY;
       });
-      spyOn(authStorageService, 'getToken').and.returnValue(
-        token.asObservable().pipe(observeOn(queueScheduler))
-      );
       service
         .handleExpiredAccessToken(
           new HttpRequest('GET', 'some-server/occ/cart'),
-          { handle: handler } as HttpHandler
+          { handle: handler } as HttpHandler,
+          initialToken
         )
         .pipe(take(1))
         .subscribe((res: any) => {
@@ -212,100 +218,109 @@ describe('AuthHttpHeaderService', () => {
         });
     });
 
-    it('should invoke expired refresh token handler when there is no refresh token', () => {
+    it('should invoke expired refresh token handler when there is no refresh token', (done) => {
+      const initialToken: AuthToken = {
+        access_token: `token`,
+        access_token_stored_at: `123`,
+      };
+      getTokenFromStorage.next(initialToken);
       const handler = jasmine.createSpy('handler', (a: any) => of(a));
       spyOn(oAuthLibWrapperService, 'refreshToken').and.callThrough();
-      spyOn(service, 'handleExpiredRefreshToken').and.stub();
-      spyOn(authStorageService, 'getToken').and.returnValue(
-        of({
-          access_token: `token`,
-        } as AuthToken)
-      );
+      spyOn(service, 'handleExpiredRefreshToken').and.callFake(() => {
+        getTokenFromStorage.next({} as AuthToken);
+      });
       service
         .handleExpiredAccessToken(
           new HttpRequest('GET', 'some-server/occ/cart'),
-          { handle: handler } as HttpHandler
+          { handle: handler } as HttpHandler,
+          initialToken
         )
         .subscribe({
           complete: () => {
             // check that we didn't created new requests
             expect(handler).not.toHaveBeenCalled();
+            expect(oAuthLibWrapperService.refreshToken).not.toHaveBeenCalled();
+            expect(service.handleExpiredRefreshToken).toHaveBeenCalled();
+            done();
           },
         });
-      expect(oAuthLibWrapperService.refreshToken).not.toHaveBeenCalled();
-      expect(service.handleExpiredRefreshToken).toHaveBeenCalled();
     });
 
     it('should refresh token only once when method is invoked multiple times at the same time', (done) => {
-      const token = new BehaviorSubject<AuthToken>({
+      const initialToken: AuthToken = {
         access_token: `old_token`,
         access_token_stored_at: '123',
         refresh_token: 'ref_token',
-      });
+      };
+      getTokenFromStorage.next(initialToken);
       const handler = (a: any) => of(a);
       spyOn(oAuthLibWrapperService, 'refreshToken').and.callFake(() => {
-        token.next({
+        getTokenFromStorage.next({
           access_token: `new_token`,
           access_token_stored_at: '456',
           refresh_token: 'ref_token',
         });
-        return EMPTY;
       });
-      spyOn(authStorageService, 'getToken').and.returnValue(
-        token.asObservable().pipe(observeOn(queueScheduler))
-      );
+      const results: any[] = [];
 
       merge(
         service.handleExpiredAccessToken(
           new HttpRequest('GET', 'some-server/1/'),
-          { handle: handler } as HttpHandler
+          { handle: handler } as HttpHandler,
+          initialToken
         ),
         service.handleExpiredAccessToken(
           new HttpRequest('GET', 'some-server/2/'),
-          { handle: handler } as HttpHandler
+          { handle: handler } as HttpHandler,
+          initialToken
         )
-      ).subscribe((res: any) => {
-        expect(res.headers.get('Authorization')).toEqual('Bearer new_token');
-        expect(res.url).toEqual('some-server/1/');
-        expect(res.method).toEqual('GET');
-        expect(oAuthLibWrapperService.refreshToken).toHaveBeenCalledTimes(1);
-        done();
+      ).subscribe((res) => {
+        results.push(res);
+        if (results.length === 2) {
+          results.forEach((r) =>
+            expect(r.headers.get('Authorization')).toEqual('Bearer new_token')
+          );
+          const url1 = results.find((r) => r.url === 'some-server/1/');
+          expect(url1).toBeTruthy();
+          const url2 = results.find((r) => r.url === 'some-server/2/');
+          expect(url2).toBeTruthy();
+          expect(oAuthLibWrapperService.refreshToken).toHaveBeenCalledTimes(1);
+          done();
+        }
       });
     });
 
-    // it('should not attempt to refresh the token when there was a logout before the token expired', () => {
-    //   const token: AuthToken = {
-    //     access_token: `token`,
-    //     access_token_stored_at: '123',
-    //   };
+    it('should not attempt to refresh the token when there was a logout before the token expired', fakeAsync(() => {
+      const initialToken: AuthToken = {
+        access_token: `token`,
+        access_token_stored_at: '123',
+      };
+      getTokenFromStorage.next(initialToken);
+      const handler = jasmine.createSpy('handler', (a: any) => of(a));
+      logoutInProgressSubject.next(true);
 
-    //   logoutInProgressSubject.next(true);
-    //   const handler = jasmine.createSpy('handler', (a: any) => of(a));
-    //   spyOn(oAuthLibWrapperService, 'refreshToken').and.callThrough();
-    //   spyOn(service, 'handleExpiredRefreshToken').and.stub();
-    //   spyOn(authStorageService, 'getToken').and.returnValue(of(token));
+      spyOn(oAuthLibWrapperService, 'refreshToken').and.callThrough();
 
-    //   service
-    //     .handleExpiredAccessToken(
-    //       new HttpRequest('GET', 'some-server/occ/cart'),
-    //       { handle: handler } as HttpHandler,
-    //       token
-    //     )
-    //     .subscribe({
-    //       complete: () => {
-    //         // check that we didn't created new requests
-    //         expect(handler).not.toHaveBeenCalled();
-    //       },
-    //     });
-    //   expect(oAuthLibWrapperService.refreshToken).not.toHaveBeenCalled();
+      service
+        .handleExpiredAccessToken(
+          new HttpRequest('GET', 'some-server/occ/cart'),
+          { handle: handler } as HttpHandler,
+          initialToken
+        )
+        .subscribe({
+          complete: () => {
+            expect(oAuthLibWrapperService.refreshToken).not.toHaveBeenCalled();
+            expect(handler).not.toHaveBeenCalled();
+          },
+        });
 
-    //   logoutInProgressSubject.next(false);
-    //   expect(handler).toHaveBeenCalled();
-    // });
+      setTimeout(() => {
+        getTokenFromStorage.next({} as AuthToken);
+      }, 100);
+      tick(101);
+    }));
 
     it('should not refresh token when the given token is already different than the token used for failing refresh', (done) => {
-      refreshInProgressSubject.next(false);
-      logoutInProgressSubject.next(false);
       const initialToken: AuthToken = {
         access_token: `old_token`,
         access_token_stored_at: '123',
@@ -332,18 +347,23 @@ describe('AuthHttpHeaderService', () => {
   });
 
   describe('handleExpiredRefreshToken', () => {
+    function wait(): Promise<void> {
+      return new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), 5);
+      });
+    }
+
     it('should logout user, save current navigation url, and redirect to login page', async () => {
-      refreshInProgressSubject.next(false);
-      logoutInProgressSubject.next(false);
-      spyOn(authService, 'coreLogout').and.callThrough();
+      spyOn(authService, 'coreLogout').and.callFake(wait);
       spyOn(routingService, 'go').and.callThrough();
       spyOn(globalMessageService, 'add').and.callThrough();
 
       service.handleExpiredRefreshToken();
-      // wait for the internal coreLogout() to resolve before assertions
-      await Promise.resolve();
 
       expect(authService.coreLogout).toHaveBeenCalled();
+      expect(routingService.go).not.toHaveBeenCalled();
+      await wait();
+
       expect(
         authRedirectService.saveCurrentNavigationUrl
       ).toHaveBeenCalledBefore(routingService.go);

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
@@ -1,7 +1,27 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { EMPTY, Observable } from 'rxjs';
-import { filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { Injectable, OnDestroy } from '@angular/core';
+import {
+  combineLatest,
+  defer,
+  EMPTY,
+  Observable,
+  queueScheduler,
+  Subject,
+  Subscription,
+  using,
+} from 'rxjs';
+import {
+  filter,
+  map,
+  observeOn,
+  pairwise,
+  shareReplay,
+  skipWhile,
+  switchMap,
+  take,
+  tap,
+  withLatestFrom,
+} from 'rxjs/operators';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
 import { OccEndpointsService } from '../../../occ/services/occ-endpoints.service';
@@ -18,11 +38,78 @@ import { OAuthLibWrapperService } from './oauth-lib-wrapper.service';
 @Injectable({
   providedIn: 'root',
 })
-export class AuthHttpHeaderService {
+export class AuthHttpHeaderService implements OnDestroy {
   /**
    * Indicates whether the access token is being refreshed
+   *
+   * @deprecated will be removed in the next major. Use `AuthService.refreshInProgress$` instead.
    */
+  // TODO:#13421 - legacy, remove this flag
   protected refreshInProgress = false;
+
+  /**
+   * Starts the refresh of the access token
+   */
+  protected refreshTokenTrigger$ = new Subject<AuthToken>();
+
+  /**
+   * Internal token streams which reads the latest from the storage.
+   * Emits the token or `undefined`
+   */
+  protected token$: Observable<
+    AuthToken | undefined
+  > = this.authStorageService
+    .getToken()
+    .pipe(map((token) => (token?.access_token ? token : undefined)));
+
+  /**
+   * Compares the previous and the new token in order to stop the refresh or logout processes
+   */
+  protected stopProgress$ = this.token$.pipe(
+    // Keeps the previous and the new token
+    pairwise(),
+    tap(([oldToken, newToken]) => {
+      // if we got the new token we know that either the refresh or logout finished
+      if (oldToken?.access_token !== newToken?.access_token) {
+        this.authService.setLogoutProgress(false);
+        this.authService.setRefreshProgress(false);
+      }
+    })
+  );
+
+  /**
+   * Refreshes the token only if currently there's no refresh nor logout in progress.
+   * If the refresh token is not present, it triggers the logout process
+   */
+  protected refreshToken$ = this.refreshTokenTrigger$.pipe(
+    withLatestFrom(
+      this.authService.refreshInProgress$,
+      this.authService.logoutInProgress$
+    ),
+    filter(
+      ([, refreshInProgress, logoutInProgress]) =>
+        !refreshInProgress && !logoutInProgress
+    ),
+    tap(([token]) => {
+      if (token?.refresh_token) {
+        this.oAuthLibWrapperService.refreshToken();
+        this.authService.setRefreshProgress(true);
+      } else {
+        this.handleExpiredRefreshToken();
+      }
+    })
+  );
+
+  /**
+   * Kicks of the process by listening to the new token and refresh token processes.
+   * This token should be used when retrying the failed http request.
+   */
+  protected tokenToRetryRequest$ = using(
+    () => this.refreshToken$.subscribe(),
+    () => this.getStableToken()
+  ).pipe(shareReplay({ refCount: true, bufferSize: 1 }));
+
+  protected subscriptions = new Subscription();
 
   constructor(
     protected authService: AuthService,
@@ -32,7 +119,12 @@ export class AuthHttpHeaderService {
     protected occEndpoints: OccEndpointsService,
     protected globalMessageService: GlobalMessageService,
     protected authRedirectService: AuthRedirectService
-  ) {}
+  ) {
+    // We need to have stopProgress$ stream active for the whole time,
+    // so when the logout finishes we finish it's process.
+    // It could happen when retryToken$ is not active.
+    this.subscriptions.add(this.stopProgress$.subscribe());
+  }
 
   /**
    * Checks if request should be handled by this service (if it's OCC call).
@@ -41,16 +133,25 @@ export class AuthHttpHeaderService {
     return this.isOccUrl(request.url);
   }
 
+  public shouldAddAuthorizationHeader(request: HttpRequest<any>): boolean {
+    const hasAuthorizationHeader = !!this.getAuthorizationHeader(request);
+    const isOccUrl = this.isOccUrl(request.url);
+    return !hasAuthorizationHeader && isOccUrl;
+  }
+
   /**
    * Adds `Authorization` header for OCC calls.
    */
-  public alterRequest(request: HttpRequest<any>): HttpRequest<any> {
+  public alterRequest(
+    request: HttpRequest<any>,
+    token?: AuthToken
+  ): HttpRequest<any> {
     const hasAuthorizationHeader = !!this.getAuthorizationHeader(request);
     const isOccUrl = this.isOccUrl(request.url);
     if (!hasAuthorizationHeader && isOccUrl) {
       return request.clone({
         setHeaders: {
-          ...this.createAuthorizationHeader(),
+          ...this.createAuthorizationHeader(token),
         },
       });
     }
@@ -66,16 +167,25 @@ export class AuthHttpHeaderService {
     return rawValue;
   }
 
-  protected createAuthorizationHeader(): { Authorization: string } | {} {
-    let token: AuthToken | undefined;
-    this.authStorageService
-      .getToken()
-      .subscribe((tok) => (token = tok))
-      .unsubscribe();
-
+  protected createAuthorizationHeader(
+    token?: AuthToken
+  ): { Authorization: string } | {} {
     if (token?.access_token) {
       return {
         Authorization: `${token.token_type || 'Bearer'} ${token.access_token}`,
+      };
+    }
+    let currentToken: AuthToken | undefined;
+    this.authStorageService
+      .getToken()
+      .subscribe((token) => (currentToken = token))
+      .unsubscribe();
+
+    if (currentToken?.access_token) {
+      return {
+        Authorization: `${currentToken.token_type || 'Bearer'} ${
+          currentToken.access_token
+        }`,
       };
     }
     return {};
@@ -86,8 +196,23 @@ export class AuthHttpHeaderService {
    */
   public handleExpiredAccessToken(
     request: HttpRequest<any>,
-    next: HttpHandler
+    next: HttpHandler,
+    // TODO:#13421 make required
+    initialToken?: AuthToken
   ): Observable<HttpEvent<AuthToken>> {
+    // TODO:#13421 remove this if-statement, and just return the stream.
+    if (initialToken) {
+      return this.getValidToken(initialToken).pipe(
+        switchMap((token) =>
+          // we break the stream with EMPTY when we don't have the token. This prevents sending the requests with `Authorization: bearer undefined` header
+          token
+            ? next.handle(this.createNewRequestWithNewToken(request, token))
+            : EMPTY
+        )
+      );
+    }
+
+    // TODO:#13421 legacy - remove in 5.0
     return this.handleExpiredToken().pipe(
       switchMap((token) => {
         return token
@@ -113,23 +238,26 @@ export class AuthHttpHeaderService {
 
     // Logout user
     // TODO(#9638): Use logout route when it will support passing redirect url
-    this.authService.coreLogout();
+    this.authService.coreLogout().finally(() => {
+      this.routingService.go({ cxRoute: 'login' });
 
-    this.routingService.go({ cxRoute: 'login' });
-
-    this.globalMessageService.add(
-      {
-        key: 'httpHandlers.sessionExpired',
-      },
-      GlobalMessageType.MSG_TYPE_ERROR
-    );
+      this.globalMessageService.add(
+        {
+          key: 'httpHandlers.sessionExpired',
+        },
+        GlobalMessageType.MSG_TYPE_ERROR
+      );
+    });
   }
 
+  // TODO:#13421 - remove this method
   /**
    * Attempts to refresh token if possible.
    * If it is not possible calls `handleExpiredRefreshToken`.
    *
    * @return observable which omits new access_token. (Warn: might never emit!).
+   *
+   * @deprecated will be removed in the next major. Use `getValidToken()` instead
    */
   protected handleExpiredToken(): Observable<AuthToken | undefined> {
     const stream = this.authStorageService.getToken();
@@ -150,10 +278,58 @@ export class AuthHttpHeaderService {
         oldToken = oldToken || token;
       }),
       filter((token) => oldToken.access_token !== token.access_token),
-      tap(() => (this.refreshInProgress = false)),
+      tap(() => {
+        this.refreshInProgress = false;
+      }),
       map((token) => (token?.access_token ? token : undefined)),
       take(1)
     );
+  }
+
+  /**
+   * Emits the token or `undefined` only when the refresh or the logout processes are finished.
+   */
+  getStableToken(): Observable<AuthToken | undefined> {
+    return combineLatest([
+      this.token$,
+      this.authService.refreshInProgress$,
+      this.authService.logoutInProgress$,
+    ]).pipe(
+      observeOn(queueScheduler),
+      filter(
+        ([_, refreshInProgress, logoutInProgress]) =>
+          !refreshInProgress && !logoutInProgress
+      ),
+      switchMap(() => this.token$)
+    );
+  }
+
+  /**
+   * Returns a valid access token.
+   * It will attempt to refresh it if the current one expired; emits after the new one is retrieved.
+   */
+  protected getValidToken(
+    requestToken: AuthToken
+  ): Observable<AuthToken | undefined> {
+    return defer(() => {
+      // flag to only refresh token only on first emission
+      let refreshTriggered = false;
+      return this.tokenToRetryRequest$.pipe(
+        tap((token) => {
+          // we want to refresh the access token only when it is old.
+          // this is a guard for the case when there are multiple parallel http calls
+          if (
+            token?.access_token === requestToken?.access_token &&
+            !refreshTriggered
+          ) {
+            this.refreshTokenTrigger$.next(token);
+          }
+          refreshTriggered = true;
+        }),
+        skipWhile((token) => token?.access_token === requestToken.access_token),
+        take(1)
+      );
+    });
   }
 
   protected createNewRequestWithNewToken(
@@ -166,5 +342,9 @@ export class AuthHttpHeaderService {
       },
     });
     return request;
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
   }
 }


### PR DESCRIPTION
This PR improves the access and refresh token handling, and the session management in general. On of the key updates are:

- fixed spinner issue when a user logs back in and is redirected to the 2nd or 3rd checkout step
- making the multiple request handling with expired access tokens bullet proof
- decreasing 401 calls to a minimum
- waiting for the logout process to finish before redirecting to the login page
- don't attempt to refresh the token if the logout is in progress
