### PR TITLE
feat: Add maxRenderTime option

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -1,12 +1,12 @@
 /* webpackIgnore: true */
+import { Request, Response } from 'express';
 import * as fs from 'fs';
+import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
+import { RenderingCache } from './rendering-cache';
 import {
   RenderingStrategy,
   SsrOptimizationOptions,
 } from './ssr-optimization-options';
-import { RenderingCache } from './rendering-cache';
-import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
-import { Request, Response } from 'express';
 
 /**
  * The rendered pages are kept in memory to be served on next request. If the `cache` is set to `false`, the
@@ -62,7 +62,7 @@ export class OptimizedSsrEngine {
     );
 
     if (isRendering) {
-      this.log(`CSR fallback: rendering in progress (${request.url})`);
+      this.log(`CSR fallback: rendering in progress (${request?.originalUrl})`);
     } else if (concurrencyLimitExceed) {
       this.log(
         `CSR fallback: Concurrency limit exceeded (${this.ssrOptions?.concurrency})`
@@ -132,7 +132,7 @@ export class OptimizedSsrEngine {
             waitingForRender = undefined;
             this.fallbackToCsr(response, filePath, callback);
             this.log(
-              `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${request?.url}`,
+              `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${request?.originalUrl}`,
               false
             );
           }, timeout);
@@ -142,11 +142,32 @@ export class OptimizedSsrEngine {
 
         // start rendering
         this.renderingCache.setAsRendering(renderingKey);
-        this.log(`Rendering started (${request?.url})`);
+
+        // setting the timeout for handing renders that might not ever finish due to various reason and won't decrease the `this.currentConcurrency--`.
+        let maxRenderTimeout: NodeJS.Timeout | undefined = setTimeout(() => {
+          this.currentConcurrency--;
+          this.renderingCache.clear(renderingKey);
+          maxRenderTimeout = undefined;
+
+          this.log(
+            `Rendering of ${request?.originalUrl} was not able to complete. This might cause memory leaks!`,
+            false
+          );
+        }, this.ssrOptions?.maxRenderTime ?? 300000); // 300000ms == 5 minutes
+
+        this.log(`Rendering started (${request?.originalUrl})`);
         this.expressEngine(filePath, options, (err, html) => {
+          if (!maxRenderTimeout) {
+            // ignore this render's result because it exceeded maxRenderTimeout
+            this.log(
+              `Rendering of ${request.originalUrl} completed after the specified maxRenderTime, therefore it was ignored.`
+            );
+            return;
+          }
+          clearTimeout(maxRenderTimeout);
           this.currentConcurrency--;
 
-          this.log(`Rendering completed (${request?.url})`);
+          this.log(`Rendering completed (${request?.originalUrl})`);
 
           if (waitingForRender) {
             // if request is still waiting for render, return it
@@ -169,7 +190,7 @@ export class OptimizedSsrEngine {
         this.fallbackToCsr(response, filePath, callback);
       }
     } else {
-      this.log(`Render from cache (${request?.url})`);
+      this.log(`Render from cache (${request?.originalUrl})`);
     }
   }
 

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -143,7 +143,8 @@ export class OptimizedSsrEngine {
         // start rendering
         this.renderingCache.setAsRendering(renderingKey);
 
-        // setting the timeout for handing renders that might not ever finish due to various reason and won't decrease the `this.currentConcurrency--`.
+        // setting the timeout for hanging renders that might not ever finish due to various reasons
+        // releasing concurrency slots by decreasing the `this.currentConcurrency--`.
         let maxRenderTimeout: NodeJS.Timeout | undefined = setTimeout(() => {
           this.currentConcurrency--;
           this.renderingCache.clear(renderingKey);

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -60,6 +60,21 @@ export interface SsrOptimizationOptions {
   forcedSsrTimeout?: number;
 
   /**
+   * The time for how long the render is expected to finish in.
+   * Exceeding this timeout will decrease the concurrency limit,
+   * but may not release the rendering resources taken by the render,
+   * which may cause additional memory usage on the server.
+   *
+   * It will log which render is exceeding the render time,
+   * which is useful for debugging issues.
+   *
+   * The value should always be higher than `timeout` and `forcedSsrTimeout`.
+   *
+   * Default value is 300 seconds (5 minutes).
+   */
+  maxRenderTime?: number;
+
+  /**
    * Enable detailed logs for troubleshooting problems
    */
   debug?: boolean;

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -61,8 +61,9 @@ export interface SsrOptimizationOptions {
 
   /**
    * The time for how long the render is expected to finish in.
-   * Exceeding this timeout will decrease the concurrency limit,
-   * but may not release the rendering resources taken by the render,
+   * Exceeding this timeout will decrease the concurrency limit
+   * and allow for the new request to be server-side rendered.
+   * However, this may not release the rendering resources for the hanging render,
    * which may cause additional memory usage on the server.
    *
    * It will log which render is exceeding the render time,


### PR DESCRIPTION
This PR adds the `maxRenderTime` option which is the time for how long the render is expected to finish in.
Exceeding this timeout will decrease the concurrency limit and allow for the new request to be server-side rendered.
However, this may not release the rendering resources for the hanging render, which may cause additional memory usage on the server