### PR TITLE
feat: Add maxRenderTime option (#13490)

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -60,6 +60,22 @@ export interface SsrOptimizationOptions {
   forcedSsrTimeout?: number;
 
   /**
+   * The time for how long the render is expected to finish in.
+   * Exceeding this timeout will decrease the concurrency limit
+   * and allow for the new request to be server-side rendered.
+   * However, this may not release the rendering resources for the hanging render,
+   * which may cause additional memory usage on the server.
+   *
+   * It will log which render is exceeding the render time,
+   * which is useful for debugging issues.
+   *
+   * The value should always be higher than `timeout` and `forcedSsrTimeout`.
+   *
+   * Default value is 300 seconds (5 minutes).
+   */
+  maxRenderTime?: number;
+
+  /**
    * Enable detailed logs for troubleshooting problems
    */
   debug?: boolean;


### PR DESCRIPTION
This PR adds the maxRenderTime option which is the time for how long the render is expected to finish in.
Exceeding this timeout will decrease the concurrency limit and allow for the new request to be server-side rendered.
However, this may not release the rendering resources for the hanging render, which may cause additional memory usage on the server