### PR TITLE
feat: Add maxRenderTime option (#13490)

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -1,5 +1,4 @@
 import { fakeAsync, flush, tick } from '@angular/core/testing';
-import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
 import { OptimizedSsrEngine } from './optimized-ssr-engine';
 import {
   RenderingStrategy,
@@ -25,7 +24,7 @@ class TestEngineRunner {
 
   renderCount = 0;
   optimizedSsrEngine: OptimizedSsrEngine;
-  engineInstance: NgExpressEngineInstance;
+  engineInstance;
 
   constructor(options: SsrOptimizationOptions, renderTime?: number) {
     // mocked engine instance that will render test output in 100 milliseconds

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -1,12 +1,12 @@
 /* webpackIgnore: true */
+import { Request, Response } from 'express';
 import * as fs from 'fs';
+import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
+import { RenderingCache } from './rendering-cache';
 import {
   RenderingStrategy,
   SsrOptimizationOptions,
 } from './ssr-optimization-options';
-import { RenderingCache } from './rendering-cache';
-import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
-import { Request, Response } from 'express';
 
 /**
  * The rendered pages are kept in memory to be served on next request. If the `cache` is set to `false`, the
@@ -62,7 +62,7 @@ export class OptimizedSsrEngine {
     );
 
     if (isRendering) {
-      this.log(`CSR fallback: rendering in progress (${request.url})`);
+      this.log(`CSR fallback: rendering in progress (${request?.originalUrl})`);
     } else if (concurrencyLimitExceed) {
       this.log(
         `CSR fallback: Concurrency limit exceeded (${this.ssrOptions.concurrency})`
@@ -131,7 +131,7 @@ export class OptimizedSsrEngine {
             waitingForRender = undefined;
             this.fallbackToCsr(response, filePath, callback);
             this.log(
-              `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${request?.url}`,
+              `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${request?.originalUrl}`,
               false
             );
           }, timeout);
@@ -141,11 +141,33 @@ export class OptimizedSsrEngine {
 
         // start rendering
         this.renderingCache.setAsRendering(renderingKey);
-        this.log(`Rendering started (${request?.url})`);
+
+        // setting the timeout for hanging renders that might not ever finish due to various reasons
+        // releasing concurrency slots by decreasing the `this.currentConcurrency--`.
+        let maxRenderTimeout: NodeJS.Timeout | undefined = setTimeout(() => {
+          this.currentConcurrency--;
+          this.renderingCache.clear(renderingKey);
+          maxRenderTimeout = undefined;
+
+          this.log(
+            `Rendering of ${request?.originalUrl} was not able to complete. This might cause memory leaks!`,
+            false
+          );
+        }, this.ssrOptions?.maxRenderTime ?? 300000); // 300000ms == 5 minutes
+
+        this.log(`Rendering started (${request?.originalUrl})`);
         this.expressEngine(filePath, options, (err, html) => {
+          if (!maxRenderTimeout) {
+            // ignore this render's result because it exceeded maxRenderTimeout
+            this.log(
+              `Rendering of ${request.originalUrl} completed after the specified maxRenderTime, therefore it was ignored.`
+            );
+            return;
+          }
+          clearTimeout(maxRenderTimeout);
           this.currentConcurrency--;
 
-          this.log(`Rendering completed (${request?.url})`);
+          this.log(`Rendering completed (${request?.originalUrl})`);
 
           if (waitingForRender) {
             // if request is still waiting for render, return it
@@ -168,7 +190,7 @@ export class OptimizedSsrEngine {
         this.fallbackToCsr(response, filePath, callback);
       }
     } else {
-      this.log(`Render from cache (${request?.url})`);
+      this.log(`Render from cache (${request?.originalUrl})`);
     }
   }
 

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -60,6 +60,22 @@ export interface SsrOptimizationOptions {
   forcedSsrTimeout?: number;
 
   /**
+   * The time for how long the render is expected to finish in.
+   * Exceeding this timeout will decrease the concurrency limit
+   * and allow for the new request to be server-side rendered.
+   * However, this may not release the rendering resources for the hanging render,
+   * which may cause additional memory usage on the server.
+   *
+   * It will log which render is exceeding the render time,
+   * which is useful for debugging issues.
+   *
+   * The value should always be higher than `timeout` and `forcedSsrTimeout`.
+   *
+   * Default value is 300 seconds (5 minutes).
+   */
+  maxRenderTime?: number;
+
+  /**
    * Enable detailed logs for troubleshooting problems
    */
   debug?: boolean;


### PR DESCRIPTION
This PR adds the maxRenderTime option which is the time for how long the render is expected to finish in.
Exceeding this timeout will decrease the concurrency limit and allow for the new request to be server-side rendered.
However, this may not release the rendering resources for the hanging render, which may cause additional memory usage on the server