### PR TITLE
fix: remove configKey from storage when supplied with undefined value

### DIFF
--- a/projects/core/src/state/utils/browser-storage.spec.ts
+++ b/projects/core/src/state/utils/browser-storage.spec.ts
@@ -74,6 +74,12 @@ describe('Browser storage utilities', () => {
         persistToStorage('a', undefined, sessionStorageMock);
         expect(sessionStorageMock.setItem).not.toHaveBeenCalled();
       });
+      it('should try to remove the key', () => {
+        spyOn(sessionStorageMock, 'removeItem').and.stub();
+
+        persistToStorage('a', undefined, sessionStorageMock);
+        expect(sessionStorageMock.removeItem).toHaveBeenCalled();
+      });
     });
     describe('when the provided value exists', () => {
       it('should persist it', () => {

--- a/projects/core/src/state/utils/browser-storage.ts
+++ b/projects/core/src/state/utils/browser-storage.ts
@@ -34,8 +34,12 @@ export function persistToStorage(
   value: any,
   storage: Storage
 ): void {
-  if (!isSsr(storage) && value) {
-    storage.setItem(configKey, JSON.stringify(value));
+  if (!isSsr(storage)) {
+    if (value) {
+      storage.setItem(configKey, JSON.stringify(value));
+    } else {
+      storage.removeItem(configKey);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes GH-13544 by allowing undefined to be passed as state to the storage sync mechanism in order to remove a configKey and value from storage.