### PR TITLE
chore: Update release info/configs for 2105

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -55,17 +55,20 @@ assignees: ''
   - [ ] Download and rename in root directory `https://github.tools.sap/cx-commerce/spartacussampledata/archive/release/2005/next.tar.gz` -> `spartacussampledata.2005.tar.gz`
   - [ ] Download and rename in root directory `https://github.tools.sap/cx-commerce/spartacussampledata/archive/release/2011/next.zip` -> `spartacussampledata.2011.zip`
   - [ ] Download and rename in root directory `https://github.tools.sap/cx-commerce/spartacussampledata/archive/release/2011/next.tar.gz` -> `spartacussampledata.2011.tar.gz`
+  - [ ] Download and rename in root directory `https://github.tools.sap/cx-commerce/spartacussampledata/archive/release/2105/next.zip` -> `spartacussampledata.2105.zip`
+  - [ ] Download and rename in root directory `https://github.tools.sap/cx-commerce/spartacussampledata/archive/release/2105/next.tar.gz` -> `spartacussampledata.2105.tar.gz`
 
 
 ### For all operative systems
 
 Do the following steps to keep track of spartacussampledata releases:
 
-- [ ] Tag sample data branches for each version (1905, 2005, 2011):
+- [ ] Tag sample data branches for each version (1905, 2005, 2011, 2105):
   - [ ] `git clone https://github.tools.sap/cx-commerce/spartacussampledata` (if already present `cd spartacussampledata && git fetch origin`)
   - [ ] tag the final commit on [release/1905/next](https://github.tools.sap/cx-commerce/spartacussampledata/commits/release/1905/next) branch: `git tag 1905-*.*.* HEAD-COMMIT-HASH-FROM-release/1905/next`
   - [ ] tag the final commit on [release/2005/next](https://github.tools.sap/cx-commerce/spartacussampledata/commits/release/2005/next) branch: `git tag 2005-*.*.* HEAD-COMMIT-HASH-FROM-release/2005/next`
   - [ ] tag the final commit on [release/2011/next](https://github.tools.sap/cx-commerce/spartacussampledata/commits/release/2011/next) branch: `git tag 2011-*.*.* HEAD-COMMIT-HASH-FROM-release/2011/next`
+  - [ ] tag the final commit on [release/2105/next](https://github.tools.sap/cx-commerce/spartacussampledata/commits/release/2105/next) branch: `git tag 2105-*.*.* HEAD-COMMIT-HASH-FROM-release/2105/next`
   - [ ] push created tags: `git push origin --tags`
 
 ---

--- a/projects/core/.release-it.json
+++ b/projects/core/.release-it.json
@@ -22,7 +22,9 @@
       "../../spartacussampledata.2005.zip",
       "../../spartacussampledata.2005.tar.gz",
       "../../spartacussampledata.2011.zip",
-      "../../spartacussampledata.2011.tar.gz"
+      "../../spartacussampledata.2011.tar.gz",
+      "../../spartacussampledata.2105.zip",
+      "../../spartacussampledata.2105.tar.gz"
     ],
     "releaseName": "@spartacus/core@${version}",
     "releaseNotes": "ts-node ../../scripts/changelog.ts --verbose --lib core --to core-${version}"

--- a/projects/storefrontlib/.release-it.json
+++ b/projects/storefrontlib/.release-it.json
@@ -22,7 +22,9 @@
       "../../spartacussampledata.2005.zip",
       "../../spartacussampledata.2005.tar.gz",
       "../../spartacussampledata.2011.zip",
-      "../../spartacussampledata.2011.tar.gz"
+      "../../spartacussampledata.2011.tar.gz",
+      "../../spartacussampledata.2105.zip",
+      "../../spartacussampledata.2105.tar.gz"
     ],
     "releaseName": "@spartacus/storefront@${version}",
     "releaseNotes": "ts-node ../../scripts/changelog.ts --verbose --lib storefront --to storefront-${version}"

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -13,6 +13,8 @@ function cleanup {
     delete_file spartacussampledata.2005.tar.gz
     delete_file spartacussampledata.2011.zip
     delete_file spartacussampledata.2011.tar.gz
+    delete_file spartacussampledata.2105.zip
+    delete_file spartacussampledata.2105.tar.gz
 
     delete_dir coverage
     delete_dir dist
@@ -65,6 +67,11 @@ function zipSamplesAddOn {
     mv spartacussampledata.2011.tar.gz ../
     git archive -o spartacussampledata.2011.zip HEAD
     mv spartacussampledata.2011.zip ../
+    git co release/2105/next
+    git archive -o spartacussampledata.2105.tar.gz HEAD
+    mv spartacussampledata.2105.tar.gz ../
+    git archive -o spartacussampledata.2105.zip HEAD
+    mv spartacussampledata.2105.zip ../
     cd ..
     delete_dir spartacussampledata
 }


### PR DESCRIPTION
As we support 2105 we should attach 2105 spartacussampledata with each new release.