### PR TITLE
chore: Remove vscode chrome debugger extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,6 @@
   "recommendations": [
     // Angular Language Service
     "Angular.ng-template",
-    // Debugger for Chrome
-    "msjsdiag.debugger-for-chrome",
     // Prettier - Code formatter
     "esbenp.prettier-vscode",
     // The ng lint command uses ESLint under the hood.


### PR DESCRIPTION
This PR removes the deprecated VSCode's chrome debugger extensions from the list of required extensions.