### PR TITLE
fix: Prevent @spartacus/styles re-import by cart feature 4.0.x

### DIFF
--- a/feature-libs/cart/_index.scss
+++ b/feature-libs/cart/_index.scss
@@ -1,4 +1,6 @@
-@import '~@spartacus/styles';
+@import '~@spartacus/styles/scss/core';
+@import '~@spartacus/styles/scss/app';
+@import '~@spartacus/styles/scss/components/cart/cart-details';
 
 @import '~bootstrap/scss/functions';
 @import '~bootstrap/scss/variables';

--- a/projects/storefrontstyles/scss/theme/sparta/_fonts.scss
+++ b/projects/storefrontstyles/scss/theme/sparta/_fonts.scss
@@ -1,1 +1,1 @@
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700');
+@import url('#{$font-url}');

--- a/projects/storefrontstyles/scss/theme/sparta/_variables.scss
+++ b/projects/storefrontstyles/scss/theme/sparta/_variables.scss
@@ -14,6 +14,10 @@ $font-family-sans-serif: 'Open Sans', -apple-system, BlinkMacSystemFont,
   'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji',
   'Segoe UI Emoji', 'Segoe UI Symbol';
 
+// TODO: Replace `$font-url` with swap url in 5.0 to use swap strategy by default.
+// $font-url: 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap' !default;
+$font-url: 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' !default;
+
 // change theme-colors here
 $primary: #fe5757 !default;
 $secondary: #747881 !default;


### PR DESCRIPTION
Closes #13563
Closes #12714

BREAKING CHANGE: @spartacus/styles has been removed from cart feature styles file, because it caused problems with overriding SCSS variables. If storefront styling depended on such inappropriate import it may now require adding @spartacus/styles