### PR TITLE
fix: Remove top and bottom border of input of ItemCounterComponent

### DIFF
--- a/projects/storefrontstyles/scss/components/cart/_item-counter.scss
+++ b/projects/storefrontstyles/scss/components/cart/_item-counter.scss
@@ -30,10 +30,10 @@
     display: inline-flex;
 
     input {
-      border-width: 0 1px;
       border: solid 1px var(--cx-color-light);
-      max-height: 46px;
+      border-width: 0 1px;
       padding: 12px 9px;
+      max-height: 48px;
       width: 46%;
 
       &:focus {


### PR DESCRIPTION
Closes #13731 
Updated look, this is what it looked like before a recent change:
<img width="416" alt="Screen Shot 2021-09-15 at 11 54 34 AM" src="https://user-images.githubusercontent.com/49131189/133468430-804bfff5-cece-4385-9144-fddbc5199402.png">
