### PR TITLE
fix: clear QuickOrder recommendations on empty string

### DIFF
--- a/feature-libs/cart/quick-order/assets/translations/en/quick-order.i18n.ts
+++ b/feature-libs/cart/quick-order/assets/translations/en/quick-order.i18n.ts
@@ -20,7 +20,7 @@ export const quickOrderForm = {
 export const quickOrderList = {
   addToCart: 'Add to cart',
   emptyList: 'Empty list',
-  header: 'Add Products/Skus',
+  header: 'Add Products/SKUs',
   subHeader: 'You can add up to {{ limit }} valid SKU at a time.',
   errorProceedingToCart: 'Error proceeding to Cart.',
   warningProceedingToCart: 'Warning proceeding to Cart.',

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
@@ -71,19 +71,23 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
   }
 
   onBlur(element: Element): void {
-    const elementList = Array.from(element.classList);
+    if(element) {
+      const elementList = Array.from(element.classList);
 
-    if ((elementList || []).includes('quick-order-results-products')) {
-      return;
+      if ((elementList || []).includes('quick-order-results-products')) {
+        return;
+      }
     }
 
     this.close();
   }
 
   clear(event?: Event): void {
+    console.log('here');
     event?.preventDefault();
-
+    console.log(this.form.get('product'));
     this.form.reset();
+    console.log(this.form.get('product'));
     this.close();
   }
 
@@ -175,8 +179,8 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
     this.validateProductControl(this.isDisabled);
   }
 
-  protected isEmpty(product: string): boolean {
-    return(product.trim() === '' || product == null);
+  protected isEmpty(product?: string): boolean {
+    return(product?.trim() === '' || product == null);
   }
 
   protected watchQueryChange(): Subscription {

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
@@ -83,18 +83,20 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
   }
 
   clear(event?: Event): void {
-    console.log('here');
     event?.preventDefault();
-    console.log(this.form.get('product'));
-    this.form.reset();
-    console.log(this.form.get('product'));
-    this.close();
+
+    this.toggleBodyClass('quick-order-searchbox-is-active', false);
+
+    let product = this.form.get('product')?.value;
+    if(!!product){
+      this.form.reset();
+      this.close();
+    }
   }
 
   add(product: Product, event?: Event): void {
     event?.preventDefault();
     this.quickOrderService.addProduct(product);
-    this.clear();
   }
 
   addProduct(event: Event): void {
@@ -230,7 +232,6 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
   }
 
   protected close(): void {
-    this.toggleBodyClass('quick-order-searchbox-is-active', false);
     this.resetFocusedElementIndex();
     this.clearResults();
   }

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
@@ -175,6 +175,10 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
     this.validateProductControl(this.isDisabled);
   }
 
+  protected isEmpty(product: string): boolean {
+    return(product.trim() === '' || product == null);
+  }
+
   protected watchQueryChange(): Subscription {
     return this.form.valueChanges
       .pipe(
@@ -182,6 +186,12 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
         debounceTime(300),
         filter((value) => {
           if (this.config.quickOrderForm) {
+            //Check if input to quick order is an empty after deleting input manually
+            if(this.isEmpty(value.product)){
+              //Clear recommendation results on empty string
+              this.clear();
+              return false;
+            }
             return (
               !!value.product &&
               value.product.length >=


### PR DESCRIPTION
This is the behaviour of the recommendations when the input is deleted manually (pressing backspace/delete for each character)
Entering search input....
<img width="340" alt="Screen Shot 2021-09-17 at 10 05 32 AM" src="https://user-images.githubusercontent.com/49131189/133796335-6fb8db31-2a63-41dd-8b8a-2ee389771523.png">

Then deleting it character by character
<img width="344" alt="Screen Shot 2021-09-17 at 10 05 42 AM" src="https://user-images.githubusercontent.com/49131189/133796236-07c3c2ff-c78e-4abd-8bb4-6e68fd3a6668.png">
