### PR TITLE
fix: set maxRenderTimeout only once per render, but not once per every request

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -837,6 +837,26 @@ describe('OptimizedSsrEngine', () => {
           flush();
         }));
 
+        it('and concurrency limit should NOT fallback to CSR, when the request is for a pending render', fakeAsync(() => {
+          const engineRunner = new TestEngineRunner({
+            reuseCurrentRendering: true,
+            timeout: 200,
+            concurrency: 1,
+          });
+          spyOn<any>(engineRunner.optimizedSsrEngine, 'log').and.callThrough();
+
+          engineRunner.request('a');
+          engineRunner.request('a');
+
+          tick(200);
+          expect(
+            engineRunner.optimizedSsrEngine['log']
+          ).not.toHaveBeenCalledWith(
+            `CSR fallback: Concurrency limit exceeded (1)`
+          );
+          expect(engineRunner.renders).toEqual(['a-0', 'a-0']);
+        }));
+
         it('combined with a different request should take up two concurrency slots', fakeAsync(() => {
           const timeout = 300;
           const engineRunner = new TestEngineRunner(

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -343,7 +343,7 @@ export class OptimizedSsrEngine {
     options: any;
     renderCallback: SsrCallbackFn;
     request: Request;
-  }) {
+  }): void {
     const renderingKey = this.getRenderingKey(request);
 
     // Setting the timeout for hanging renders that might not ever finish due to various reasons.

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -201,12 +201,12 @@ export class OptimizedSsrEngine {
 
     const renderingKey = this.getRenderingKey(request);
 
-    let waitingForRender: NodeJS.Timeout | undefined;
+    let requestTimeout: NodeJS.Timeout | undefined;
     if (this.shouldTimeout(request)) {
       // establish timeout for rendering
       const timeout = this.getTimeout(request);
-      waitingForRender = setTimeout(() => {
-        waitingForRender = undefined;
+      requestTimeout = setTimeout(() => {
+        requestTimeout = undefined;
         this.fallbackToCsr(response, filePath, callback);
         this.log(
           `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${request?.originalUrl}`,
@@ -221,9 +221,9 @@ export class OptimizedSsrEngine {
     }
 
     const renderCallback: SsrCallbackFn = (err, html) => {
-      if (waitingForRender) {
+      if (requestTimeout) {
         // if request is still waiting for render, return it
-        clearTimeout(waitingForRender);
+        clearTimeout(requestTimeout);
         callback(err, html);
 
         // store the render only if caching is enabled

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -85,7 +85,7 @@ export class OptimizedSsrEngine {
    * OR when the concurrency limit is exceeded.
    */
   protected shouldRender(request: Request): boolean {
-    const concurrencyLimitExceeded = this.isConcurrencyLimitExceeded();
+    const concurrencyLimitExceeded = this.isConcurrencyLimitExceeded(request);
 
     const fallBack =
       this.isRendering(request) && !this.ssrOptions?.reuseCurrentRendering;
@@ -116,9 +116,14 @@ export class OptimizedSsrEngine {
   /**
    * Checks for the concurrency limit
    *
-   * @returns true if the concurrency limit has been exceeded
+   * @returns true if rendering this request would exceed the concurrency limit
    */
-  protected isConcurrencyLimitExceeded(): boolean {
+  protected isConcurrencyLimitExceeded(request: Request): boolean {
+    // If we can reuse a pending render, we don't take up a new concurrency slot
+    if (this.ssrOptions?.reuseCurrentRendering && this.isRendering(request)) {
+      return false;
+    }
+
     return this.ssrOptions?.concurrency
       ? this.currentConcurrency >= this.ssrOptions.concurrency
       : false;

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -324,6 +324,15 @@ export class OptimizedSsrEngine {
     );
   }
 
+  /**
+   * Delegates the render to the original _Angular Universal express engine_.
+   *
+   * There is no way to abort the running render of Angular Universal.
+   * So if the render doesn't complete in the configured `maxRenderTime`,
+   * we just consider the render task as hanging (note: it's a potential memory leak!).
+   * Later on, even if the render completes somewhen in the future, we will ignore
+   * its result.
+   */
   private startRender({
     filePath,
     options,
@@ -339,8 +348,7 @@ export class OptimizedSsrEngine {
 
     // Setting the timeout for hanging renders that might not ever finish due to various reasons.
     // After the configured `maxRenderTime` passes, we consider the rendering task as hanging,
-    // and release the concurrency slot.
-    // Even if the rendering task completes in the future in the background, we will ignore its result.
+    // and release the concurrency slot and forget all callbacks waiting for the render's result.
     let maxRenderTimeout: NodeJS.Timeout | undefined = setTimeout(() => {
       this.renderingCache.clear(renderingKey);
       maxRenderTimeout = undefined;

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -324,9 +324,8 @@ export class OptimizedSsrEngine {
       });
     }
 
-    const renderCallbacksCount = this.renderCallbacks.get(renderingKey)?.length;
     this.log(
-      `${renderCallbacksCount} rendering callbacks are waiting for the render to complete (${request?.originalUrl})`
+      `Request is waiting for the render to complete (${request?.originalUrl})`
     );
   }
 


### PR DESCRIPTION
improvement for https://github.com/SAP/spartacus/pull/13680

- MAIN CHANGE: set maxRenderTimeout only once per render, but not once per every request
- change the log message to be more precise
   ```diff
   - N requests waiting for the render to complete (URL)
   + Request is waiting for the render to complete (URL)
   ```
   Note: some requests might be no longer waiting, because after timeout they were served with a CSR fallback
- rename `waitingForRender` variable to `requestTimeout`, becasue it was confusing - the timeout is related to the request, but not to the render
- by the way:
  - encapsulated all logic related to the render itself (execute the render, set max render time, handle concurrency of renders) inside one method `startRender`
  - get rid of the conditional logic for changing the `currentConcurrency` state
  - get rid of the variable/param `isFirstRequestForKey` (now we check whether someting is rendering in just one place) 
  - fix and unit-test: don't exceed the concurrency limit if the request is for a key that is alreaby being rendered
  - drop method `isRendering(request)`, as its parameter was confusing (we don't check if the reuqest is being rendered, but if there is a pending render for the renderingKey).


Tradeoffs:
- now the responsibilities are more split, but we increased the chain of nested custom callbacks:
  1st callback: for abandoning the result in case of `maxRenderTime`
  2nd callback: for reusing the result for many waiting requests (when `reuseCurrentRendering` is enabled)
  3rd callback: for actual responding to the request if it didn't timeout and for clearing/storing result in the cache

Possible improvements in the future, independent from this PR:
- the 3rd callback seems to have too many responsibilities mixed
- now we touch the `renderingCache` in distant places/callbacks:
   We clear cache in `maxRenderTimeout` logic.
   We clear/set the cache on each request handling (even if they reused the same result, when option `reuseCurrentRendering` was enabled).