### PR TITLE
chore: improve debug logs for ssr when config `reuseCurrentRendering` is enabled

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -310,10 +310,6 @@ export class OptimizedSsrEngine {
     }
     this.renderCallbacks.get(renderingKey)?.push(renderCallback);
 
-    this.log(
-      `Request is waiting for the SSR rendering to complete (${request?.originalUrl})`
-    );
-
     if (!this.renderingCache.isRendering(renderingKey)) {
       this.startRender({
         filePath,
@@ -331,6 +327,10 @@ export class OptimizedSsrEngine {
         },
       });
     }
+
+    this.log(
+      `Request is waiting for the SSR rendering to complete (${request?.originalUrl})`
+    );
   }
 
   /**

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -232,6 +232,10 @@ export class OptimizedSsrEngine {
         clearTimeout(requestTimeout);
         callback(err, html);
 
+        this.log(
+          `Request is resolved with the SSR rendering result (${request?.originalUrl})`
+        );
+
         // store the render only if caching is enabled
         if (this.ssrOptions?.cache) {
           this.renderingCache.store(renderingKey, err, html);
@@ -306,6 +310,10 @@ export class OptimizedSsrEngine {
     }
     this.renderCallbacks.get(renderingKey)?.push(renderCallback);
 
+    this.log(
+      `Request is waiting for the SSR rendering to complete (${request?.originalUrl})`
+    );
+
     if (!this.renderingCache.isRendering(renderingKey)) {
       this.startRender({
         filePath,
@@ -323,10 +331,6 @@ export class OptimizedSsrEngine {
         },
       });
     }
-
-    this.log(
-      `Request is waiting for the render to complete (${request?.originalUrl})`
-    );
   }
 
   /**


### PR DESCRIPTION
Added a message for each resolved request after the SSR rendering completes.

With the config `reuseCurrentRendering` enabled, for a single request, the debug console looks like in the following example:
```
Rendering started (/)
Request is waiting for the SSR rendering to complete (/)
Rendering completed (/)
Request is resolved with the SSR rendering result (/)
```

or in case of 2nd parallel request for the same URL:
```
Rendering started (/)
Request is waiting for the SSR rendering to complete (/)
Request is waiting for the SSR rendering to complete (/)
Rendering completed (/)
Request is resolved with the SSR rendering result (/)
Request is resolved with the SSR rendering result (/)
```


related to #13623