### PR TITLE
fix: add option for reusing a pending SSR render for subsequent similar requests (instead of fallback to CSR) [for 3.4.x]

### DIFF
--- a/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
+++ b/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
@@ -1,9 +1,12 @@
 import { NgModuleFactory, StaticProvider, Type } from '@angular/core';
-import { SERVER_REQUEST_ORIGIN, SERVER_REQUEST_URL } from '@spartacus/core';
-import { OptimizedSsrEngine } from '../optimized-engine/optimized-ssr-engine';
-import { SsrOptimizationOptions } from '../optimized-engine/ssr-optimization-options';
 import { REQUEST } from '@nguniversal/express-engine/tokens';
+import { SERVER_REQUEST_ORIGIN, SERVER_REQUEST_URL } from '@spartacus/core';
 import { Request } from 'express';
+import {
+  OptimizedSsrEngine,
+  SsrCallbackFn,
+} from '../optimized-engine/optimized-ssr-engine';
+import { SsrOptimizationOptions } from '../optimized-engine/ssr-optimization-options';
 
 /**
  * These are the allowed options for the engine
@@ -29,8 +32,8 @@ export interface RenderOptions extends NgSetupOptions {
 
 export type NgExpressEngineInstance = (
   filePath: string,
-  options: RenderOptions,
-  callback: (err?: Error | null, html?: string) => void
+  options: object,
+  callback: SsrCallbackFn
 ) => void;
 
 export type NgExpressEngine = (

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -1,10 +1,11 @@
 import { fakeAsync, flush, tick } from '@angular/core/testing';
-import { OptimizedSsrEngine } from './optimized-ssr-engine';
+import { OptimizedSsrEngine, SsrCallbackFn } from './optimized-ssr-engine';
 import {
   RenderingStrategy,
   SsrOptimizationOptions,
 } from './ssr-optimization-options';
 
+const defaultRenderTime = 100;
 /**
  * Helper class to easily create and test engine wrapper against mocked engine.
  *
@@ -31,11 +32,11 @@ class TestEngineRunner {
     const engineInstanceMock = (
       filePath: string,
       _: any,
-      callback: Function
+      callback: SsrCallbackFn
     ) => {
       setTimeout(() => {
         callback(undefined, `${filePath}-${this.renderCount++}`);
-      }, renderTime ?? 100);
+      }, renderTime ?? defaultRenderTime);
     };
 
     this.optimizedSsrEngine = new OptimizedSsrEngine(
@@ -61,13 +62,21 @@ class TestEngineRunner {
     };
 
     this.engineInstance(url, optionsMock, (_, html) => {
-      this.renders.push(html);
+      this.renders.push(html ?? '');
       this.responseParams.push(response);
     });
 
     return this;
   }
 }
+
+const getCurrentConcurrency = (
+  engineRunner: TestEngineRunner
+): { currentConcurrency: number } => {
+  return {
+    currentConcurrency: engineRunner.optimizedSsrEngine['currentConcurrency'],
+  };
+};
 
 describe('OptimizedSsrEngine', () => {
   describe('timeout option', () => {
@@ -100,14 +109,20 @@ describe('OptimizedSsrEngine', () => {
     it('should return timed out render in the followup request, also when timeout is set to 0', fakeAsync(() => {
       const engineRunner = new TestEngineRunner({ timeout: 0 }).request('a');
       expect(engineRunner.renders).toEqual(['']);
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(1);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 1,
+      });
 
       tick(200);
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(0);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 0,
+      });
 
       engineRunner.request('a');
       expect(engineRunner.renders[1]).toEqual('a-0');
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(0);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 0,
+      });
     }));
   });
 
@@ -159,17 +174,23 @@ describe('OptimizedSsrEngine', () => {
         cache: true,
         timeout: 200,
       }).request('a');
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(1);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 1,
+      });
 
       tick(200);
 
       engineRunner.request('a');
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(0);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 0,
+      });
 
       tick(200);
 
       engineRunner.request('a');
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(0);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 0,
+      });
 
       tick(200);
 
@@ -311,15 +332,15 @@ describe('OptimizedSsrEngine', () => {
         ).and.callThrough();
 
         engineRunner.request('a');
-        expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(
-          1
-        );
+        expect(getCurrentConcurrency(engineRunner)).toEqual({
+          currentConcurrency: 1,
+        });
 
         tick(1);
         engineRunner.request('a');
-        expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(
-          2
-        );
+        expect(getCurrentConcurrency(engineRunner)).toEqual({
+          currentConcurrency: 2,
+        });
         expect(engineRunner.renders).toEqual([]);
 
         tick(100);
@@ -327,9 +348,9 @@ describe('OptimizedSsrEngine', () => {
         expect(
           engineRunner.optimizedSsrEngine['expressEngine']
         ).toHaveBeenCalledTimes(2);
-        expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(
-          0
-        );
+        expect(getCurrentConcurrency(engineRunner)).toEqual({
+          currentConcurrency: 0,
+        });
       }));
     });
 
@@ -384,23 +405,23 @@ describe('OptimizedSsrEngine', () => {
           renderingStrategyResolver: () => RenderingStrategy.DEFAULT,
           timeout: 200,
         }).request('a');
-        expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(
-          1
-        );
+        expect(getCurrentConcurrency(engineRunner)).toEqual({
+          currentConcurrency: 1,
+        });
 
         tick(1);
         engineRunner.request('a');
-        expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(
-          1
-        );
+        expect(getCurrentConcurrency(engineRunner)).toEqual({
+          currentConcurrency: 1,
+        });
 
         expect(engineRunner.renders).toEqual(['']); // immediate fallback to CSR for the 2nd request for the same key
 
         tick(100);
         expect(engineRunner.renders).toEqual(['', 'a-0']);
-        expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(
-          0
-        );
+        expect(getCurrentConcurrency(engineRunner)).toEqual({
+          currentConcurrency: 0,
+        });
       }));
     });
 
@@ -430,18 +451,24 @@ describe('OptimizedSsrEngine', () => {
         timeout: 50,
         forcedSsrTimeout: 80,
       }).request('a');
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(1);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 1,
+      });
 
       tick(60);
       expect(engineRunner.renders).toEqual([]);
 
       tick(50);
       expect(engineRunner.renders).toEqual(['']);
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(0);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 0,
+      });
 
       engineRunner.request('a');
       expect(engineRunner.renders).toEqual(['', 'a-0']);
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(0);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 0,
+      });
     }));
 
     it('should not affect DEFAULT rendering strategy', fakeAsync(() => {
@@ -533,7 +560,9 @@ describe('OptimizedSsrEngine', () => {
       // issue two requests
       engineRunner.request(hangingRequest);
       engineRunner.request(csrRequest);
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(1);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 1,
+      });
 
       tick(1);
       // while the concurrency slot is busy rendering the first hanging request, the second request gets the CSR version
@@ -541,7 +570,9 @@ describe('OptimizedSsrEngine', () => {
         `CSR fallback: Concurrency limit exceeded (1)`
       );
       expect(engineRunner.renderCount).toEqual(0);
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(1);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 1,
+      });
 
       tick(maxRenderTime);
       expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
@@ -556,7 +587,9 @@ describe('OptimizedSsrEngine', () => {
       expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
         `Rendering started (${ssrRequest})`
       );
-      expect(engineRunner.optimizedSsrEngine['currentConcurrency']).toEqual(1);
+      expect(getCurrentConcurrency(engineRunner)).toEqual({
+        currentConcurrency: 1,
+      });
 
       flush();
     }));
@@ -584,5 +617,391 @@ describe('OptimizedSsrEngine', () => {
       expect(engineRunner.renders).toEqual(['']); // if the result was cached, the 2nd request would get immediately 'a-0'
       flush();
     }));
+  });
+
+  describe('reuseCurrentRendering', () => {
+    const requestUrl = 'a';
+    const differentUrl = 'b';
+
+    const getRenderCallbacksCount = (
+      engineRunner: TestEngineRunner,
+      renderingKey: string
+    ): { renderCallbacksCount: number } => {
+      return {
+        renderCallbacksCount:
+          engineRunner.optimizedSsrEngine['renderCallbacks'].get(renderingKey)
+            ?.length ?? 0,
+      };
+    };
+
+    describe('when disabled', () => {
+      it('should fallback to CSR for parallel subsequent requests for the same rendering key', fakeAsync(() => {
+        const timeout = 300;
+        const engineRunner = new TestEngineRunner({ timeout }, 400);
+        spyOn<any>(engineRunner.optimizedSsrEngine, 'log').and.callThrough();
+
+        engineRunner.request(requestUrl);
+        expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+          renderCallbacksCount: 0,
+        });
+
+        tick(200);
+        engineRunner.request(requestUrl);
+        expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+          renderCallbacksCount: 0,
+        });
+
+        tick(100);
+        expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+          `CSR fallback: rendering in progress (${requestUrl})`
+        );
+        expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+          `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
+          false
+        );
+        expect(engineRunner.renders).toEqual(['', '']);
+
+        flush();
+      }));
+    });
+
+    describe('when enabled', () => {
+      describe('multiple subsequent requests for the same rendering key should reuse the same render', () => {
+        it('and the first request should timeout', fakeAsync(() => {
+          const timeout = 300;
+          const engineRunner = new TestEngineRunner(
+            { timeout, reuseCurrentRendering: true },
+            400
+          );
+          spyOn<any>(engineRunner.optimizedSsrEngine, 'log').and.callThrough();
+
+          engineRunner.request(requestUrl);
+          tick(200);
+
+          engineRunner.request(requestUrl);
+
+          tick(100);
+          expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+            `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
+            false
+          );
+
+          tick(100);
+          expect(engineRunner.renderCount).toEqual(1);
+          expect(engineRunner.renders).toEqual(['', `${requestUrl}-0`]);
+          flush();
+        }));
+
+        it('and honour the timeout option', fakeAsync(() => {
+          const timeout = 300;
+          const engineRunner = new TestEngineRunner(
+            { timeout, reuseCurrentRendering: true },
+            1000
+          );
+          const logSpy = spyOn<any>(
+            engineRunner.optimizedSsrEngine,
+            'log'
+          ).and.callThrough();
+
+          engineRunner.request(requestUrl);
+
+          tick(200);
+
+          engineRunner.request(requestUrl);
+
+          //1st times out
+          tick(100);
+          // 2nd request times out
+          tick(200);
+
+          let renderExceedMessageCount = 0;
+          logSpy.calls.allArgs().forEach((args: unknown[]) => {
+            args.forEach((message: unknown) => {
+              if (
+                message ===
+                `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`
+              ) {
+                renderExceedMessageCount++;
+              }
+            });
+          });
+
+          expect(renderExceedMessageCount).toBe(2);
+          expect(engineRunner.renderCount).toEqual(0);
+          expect(engineRunner.renders).toEqual(['', '']);
+
+          flush();
+        }));
+
+        it('also when the rendering strategy is ALWAYS_SSR', fakeAsync(() => {
+          const timeout = 300;
+          const engineRunner = new TestEngineRunner(
+            {
+              timeout,
+              reuseCurrentRendering: true,
+              renderingStrategyResolver: () => RenderingStrategy.ALWAYS_SSR,
+            },
+            400
+          );
+
+          engineRunner.request(requestUrl);
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 1,
+          });
+          expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+            renderCallbacksCount: 1,
+          });
+
+          tick(200);
+          engineRunner.request(requestUrl);
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 1,
+          });
+          expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+            renderCallbacksCount: 2,
+          });
+
+          tick(200);
+
+          expect(engineRunner.renderCount).toEqual(1);
+          expect(engineRunner.renders).toEqual([
+            `${requestUrl}-0`,
+            `${requestUrl}-0`,
+          ]);
+          flush();
+        }));
+
+        it('and take up only one concurrent slot', fakeAsync(() => {
+          const timeout = 300;
+          const engineRunner = new TestEngineRunner(
+            { timeout, reuseCurrentRendering: true, concurrency: 2 },
+            400
+          );
+          spyOn<any>(engineRunner.optimizedSsrEngine, 'log').and.callThrough();
+
+          // start 1st request
+          engineRunner.request(requestUrl);
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 1,
+          });
+          expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+            renderCallbacksCount: 1,
+          });
+
+          // start 2nd request
+          tick(200);
+          engineRunner.request(requestUrl);
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 1,
+          });
+          expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+            renderCallbacksCount: 2,
+          });
+
+          // start 3rd request
+          engineRunner.request(requestUrl);
+          expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+            renderCallbacksCount: 3,
+          });
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 1,
+          });
+
+          // 1st request timeout
+          tick(100);
+          expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+            `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
+            false
+          );
+          expect(engineRunner.renders).toEqual(['']); // the first request fallback to CSR due to timeout
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 1,
+          }); // the render still continues in the background
+
+          // eventually the render succeeds and 2 remaining requests get the same response:
+          tick(100);
+          expect(engineRunner.renderCount).toEqual(1);
+          expect(engineRunner.renders).toEqual([
+            '', // CSR fallback of the 1st request due to it timed out
+            `${requestUrl}-0`,
+            `${requestUrl}-0`,
+          ]);
+          expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+            renderCallbacksCount: 0,
+          });
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 0,
+          });
+
+          flush();
+        }));
+
+        it('and concurrency limit should NOT fallback to CSR, when the request is for a pending render', fakeAsync(() => {
+          const engineRunner = new TestEngineRunner({
+            reuseCurrentRendering: true,
+            timeout: 200,
+            concurrency: 1,
+          });
+          spyOn<any>(engineRunner.optimizedSsrEngine, 'log').and.callThrough();
+
+          engineRunner.request('a');
+          engineRunner.request('a');
+
+          tick(200);
+          expect(
+            engineRunner.optimizedSsrEngine['log']
+          ).not.toHaveBeenCalledWith(
+            `CSR fallback: Concurrency limit exceeded (1)`
+          );
+          expect(engineRunner.renders).toEqual(['a-0', 'a-0']);
+        }));
+
+        it('combined with a different request should take up two concurrency slots', fakeAsync(() => {
+          const timeout = 300;
+          const engineRunner = new TestEngineRunner(
+            { timeout, reuseCurrentRendering: true, concurrency: 2 },
+            200
+          );
+          engineRunner
+            .request(requestUrl)
+            .request(requestUrl)
+            .request(requestUrl)
+            .request(requestUrl)
+            .request(requestUrl);
+
+          tick(20);
+          expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+            renderCallbacksCount: 5,
+          });
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 1,
+          });
+
+          engineRunner.request(differentUrl);
+          tick(20);
+          expect(getRenderCallbacksCount(engineRunner, differentUrl)).toEqual({
+            renderCallbacksCount: 1,
+          });
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 2,
+          });
+
+          tick(250);
+          expect(engineRunner.renders).toEqual([
+            'a-0',
+            'a-0',
+            'a-0',
+            'a-0',
+            'a-0',
+            'b-1',
+          ]);
+          expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
+            renderCallbacksCount: 0,
+          });
+          expect(getRenderCallbacksCount(engineRunner, differentUrl)).toEqual({
+            renderCallbacksCount: 0,
+          });
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 0,
+          });
+
+          flush();
+        }));
+      });
+
+      describe('combined with maxRenderTime option', () => {
+        it('should free up only one concurrent slot when the render is hanging for many waiting requests', fakeAsync(() => {
+          const hangingRequest = 'a';
+          const ssrRequest = 'b';
+          const renderTime = 200;
+          const maxRenderTime = renderTime - 50; // shorter than the predicted render time
+          const engineRunner = new TestEngineRunner(
+            { concurrency: 2, maxRenderTime, reuseCurrentRendering: true },
+            renderTime
+          );
+          spyOn<any>(engineRunner.optimizedSsrEngine, 'log').and.callThrough();
+
+          engineRunner.request(hangingRequest);
+          engineRunner.request(hangingRequest);
+          engineRunner.request(hangingRequest);
+
+          tick(1);
+          expect(engineRunner.renderCount).toEqual(0);
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 1,
+          });
+          expect(getRenderCallbacksCount(engineRunner, hangingRequest)).toEqual(
+            {
+              renderCallbacksCount: 3,
+            }
+          );
+
+          tick(maxRenderTime);
+          expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+            `Rendering of ${hangingRequest} was not able to complete. This might cause memory leaks!`,
+            false
+          );
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 0,
+          });
+          expect(getRenderCallbacksCount(engineRunner, hangingRequest)).toEqual(
+            {
+              renderCallbacksCount: 0,
+            }
+          );
+
+          // even though the hanging request is still rendering, we've freed up a slot for a new request
+          engineRunner.request(ssrRequest);
+          tick(1);
+          expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+            `Rendering started (${ssrRequest})`
+          );
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 1,
+          });
+          expect(getRenderCallbacksCount(engineRunner, ssrRequest)).toEqual({
+            renderCallbacksCount: 1,
+          });
+
+          flush();
+
+          expect(getCurrentConcurrency(engineRunner)).toEqual({
+            currentConcurrency: 0,
+          });
+          expect(getRenderCallbacksCount(engineRunner, ssrRequest)).toEqual({
+            renderCallbacksCount: 0,
+          });
+        }));
+      });
+
+      it('should perform separate renders for different rendering keys', fakeAsync(() => {
+        const timeout = 300;
+        const engineRunner = new TestEngineRunner(
+          { timeout, reuseCurrentRendering: true },
+          400
+        );
+        spyOn<any>(engineRunner.optimizedSsrEngine, 'log').and.callThrough();
+
+        engineRunner.request(requestUrl);
+        tick(200);
+
+        engineRunner.request(differentUrl);
+        tick(300);
+
+        expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+          `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
+          false
+        );
+        expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+          `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${differentUrl}`,
+          false
+        );
+
+        expect(engineRunner.renderCount).toEqual(1);
+        expect(engineRunner.renders).toEqual(['', '']);
+
+        flush();
+      }));
+    });
   });
 });

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -8,6 +8,17 @@ import {
   SsrOptimizationOptions,
 } from './ssr-optimization-options';
 
+export type SsrCallbackFn = (
+  /**
+   * Error that might've occurred while rendering.
+   */
+  err?: Error | null | undefined,
+  /**
+   * HTML response.
+   */
+  html?: string | undefined
+) => void;
+
 /**
  * The rendered pages are kept in memory to be served on next request. If the `cache` is set to `false`, the
  * response is evicted as soon as the first successful response is successfully returned.
@@ -16,6 +27,18 @@ export class OptimizedSsrEngine {
   protected currentConcurrency = 0;
   protected renderingCache = new RenderingCache(this.ssrOptions);
   private templateCache = new Map<string, string>();
+
+  /**
+   * When the config `reuseCurrentRendering` is enabled, we want perform
+   * only one render for one rendering key and reuse the html result
+   * for all the pending requests for the same rendering key.
+   * Therefore we need to store the callbacks for all the pending requests
+   * and invoke them with the html after the render completes.
+   *
+   * This Map should be used only when `reuseCurrentRendering` config is enabled.
+   * It's indexed by the rendering keys.
+   */
+  private renderCallbacks = new Map<string, SsrCallbackFn[]>();
 
   get engineInstance(): NgExpressEngineInstance {
     return this.renderResponse.bind(this);
@@ -34,8 +57,8 @@ export class OptimizedSsrEngine {
   protected fallbackToCsr(
     response: Response,
     filePath: string,
-    callback: (err?: Error | null, html?: string) => void
-  ) {
+    callback: SsrCallbackFn
+  ): void {
     response.set('Cache-Control', 'no-store');
     callback(undefined, this.getDocument(filePath));
   }
@@ -52,31 +75,66 @@ export class OptimizedSsrEngine {
       : RenderingStrategy.DEFAULT;
   }
 
+  /**
+   * When returns true, the server side rendering should be performed.
+   * When returns false, the CSR fallback should be returned.
+   *
+   * We should not render, when there is already
+   * a pending rendering for the same rendering key
+   * (unless the `reuseCurrentRendering` config option is enabled)
+   * OR when the concurrency limit is exceeded.
+   */
   protected shouldRender(request: Request): boolean {
-    const concurrencyLimitExceed = this.ssrOptions?.concurrency
-      ? this.currentConcurrency >= this.ssrOptions.concurrency
-      : false;
-
-    const isRendering = this.renderingCache.isRendering(
-      this.getRenderingKey(request)
+    const renderingKey = this.getRenderingKey(request);
+    const concurrencyLimitExceeded = this.isConcurrencyLimitExceeded(
+      renderingKey
     );
+    const fallBack =
+      this.renderingCache.isRendering(renderingKey) &&
+      !this.ssrOptions?.reuseCurrentRendering;
 
-    if (isRendering) {
+    if (fallBack) {
       this.log(`CSR fallback: rendering in progress (${request?.originalUrl})`);
-    } else if (concurrencyLimitExceed) {
+    } else if (concurrencyLimitExceeded) {
       this.log(
         `CSR fallback: Concurrency limit exceeded (${this.ssrOptions?.concurrency})`
       );
     }
 
     return (
-      (!isRendering &&
-        !concurrencyLimitExceed &&
+      (!fallBack &&
+        !concurrencyLimitExceeded &&
         this.getRenderingStrategy(request) !== RenderingStrategy.ALWAYS_CSR) ||
       this.getRenderingStrategy(request) === RenderingStrategy.ALWAYS_SSR
     );
   }
 
+  /**
+   * Checks for the concurrency limit
+   *
+   * @returns true if rendering this request would exceed the concurrency limit
+   */
+  private isConcurrencyLimitExceeded(renderingKey: string): boolean {
+    // If we can reuse a pending render for this request, we don't take up a new concurrency slot.
+    // In that case we don't exceed the concurrency limit even if the `currentConcurrency`
+    // already reaches the limit.
+    if (
+      this.ssrOptions?.reuseCurrentRendering &&
+      this.renderingCache.isRendering(renderingKey)
+    ) {
+      return false;
+    }
+
+    return this.ssrOptions?.concurrency
+      ? this.currentConcurrency >= this.ssrOptions.concurrency
+      : false;
+  }
+
+  /**
+   * Returns true, when the `timeout` option has been configured to non-zero value OR
+   * when the rendering strategy for the given request is ALWAYS_SSR.
+   * Otherwise, it returns false.
+   */
   protected shouldTimeout(request: Request): boolean {
     return (
       !!this.ssrOptions?.timeout ||
@@ -84,15 +142,27 @@ export class OptimizedSsrEngine {
     );
   }
 
+  /**
+   * Returns the timeout value.
+   *
+   * In case of the rendering strategy ALWAYS_SSR, it returns the config `forcedSsrTimeout`.
+   * Otherwise, it returns the config `timeout`.
+   */
   protected getTimeout(request: Request): number {
     return this.getRenderingStrategy(request) === RenderingStrategy.ALWAYS_SSR
       ? this.ssrOptions?.forcedSsrTimeout ?? 60000
       : this.ssrOptions?.timeout ?? 0;
   }
 
+  /**
+   * If there is an available cached response for this rendering key,
+   * it invokes the given render callback with the response and returns true.
+   *
+   * Otherwise, it returns false.
+   */
   protected returnCachedRender(
     request: Request,
-    callback: (err?: Error | null, html?: string) => void
+    callback: SsrCallbackFn
   ): boolean {
     const key = this.getRenderingKey(request);
 
@@ -110,92 +180,79 @@ export class OptimizedSsrEngine {
     return false;
   }
 
+  /**
+   * Handles the request and invokes the given `callback` with the result html / error.
+   *
+   * The result might be ether:
+   * - a CSR fallback with a basic `index.html` content
+   * - a result rendered by the original Angular Universal express engine
+   * - a result from the in-memory cache (which was previously rendered by Angular Universal express engine).
+   */
   protected renderResponse(
     filePath: string,
     options: any,
-    callback: (err?: Error | null, html?: string) => void
+    callback: SsrCallbackFn
   ): void {
     const request: Request = options.req;
     const response: Response = options.res || options.req.res;
 
+    if (this.returnCachedRender(request, callback)) {
+      this.log(`Render from cache (${request?.originalUrl})`);
+      return;
+    }
+    if (!this.shouldRender(request)) {
+      this.fallbackToCsr(response, filePath, callback);
+      return;
+    }
+
     const renderingKey = this.getRenderingKey(request);
 
-    if (!this.returnCachedRender(request, callback)) {
-      if (this.shouldRender(request)) {
-        this.currentConcurrency++;
-        let waitingForRender: NodeJS.Timeout | undefined;
-
-        if (this.shouldTimeout(request)) {
-          // establish timeout for rendering
-          const timeout = this.getTimeout(request);
-          waitingForRender = setTimeout(() => {
-            waitingForRender = undefined;
-            this.fallbackToCsr(response, filePath, callback);
-            this.log(
-              `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${request?.originalUrl}`,
-              false
-            );
-          }, timeout);
-        } else {
-          this.fallbackToCsr(response, filePath, callback);
-        }
-
-        // start rendering
-        this.renderingCache.setAsRendering(renderingKey);
-
-        // setting the timeout for hanging renders that might not ever finish due to various reasons
-        // releasing concurrency slots by decreasing the `this.currentConcurrency--`.
-        let maxRenderTimeout: NodeJS.Timeout | undefined = setTimeout(() => {
-          this.currentConcurrency--;
-          this.renderingCache.clear(renderingKey);
-          maxRenderTimeout = undefined;
-
-          this.log(
-            `Rendering of ${request?.originalUrl} was not able to complete. This might cause memory leaks!`,
-            false
-          );
-        }, this.ssrOptions?.maxRenderTime ?? 300000); // 300000ms == 5 minutes
-
-        this.log(`Rendering started (${request?.originalUrl})`);
-        this.expressEngine(filePath, options, (err, html) => {
-          if (!maxRenderTimeout) {
-            // ignore this render's result because it exceeded maxRenderTimeout
-            this.log(
-              `Rendering of ${request.originalUrl} completed after the specified maxRenderTime, therefore it was ignored.`
-            );
-            return;
-          }
-          clearTimeout(maxRenderTimeout);
-          this.currentConcurrency--;
-
-          this.log(`Rendering completed (${request?.originalUrl})`);
-
-          if (waitingForRender) {
-            // if request is still waiting for render, return it
-            clearTimeout(waitingForRender);
-            callback(err, html);
-
-            // store the render only if caching is enabled
-            if (this.ssrOptions?.cache) {
-              this.renderingCache.store(renderingKey, err, html);
-            } else {
-              this.renderingCache.clear(renderingKey);
-            }
-          } else {
-            // store the render for future use
-            this.renderingCache.store(renderingKey, err, html);
-          }
-        });
-      } else {
-        // if there is already rendering in progress, return the fallback
+    let requestTimeout: NodeJS.Timeout | undefined;
+    if (this.shouldTimeout(request)) {
+      // establish timeout for rendering
+      const timeout = this.getTimeout(request);
+      requestTimeout = setTimeout(() => {
+        requestTimeout = undefined;
         this.fallbackToCsr(response, filePath, callback);
-      }
+        this.log(
+          `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${request?.originalUrl}`,
+          false
+        );
+      }, timeout);
     } else {
-      this.log(`Render from cache (${request?.originalUrl})`);
+      // Here we respond with the fallback to CSR, but we don't `return`.
+      // We let the actual rendering task to happen in the background
+      // to eventually store the rendered result in the cache.
+      this.fallbackToCsr(response, filePath, callback);
     }
+
+    const renderCallback: SsrCallbackFn = (err, html) => {
+      if (requestTimeout) {
+        // if request is still waiting for render, return it
+        clearTimeout(requestTimeout);
+        callback(err, html);
+
+        // store the render only if caching is enabled
+        if (this.ssrOptions?.cache) {
+          this.renderingCache.store(renderingKey, err, html);
+        } else {
+          this.renderingCache.clear(renderingKey);
+        }
+      } else {
+        // store the render for future use
+        this.renderingCache.store(renderingKey, err, html);
+      }
+    };
+
+    this.handleRender({
+      filePath,
+      options,
+      renderCallback,
+      request,
+    });
   }
 
-  protected log(message: string, debug = true) {
+  protected log(message: string, debug = true): void {
     if (!debug || this.ssrOptions?.debug) {
       console.log(message);
     }
@@ -213,5 +270,121 @@ export class OptimizedSsrEngine {
     }
 
     return doc;
+  }
+
+  /**
+   * Delegates the render to the original _Angular Universal express engine_.
+   *
+   * In case when the config `reuseCurrentRendering` is enabled and **if there is already a pending
+   * render task for the same rendering key**, it doesn't delegate a new render to Angular Universal.
+   * Instead, it waits for the current rendering to complete and then reuse the result for all waiting requests.
+   */
+  private handleRender({
+    filePath,
+    options,
+    renderCallback,
+    request,
+  }: {
+    filePath: string;
+    options: any;
+    renderCallback: SsrCallbackFn;
+    request: Request;
+  }): void {
+    if (!this.ssrOptions?.reuseCurrentRendering) {
+      this.startRender({
+        filePath,
+        options,
+        renderCallback,
+        request,
+      });
+      return;
+    }
+
+    const renderingKey = this.getRenderingKey(request);
+    if (!this.renderCallbacks.has(renderingKey)) {
+      this.renderCallbacks.set(renderingKey, []);
+    }
+    this.renderCallbacks.get(renderingKey)?.push(renderCallback);
+
+    if (!this.renderingCache.isRendering(renderingKey)) {
+      this.startRender({
+        filePath,
+        options,
+        request,
+        renderCallback: (err, html) => {
+          // Share the result of the render with all awaiting requests for the same key:
+
+          // Note: we access the Map at the moment of the render finished (don't store value in a local variable),
+          //       because in the meantime something might have deleted the value (i.e. when `maxRenderTime` passed).
+          this.renderCallbacks
+            .get(renderingKey)
+            ?.forEach((cb) => cb(err, html)); // pass the shared result to all waiting rendering callbacks
+          this.renderCallbacks.delete(renderingKey);
+        },
+      });
+    }
+
+    this.log(
+      `Request is waiting for the render to complete (${request?.originalUrl})`
+    );
+  }
+
+  /**
+   * Delegates the render to the original _Angular Universal express engine_.
+   *
+   * There is no way to abort the running render of Angular Universal.
+   * So if the render doesn't complete in the configured `maxRenderTime`,
+   * we just consider the render task as hanging (note: it's a potential memory leak!).
+   * Later on, even if the render completes somewhen in the future, we will ignore
+   * its result.
+   */
+  private startRender({
+    filePath,
+    options,
+    renderCallback,
+    request,
+  }: {
+    filePath: string;
+    options: any;
+    renderCallback: SsrCallbackFn;
+    request: Request;
+  }): void {
+    const renderingKey = this.getRenderingKey(request);
+
+    // Setting the timeout for hanging renders that might not ever finish due to various reasons.
+    // After the configured `maxRenderTime` passes, we consider the rendering task as hanging,
+    // and release the concurrency slot and forget all callbacks waiting for the render's result.
+    let maxRenderTimeout: NodeJS.Timeout | undefined = setTimeout(() => {
+      this.renderingCache.clear(renderingKey);
+      maxRenderTimeout = undefined;
+      this.currentConcurrency--;
+      if (this.ssrOptions?.reuseCurrentRendering) {
+        this.renderCallbacks.delete(renderingKey);
+      }
+      this.log(
+        `Rendering of ${request?.originalUrl} was not able to complete. This might cause memory leaks!`,
+        false
+      );
+    }, this.ssrOptions?.maxRenderTime ?? 300000); // 300000ms == 5 minutes
+
+    this.log(`Rendering started (${request?.originalUrl})`);
+    this.renderingCache.setAsRendering(renderingKey);
+    this.currentConcurrency++;
+
+    this.expressEngine(filePath, options, (err, html) => {
+      if (!maxRenderTimeout) {
+        // ignore this render's result because it exceeded maxRenderTimeout
+        this.log(
+          `Rendering of ${request.originalUrl} completed after the specified maxRenderTime, therefore it was ignored.`
+        );
+        return;
+      }
+      clearTimeout(maxRenderTimeout);
+
+      this.log(`Rendering completed (${request?.originalUrl})`);
+      this.currentConcurrency--;
+
+      renderCallback(err, html);
+    });
   }
 }

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -232,6 +232,10 @@ export class OptimizedSsrEngine {
         clearTimeout(requestTimeout);
         callback(err, html);
 
+        this.log(
+          `Request is resolved with the SSR rendering result (${request?.originalUrl})`
+        );
+
         // store the render only if caching is enabled
         if (this.ssrOptions?.cache) {
           this.renderingCache.store(renderingKey, err, html);
@@ -325,7 +329,7 @@ export class OptimizedSsrEngine {
     }
 
     this.log(
-      `Request is waiting for the render to complete (${request?.originalUrl})`
+      `Request is waiting for the SSR rendering to complete (${request?.originalUrl})`
     );
   }
 

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -71,9 +71,33 @@ export interface SsrOptimizationOptions {
    *
    * The value should always be higher than `timeout` and `forcedSsrTimeout`.
    *
-   * Default value is 300 seconds (5 minutes).
+   * Default value is 300000 milliseconds (5 minutes).
    */
   maxRenderTime?: number;
+
+  /**
+   * Instead of immediately falling back to CSR
+   * while a render for the same key is in progress, this option will make
+   * the subsequent requests for this key wait for the current render.
+   *
+   * All pending requests that for the same rendering key will
+   * take up only _one_ concurrency slot, because there is only
+   * one actual rendering task being performed.
+   *
+   * Each request independently honors the `timeout` option.
+   * E.g., consider the following setup where `timeout` option
+   * is set to 3s, and the given request takes 4s to render.
+   * The flow is as follows:
+   *
+   * - 1st request arrives and triggers the SSR.
+   * - 2nd request for the same URL arrives 2s after the 1st one.
+   *    Instead of falling back to CSR, it waits (with its own timeout)
+   *    for the render of the first request.
+   * - 1st request times out after 3s, and falls back to CSR.
+   * - one second after the timeout, the current render finishes.
+   * - the 2nd request returns SSR after only 2s of waiting.
+   */
+  reuseCurrentRendering?: boolean;
 
   /**
    * Enable detailed logs for troubleshooting problems

--- a/projects/storefrontapp/server.ts
+++ b/projects/storefrontapp/server.ts
@@ -1,6 +1,10 @@
 import { APP_BASE_HREF } from '@angular/common';
 import { ngExpressEngine as engine } from '@nguniversal/express-engine';
-import { NgExpressEngineDecorator } from '@spartacus/setup/ssr';
+import {
+  NgExpressEngineDecorator,
+  SsrOptimizationOptions,
+} from '@spartacus/setup/ssr';
+import { Express } from 'express';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import 'zone.js/dist/zone-node';
@@ -10,11 +14,17 @@ import { AppServerModule } from './src/main.server';
 // And we need to use esModuleInterop option in ssr dev mode, because i18next enforce usage of this option for cjs module.
 const express = require('express');
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine);
+const ssrOptions: SsrOptimizationOptions = {
+  concurrency: 20,
+  timeout: Number(process.env.SSR_TIMEOUT ?? 3000),
+  reuseCurrentRendering: true,
+};
+
+const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app() {
-  const server = express();
+  const server: Express = express();
   const distFolder = join(process.cwd(), 'dist/storefrontapp');
   const indexHtml = existsSync(join(distFolder, 'index.original.html'))
     ? 'index.original.html'


### PR DESCRIPTION
backport of PRs #13680 and #13820 to 3.4.x

Before this PR:
When the html for a request was being rendered and in the meantime new requests arrived for the same rendering key (e.g. for the same URL), they were resolved immediately with a CSR fallback.

This PR preserves the previous default behavior, but also adds a new opt-in config that helps avoiding unnecessary CSR fallbacks.

The new opt-in config `reuseCurrentRendering` allows the subsequent requests to wait for the result of the pending render that was triggered by the 1st request. Finally, the all the waiting requests for the same rendering key (e.g. URL) will reuse the result of a single completed render.

Note 1: Same as previously, each request can time out independently (according to the `timeout` config) and then this request is resolved with a CSR fallback. However, with the new config `reuseCurrentRendering` enabled, other requests (which didn't time out yet) can still wait for the result of the render.

Note 2: The existing config `concurency` limits the number of the pending renders. So when config `reuseCurrentRendering` is enabled,  requests for the same rendering key take up just one concurrency slot, because they share just one pending render.

Note 3: Previously the `RenderinStrategy.ALWAYS_SSR` caused triggering of a new render for each request, even if there was a pending render for the same rendering key. This PR preserves the previous default behavior. However, with the new config `reuseCurrentRendering` enabled, the subsequent requests for the same key won't trigger new renders, but will wait for the pending render to complete.

closes #13623