### PR TITLE
fix: global message layout for html dir=rtl (#13884)

### DIFF
--- a/projects/storefrontstyles/scss/cxbase/blocks/alert.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/alert.scss
@@ -80,5 +80,13 @@
     position: var(--cx-position, absolute);
     top: var(--cx-top, 32%);
     right: 3rem;
+
+    @include forVersion(4.1) {
+      right: auto;
+      &::before {
+        content: '';
+        margin: 0 45vw;
+      }
+    }
   }
 }

--- a/projects/storefrontstyles/scss/cxbase/blocks/alert.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/alert.scss
@@ -81,7 +81,7 @@
     top: var(--cx-top, 32%);
     right: 3rem;
 
-    @include forVersion(4.1) {
+    @include forVersion(4.2) {
       right: auto;
       &::before {
         content: '';


### PR DESCRIPTION
Closes #13884

New layout for global message on small screen reading right-to-left
<img width="514" alt="Screen Shot 2021-09-23 at 3 22 03 PM" src="https://user-images.githubusercontent.com/49131189/134570488-f0a4158e-81d5-4875-8b9c-ed87554c65d9.png">


