### PR TITLE
chore: Setup for bundle analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=12 <17"
   },
   "scripts": {
-    "build:analyze": "yarn build --stats-json && npx webpack-bundle-analyzer dist/storefrontapp/stats.json",
+    "build:analyze": "yarn build --stats-json && npx --yes webpack-bundle-analyzer dist/storefrontapp/stats.json",
     "build": "env-cmd --no-override -e dev,b2c,$SPA_ENV ng build storefrontapp --configuration production",
     "build:asm": "yarn --cwd feature-libs/asm run build:schematics && ng build asm --configuration production",
     "build:user": "yarn --cwd feature-libs/user run build:schematics && ng build user --configuration production",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=12 <17"
   },
   "scripts": {
+    "build:analyze": "yarn build --stats-json && npx webpack-bundle-analyzer dist/storefrontapp/stats.json",
     "build": "env-cmd --no-override -e dev,b2c,$SPA_ENV ng build storefrontapp --configuration production",
     "build:asm": "yarn --cwd feature-libs/asm run build:schematics && ng build asm --configuration production",
     "build:user": "yarn --cwd feature-libs/user run build:schematics && ng build user --configuration production",


### PR DESCRIPTION
- used npx to only download webpack-bundle-analyzer so it's not installed on every `yarn i`