### PR TITLE
fix: Mini-cart total (hidden by default) is not updated after checkout

### DIFF
--- a/projects/storefrontlib/cms-components/cart/mini-cart/mini-cart.component.spec.ts
+++ b/projects/storefrontlib/cms-components/cart/mini-cart/mini-cart.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
@@ -18,8 +18,8 @@ import { MiniCartComponent } from './mini-cart.component';
   name: 'cxUrl',
 })
 class MockUrlPipe implements PipeTransform {
-  transform(options: UrlCommandRoute): string {
-    return options.cxRoute;
+  transform(options: UrlCommandRoute): string | undefined {
+    return options?.cxRoute;
   }
 }
 
@@ -28,7 +28,7 @@ class MockUrlPipe implements PipeTransform {
   template: '',
 })
 class MockCxIconComponent {
-  @Input() type;
+  @Input() type: any;
 }
 
 const testCart: Cart = {
@@ -39,6 +39,7 @@ const testCart: Cart = {
   totalPrice: {
     currencyIso: 'USD',
     value: 10.0,
+    formattedValue: '$10.0',
   },
   totalPriceWithTax: {
     currencyIso: 'USD',
@@ -95,7 +96,7 @@ describe('MiniCartComponent', () => {
     expect(miniCartComponent).toBeTruthy();
   });
 
-  describe('template', () => {
+  describe('UI tests', () => {
     beforeEach(() => {
       fixture.detectChanges();
     });
@@ -106,18 +107,41 @@ describe('MiniCartComponent', () => {
       expect(linkHref).toBe('/cart');
     });
 
-    it('should show 0 items when cart is not loaded', () => {
-      const cartItemsNumber = fixture.debugElement.query(By.css('.count'))
-        .nativeElement.innerText;
-      expect(cartItemsNumber).toEqual('miniCart.count count:0');
+    describe('when mini-cart is not loaded', () => {
+      it('should show 0 items when mini-cart is not loaded', () => {
+        const cartItemsNumber = fixture.debugElement.query(By.css('.count'))
+          .nativeElement.innerText;
+        expect(cartItemsNumber).toEqual('miniCart.count count:0');
+      });
+
+      it('should show $0.00 total when mini-cart is not loaded', () => {
+        const cartTotalPrice = fixture.debugElement.query(By.css('.total'))
+          .nativeElement.innerText;
+        expect(cartTotalPrice).toEqual('miniCart.total total:0.00 ');
+      });
     });
 
-    it('should contain number of items in cart', () => {
-      activeCart.next(testCart);
-      fixture.detectChanges();
-      const cartItemsNumber = fixture.debugElement.query(By.css('.count'))
-        .nativeElement.innerText;
-      expect(cartItemsNumber).toEqual('miniCart.count count:1');
+    describe('when mini-cart is loaded', () => {
+      beforeEach(() => {
+        activeCart.next(testCart);
+        fixture.detectChanges();
+      });
+
+      it('should contain number of items in mini-cart', () => {
+        const cartItemsNumber = fixture.debugElement.query(By.css('.count'))
+          .nativeElement.innerText;
+        expect(cartItemsNumber).toEqual(
+          `miniCart.count count:${testCart.deliveryItemsQuantity}`
+        );
+      });
+
+      it('should contain total price in mini-cart', () => {
+        const cartTotalPrice = fixture.debugElement.query(By.css('.total'))
+          .nativeElement.innerText;
+        expect(cartTotalPrice).toEqual(
+          `miniCart.total total:${testCart.totalPrice?.formattedValue} `
+        );
+      });
     });
   });
 });

--- a/projects/storefrontlib/cms-components/cart/mini-cart/mini-cart.component.spec.ts
+++ b/projects/storefrontlib/cms-components/cart/mini-cart/mini-cart.component.spec.ts
@@ -109,15 +109,17 @@ describe('MiniCartComponent', () => {
 
     describe('when mini-cart is not loaded', () => {
       it('should show 0 items when mini-cart is not loaded', () => {
-        const cartItemsNumber = fixture.debugElement.query(By.css('.count'))
-          .nativeElement.innerText;
+        const cartItemsNumber = fixture.debugElement
+          .query(By.css('.count'))
+          .nativeElement.innerText.trim();
         expect(cartItemsNumber).toEqual('miniCart.count count:0');
       });
 
       it('should show $0.00 total when mini-cart is not loaded', () => {
-        const cartTotalPrice = fixture.debugElement.query(By.css('.total'))
-          .nativeElement.innerText;
-        expect(cartTotalPrice).toEqual('miniCart.total total:0.00 ');
+        const cartTotalPrice = fixture.debugElement
+          .query(By.css('.total'))
+          .nativeElement.innerText.trim();
+        expect(cartTotalPrice).toEqual('miniCart.total total:0.00');
       });
     });
 
@@ -128,18 +130,20 @@ describe('MiniCartComponent', () => {
       });
 
       it('should contain number of items in mini-cart', () => {
-        const cartItemsNumber = fixture.debugElement.query(By.css('.count'))
-          .nativeElement.innerText;
+        const cartItemsNumber = fixture.debugElement
+          .query(By.css('.count'))
+          .nativeElement.innerText.trim();
         expect(cartItemsNumber).toEqual(
           `miniCart.count count:${testCart.deliveryItemsQuantity}`
         );
       });
 
       it('should contain total price in mini-cart', () => {
-        const cartTotalPrice = fixture.debugElement.query(By.css('.total'))
-          .nativeElement.innerText;
+        const cartTotalPrice = fixture.debugElement
+          .query(By.css('.total'))
+          .nativeElement.innerText.trim();
         expect(cartTotalPrice).toEqual(
-          `miniCart.total total:${testCart.totalPrice?.formattedValue} `
+          `miniCart.total total:${testCart.totalPrice?.formattedValue}`
         );
       });
     });

--- a/projects/storefrontlib/cms-components/cart/mini-cart/mini-cart.component.ts
+++ b/projects/storefrontlib/cms-components/cart/mini-cart/mini-cart.component.ts
@@ -17,9 +17,10 @@ export class MiniCartComponent {
     map((cart) => cart.deliveryItemsQuantity || 0)
   );
 
-  total$: Observable<string> = this.activeCartService
-    .getActive()
-    .pipe(map((cart) => cart.totalPrice?.formattedValue || '$0.00'));
+  total$: Observable<string> = this.activeCartService.getActive().pipe(
+    startWith({ totalPrice: { formattedValue: '0.00' } }),
+    map((cart) => cart.totalPrice?.formattedValue || '0.00')
+  );
 
   constructor(protected activeCartService: ActiveCartService) {}
 }

--- a/projects/storefrontlib/cms-components/cart/mini-cart/mini-cart.component.ts
+++ b/projects/storefrontlib/cms-components/cart/mini-cart/mini-cart.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ActiveCartService } from '@spartacus/core';
 import { Observable } from 'rxjs';
-import { filter, map, startWith } from 'rxjs/operators';
+import { map, startWith } from 'rxjs/operators';
 import { ICON_TYPE } from '../../misc/icon/icon.model';
 
 @Component({
@@ -17,10 +17,9 @@ export class MiniCartComponent {
     map((cart) => cart.deliveryItemsQuantity || 0)
   );
 
-  total$: Observable<string> = this.activeCartService.getActive().pipe(
-    filter((cart) => !!cart.totalPrice),
-    map((cart) => cart.totalPrice.formattedValue)
-  );
+  total$: Observable<string> = this.activeCartService
+    .getActive()
+    .pipe(map((cart) => cart.totalPrice?.formattedValue || '$0.00'));
 
   constructor(protected activeCartService: ActiveCartService) {}
 }


### PR DESCRIPTION
closes https://sapjira.wdf.sap.corp/projects/CXSPA/issues/CXSPA-36?filter=allopenissues

ServiceNow customer caught bug and requested to do by Bill


---------------
Reason why I opted for '0.00' is basically that 'number' is universal for any currency. We can also put 0 instead

I can always create a pipe that passes the `isoCode` and `'number'` to prepend the appropriate currency label, or follow the appropriate structure for the label and number depending on the norm of other countries, **however, we would have 180 use case to follow through. I believe this is the safer bet for when we lose/don't have the cart**