### PR TITLE
fix: Remove aria-autocomplete from searchbox

### DIFF
--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.html
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.html
@@ -5,7 +5,6 @@
     autocomplete="off"
     aria-describedby="initialDescription"
     aria-controls="results"
-    aria-autocomplete="both"
     [attr.aria-label]="'common.search' | cxTranslate"
     (focus)="open()"
     (click)="open()"


### PR DESCRIPTION
Adding a `type="text"` did not solve the issue. The listed items are still being vocalized by the SR. 
Tested on MacOS
closes #13432 