### PR TITLE
fix: Add CDC login and register routes with authFlow property for correct redirect after login

### DIFF
--- a/integration-libs/cdc/root/cdc-root.module.ts
+++ b/integration-libs/cdc/root/cdc-root.module.ts
@@ -2,10 +2,12 @@ import { APP_INITIALIZER, NgModule } from '@angular/core';
 import {
   CmsConfig,
   ConfigInitializerService,
+  provideDefaultConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
 import { LogoutGuard } from '@spartacus/storefront';
 import { tap } from 'rxjs/operators';
+import { defaultCdcRoutingConfig } from './config/default-cdc-routing-config';
 import { CDC_CORE_FEATURE, CDC_FEATURE } from './feature-name';
 import { CdcLogoutGuard } from './guards/cdc-logout.guard';
 import { CdcJsService } from './service/cdc-js.service';
@@ -42,6 +44,7 @@ export function defaultCdcComponentsConfig(): CmsConfig {
 @NgModule({
   providers: [
     provideDefaultConfigFactory(defaultCdcComponentsConfig),
+    provideDefaultConfig(defaultCdcRoutingConfig),
     { provide: LogoutGuard, useExisting: CdcLogoutGuard },
     {
       provide: APP_INITIALIZER,

--- a/integration-libs/cdc/root/config/default-cdc-routing-config.ts
+++ b/integration-libs/cdc/root/config/default-cdc-routing-config.ts
@@ -1,0 +1,21 @@
+import { RoutesConfig, RoutingConfig } from '@spartacus/core';
+
+export const defaultCdcRoutesConfig: RoutesConfig = {
+  // semantic links for login related pages
+  login: {
+    paths: ['cdc/login'],
+    protected: false,
+    authFlow: true,
+  },
+  register: {
+    paths: ['cdc/login/register'],
+    protected: false,
+    authFlow: true,
+  },
+};
+
+export const defaultCdcRoutingConfig: RoutingConfig = {
+  routing: {
+    routes: defaultCdcRoutesConfig,
+  },
+};


### PR DESCRIPTION
Currently you are not redirected after login from CDC widget, because of the change introduced with auth redirect setup. This aligns the lib to our approach using `authFlow` routes to mark pages that you should not be redirected to.