### PR TITLE
fix: Intermittent scroll page navigation for iOS

### DIFF
--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -15,7 +15,7 @@ import { Environment } from './models/environment.model';
 
 export const environment: Environment = {
   production: false,
-  occBaseUrl: buildProcess.env.CX_BASE_URL,
+  occBaseUrl: 'https://40.76.109.9:9002',
   occApiPrefix: '/occ/v2/',
   cds: buildProcess.env.CX_CDS ?? false,
   b2b: buildProcess.env.CX_B2B ?? false,

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -15,7 +15,7 @@ import { Environment } from './models/environment.model';
 
 export const environment: Environment = {
   production: false,
-  occBaseUrl: 'https://40.76.109.9:9002',
+  occBaseUrl: buildProcess.env.CX_BASE_URL,
   occApiPrefix: '/occ/v2/',
   cds: buildProcess.env.CX_CDS ?? false,
   b2b: buildProcess.env.CX_B2B ?? false,

--- a/projects/storefrontlib/router/on-navigate.service.spec.ts
+++ b/projects/storefrontlib/router/on-navigate.service.spec.ts
@@ -51,7 +51,7 @@ function emitPairScrollEvent(
   );
 }
 
-describe('OnNavigateService', () => {
+fdescribe('OnNavigateService', () => {
   let service: OnNavigateService;
   let config: OnNavigateConfig;
   let viewportScroller: ViewportScroller;
@@ -113,7 +113,7 @@ describe('OnNavigateService', () => {
 
       emitPairScrollEvent(null);
 
-      tick();
+      tick(100);
 
       expect(viewportScroller.scrollToPosition).toHaveBeenCalledWith([0, 0]);
     }));
@@ -149,7 +149,7 @@ describe('OnNavigateService', () => {
 
       emitPairScrollEvent(null, '/test3');
 
-      tick();
+      tick(100);
 
       expect(viewportScroller.scrollToPosition).toHaveBeenCalledWith([0, 0]);
     }));
@@ -159,7 +159,7 @@ describe('OnNavigateService', () => {
 
       emitPairScrollEvent([1000, 500]);
 
-      tick();
+      tick(100);
 
       expect(viewportScroller.scrollToPosition).toHaveBeenCalledWith([
         1000, 500,

--- a/projects/storefrontlib/router/on-navigate.service.spec.ts
+++ b/projects/storefrontlib/router/on-navigate.service.spec.ts
@@ -108,13 +108,15 @@ describe('OnNavigateService', () => {
   });
 
   describe('setResetViewOnNavigate()', () => {
-    it('should scroll to the top on navigation when no position (forward navigation)', () => {
+    it('should scroll to the top on navigation when no position (forward navigation)', fakeAsync(() => {
       service.setResetViewOnNavigate(true);
 
       emitPairScrollEvent(null);
 
+      tick();
+
       expect(viewportScroller.scrollToPosition).toHaveBeenCalledWith([0, 0]);
-    });
+    }));
 
     it('should NOT scroll to the top on navigation when route has query strings', () => {
       config.enableResetViewOnNavigate.ignoreQueryString = true;
@@ -140,14 +142,17 @@ describe('OnNavigateService', () => {
       ]);
     });
 
-    it('should scroll to the top on navigation when route is not part of the ignored config routes', () => {
+    it('should scroll to the top on navigation when route is not part of the ignored config routes', fakeAsync(() => {
       config.enableResetViewOnNavigate.ignoreRoutes = ['test1', 'test2'];
 
       service.setResetViewOnNavigate(true);
 
       emitPairScrollEvent(null, '/test3');
+
+      tick();
+
       expect(viewportScroller.scrollToPosition).toHaveBeenCalledWith([0, 0]);
-    });
+    }));
 
     it('should scroll to a position on navigation when scroll contains position (backward navigation)', fakeAsync(() => {
       service.setResetViewOnNavigate(true);

--- a/projects/storefrontlib/router/on-navigate.service.spec.ts
+++ b/projects/storefrontlib/router/on-navigate.service.spec.ts
@@ -51,7 +51,7 @@ function emitPairScrollEvent(
   );
 }
 
-fdescribe('OnNavigateService', () => {
+describe('OnNavigateService', () => {
   let service: OnNavigateService;
   let config: OnNavigateConfig;
   let viewportScroller: ViewportScroller;

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -84,7 +84,7 @@ export class OnNavigateService {
             console.log('page routes', event);
             setTimeout(
               () => this.viewportScroller.scrollToPosition([0, 0]),
-              500
+              100
             );
           }
         });

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -71,7 +71,7 @@ export class OnNavigateService {
               return;
             }
 
-            this.viewportScroller.scrollToPosition([0, 0]);
+            setTimeout(() => this.viewportScroller.scrollToPosition([0, 0]));
           }
 
           this.hostComponent?.location?.nativeElement.focus();

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -6,6 +6,7 @@ import {
   Injector,
 } from '@angular/core';
 import { Router, Scroll } from '@angular/router';
+import { WindowRef } from '@spartacus/core';
 import { Subscription } from 'rxjs';
 import { filter, pairwise } from 'rxjs/operators';
 import { OnNavigateConfig } from './config';
@@ -24,7 +25,8 @@ export class OnNavigateService {
     protected config: OnNavigateConfig,
     protected router: Router,
     protected viewportScroller: ViewportScroller,
-    protected injector: Injector
+    protected injector: Injector,
+    protected winRef: WindowRef
   ) {}
 
   /**
@@ -53,8 +55,13 @@ export class OnNavigateService {
         .subscribe((event) => {
           const previousRoute = event[0];
           const currentRoute = event[1];
-          this.hostComponent?.location?.nativeElement.focus();
-          console.log('host', this.hostComponent);
+          console.log('1', this.hostComponent?.location?.nativeElement);
+          console.log(this.winRef?.document?.activeElement?.tagName);
+          console.log(this.winRef?.document?.activeElement);
+          // this.hostComponent?.location?.nativeElement.focus();
+          console.log('2', this.hostComponent?.location?.nativeElement);
+          console.log(this.winRef?.document?.activeElement?.tagName);
+          console.log(this.winRef?.document?.activeElement);
 
           if (currentRoute.position) {
             console.log('browser controls', event);

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -82,7 +82,10 @@ export class OnNavigateService {
             }
             console.log('using winref instead of viewportscroller');
             console.log('page routes', event);
-            this.winRef.document.body.scrollIntoView();
+            setTimeout(
+              () => this.viewportScroller.scrollToPosition([0, 0]),
+              500
+            );
           }
         });
     }

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -53,8 +53,11 @@ export class OnNavigateService {
         .subscribe((event) => {
           const previousRoute = event[0];
           const currentRoute = event[1];
+          this.hostComponent?.location?.nativeElement.focus();
+          console.log('host', this.hostComponent);
 
           if (currentRoute.position) {
+            console.log('browser controls', event);
             // allow the pages to be repainted before scrolling to proper position
             setTimeout(() =>
               this.viewportScroller.scrollToPosition(currentRoute.position)
@@ -70,11 +73,9 @@ export class OnNavigateService {
             if (this.isChildRoute(currentRoute)) {
               return;
             }
-
-            setTimeout(() => this.viewportScroller.scrollToPosition([0, 0]));
+            console.log('page routes', event);
+            this.viewportScroller.scrollToPosition([0, 0]);
           }
-
-          this.hostComponent?.location?.nativeElement.focus();
         });
     }
   }

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -80,7 +80,7 @@ export class OnNavigateService {
             if (this.isChildRoute(currentRoute)) {
               return;
             }
-            console.log('using winref instead of viewportscroller');
+
             console.log('page routes', event);
             setTimeout(
               () => this.viewportScroller.scrollToPosition([0, 0]),

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -6,7 +6,6 @@ import {
   Injector,
 } from '@angular/core';
 import { Router, Scroll } from '@angular/router';
-import { WindowRef } from '@spartacus/core';
 import { Subscription } from 'rxjs';
 import { filter, pairwise } from 'rxjs/operators';
 import { OnNavigateConfig } from './config';
@@ -25,8 +24,7 @@ export class OnNavigateService {
     protected config: OnNavigateConfig,
     protected router: Router,
     protected viewportScroller: ViewportScroller,
-    protected injector: Injector,
-    protected winRef: WindowRef
+    protected injector: Injector
   ) {}
 
   /**
@@ -55,16 +53,8 @@ export class OnNavigateService {
         .subscribe((event) => {
           const previousRoute = event[0];
           const currentRoute = event[1];
-          console.log('1', this.hostComponent?.location?.nativeElement);
-          console.log(this.winRef?.document?.activeElement?.tagName);
-          console.log(this.winRef?.document?.activeElement);
-          this.hostComponent?.location?.nativeElement.focus();
-          console.log('2', this.hostComponent?.location?.nativeElement);
-          console.log(this.winRef?.document?.activeElement?.tagName);
-          console.log(this.winRef?.document?.activeElement);
 
           if (currentRoute.position) {
-            console.log('browser controls', event);
             // allow the pages to be repainted before scrolling to proper position
             setTimeout(() =>
               this.viewportScroller.scrollToPosition(currentRoute.position)
@@ -81,12 +71,13 @@ export class OnNavigateService {
               return;
             }
 
-            console.log('page routes', event);
             setTimeout(
               () => this.viewportScroller.scrollToPosition([0, 0]),
               100
             );
           }
+
+          this.hostComponent?.location?.nativeElement.focus();
         });
     }
   }

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -80,6 +80,7 @@ export class OnNavigateService {
             if (this.isChildRoute(currentRoute)) {
               return;
             }
+            console.log('using winref instead of viewportscroller');
             console.log('page routes', event);
             this.winRef.document.body.scrollIntoView();
           }

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -58,7 +58,7 @@ export class OnNavigateService {
           console.log('1', this.hostComponent?.location?.nativeElement);
           console.log(this.winRef?.document?.activeElement?.tagName);
           console.log(this.winRef?.document?.activeElement);
-          // this.hostComponent?.location?.nativeElement.focus();
+          this.hostComponent?.location?.nativeElement.focus();
           console.log('2', this.hostComponent?.location?.nativeElement);
           console.log(this.winRef?.document?.activeElement?.tagName);
           console.log(this.winRef?.document?.activeElement);
@@ -81,7 +81,7 @@ export class OnNavigateService {
               return;
             }
             console.log('page routes', event);
-            this.viewportScroller.scrollToPosition([0, 0]);
+            this.winRef.document.body.scrollIntoView();
           }
         });
     }


### PR DESCRIPTION
Issue only seen in iphone chrome when we navigate in pages from hamburger menu to plp page and to pdp. Pdp page on navigation view gets placed near middle or near bottom 'at times'. (not using browser controls)

**Solution is to wait for the page to finish repainting before navigating to the top of the page + additional 0.1 s for the image load on pdp page that pushes the view (only in ios chrome)**

closes GH-14206