### PR TITLE
fix: Improve SSR logging related to maxRenderTime (#14198)

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -610,7 +610,8 @@ describe('OptimizedSsrEngine', () => {
 
       tick(fiveMinutes + 101);
       expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
-        `Rendering of ${requestUrl} completed after the specified maxRenderTime, therefore it was ignored.`
+        `Rendering of ${requestUrl} completed after the specified maxRenderTime, therefore it was ignored.`,
+        false
       );
       expect(engineRunner.renders).toEqual(['']);
 

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -378,7 +378,8 @@ export class OptimizedSsrEngine {
       if (!maxRenderTimeout) {
         // ignore this render's result because it exceeded maxRenderTimeout
         this.log(
-          `Rendering of ${request.originalUrl} completed after the specified maxRenderTime, therefore it was ignored.`
+          `Rendering of ${request.originalUrl} completed after the specified maxRenderTime, therefore it was ignored.`,
+          false
         );
         return;
       }


### PR DESCRIPTION
This PR enables a message log about a hanging render finishing after the maxRenderTime expires (previously it was logged only on the debug level).