### PR TITLE
fix: SSR - expose getDefaultResolverKey function

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -12,10 +12,9 @@ import {
 } from './ssr-optimization-options';
 
 /**
- * Returns the default resolver key.
- * Used only if `renderKeyResolver` option is not provided.
+ * Returns the full url for the given SSR Request.
  */
-export const getDefaultResolverKey = getRequestUrl;
+export const getDefaultRenderKey = getRequestUrl;
 
 export type SsrCallbackFn = (
   /**
@@ -75,7 +74,7 @@ export class OptimizedSsrEngine {
   protected getRenderingKey(request: Request): string {
     return this.ssrOptions?.renderKeyResolver
       ? this.ssrOptions.renderKeyResolver(request)
-      : getDefaultResolverKey(request);
+      : getDefaultRenderKey(request);
   }
 
   protected getRenderingStrategy(request: Request): RenderingStrategy {

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -11,6 +11,12 @@ import {
   SsrOptimizationOptions,
 } from './ssr-optimization-options';
 
+/**
+ * Returns the default resolver key.
+ * Used only if `renderKeyResolver` option is not provided.
+ */
+export const getDefaultResolverKey = getRequestUrl;
+
 export type SsrCallbackFn = (
   /**
    * Error that might've occurred while rendering.
@@ -69,7 +75,7 @@ export class OptimizedSsrEngine {
   protected getRenderingKey(request: Request): string {
     return this.ssrOptions?.renderKeyResolver
       ? this.ssrOptions.renderKeyResolver(request)
-      : getRequestUrl(request);
+      : getDefaultResolverKey(request);
   }
 
   protected getRenderingStrategy(request: Request): RenderingStrategy {


### PR DESCRIPTION
This PR exposes `getDefaultResolverKey` function which is used by Spartacus only if the `renderKeyResolver` SSR option is not provided.