### PR TITLE
fix: Domain handling in SSR for render key (#14036)

### DIFF
--- a/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.spec.ts
+++ b/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.spec.ts
@@ -1,10 +1,10 @@
+import { SERVER_REQUEST_URL } from '@spartacus/core';
 import {
   decorateExpressEngine,
   NgExpressEngine,
   NgExpressEngineDecorator,
   NgExpressEngineInstance,
 } from './ng-express-engine-decorator';
-import { SERVER_REQUEST_URL } from '@spartacus/core';
 
 describe('NgExpressEngineDecorator', () => {
   describe('get', () => {
@@ -87,13 +87,21 @@ describe('decorateExpressEngine', () => {
   let engineInstance;
 
   beforeEach(() => {
+    const app = {
+      get:
+        (_name: string): any =>
+        (_connectionRemoteAddress: string) => {},
+    };
+
     mockOptions = {
       req: {
         protocol: 'https',
         originalUrl: '/electronics/en/USD/cart',
         get: jasmine.createSpy('req.get').and.returnValue('site.com'),
+        app,
+        connection: {},
       },
-      res: {
+      res: <Partial<Response>>{
         set: jasmine.createSpy('req.set'),
       },
     } as any;

--- a/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
+++ b/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
@@ -82,11 +82,11 @@ export function getServerRequestProviders(): StaticProvider[] {
   ];
 }
 
-function getRequestUrl(req: Request): string {
+export function getRequestUrl(req: Request): string {
   return getRequestOrigin(req) + req.originalUrl;
 }
 
-function getRequestOrigin(req: Request): string {
+export function getRequestOrigin(req: Request): string {
   // If express is resolving and trusting X-Forwarded-Host, we want to take it
   // into an account to properly generate request origin.
   const trustProxyFn = req.app.get('trust proxy fn');

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -1,4 +1,7 @@
 import { fakeAsync, flush, tick } from '@angular/core/testing';
+import { Application, Request } from 'express';
+import { IncomingHttpHeaders } from 'http';
+import { Socket } from 'net';
 import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
 import { OptimizedSsrEngine, SsrCallbackFn } from './optimized-ssr-engine';
 import {
@@ -7,6 +10,8 @@ import {
 } from './ssr-optimization-options';
 
 const defaultRenderTime = 100;
+const host = 'my.shop.com';
+
 /**
  * Helper class to easily create and test engine wrapper against mocked engine.
  *
@@ -48,21 +53,40 @@ class TestEngineRunner {
   }
 
   /** Run request against the engine. The result will be stored in rendering property. */
-  request(url: string, params?: { httpHeaders?: { [key: string]: string } }) {
+  request(
+    url: string,
+    params?: {
+      /** headers */
+      httpHeaders?: IncomingHttpHeaders;
+    }
+  ): TestEngineRunner {
     const response: { [key: string]: string } = {};
-    const headers = new Headers(params?.httpHeaders ?? {});
+    const headers = params?.httpHeaders ?? { host };
+    /** used when resolving getRequestUrl() and getRequestOrigin() */
+    const app = <Partial<Application>>{
+      get:
+        (_name: string): any =>
+        (_connectionRemoteAddress: string) =>
+          true,
+    };
+
     const optionsMock = {
       req: <Partial<Request>>{
+        protocol: 'https',
         originalUrl: url,
         headers,
-        get: (header: string): string | null => headers.get(header),
+        get: (header: string): string | string[] | null | undefined => {
+          return headers[header];
+        },
+        app,
+        connection: <Partial<Socket>>{},
       },
       res: <Partial<Response>>{
         set: (key: string, value: any) => (response[key] = value),
       },
     };
 
-    this.engineInstance(url, optionsMock, (_, html) => {
+    this.engineInstance(url, optionsMock, (_, html): void => {
       this.renders.push(html ?? '');
       this.responseParams.push(response);
     });
@@ -272,6 +296,51 @@ describe('OptimizedSsrEngine', () => {
   });
 
   describe('renderKeyResolver option', () => {
+    describe('default key resolver', () => {
+      it('should be used when the custom one is provided', fakeAsync(() => {
+        const engineRunner = new TestEngineRunner({
+          timeout: 200,
+          cache: true,
+        });
+        spyOn(
+          engineRunner.optimizedSsrEngine as any,
+          'isConcurrencyLimitExceeded'
+        ).and.callThrough();
+
+        const route = 'home';
+        engineRunner.request(route);
+        tick(200);
+
+        expect(
+          engineRunner.optimizedSsrEngine['isConcurrencyLimitExceeded']
+        ).toHaveBeenCalledWith(`https://${host}${route}`);
+      }));
+
+      it('should use the X-Forwarded-Host header to resolve the origin', fakeAsync(() => {
+        const engineRunner = new TestEngineRunner({
+          timeout: 200,
+          cache: true,
+        });
+        spyOn(
+          engineRunner.optimizedSsrEngine as any,
+          'isConcurrencyLimitExceeded'
+        );
+
+        const domain = 'my.shop.com/';
+        const route = 'home';
+        engineRunner.request(route, {
+          httpHeaders: {
+            'X-Forwarded-Host': domain,
+          },
+        });
+        tick(200);
+
+        expect(
+          engineRunner.optimizedSsrEngine['isConcurrencyLimitExceeded']
+        ).toHaveBeenCalledWith(`https://${domain}${route}`);
+      }));
+    });
+
     it('should use custom render key resolver', fakeAsync(() => {
       const engineRunner = new TestEngineRunner({
         renderKeyResolver: (req) => req.originalUrl.substr(0, 2),
@@ -624,14 +693,18 @@ describe('OptimizedSsrEngine', () => {
     const requestUrl = 'a';
     const differentUrl = 'b';
 
+    const getRenderingKey = (requestUrl: string): string =>
+      `https://${host}${requestUrl}`;
+
     const getRenderCallbacksCount = (
       engineRunner: TestEngineRunner,
-      renderingKey: string
+      requestUrl: string
     ): { renderCallbacksCount: number } => {
       return {
         renderCallbacksCount:
-          engineRunner.optimizedSsrEngine['renderCallbacks'].get(renderingKey)
-            ?.length ?? 0,
+          engineRunner.optimizedSsrEngine['renderCallbacks'].get(
+            getRenderingKey(requestUrl)
+          )?.length ?? 0,
       };
     };
 
@@ -914,6 +987,7 @@ describe('OptimizedSsrEngine', () => {
         it('should free up only one concurrent slot when the render is hanging for many waiting requests', fakeAsync(() => {
           const hangingRequest = 'a';
           const ssrRequest = 'b';
+
           const renderTime = 200;
           const maxRenderTime = renderTime - 50; // shorter than the predicted render time
           const engineRunner = new TestEngineRunner(

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -1,7 +1,10 @@
 /* webpackIgnore: true */
 import { Request, Response } from 'express';
 import * as fs from 'fs';
-import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
+import {
+  getRequestUrl,
+  NgExpressEngineInstance,
+} from '../engine-decorator/ng-express-engine-decorator';
 import { RenderingCache } from './rendering-cache';
 import {
   RenderingStrategy,
@@ -66,7 +69,7 @@ export class OptimizedSsrEngine {
   protected getRenderingKey(request: Request): string {
     return this.ssrOptions?.renderKeyResolver
       ? this.ssrOptions.renderKeyResolver(request)
-      : request.originalUrl;
+      : getRequestUrl(request);
   }
 
   protected getRenderingStrategy(request: Request): RenderingStrategy {
@@ -204,8 +207,6 @@ export class OptimizedSsrEngine {
       return;
     }
 
-    const renderingKey = this.getRenderingKey(request);
-
     let requestTimeout: NodeJS.Timeout | undefined;
     if (this.shouldTimeout(request)) {
       // establish timeout for rendering
@@ -225,7 +226,8 @@ export class OptimizedSsrEngine {
       this.fallbackToCsr(response, filePath, callback);
     }
 
-    const renderCallback: SsrCallbackFn = (err, html) => {
+    const renderingKey = this.getRenderingKey(request);
+    const renderCallback: SsrCallbackFn = (err, html): void => {
       if (requestTimeout) {
         // if request is still waiting for render, return it
         clearTimeout(requestTimeout);

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -40,7 +40,7 @@ export interface SsrOptimizationOptions {
 
   /**
    * Allows overriding default key generator for custom differentiating
-   * between rendered pages. By default it uses req.originalUrl
+   * between rendered pages. By default it uses the full request URL.
    *
    * @param req
    */
@@ -55,7 +55,7 @@ export interface SsrOptimizationOptions {
 
   /**
    * Time in milliseconds to wait for rendering when SSR_ALWAYS render strategy is set for the request.
-   * Default value is 60 seconds.
+   * Default value is 60000 milliseconds (1 minute).
    */
   forcedSsrTimeout?: number;
 


### PR DESCRIPTION
This PR takes the whole domain when resolving the rendering key in SSR.
Without it, the sites which embed the site info in their domain won't render properly (e.g. my-site.rs, my-site.ca, my-site.pl, etc.).