### PR TITLE
fix: align-right hanging digits of total price (#14096)

### DIFF
--- a/projects/storefrontstyles/scss/components/cart/_cart-item.scss
+++ b/projects/storefrontstyles/scss/components/cart/_cart-item.scss
@@ -139,6 +139,7 @@
     }
 
     .cx-value {
+      text-align: end;
       word-break: break-word;
     }
   }


### PR DESCRIPTION
Fixes a bug from closed issue #14096 