### PR TITLE
Display a 'Select a value' error message for required single-selection attribute types

### DIFF
--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.spec.ts
@@ -769,7 +769,7 @@ describe('OccConfiguratorVariantNormalizer', () => {
       expect(attributeDDWithValues.incomplete).toBe(false);
     });
 
-    it('should set incomplete by drop-down type with retract option correctly', () => {
+    it('should set incomplete for drop-down type with retract option correctly', () => {
       attributeDDWithValues.selectedSingleValue =
         OccConfiguratorVariantNormalizer.RETRACT_VALUE_CODE;
       occConfiguratorVariantNormalizer.compileAttributeIncomplete(

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.spec.ts
@@ -747,7 +747,7 @@ describe('OccConfiguratorVariantNormalizer', () => {
       expect(attributeRBWithValues.incomplete).toBe(false);
     });
 
-    it('should set incomplete by radio button type with retract option correctly', () => {
+    it('should set incomplete for radio button type with retract option correctly', () => {
       attributeRBWithValues.selectedSingleValue =
         OccConfiguratorVariantNormalizer.RETRACT_VALUE_CODE;
       occConfiguratorVariantNormalizer.compileAttributeIncomplete(

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.spec.ts
@@ -747,6 +747,16 @@ describe('OccConfiguratorVariantNormalizer', () => {
       expect(attributeRBWithValues.incomplete).toBe(false);
     });
 
+    it('should set incomplete by radio button type with retract option correctly', () => {
+      attributeRBWithValues.selectedSingleValue =
+        OccConfiguratorVariantNormalizer.RETRACT_VALUE_CODE;
+      occConfiguratorVariantNormalizer.compileAttributeIncomplete(
+        attributeRBWithValues
+      );
+
+      expect(attributeRBWithValues.incomplete).toBe(true);
+    });
+
     it('should set incomplete by drop-down type correctly', () => {
       occConfiguratorVariantNormalizer.compileAttributeIncomplete(
         attributeDDWoValues
@@ -757,6 +767,16 @@ describe('OccConfiguratorVariantNormalizer', () => {
 
       expect(attributeDDWoValues.incomplete).toBe(true);
       expect(attributeDDWithValues.incomplete).toBe(false);
+    });
+
+    it('should set incomplete by drop-down type with retract option correctly', () => {
+      attributeDDWithValues.selectedSingleValue =
+        OccConfiguratorVariantNormalizer.RETRACT_VALUE_CODE;
+      occConfiguratorVariantNormalizer.compileAttributeIncomplete(
+        attributeDDWithValues
+      );
+
+      expect(attributeDDWithValues.incomplete).toBe(true);
     });
 
     it('should set incomplete by single-selection-image type correctly', () => {

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.ts
@@ -379,7 +379,16 @@ export class OccConfiguratorVariantNormalizer
 
     switch (attribute.uiType) {
       case Configurator.UiType.RADIOBUTTON:
-      case Configurator.UiType.DROPDOWN:
+      case Configurator.UiType.DROPDOWN: {
+        if (
+          !attribute.selectedSingleValue ||
+          attribute.selectedSingleValue ===
+            OccConfiguratorVariantNormalizer.RETRACT_VALUE_CODE
+        ) {
+          attribute.incomplete = true;
+        }
+        break;
+      }
       case Configurator.UiType.SINGLE_SELECTION_IMAGE: {
         if (!attribute.selectedSingleValue) {
           attribute.incomplete = true;


### PR DESCRIPTION
Display a 'Select a value' error message for required single-selection attribute types if the retract value is selected and the group has been visited