### PR TITLE
fix: Use useExisting in CmsOccModule

### DIFF
--- a/projects/core/src/occ/adapters/cms/cms-occ.module.ts
+++ b/projects/core/src/occ/adapters/cms/cms-occ.module.ts
@@ -1,18 +1,18 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { CmsPageAdapter } from '../../../cms/connectors/page/cms-page.adapter';
-import { OccCmsComponentAdapter } from './occ-cms-component.adapter';
-import { OccCmsPageNormalizer } from './converters/occ-cms-page-normalizer';
-import { OccCmsPageAdapter } from './occ-cms-page.adapter';
-import { CMS_PAGE_NORMALIZER } from '../../../cms/connectors/page/converters';
 import { CmsComponentAdapter } from '../../../cms/connectors/component/cms-component.adapter';
+import { CmsPageAdapter } from '../../../cms/connectors/page/cms-page.adapter';
+import { CMS_PAGE_NORMALIZER } from '../../../cms/connectors/page/converters';
+import { OccCmsPageNormalizer } from './converters/occ-cms-page-normalizer';
+import { OccCmsComponentAdapter } from './occ-cms-component.adapter';
+import { OccCmsPageAdapter } from './occ-cms-page.adapter';
 
 @NgModule({
   imports: [CommonModule],
   providers: [
     {
       provide: CmsPageAdapter,
-      useClass: OccCmsPageAdapter,
+      useExisting: OccCmsPageAdapter,
     },
     {
       provide: CMS_PAGE_NORMALIZER,
@@ -21,7 +21,7 @@ import { CmsComponentAdapter } from '../../../cms/connectors/component/cms-compo
     },
     {
       provide: CmsComponentAdapter,
-      useClass: OccCmsComponentAdapter,
+      useExisting: OccCmsComponentAdapter,
     },
   ],
 })


### PR DESCRIPTION
This PR switches from using `useClass` to `useExisting` in `CmsOccModule`.