### PR TITLE
chore: Handle errors in checkout-steps to not cause infinite spinner

### DIFF
--- a/feature-libs/checkout/b2b/components/checkout-shipping-address/checkout-shipping-address.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-shipping-address/checkout-shipping-address.component.ts
@@ -22,7 +22,7 @@ import {
   UserCostCenterService,
 } from '@spartacus/core';
 import { Card } from '@spartacus/storefront';
-import { Observable, of } from 'rxjs';
+import { Observable, of, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
 
 export interface CardWithAddress {
@@ -40,6 +40,7 @@ export class B2BCheckoutShippingAddressComponent
   implements OnInit, OnDestroy
 {
   isAccountPayment = false;
+  protected subscriptions = new Subscription();
 
   constructor(
     protected userAddressService: UserAddressService,
@@ -113,5 +114,9 @@ export class B2BCheckoutShippingAddressComponent
     if (!this.isAccountPayment) {
       super.ngOnInit();
     }
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
   }
 }

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
@@ -42,8 +42,7 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
   selectedMethod$: Observable<PaymentDetails>;
   isGuestCheckout = false;
   newPaymentFormManuallyOpened = false;
-  paymentSavingInProgress$: BehaviorSubject<boolean> =
-    new BehaviorSubject<boolean>(false);
+  paymentSavingInProgress$ = new BehaviorSubject<boolean>(false);
   subscriptions: Subscription = new Subscription();
 
   backBtnText = this.checkoutStepService.getBackBntText(this.activatedRoute);
@@ -98,7 +97,7 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
                   this.sendPaymentMethodFailGlobalMessage(paymentInfo[key]);
                 }
               });
-              // TODO: this.checkoutService.clearCheckoutStep(3);
+              // TODO:#checkout this.checkoutService.clearCheckoutStep(3);
             } else if (this.shouldRedirect) {
               this.next();
             }

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
@@ -177,6 +177,7 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.checkoutPaymentFacade.setPaymentDetails(paymentDetails).subscribe({
         complete: () => this.paymentSavingInProgress$.next(false),
+        error: () => this.paymentSavingInProgress$.next(false),
       })
     );
   }
@@ -202,6 +203,7 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.checkoutPaymentFacade.createPaymentDetails(details).subscribe({
         complete: () => this.paymentSavingInProgress$.next(false),
+        error: () => this.paymentSavingInProgress$.next(false),
       })
     );
     this.shouldRedirect = true;

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
@@ -35,6 +35,8 @@ import { CheckoutStepService } from '../services/checkout-step.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
+  protected subscriptions = new Subscription();
+
   iconTypes = ICON_TYPE;
   existingPaymentMethods$: Observable<PaymentDetails[]>;
   isLoading$: Observable<boolean>;
@@ -43,7 +45,6 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
   isGuestCheckout = false;
   newPaymentFormManuallyOpened = false;
   paymentSavingInProgress$ = new BehaviorSubject<boolean>(false);
-  subscriptions: Subscription = new Subscription();
 
   backBtnText = this.checkoutStepService.getBackBntText(this.activatedRoute);
 

--- a/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
+++ b/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CheckoutDeliveryAddressFacade } from '@spartacus/checkout/base/root';
 import {
@@ -13,7 +8,7 @@ import {
   UserAddressService,
 } from '@spartacus/core';
 import { Card } from '@spartacus/storefront';
-import { combineLatest, Observable, Subscription } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 import { CheckoutStepService } from '../services/checkout-step.service';
 
@@ -27,13 +22,11 @@ export interface CardWithAddress {
   templateUrl: './checkout-shipping-address.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CheckoutShippingAddressComponent implements OnInit, OnDestroy {
+export class CheckoutShippingAddressComponent implements OnInit {
   addressFormOpened = false;
   forceLoader = false; // this helps with smoother steps transition
   selectedAddress: Address | undefined;
   doneAutoSelect = false;
-
-  protected subscriptions = new Subscription();
 
   constructor(
     protected userAddressService: UserAddressService,
@@ -186,9 +179,5 @@ export class CheckoutShippingAddressComponent implements OnInit, OnDestroy {
 
   back(): void {
     this.checkoutStepService.back(this.activatedRoute);
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.unsubscribe();
   }
 }

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
@@ -58,9 +58,9 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
           mappingLabels: labelsMap,
         };
       }),
-      mergeMap((sub) => {
+      mergeMap((sub) =>
         // create a subscription directly with payment provider
-        return this.createSubWithProvider(sub.url, sub.parameters).pipe(
+        this.createSubWithProvider(sub.url, sub.parameters).pipe(
           map((response) => this.extractPaymentDetailsFromHtml(response)),
           mergeMap((fromPaymentProvider) => {
             fromPaymentProvider['defaultPayment'] =
@@ -78,8 +78,8 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
               this.converter.pipeable(PAYMENT_DETAILS_NORMALIZER)
             );
           })
-        );
-      })
+        )
+      )
     );
   }
 

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.ts
@@ -28,7 +28,7 @@ export class CheckoutScheduledReplenishmentPlaceOrderComponent
   extends CheckoutPlaceOrderComponent
   implements OnInit, OnDestroy
 {
-  private subscriptions = new Subscription();
+  protected subscriptions = new Subscription();
 
   currentOrderType: ORDER_TYPE;
   scheduleReplenishmentFormData: ScheduleReplenishmentForm;

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.ts
@@ -23,7 +23,7 @@ import { CheckoutReplenishmentFormService } from '../services/checkout-replenish
 export class CheckoutScheduleReplenishmentOrderComponent
   implements OnInit, OnDestroy
 {
-  private subscription: Subscription = new Subscription();
+  protected subscription = new Subscription();
 
   iconTypes = ICON_TYPE;
   orderTypes = ORDER_TYPE;

--- a/projects/core/src/util/normalize-http-error.spec.ts
+++ b/projects/core/src/util/normalize-http-error.spec.ts
@@ -84,4 +84,14 @@ describe('normalizeHttpError', () => {
       expect(result instanceof HttpErrorModel).toBeTruthy();
     });
   });
+
+  describe('when the provided error is an instance of HttpErrorModel due to backoff mechanism', () => {
+    it('should return the normalized error', () => {
+      const normalizedError = new HttpErrorModel();
+      normalizedError.status = 400;
+
+      const result = normalizeHttpError(normalizedError);
+      expect(result).toEqual(normalizedError);
+    });
+  });
 });

--- a/projects/core/src/util/normalize-http-error.ts
+++ b/projects/core/src/util/normalize-http-error.ts
@@ -13,6 +13,10 @@ import { HttpErrorModel } from '../model/misc.model';
 export function normalizeHttpError(
   error: HttpErrorResponse | any
 ): HttpErrorModel | undefined {
+  if (error instanceof HttpErrorModel) {
+    return error;
+  }
+
   if (error instanceof HttpErrorResponse) {
     const normalizedError = new HttpErrorModel();
     normalizedError.message = error.message;

--- a/projects/core/src/util/normalize-http-error.ts
+++ b/projects/core/src/util/normalize-http-error.ts
@@ -11,7 +11,7 @@ import { HttpErrorModel } from '../model/misc.model';
  * (which usually happens when logic in NgRx Effect is not sealed correctly)
  */
 export function normalizeHttpError(
-  error: HttpErrorResponse | any
+  error: HttpErrorResponse | HttpErrorModel | any
 ): HttpErrorModel | undefined {
   if (error instanceof HttpErrorModel) {
     return error;


### PR DESCRIPTION
This PR fixes the infinite spinner issue on the payment step.
It also address a case when normalizeHttpError is called with an already normalized error.
Finally, it aligns some subscription management in payment step components.