### PR TITLE
fix: Handle lazy load trigger cms mapping from multiple feature module

### DIFF
--- a/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
+++ b/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
@@ -20,6 +20,8 @@ export function defaultCheckoutComponentsConfig() {
           'CheckoutPaymentType',
           'CheckoutReviewOrder',
           'CheckoutShippingAddress',
+          'CheckoutPaymentDetails',
+          'CheckoutDeliveryMode',
         ],
       },
       // by default core is bundled together with components

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -18,7 +18,7 @@ export const environment: Environment = {
   occBaseUrl: buildProcess.env.CX_BASE_URL,
   occApiPrefix: '/occ/v2/',
   cds: buildProcess.env.CX_CDS ?? false,
-  b2b: true ?? buildProcess.env.CX_B2B ?? false,
+  b2b: buildProcess.env.CX_B2B ?? false,
   cdc: buildProcess.env.CX_CDC ?? false,
   cpq: buildProcess.env.CX_CPQ ?? false,
   digitalPayments: buildProcess.env.CX_DIGITAL_PAYMENTS ?? false,

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -18,7 +18,7 @@ export const environment: Environment = {
   occBaseUrl: buildProcess.env.CX_BASE_URL,
   occApiPrefix: '/occ/v2/',
   cds: buildProcess.env.CX_CDS ?? false,
-  b2b: buildProcess.env.CX_B2B ?? false,
+  b2b: true ?? buildProcess.env.CX_B2B ?? false,
   cdc: buildProcess.env.CX_CDC ?? false,
   cpq: buildProcess.env.CX_CPQ ?? false,
   digitalPayments: buildProcess.env.CX_DIGITAL_PAYMENTS ?? false,

--- a/projects/storefrontlib/cms-structure/services/cms-features.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-features.service.ts
@@ -33,6 +33,11 @@ export class CmsFeaturesService {
   // maps componentType to feature
   private componentFeatureMap: Map<string, string> = new Map();
 
+  private componentExistingConfigurationMap: Map<
+    string,
+    CmsComponentMapping | undefined
+  > = new Map();
+
   /*
    * Contains either FeatureInstance or FeatureInstance resolver for not yet
    * resolved feature modules
@@ -170,8 +175,17 @@ export class CmsFeaturesService {
     // extract cms components configuration from feature config
     for (const componentType of featureConfig.cmsComponents ?? []) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
+      // update same cms component mapping's configuration if configuration exist
+      if (resolvedConfiguration.cmsComponents?.[componentType]) {
+        this.componentExistingConfigurationMap.set(
+          componentType,
+          resolvedConfiguration.cmsComponents?.[componentType]
+        );
+      }
+
       featureInstance.componentsMappings![componentType] =
-        resolvedConfiguration.cmsComponents?.[componentType] ?? {};
+        this.componentExistingConfigurationMap.get(componentType);
     }
     return featureInstance;
   }

--- a/projects/storefrontlib/cms-structure/services/cms-features.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-features.service.ts
@@ -176,7 +176,11 @@ export class CmsFeaturesService {
     for (const componentType of featureConfig.cmsComponents ?? []) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 
-      // update same cms component mapping's configuration if configuration exist
+      /**
+       * update same cms component mapping's configuration found
+       * across all feature instance if the configuration exist
+       * in order to use the latest configuration
+       **/
       if (resolvedConfiguration.cmsComponents?.[componentType]) {
         this.componentExistingConfigurationMap.set(
           componentType,

--- a/projects/storefrontlib/cms-structure/services/cms-features.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-features.service.ts
@@ -174,8 +174,6 @@ export class CmsFeaturesService {
 
     // extract cms components configuration from feature config
     for (const componentType of featureConfig.cmsComponents ?? []) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-
       /**
        * update same cms component mapping's configuration found
        * across all feature instance if the configuration exist
@@ -188,6 +186,7 @@ export class CmsFeaturesService {
         );
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       featureInstance.componentsMappings![componentType] =
         this.componentExistingConfigurationMap.get(componentType);
     }

--- a/todo.md
+++ b/todo.md
@@ -5,27 +5,8 @@
 3. make a dependency on the cart lib (whenever cart is merged)
    1. should we do it in the feature-libs/checkout/base/root/checkout-root.module.ts _or_ in the projects/storefrontapp/src/app/spartacus/features/checkout-feature.module.ts?
    2. the latter will require schematics to be updated
-4. BUG - There's a TS error on the last checkout step (review order) when running b2b. Seems related to import-export. 
-   ```ts
-      ERROR TypeError: can't access property "__source", token is undefined
-      Angular 2
-      get routing-context.service.ts:57
-      RxJS 50
-      Angular 4
-      ExportOrderEntriesComponent_Template export-order-entries.component.html:2
-   ```
-5. BUG - When doing b2b checkout:
-   1. select the credit card payment method
-   2. go all the way to the last step (review order)
-   3. notice the delivery method is there
-   4. go back to the previous step (payment), and refresh browser
-   5. go to the last step - the delivery mode is not there.
-6. BUG - the payment method infinite spinner:
-   1. repeat the steps above
-   2. go to the first step (payment method)
-   3. notice the infinite spinner
-7. Styles - create styles per entry point
-8. Check if the new checkout is aligned with the current state of components / guards / services / features / etc. For example, check:
+4. Styles - create styles per entry point
+5. Check if the new checkout is aligned with the current state of components / guards / services / features / etc. For example, check:
    1. Is the cart validation properly applied in the new checkout?
    2. https://github.com/SAP/spartacus/issues/14386
    3. Do we need to apply this express checkout fix to the base checkout? https://github.com/SAP/spartacus/pull/14418/files
@@ -37,7 +18,7 @@
    9. Jerry's https://github.com/SAP/spartacus/pull/14401/files
    10. Monitor develop using Patrick's script: https://sap-cx.slack.com/archives/C02L8BUATM5/p1638291772009300. 
    11. ...
-9. Is the checkout properly using the new cart lib?
+6. Is the checkout properly using the new cart lib?
    1. CORE
       - ActiveCartService - we added a method. Move it to the cart lib.
       - Cart - just a model, not important.
@@ -48,26 +29,26 @@
    2. Storefrontlib
       - CartSharedModule - seems important how to import it without breaking LL?
       - CartValidationGuard - seems important. How to import it without breaking LL?
-10.  check the event listeners for the following scenario:
+7.  check the event listeners for the following scenario:
     1.  a user started the checkout, entered their delivery address, and set the delivery mode, and the data is sent on the back-end for the active cart
     2.  the user changes their mind, and navigates away from the checkout page to homepage, and refreshes the browser.
     3.  after it, they decide to change their address in the profile menu. 
     4.  if they now start the checkout (and LL the feature), the current back-end data is _not_ valid for the active cart - we must reset the set delivery mode, and load the supported delivery modes again for the new address.
     5.  if the listener was in the root module, it can listen to the userupdateaddress event, ll the checkout, and issue a reset query event
-11. Check how do various checkouts work:
+8. Check how do various checkouts work:
     1.  base only (without b2b and repl)
     2.  b2b (without repl)
-12. Check other features which are using the old checkout:
+9. Check other features which are using the old checkout:
    3. Digital Payments
    4. CDS
    5. Anything else? Some internal features?
-13. remove orderType$ from feature-libs/checkout/scheduled-replenishment/root/facade/checkout-scheduled-replenishment.facade.ts - re-watch ep17, from ~30:00 - ~45:00
-14. align the event names - prefix them with Checkout?
-15. Rename b2b and repl endpoint config keys - https://github.com/SAP/spartacus/pull/14495/files#r760445274
-16. When we were renaming components / folders to have the checkout prefix, we intentionally left out the components' prefix untouched.
+10. remove orderType$ from feature-libs/checkout/scheduled-replenishment/root/facade/checkout-scheduled-replenishment.facade.ts - re-watch ep17, from ~30:00 - ~45:00
+11. align the event names - prefix them with Checkout?
+12. Rename b2b and repl endpoint config keys - https://github.com/SAP/spartacus/pull/14495/files#r760445274
+13. When we were renaming components / folders to have the checkout prefix, we intentionally left out the components' prefix untouched.
    6. Rename the checkout components' selectors to have the checkout prefix?
-17. query debounce - `feature/query-debounce`
-18. converters and any - https://github.com/SAP/spartacus/pull/14165#discussion_r751912800
+14. query debounce - `feature/query-debounce`
+15. converters and any - https://github.com/SAP/spartacus/pull/14165#discussion_r751912800
 
 
 ## Near the end
@@ -113,6 +94,15 @@
       1. the _base_ checkout depends on _cart_
       2. the _b2b_ / _repl_ depend on _base_
       3. when landing on a _b2b_ step, will the order of chunks being loaded be the following: _cart_ first, then _base_, and lastly the _b2b_ chunk?
+8. There's a TS error on the last checkout step (review order) when running b2b. Seems related to import-export. (fix existing issue from develop)
+   ```ts
+      ERROR TypeError: can't access property "__source", token is undefined
+      Angular 2
+      get routing-context.service.ts:57
+      RxJS 50
+      Angular 4
+      ExportOrderEntriesComponent_Template export-order-entries.component.html:2
+   ```
 
 ### Future
 


### PR DESCRIPTION
Use case:

If there are many feature modules that uses the 'same' cms component to lazy load the feature, but one of the features has no cms configuration, then the mapping will use the latest configuration from the chunk. In this case, b2b checkout was loaded last before the base checkout. B2b checkout has no cms mapping that initializes `CheckoutPaymentDetails` and `CheckoutDeliveryMode`, therefore it's configuration is an empty object.

Example:
base checkout entrypoint gets loaded when `CheckoutPaymentDetails` and `CheckoutDeliveryMode` exist,  and has the cms mapping in here to a component

Whereas, b2b checkout entrypoints contains them as well, but has no cms mapping to a component. 

Therefore, we need to use the latest configuration found from a feature library

**Solution:**

If there are many same cms component, we should always use the latest existing chunk's configuration from any lazy loaded feature module.


Fixes: 
https://github.com/SAP/spartacus/blob/epic/checkout-refactor-c-and-q/todo.md
for 5. and 6. 

```
5. BUG - When doing b2b checkout:
select the credit card payment method
go all the way to the last step (review order)
notice the delivery method is there
go back to the previous step (payment), and refresh browser
go to the last step - the delivery mode is not there.

6. BUG - the payment method infinite spinner:
repeat the steps above
go to the first step (payment method)
notice the infinite spinner
```