### PR TITLE
fix: go to list start when filtered set changes

### DIFF
--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.ts
@@ -18,7 +18,11 @@ import { VisualPickingProductListService } from './visual-picking-product-list.s
 export class VisualPickingProductListComponent implements OnInit {
   constructor(
     protected visualPickingProductListService: VisualPickingProductListService
-  ) {}
+  ) {
+    this.filteredItems$.subscribe(() => {
+      this.activeSlideStartIndex = 0;
+    });
+  }
 
   @Input() title: string;
   @Input() singleSelection = true;


### PR DESCRIPTION
This fixes a bug in which results are not always shown when
filtering performed when on a page other than the first page
in the spare parts list.