### PR TITLE
chore: load one checkout entrypoint chunk instead of multiple small checkout chunks

### DIFF
--- a/feature-libs/checkout/b2b/checkout-b2b.module.ts
+++ b/feature-libs/checkout/b2b/checkout-b2b.module.ts
@@ -2,9 +2,11 @@ import { NgModule } from '@angular/core';
 import { CheckoutB2BComponentsModule } from '@spartacus/checkout/b2b/components';
 import { CheckoutB2BCoreModule } from '@spartacus/checkout/b2b/core';
 import { CheckoutB2BOccModule } from '@spartacus/checkout/b2b/occ';
+import { CheckoutModule } from '@spartacus/checkout/base';
 
 @NgModule({
   imports: [
+    CheckoutModule,
     CheckoutB2BComponentsModule,
     CheckoutB2BCoreModule,
     CheckoutB2BOccModule,

--- a/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
+++ b/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
@@ -1,5 +1,8 @@
 import { NgModule } from '@angular/core';
-import { CHECKOUT_FEATURE } from '@spartacus/checkout/base/root';
+import {
+  CheckoutRootModule,
+  CHECKOUT_FEATURE,
+} from '@spartacus/checkout/base/root';
 import {
   CmsConfig,
   provideDefaultConfig,
@@ -48,7 +51,7 @@ export function defaultCheckoutComponentsConfig() {
 }
 
 @NgModule({
-  imports: [CheckoutB2BEventModule],
+  imports: [CheckoutRootModule, CheckoutB2BEventModule],
   providers: [
     provideDefaultConfig(defaultCheckoutB2BRoutingConfig),
     provideDefaultConfigFactory(defaultCheckoutComponentsConfig),

--- a/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
+++ b/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import {
   CheckoutRootModule,
+  CHECKOUT_BASE_CMS_COMPONENTS,
   CHECKOUT_FEATURE,
 } from '@spartacus/checkout/base/root';
 import {
@@ -15,32 +16,17 @@ import {
   CHECKOUT_B2B_FEATURE,
 } from './feature-name';
 
+export const CHECKOUT_B2B_CMS_COMPONENTS: string[] = [
+  ...CHECKOUT_BASE_CMS_COMPONENTS,
+  'CheckoutCostCenterComponent',
+  'CheckoutPaymentType',
+];
+
 export function defaultCheckoutComponentsConfig() {
   const config: CmsConfig = {
     featureModules: {
       [CHECKOUT_B2B_FEATURE]: {
-        cmsComponents: [
-          // b2b cms components
-          'CheckoutCostCenterComponent',
-          'CheckoutPaymentType',
-
-          // base cms components
-          'CheckoutReviewOrder',
-          'CheckoutShippingAddress',
-          'CheckoutOrchestrator',
-          'CheckoutOrderSummary',
-          'CheckoutProgress',
-          'CheckoutProgressMobileBottom',
-          'CheckoutProgressMobileTop',
-          'CheckoutDeliveryMode',
-          'CheckoutPaymentDetails',
-          'CheckoutPlaceOrder',
-          'GuestCheckoutLoginComponent',
-          'OrderConfirmationThankMessageComponent',
-          'OrderConfirmationItemsComponent',
-          'OrderConfirmationTotalsComponent',
-          'OrderConfirmationOverviewComponent',
-        ],
+        cmsComponents: CHECKOUT_B2B_CMS_COMPONENTS,
       },
       [CHECKOUT_FEATURE]: CHECKOUT_B2B_FEATURE,
       // by default core is bundled together with components

--- a/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
+++ b/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { CHECKOUT_FEATURE } from '@spartacus/checkout/base/root';
 import {
   CmsConfig,
   provideDefaultConfig,
@@ -16,12 +17,29 @@ export function defaultCheckoutComponentsConfig() {
     featureModules: {
       [CHECKOUT_B2B_FEATURE]: {
         cmsComponents: [
+          // b2b cms components
           'CheckoutCostCenterComponent',
           'CheckoutPaymentType',
+
+          // base cms components
           'CheckoutReviewOrder',
           'CheckoutShippingAddress',
+          'CheckoutOrchestrator',
+          'CheckoutOrderSummary',
+          'CheckoutProgress',
+          'CheckoutProgressMobileBottom',
+          'CheckoutProgressMobileTop',
+          'CheckoutDeliveryMode',
+          'CheckoutPaymentDetails',
+          'CheckoutPlaceOrder',
+          'GuestCheckoutLoginComponent',
+          'OrderConfirmationThankMessageComponent',
+          'OrderConfirmationItemsComponent',
+          'OrderConfirmationTotalsComponent',
+          'OrderConfirmationOverviewComponent',
         ],
       },
+      [CHECKOUT_FEATURE]: CHECKOUT_B2B_FEATURE,
       // by default core is bundled together with components
       [CHECKOUT_B2B_CORE_FEATURE]: CHECKOUT_B2B_FEATURE,
     },

--- a/feature-libs/checkout/base/root/checkout-root.module.ts
+++ b/feature-libs/checkout/base/root/checkout-root.module.ts
@@ -14,27 +14,29 @@ import { CHECKOUT_CORE_FEATURE, CHECKOUT_FEATURE } from './feature-name';
 import { interceptors } from './http-interceptors/index';
 import { OrderConfirmationOrderEntriesContext } from './pages/order-confirmation-order-entries-context';
 
+export const CHECKOUT_BASE_CMS_COMPONENTS: string[] = [
+  'CheckoutOrchestrator',
+  'CheckoutOrderSummary',
+  'CheckoutProgress',
+  'CheckoutProgressMobileBottom',
+  'CheckoutProgressMobileTop',
+  'CheckoutDeliveryMode',
+  'CheckoutPaymentDetails',
+  'CheckoutPlaceOrder',
+  'CheckoutReviewOrder',
+  'CheckoutShippingAddress',
+  'GuestCheckoutLoginComponent',
+  'OrderConfirmationThankMessageComponent',
+  'OrderConfirmationItemsComponent',
+  'OrderConfirmationTotalsComponent',
+  'OrderConfirmationOverviewComponent',
+];
+
 export function defaultCheckoutComponentsConfig() {
   const config: CmsConfig = {
     featureModules: {
       [CHECKOUT_FEATURE]: {
-        cmsComponents: [
-          'CheckoutOrchestrator',
-          'CheckoutOrderSummary',
-          'CheckoutProgress',
-          'CheckoutProgressMobileBottom',
-          'CheckoutProgressMobileTop',
-          'CheckoutDeliveryMode',
-          'CheckoutPaymentDetails',
-          'CheckoutPlaceOrder',
-          'CheckoutReviewOrder',
-          'CheckoutShippingAddress',
-          'GuestCheckoutLoginComponent',
-          'OrderConfirmationThankMessageComponent',
-          'OrderConfirmationItemsComponent',
-          'OrderConfirmationTotalsComponent',
-          'OrderConfirmationOverviewComponent',
-        ],
+        cmsComponents: CHECKOUT_BASE_CMS_COMPONENTS,
         dependencies: [CART_FEATURE],
       },
       // by default core is bundled together with components

--- a/feature-libs/checkout/scheduled-replenishment/checkout-scheduled-replenishment.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/checkout-scheduled-replenishment.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
+import { CheckoutB2BModule } from '@spartacus/checkout/b2b';
 import { CheckoutScheduledReplenishmentComponentsModule } from '@spartacus/checkout/scheduled-replenishment/components';
 import { CheckoutScheduledReplenishmentCoreModule } from '@spartacus/checkout/scheduled-replenishment/core';
 import { CheckoutScheduledReplenishmentOccModule } from '@spartacus/checkout/scheduled-replenishment/occ';
 
 @NgModule({
   imports: [
+    CheckoutB2BModule,
     CheckoutScheduledReplenishmentComponentsModule,
     CheckoutScheduledReplenishmentCoreModule,
     CheckoutScheduledReplenishmentOccModule,

--- a/feature-libs/checkout/scheduled-replenishment/root/checkout-scheduled-replenishment-root.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/root/checkout-scheduled-replenishment-root.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import {
   CheckoutB2BRootModule,
+  CHECKOUT_B2B_CMS_COMPONENTS,
   CHECKOUT_B2B_FEATURE,
 } from '@spartacus/checkout/b2b/root';
 import {
@@ -15,39 +16,20 @@ import {
   CHECKOUT_SCHEDULED_REPLENISHMENT_FEATURE,
 } from './feature-name';
 
+export const CHECKOUT_SCHEDULED_REPLENISHMENT_CMS_COMPONENTS: string[] = [
+  ...CHECKOUT_B2B_CMS_COMPONENTS,
+  'CheckoutScheduleReplenishmentOrder',
+  'ReplenishmentConfirmationMessageComponent',
+  'ReplenishmentConfirmationOverviewComponent',
+  'ReplenishmentConfirmationItemsComponent',
+  'ReplenishmentConfirmationTotalsComponent',
+];
+
 export function defaultCheckoutComponentsConfig() {
   const config: CmsConfig = {
     featureModules: {
       [CHECKOUT_SCHEDULED_REPLENISHMENT_FEATURE]: {
-        cmsComponents: [
-          // scheduled replenishment cms components
-          'CheckoutScheduleReplenishmentOrder',
-          'ReplenishmentConfirmationMessageComponent',
-          'ReplenishmentConfirmationOverviewComponent',
-          'ReplenishmentConfirmationItemsComponent',
-          'ReplenishmentConfirmationTotalsComponent',
-
-          // b2b cms components
-          'CheckoutCostCenterComponent',
-          'CheckoutPaymentType',
-
-          // base cms components
-          'CheckoutReviewOrder',
-          'CheckoutShippingAddress',
-          'CheckoutOrchestrator',
-          'CheckoutOrderSummary',
-          'CheckoutProgress',
-          'CheckoutProgressMobileBottom',
-          'CheckoutProgressMobileTop',
-          'CheckoutDeliveryMode',
-          'CheckoutPaymentDetails',
-          'CheckoutPlaceOrder',
-          'GuestCheckoutLoginComponent',
-          'OrderConfirmationThankMessageComponent',
-          'OrderConfirmationItemsComponent',
-          'OrderConfirmationTotalsComponent',
-          'OrderConfirmationOverviewComponent',
-        ],
+        cmsComponents: CHECKOUT_SCHEDULED_REPLENISHMENT_CMS_COMPONENTS,
       },
       [CHECKOUT_B2B_FEATURE]: CHECKOUT_SCHEDULED_REPLENISHMENT_FEATURE,
       // by default core is bundled together with components

--- a/feature-libs/checkout/scheduled-replenishment/root/checkout-scheduled-replenishment-root.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/root/checkout-scheduled-replenishment-root.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { CHECKOUT_B2B_FEATURE } from '@spartacus/checkout/b2b/root';
 import {
   CmsConfig,
   provideDefaultConfig,
@@ -16,15 +17,36 @@ export function defaultCheckoutComponentsConfig() {
     featureModules: {
       [CHECKOUT_SCHEDULED_REPLENISHMENT_FEATURE]: {
         cmsComponents: [
-          'CheckoutPlaceOrder',
+          // scheduled replenishment cms components
           'CheckoutScheduleReplenishmentOrder',
-          'OrderConfirmationThankMessageComponent',
           'ReplenishmentConfirmationMessageComponent',
           'ReplenishmentConfirmationOverviewComponent',
           'ReplenishmentConfirmationItemsComponent',
           'ReplenishmentConfirmationTotalsComponent',
+
+          // b2b cms components
+          'CheckoutCostCenterComponent',
+          'CheckoutPaymentType',
+
+          // base cms components
+          'CheckoutReviewOrder',
+          'CheckoutShippingAddress',
+          'CheckoutOrchestrator',
+          'CheckoutOrderSummary',
+          'CheckoutProgress',
+          'CheckoutProgressMobileBottom',
+          'CheckoutProgressMobileTop',
+          'CheckoutDeliveryMode',
+          'CheckoutPaymentDetails',
+          'CheckoutPlaceOrder',
+          'GuestCheckoutLoginComponent',
+          'OrderConfirmationThankMessageComponent',
+          'OrderConfirmationItemsComponent',
+          'OrderConfirmationTotalsComponent',
+          'OrderConfirmationOverviewComponent',
         ],
       },
+      [CHECKOUT_B2B_FEATURE]: CHECKOUT_SCHEDULED_REPLENISHMENT_FEATURE,
       // by default core is bundled together with components
       [CHECKOUT_SCHEDULED_REPLENISHMENT_CORE_FEATURE]:
         CHECKOUT_SCHEDULED_REPLENISHMENT_FEATURE,

--- a/feature-libs/checkout/scheduled-replenishment/root/checkout-scheduled-replenishment-root.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/root/checkout-scheduled-replenishment-root.module.ts
@@ -1,5 +1,8 @@
 import { NgModule } from '@angular/core';
-import { CHECKOUT_B2B_FEATURE } from '@spartacus/checkout/b2b/root';
+import {
+  CheckoutB2BRootModule,
+  CHECKOUT_B2B_FEATURE,
+} from '@spartacus/checkout/b2b/root';
 import {
   CmsConfig,
   provideDefaultConfig,
@@ -56,7 +59,7 @@ export function defaultCheckoutComponentsConfig() {
 }
 
 @NgModule({
-  imports: [CheckoutScheduledReplenishmentEventModule],
+  imports: [CheckoutB2BRootModule, CheckoutScheduledReplenishmentEventModule],
   providers: [
     provideDefaultConfig(defaultCheckoutScheduledReplenishmentRoutingConfig),
     provideDefaultConfigFactory(defaultCheckoutComponentsConfig),

--- a/projects/storefrontapp/src/app/spartacus/features/checkout-b2b-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/checkout-b2b-feature.module.ts
@@ -11,11 +11,10 @@ import {
   checkoutTranslationChunksConfig,
   checkoutTranslations,
 } from '@spartacus/checkout/base/assets';
-import { CheckoutRootModule } from '@spartacus/checkout/base/root';
 import { provideConfig } from '@spartacus/core';
 
 @NgModule({
-  imports: [CheckoutRootModule, CheckoutB2BRootModule],
+  imports: [CheckoutB2BRootModule],
   providers: [
     provideConfig({
       i18n: {

--- a/projects/storefrontapp/src/app/spartacus/features/checkout-b2b-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/checkout-b2b-feature.module.ts
@@ -7,18 +7,27 @@ import {
   CheckoutB2BRootModule,
   CHECKOUT_B2B_FEATURE,
 } from '@spartacus/checkout/b2b/root';
-import { CHECKOUT_FEATURE } from '@spartacus/checkout/base/root';
+import {
+  checkoutTranslationChunksConfig,
+  checkoutTranslations,
+} from '@spartacus/checkout/base/assets';
+import { CheckoutRootModule } from '@spartacus/checkout/base/root';
 import { provideConfig } from '@spartacus/core';
 
 @NgModule({
-  imports: [CheckoutB2BRootModule],
+  imports: [CheckoutRootModule, CheckoutB2BRootModule],
   providers: [
+    provideConfig({
+      i18n: {
+        resources: checkoutTranslations,
+        chunks: checkoutTranslationChunksConfig,
+      },
+    }),
     provideConfig({
       featureModules: {
         [CHECKOUT_B2B_FEATURE]: {
           module: () =>
             import('@spartacus/checkout/b2b').then((m) => m.CheckoutB2BModule),
-          dependencies: [CHECKOUT_FEATURE],
         },
       },
       i18n: {

--- a/projects/storefrontapp/src/app/spartacus/features/checkout-scheduled-replenishment-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/checkout-scheduled-replenishment-feature.module.ts
@@ -1,11 +1,9 @@
 import { NgModule } from '@angular/core';
 import { checkoutB2BTranslations } from '@spartacus/checkout/b2b/assets';
-import { CheckoutB2BRootModule } from '@spartacus/checkout/b2b/root';
 import {
   checkoutTranslationChunksConfig,
   checkoutTranslations,
 } from '@spartacus/checkout/base/assets';
-import { CheckoutRootModule } from '@spartacus/checkout/base/root';
 import { checkoutScheduledReplenishmentTranslations } from '@spartacus/checkout/scheduled-replenishment/assets';
 import {
   CheckoutScheduledReplenishmentRootModule,
@@ -14,11 +12,7 @@ import {
 import { provideConfig } from '@spartacus/core';
 
 @NgModule({
-  imports: [
-    CheckoutRootModule,
-    CheckoutB2BRootModule,
-    CheckoutScheduledReplenishmentRootModule,
-  ],
+  imports: [CheckoutScheduledReplenishmentRootModule],
   providers: [
     provideConfig({
       i18n: {

--- a/projects/storefrontapp/src/app/spartacus/features/checkout-scheduled-replenishment-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/checkout-scheduled-replenishment-feature.module.ts
@@ -1,10 +1,16 @@
 import { NgModule } from '@angular/core';
-import { checkoutB2BTranslations } from '@spartacus/checkout/b2b/assets';
+import {
+  checkoutB2BTranslationChunksConfig,
+  checkoutB2BTranslations,
+} from '@spartacus/checkout/b2b/assets';
 import {
   checkoutTranslationChunksConfig,
   checkoutTranslations,
 } from '@spartacus/checkout/base/assets';
-import { checkoutScheduledReplenishmentTranslations } from '@spartacus/checkout/scheduled-replenishment/assets';
+import {
+  checkoutScheduledReplenishmentTranslationChunksConfig,
+  checkoutScheduledReplenishmentTranslations,
+} from '@spartacus/checkout/scheduled-replenishment/assets';
 import {
   CheckoutScheduledReplenishmentRootModule,
   CHECKOUT_SCHEDULED_REPLENISHMENT_FEATURE,
@@ -23,7 +29,7 @@ import { provideConfig } from '@spartacus/core';
     provideConfig({
       i18n: {
         resources: checkoutB2BTranslations,
-        chunks: checkoutTranslationChunksConfig,
+        chunks: checkoutB2BTranslationChunksConfig,
       },
     }),
     provideConfig({
@@ -37,7 +43,7 @@ import { provideConfig } from '@spartacus/core';
       },
       i18n: {
         resources: checkoutScheduledReplenishmentTranslations,
-        chunks: checkoutTranslationChunksConfig,
+        chunks: checkoutScheduledReplenishmentTranslationChunksConfig,
       },
     }),
   ],

--- a/projects/storefrontapp/src/app/spartacus/features/checkout-scheduled-replenishment-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/checkout-scheduled-replenishment-feature.module.ts
@@ -1,6 +1,11 @@
 import { NgModule } from '@angular/core';
-import { CHECKOUT_B2B_FEATURE } from '@spartacus/checkout/b2b/root';
-import { checkoutTranslationChunksConfig } from '@spartacus/checkout/base/assets';
+import { checkoutB2BTranslations } from '@spartacus/checkout/b2b/assets';
+import { CheckoutB2BRootModule } from '@spartacus/checkout/b2b/root';
+import {
+  checkoutTranslationChunksConfig,
+  checkoutTranslations,
+} from '@spartacus/checkout/base/assets';
+import { CheckoutRootModule } from '@spartacus/checkout/base/root';
 import { checkoutScheduledReplenishmentTranslations } from '@spartacus/checkout/scheduled-replenishment/assets';
 import {
   CheckoutScheduledReplenishmentRootModule,
@@ -9,8 +14,24 @@ import {
 import { provideConfig } from '@spartacus/core';
 
 @NgModule({
-  imports: [CheckoutScheduledReplenishmentRootModule],
+  imports: [
+    CheckoutRootModule,
+    CheckoutB2BRootModule,
+    CheckoutScheduledReplenishmentRootModule,
+  ],
   providers: [
+    provideConfig({
+      i18n: {
+        resources: checkoutTranslations,
+        chunks: checkoutTranslationChunksConfig,
+      },
+    }),
+    provideConfig({
+      i18n: {
+        resources: checkoutB2BTranslations,
+        chunks: checkoutTranslationChunksConfig,
+      },
+    }),
     provideConfig({
       featureModules: {
         [CHECKOUT_SCHEDULED_REPLENISHMENT_FEATURE]: {
@@ -18,7 +39,6 @@ import { provideConfig } from '@spartacus/core';
             import('@spartacus/checkout/scheduled-replenishment').then(
               (m) => m.CheckoutScheduledReplenishmentModule
             ),
-          dependencies: [CHECKOUT_B2B_FEATURE],
         },
       },
       i18n: {

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -56,7 +56,6 @@ import { BulkPricingFeatureModule } from './features/bulk-pricing-feature.module
 import { CartFeatureModule } from './features/cart-feature.module';
 import { CdcFeatureModule } from './features/cdc-feature.module';
 import { CdsFeatureModule } from './features/cds-feature.module';
-import { CheckoutB2BFeatureModule } from './features/checkout-b2b-feature.module';
 import { CheckoutFeatureModule } from './features/checkout-feature.module';
 import { CheckoutOldFeatureModule } from './features/checkout-old-feature.module';
 import { CheckoutScheduledReplenishmentFeatureModule } from './features/checkout-scheduled-replenishment-feature.module';
@@ -93,10 +92,7 @@ if (environment.oldCheckout) {
   CheckoutFeature = CheckoutOldFeatureModule;
 }
 if (environment.b2b && !environment.oldCheckout) {
-  featureModules.push(
-    CheckoutB2BFeatureModule,
-    CheckoutScheduledReplenishmentFeatureModule
-  );
+  CheckoutFeature = CheckoutScheduledReplenishmentFeatureModule;
 }
 
 if (environment.cdc) {
@@ -186,7 +182,6 @@ if (environment.digitalPayments) {
     /************************* Feature libraries *************************/
     UserFeatureModule,
     CartFeatureModule,
-    CheckoutFeature,
     WishListFeatureModule,
     AsmFeatureModule,
     StorefinderFeatureModule,
@@ -200,6 +195,7 @@ if (environment.digitalPayments) {
     ImportExportFeatureModule,
     ProductConfiguratorTextfieldFeatureModule,
     ImageZoomFeatureModule,
+    CheckoutFeature,
     ...featureModules,
   ],
 })


### PR DESCRIPTION
Bundle all checkout variants into one lazy loadable chunk.