### PR TITLE
[Spartacon] PoC the prefetching next page data in PLP and store in the service worker

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -106,7 +106,7 @@
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true,
-              "serviceWorker": false,
+              "serviceWorker": true,
               "tsConfig": "projects/storefrontapp/tsconfig.app.prod.json"
             },
             "development": {

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-list-component.service.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-list-component.service.spec.ts
@@ -108,7 +108,7 @@ describe('ProductListComponentService', () => {
     };
 
     let activatedRouteState: ActivatedRouterStateSnapshot;
-    const subscription: Subscription = service['searchByRouting$'].subscribe(
+    const subscription: Subscription = service['searchCriteria$'].subscribe(
       (res) => (activatedRouteState = res)
     );
 

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-list.component.html
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-list.component.html
@@ -26,6 +26,7 @@
                   [attr.aria-label]="
                     'productList.productSearchPagination' | cxTranslate
                   "
+                  [cxPlpPrefetchNextPage]="'onHover'"
                 >
                   <cx-pagination
                     [pagination]="model.pagination"
@@ -73,7 +74,7 @@
               ></cx-product-scroll>
             </ng-template>
           </div>
-          <div class="cx-sorting bottom">
+          <div class="cx-sorting bottom" [cxPlpPrefetchNextPage]="'inViewport'">
             <div class="row">
               <label
                 class="form-group cx-sort-dropdown col-12 col-lg-4 mr-auto"

--- a/projects/storefrontlib/cms-components/product/product-list/product-list.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-list.module.ts
@@ -18,6 +18,7 @@ import {
   SpinnerModule,
   StarRatingModule,
 } from '../../../shared/index';
+import { PlpPrefetchNextPageModule } from '../../../spartacon/plp-prefetch-next-page.module';
 import { AddToCartModule } from '../../cart/index';
 import { IconModule } from '../../misc/icon/index';
 import { defaultViewConfig } from '../config/default-view-config';
@@ -43,6 +44,8 @@ import { ProductViewComponent } from './product-view/product-view.component';
     InfiniteScrollModule,
     FeaturesConfigModule,
     OutletModule,
+
+    PlpPrefetchNextPageModule,
   ],
   providers: [
     provideDefaultConfig(<ViewConfig>defaultViewConfig),

--- a/projects/storefrontlib/cms-structure/pwa/ngsw-config.json
+++ b/projects/storefrontlib/cms-structure/pwa/ngsw-config.json
@@ -26,6 +26,17 @@
         "maxAge": "1d",
         "strategy": "performance"
       }
+    },
+    {
+      "name": "productSearch",
+      "urls": [
+        "*/products/search?fields*"
+      ],
+      "cacheConfig": {
+        "maxSize": 20,
+        "maxAge": "1d",
+        "strategy": "performance"
+      }
     }
   ]
 }

--- a/projects/storefrontlib/public_api.ts
+++ b/projects/storefrontlib/public_api.ts
@@ -14,6 +14,9 @@ export * from './shared/index';
 export * from './utils/index';
 export * from './base-storefront.module';
 
+// Spartacon
+export * from './spartacon/index';
+
 /** AUGMENTABLE_TYPES_START */
 export { BREAKPOINT } from './layout/config/layout-config';
 export { LAUNCH_CALLER } from './layout/launch-dialog/config/launch-config';

--- a/projects/storefrontlib/spartacon/index.ts
+++ b/projects/storefrontlib/spartacon/index.ts
@@ -1,0 +1,1 @@
+export * from './plp-prefetch-next-page.directive';

--- a/projects/storefrontlib/spartacon/plp-prefetch-next-page.directive.ts
+++ b/projects/storefrontlib/spartacon/plp-prefetch-next-page.directive.ts
@@ -1,0 +1,107 @@
+import {
+  Directive,
+  ElementRef,
+  HostListener,
+  Input,
+  NgZone,
+} from '@angular/core';
+import { ProductSearchConnector } from '@spartacus/core';
+import { take } from 'rxjs/operators';
+import { ProductListComponentService } from '../cms-components/product/product-list/container/product-list-component.service';
+
+// @NgModule({
+//   declarations: [PlpPrefetchNextPageDirective],
+//   exports: [PlpPrefetchNextPageDirective],
+// })
+// export class PlpPrefetchNextPageModule {}
+
+@Directive({ selector: '[cxPlpPrefetchNextPage]' })
+export class PlpPrefetchNextPageDirective {
+  constructor(
+    protected elementRef: ElementRef,
+    protected ngZone: NgZone,
+    protected plpComponentService: ProductListComponentService,
+    protected productSearchConnector: ProductSearchConnector
+  ) {}
+
+  protected observer: IntersectionObserver;
+
+  // eslint-disable-next-line @angular-eslint/use-lifecycle-interface
+  ngOnDestroy() {
+    this.observer?.unobserve(this.elementRef.nativeElement);
+  }
+
+  // eslint-disable-next-line @angular-eslint/use-lifecycle-interface
+  ngOnInit() {
+    if (this.prefetchStrategy === 'inViewport') {
+      this.initIntersectionObserver();
+    }
+  }
+
+  protected initIntersectionObserver() {
+    const callback = (entries: any[]) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          this.ngZone.run(() => this.preload());
+        }
+      });
+    };
+
+    this.ngZone.runOutsideAngular(() => {
+      this.observer = new IntersectionObserver(callback, {
+        root: null,
+        rootMargin: '500px',
+        threshold: 0,
+      });
+    });
+
+    this.observer.observe(this.elementRef.nativeElement);
+  }
+
+  searchCriteria$ = this.plpComponentService.searchCriteria$;
+
+  private preloadedSearchCriteria = new Map<string, boolean>();
+
+  // TODO: make it driven by intersection observer
+
+  /**
+   * Strategy, when to preload
+   */
+  @Input('cxPlpPrefetchNextPage')
+  prefetchStrategy: 'onHover' | 'inViewport' = 'onHover';
+
+  @HostListener('mouseenter')
+  onMouseEnter() {
+    if (this.prefetchStrategy === 'onHover') {
+      this.preload();
+    }
+  }
+
+  preload() {
+    console.log('⏰ start preloading the next page data!');
+
+    this.plpComponentService.searchCriteria$
+      .pipe(take(1))
+      .subscribe((criteria) => {
+        const key = JSON.stringify(criteria);
+        if (this.preloadedSearchCriteria.has(key)) {
+          return;
+        }
+        this.preloadedSearchCriteria.set(key, true);
+
+        // SPIKE - SORT CODE SHOULD ALSO BE RETRIEVED
+        const { pageSize, currentPage } = criteria;
+
+        this.productSearchConnector
+          .search(criteria.query || '', {
+            // CAUTION! query params order is important for caching keys!
+            // TO BE VERIFIED!
+            currentPage: Number(currentPage || 0) + 1, // caution, currentPage is a string
+            pageSize,
+          })
+          .subscribe(() => {
+            console.log('😌 next page data preloaded!');
+          }); // SPIKE TODO IMPROVE
+      });
+  }
+}

--- a/projects/storefrontlib/spartacon/plp-prefetch-next-page.module.ts
+++ b/projects/storefrontlib/spartacon/plp-prefetch-next-page.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { PlpPrefetchNextPageDirective } from './plp-prefetch-next-page.directive';
+
+@NgModule({
+  declarations: [PlpPrefetchNextPageDirective],
+  exports: [PlpPrefetchNextPageDirective],
+})
+export class PlpPrefetchNextPageModule {}


### PR DESCRIPTION
This is a PoC that helps making INSTANT navigations to the next PLP page (in terms paginated PLP data).

It triggers a call for next page's PLP data when scrolling down and being close to the bottom of the page. We leverage the service worker as a http cache. Eventually when the user scrolls to the bottom and doesn't find what looked for, then clicks the next page's number in the pagination component. The response is retrieved instantly from the service worker's http cache, so the navigation to the next page is instant! 

The additional benefit of using service worker's cache is that the cache data is available offline, so the user can go back and forth in the pagination, reusing the paginated data stored in the cache.

Caveats:
- ngsw config is in the control of customers (but not our library). Moreover it's a static file, so we cannot control what's cached from our lib's logic. (At the same time it's fair enough, because we don't like to make decisions in behalf of customers what to cache and how long 😉 )

Possible improvements:
- prefetch the images (of correct size, according to the display size) for the first few items in the next page's data -> so also images appear instantly 

### How to run
#### Prerequisites
The service worker might not work properly when the OCC server doesn't have the proper SSL cert. To mitigate it, I've configured a local proxy over our dev OCC server, using the `http-proxy` package:
```
npx http-proxy -p 4500 -P --no-verify https://40.76.109.9:9002
```
And I configured in the app (cmd-env) the occ baseUrl to http://localhost:4500 (see PR code)

#### To the point...
The service worker can be run only in the production build of the app. So we will serve the app using pm2 (alternatively you can use `http-server` npm package).
```
yarn build:libs
yarn build
pm2 start --name "app" serve -- dist/storefrontapp --single -p 8080 # serves Single Page App (with deep path rewrites to "/")
```
 - open http://127.0.0.1:8080/electronics-spa/en/USD/Brands/ 
 - (open the console in dev tools to observe the debug prefetching messages)
 - scroll down the product list
 - click the next page's number in the bottom pagination component
 - observe the instant page transition
 - (Note: images might not appear instantly, unless you already have already visited (loaded) them before and are taken from the ordinary browser's cache)  

### How to clear
```
pm2 delete app
```
and click the button `[Click site data]` in the `Chrome DevTools -> tab [Application] -> left menu [Storage]` to get rid of the service worker, cached app, etc. Otherwise, the next time you rebuild your app and refresh the page, you might get the stale version of the app.
<img width="794" alt="image" src="https://user-images.githubusercontent.com/4001059/146538400-d8763335-3eb2-4ebf-b40f-cf993d92ed78.png">
