### PR TITLE
chore: specify metadata source in lookup.

### DIFF
--- a/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/scene-node-to-product-lookup.service.spec.ts
+++ b/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/scene-node-to-product-lookup.service.spec.ts
@@ -127,12 +127,12 @@ const validateGetNodesParameters = (
   if (expand) {
     expect(expand.length).toBe(2);
     expect(expand[0]).toBe('hotspot');
-    expect(expand[1]).toBe('meta.SpareParts.ProductCode');
+    expect(expand[1]).toBe('metadata[CommerceCloud].SpareParts.ProductCode');
   }
   expect(filter).toBeTruthy();
   if (filter) {
     expect(filter.length).toBe(1);
-    expect(filter[0]).toBe('metadata.SpareParts.ProductCode');
+    expect(filter[0]).toBe('metadata[CommerceCloud].SpareParts.ProductCode');
   }
   expect(contentType).toBe('*');
 };

--- a/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/scene-node-to-product-lookup.service.ts
+++ b/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/scene-node-to-product-lookup.service.ts
@@ -66,8 +66,13 @@ export class SceneNodeToProductLookupService {
       .getNodes(
         sceneId,
         undefined,
-        ['hotspot', `meta.${this.usageId.category}.${this.usageId.keyName}`],
-        [`metadata.${this.usageId.category}.${this.usageId.keyName}`],
+        [
+          'hotspot',
+          `metadata[${this.usageId.source}].${this.usageId.category}.${this.usageId.keyName}`,
+        ],
+        [
+          `metadata[${this.usageId.source}].${this.usageId.category}.${this.usageId.keyName}`,
+        ],
         '*'
       )
       .pipe(

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.spec.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.spec.ts
@@ -98,7 +98,7 @@ describe('StorageV1Adapter', () => {
     it('should construct $filter query param', () => {
       sceneAdapter
         .getNodes('123', undefined, undefined, [
-          'meta.categoryNameValue.keyNameValue',
+          'metadata[sourceNameValue].categoryNameValue.keyNameValue',
           'name.nameValue',
         ])
         .subscribe((result) => {
@@ -109,7 +109,7 @@ describe('StorageV1Adapter', () => {
         (req) =>
           req.method === 'GET' &&
           req.url ===
-            'https://epd-acc-eu20-consumer.epdacc.cfapps.eu20.hana.ondemand.com/vis/public/storage/v1/scenes/123/nodes?$filter=meta.categoryNameValue.keyNameValue,name.nameValue'
+            'https://epd-acc-eu20-consumer.epdacc.cfapps.eu20.hana.ondemand.com/vis/public/storage/v1/scenes/123/nodes?$filter=metadata[sourceNameValue].categoryNameValue.keyNameValue,name.nameValue'
       );
 
       expect(mockReq.cancelled).toBeFalsy();


### PR DESCRIPTION
Using new syntax that is available in the 2111 release:
https://github.wdf.sap.corp/vis/storage-service/blob/e289d322c7ad34d72e0020cb6e76827b21a783b6/doc/VISTOR_Public.yaml#L7133