### PR TITLE
fix: Delivery mode infinite loop

### DIFF
--- a/feature-libs/checkout/b2b/components/checkout-shipping-address/checkout-shipping-address.component.html
+++ b/feature-libs/checkout/b2b/components/checkout-shipping-address/checkout-shipping-address.component.html
@@ -1,8 +1,8 @@
-<ng-container *ngIf="cards$ | async as cards">
-  <h2 class="cx-checkout-title d-none d-lg-block d-xl-block">
-    {{ 'checkoutAddress.shippingAddress' | cxTranslate }}
-  </h2>
-  <ng-container *ngIf="!shouldRedirect && !(isLoading$ | async); else loading">
+<h2 class="cx-checkout-title d-none d-lg-block d-xl-block">
+  {{ 'checkoutAddress.shippingAddress' | cxTranslate }}
+</h2>
+<ng-container *ngIf="cards$ | async as cards; else loading">
+  <ng-container *ngIf="!shouldRedirect && !(isUpdated$ | async); else loading">
     <ng-container
       *ngIf="
         isAccountPayment || (cards?.length && !addressFormOpened);
@@ -78,10 +78,10 @@
       </ng-template>
     </ng-template>
   </ng-container>
-
-  <ng-template #loading>
-    <div class="cx-spinner">
-      <cx-spinner></cx-spinner>
-    </div>
-  </ng-template>
 </ng-container>
+
+<ng-template #loading>
+  <div class="cx-spinner">
+    <cx-spinner></cx-spinner>
+  </div>
+</ng-template>

--- a/feature-libs/checkout/b2b/components/checkout-shipping-address/checkout-shipping-address.component.spec.ts
+++ b/feature-libs/checkout/b2b/components/checkout-shipping-address/checkout-shipping-address.component.spec.ts
@@ -41,8 +41,8 @@ class MockActiveCartService implements Partial<ActiveCartFacade> {
 class MockCheckoutDeliveryFacade
   implements Partial<CheckoutDeliveryAddressFacade>
 {
-  createAndSetAddress = createSpy();
-  setDeliveryAddress = createSpy();
+  createAndSetAddress = createSpy().and.returnValue(of());
+  setDeliveryAddress = createSpy().and.returnValue(of());
   getDeliveryAddressState(): Observable<QueryState<Address | undefined>> {
     return of({ loading: false, error: false, data: undefined });
   }
@@ -433,9 +433,7 @@ describe('B2BCheckoutShippingAddressComponent', () => {
     });
 
     it('should not display if existing addresses are loading', () => {
-      spyOn(userAddressService, 'getAddressesLoading').and.returnValue(
-        of(true)
-      );
+      component.isUpdated$ = of(true);
       spyOn(userAddressService, 'getAddresses').and.returnValue(of([]));
       fixture.detectChanges();
       expect(getCards().length).toEqual(0);
@@ -497,9 +495,7 @@ describe('B2BCheckoutShippingAddressComponent', () => {
     });
 
     it('should not render when existing addresses are loading', () => {
-      spyOn(userAddressService, 'getAddressesLoading').and.returnValue(
-        of(true)
-      );
+      component.isUpdated$ = of(true);
       spyOn(userAddressService, 'getAddresses').and.returnValue(of([]));
 
       fixture.detectChanges();
@@ -511,9 +507,7 @@ describe('B2BCheckoutShippingAddressComponent', () => {
     const getSpinner = () => fixture.debugElement.query(By.css('cx-spinner'));
 
     it('should render only when existing addresses are loading', () => {
-      spyOn(userAddressService, 'getAddressesLoading').and.returnValue(
-        of(true)
-      );
+      component.isUpdated$ = of(true);
       spyOn(userAddressService, 'getAddresses').and.returnValue(of([]));
 
       fixture.detectChanges();

--- a/feature-libs/checkout/b2b/components/checkout-shipping-address/checkout-shipping-address.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-shipping-address/checkout-shipping-address.component.ts
@@ -14,7 +14,10 @@ import {
   CheckoutShippingAddressComponent,
   CheckoutStepService,
 } from '@spartacus/checkout/base/components';
-import { CheckoutDeliveryAddressFacade } from '@spartacus/checkout/base/root';
+import {
+  CheckoutDeliveryAddressFacade,
+  CheckoutDeliveryModesFacade,
+} from '@spartacus/checkout/base/root';
 import {
   Address,
   TranslationService,
@@ -51,7 +54,8 @@ export class B2BCheckoutShippingAddressComponent
     protected checkoutStepService: CheckoutStepService,
     protected checkoutPaymentTypeFacade: CheckoutPaymentTypeFacade,
     protected checkoutCostCenterFacade: CheckoutCostCenterFacade,
-    protected userCostCenterService: UserCostCenterService
+    protected userCostCenterService: UserCostCenterService,
+    protected checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade
   ) {
     super(
       userAddressService,
@@ -59,7 +63,8 @@ export class B2BCheckoutShippingAddressComponent
       activatedRoute,
       translationService,
       activeCartFacade,
-      checkoutStepService
+      checkoutStepService,
+      checkoutDeliveryModesFacade
     );
   }
 

--- a/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.spec.ts
@@ -5,8 +5,8 @@ import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { DeliveryMode } from '@spartacus/cart/main/root';
 import { CheckoutDeliveryModesFacade } from '@spartacus/checkout/base/root';
-import { I18nTestingModule } from '@spartacus/core';
-import { of } from 'rxjs';
+import { CxEvent, EventService, I18nTestingModule } from '@spartacus/core';
+import { of, Subject } from 'rxjs';
 import { CheckoutConfigService } from '../services/checkout-config.service';
 import { CheckoutStepService } from '../services/checkout-step.service';
 import { CheckoutDeliveryModeComponent } from './checkout-delivery-mode.component';
@@ -37,6 +37,11 @@ class MockCheckoutStepService implements Partial<CheckoutStepService> {
   next = createSpy();
   back = createSpy();
   getBackBntText = createSpy().and.returnValue('common.back');
+}
+
+const mockEventStream$ = new Subject<CxEvent>();
+class MockEventService implements Partial<EventService> {
+  get = createSpy().and.returnValue(mockEventStream$.asObservable());
 }
 
 const mockActivatedRoute = {
@@ -83,6 +88,10 @@ describe('CheckoutDeliveryModeComponent', () => {
           {
             provide: CheckoutConfigService,
             useClass: MockCheckoutConfigService,
+          },
+          {
+            provide: EventService,
+            useClass: MockEventService,
           },
           { provide: ActivatedRoute, useValue: mockActivatedRoute },
         ],

--- a/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.spec.ts
@@ -5,8 +5,8 @@ import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { DeliveryMode } from '@spartacus/cart/main/root';
 import { CheckoutDeliveryModesFacade } from '@spartacus/checkout/base/root';
-import { CxEvent, EventService, I18nTestingModule } from '@spartacus/core';
-import { of, Subject } from 'rxjs';
+import { I18nTestingModule } from '@spartacus/core';
+import { of } from 'rxjs';
 import { CheckoutConfigService } from '../services/checkout-config.service';
 import { CheckoutStepService } from '../services/checkout-step.service';
 import { CheckoutDeliveryModeComponent } from './checkout-delivery-mode.component';
@@ -37,11 +37,6 @@ class MockCheckoutStepService implements Partial<CheckoutStepService> {
   next = createSpy();
   back = createSpy();
   getBackBntText = createSpy().and.returnValue('common.back');
-}
-
-const mockEventStream$ = new Subject<CxEvent>();
-class MockEventService implements Partial<EventService> {
-  get = createSpy().and.returnValue(mockEventStream$.asObservable());
 }
 
 const mockActivatedRoute = {
@@ -88,10 +83,6 @@ describe('CheckoutDeliveryModeComponent', () => {
           {
             provide: CheckoutConfigService,
             useClass: MockCheckoutConfigService,
-          },
-          {
-            provide: EventService,
-            useClass: MockEventService,
           },
           { provide: ActivatedRoute, useValue: mockActivatedRoute },
         ],

--- a/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.ts
@@ -7,17 +7,12 @@ import {
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { DeliveryMode } from '@spartacus/cart/main/root';
-import {
-  CheckoutDeliveryModesFacade,
-  DeliveryAddressCreatedEvent,
-} from '@spartacus/checkout/base/root';
-import { EventService } from '@spartacus/core';
-import { BehaviorSubject, combineLatest, Observable, Subscription } from 'rxjs';
+import { CheckoutDeliveryModesFacade } from '@spartacus/checkout/base/root';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import {
   distinctUntilChanged,
   filter,
   map,
-  startWith,
   withLatestFrom,
 } from 'rxjs/operators';
 import { CheckoutConfigService } from '../services/checkout-config.service';
@@ -31,8 +26,8 @@ import { CheckoutStepService } from '../services/checkout-step.service';
 export class CheckoutDeliveryModeComponent implements OnInit, OnDestroy {
   protected subscriptions = new Subscription();
 
+  selectedDeliveryModeCode$: Observable<string | undefined>;
   supportedDeliveryModes$: Observable<DeliveryMode[]>;
-  selectedDeliveryMode$: Observable<DeliveryMode>;
   continueButtonPressed = false;
 
   backBtnText = this.checkoutStepService.getBackBntText(this.activatedRoute);
@@ -50,8 +45,7 @@ export class CheckoutDeliveryModeComponent implements OnInit, OnDestroy {
     protected checkoutConfigService: CheckoutConfigService,
     protected activatedRoute: ActivatedRoute,
     protected checkoutStepService: CheckoutStepService,
-    protected checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade,
-    protected eventService: EventService
+    protected checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade
   ) {}
 
   ngOnInit(): void {
@@ -64,142 +58,34 @@ export class CheckoutDeliveryModeComponent implements OnInit, OnDestroy {
         })
       );
 
-    // this.subscriptions.add(
-    //   this.checkoutDeliveryModesFacade
-    //     .getSelectedDeliveryModeState()
-    //     .pipe(
-    //       filter((state) => !state.loading),
-    //       map((state) => state.data),
-    //       map((deliveryMode) => deliveryMode?.code),
-    //       withLatestFrom(
-    //         this.eventService
-    //           .get(DeliveryAddressCreatedEvent)
-    //           .pipe(startWith(undefined)),
-    //         this.supportedDeliveryModes$
-    //       )
-    //     )
-    //     .subscribe(
-    //       ([
-    //         selectedDeliveryModeCode,
-    //         deliveryAddressCreated,
-    //         supportedDeliveryModes,
-    //       ]) => {
-    //         console.log('new new stream', [
-    //           selectedDeliveryModeCode,
-    //           deliveryAddressCreated,
-    //           supportedDeliveryModes,
-    //         ]);
-
-    //         if (!selectedDeliveryModeCode || deliveryAddressCreated) {
-    //           console.log('support', supportedDeliveryModes);
-
-    //           selectedDeliveryModeCode =
-    //             this.checkoutConfigService.getPreferredDeliveryMode(
-    //               supportedDeliveryModes as DeliveryMode[]
-    //             );
-    //         }
-    //         if (selectedDeliveryModeCode) {
-    //           console.log('we have code');
-    //           this.mode.controls['deliveryModeId'].setValue(
-    //             selectedDeliveryModeCode
-    //           );
-    //           this.changeMode(selectedDeliveryModeCode);
-    //         }
-    //       }
-    //     )
-    // );
-
-    // this.subscriptions.add(
-    //   this.eventService
-    //     .get(DeliveryAddressCreatedEvent)
-    //     .pipe(
-    //       withLatestFrom(
-    //         this.checkoutDeliveryModesFacade
-    //           .getSelectedDeliveryModeState()
-    //           .pipe(
-    //             filter((state) => !state.loading),
-    //             map((state) => state.data),
-    //             map((deliveryMode) => deliveryMode?.code)
-    //           ),
-    //         this.supportedDeliveryModes$
-    //       )
-    //     )
-    //     .subscribe(
-    //       ([
-    //         deliveryAddressCreated,
-    //         selectedDeliveryModeCode,
-    //         supportedDeliveryModes,
-    //       ]) => {
-    //         console.log('new stream', [
-    //           deliveryAddressCreated,
-    //           selectedDeliveryModeCode,
-    //           supportedDeliveryModes,
-    //         ]);
-
-    //         if (deliveryAddressCreated || !selectedDeliveryModeCode) {
-    //           console.log('support', supportedDeliveryModes);
-
-    //           selectedDeliveryModeCode =
-    //             this.checkoutConfigService.getPreferredDeliveryMode(
-    //               supportedDeliveryModes as DeliveryMode[]
-    //             );
-    //         }
-    //         if (selectedDeliveryModeCode) {
-    //           console.log('we have code');
-    //           this.mode.controls['deliveryModeId'].setValue(
-    //             selectedDeliveryModeCode
-    //           );
-    //           this.changeMode(selectedDeliveryModeCode);
-    //         }
-    //       }
-    //     )
-    // );
+    this.selectedDeliveryModeCode$ = this.checkoutDeliveryModesFacade
+      .getSelectedDeliveryModeState()
+      .pipe(
+        filter((state) => !state.loading),
+        map((state) => state.data),
+        map((deliveryMode) => deliveryMode?.code)
+      );
 
     this.subscriptions.add(
-      combineLatest([
-        this.supportedDeliveryModes$,
-        this.eventService
-          .get(DeliveryAddressCreatedEvent)
-          .pipe(startWith(undefined)),
-      ])
-        .pipe(
-          withLatestFrom(
-            this.checkoutDeliveryModesFacade
-              .getSelectedDeliveryModeState()
-              .pipe(
-                filter((state) => !state.loading),
-                map((state) => state.data),
-                map((deliveryMode) => deliveryMode?.code)
-              )
-          )
-        )
-        .subscribe(
-          ([[supportedDeliveryModes, deliveryAddressCreated], code]) => {
-            console.log(
-              'supported',
-              supportedDeliveryModes,
-              deliveryAddressCreated,
-              code
-            );
-            if (
-              !(
-                code &&
-                !!supportedDeliveryModes.find(
-                  (deliveryMode) => deliveryMode.code === code
-                )
-              ) ||
-              deliveryAddressCreated
-            ) {
-              code = this.checkoutConfigService.getPreferredDeliveryMode(
-                supportedDeliveryModes
+      this.supportedDeliveryModes$
+        .pipe(withLatestFrom(this.selectedDeliveryModeCode$))
+        .subscribe(([deliveryModes, code]) => {
+          if (
+            !(
+              code &&
+              !!deliveryModes.find((deliveryMode) => deliveryMode.code === code)
+            )
+          ) {
+            code =
+              this.checkoutConfigService.getPreferredDeliveryMode(
+                deliveryModes
               );
-            }
-            if (code) {
-              this.mode.controls['deliveryModeId'].setValue(code);
-              this.changeMode(code);
-            }
           }
-        )
+          if (code) {
+            this.mode.controls['deliveryModeId'].setValue(code);
+            this.changeMode(code);
+          }
+        })
     );
   }
 

--- a/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.html
+++ b/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.html
@@ -1,7 +1,7 @@
-<ng-container *ngIf="cards$ | async as cards">
-  <h2 class="cx-checkout-title d-none d-lg-block d-xl-block">
-    {{ 'checkoutAddress.shippingAddress' | cxTranslate }}
-  </h2>
+<h2 class="cx-checkout-title d-none d-lg-block d-xl-block">
+  {{ 'checkoutAddress.shippingAddress' | cxTranslate }}
+</h2>
+<ng-container *ngIf="cards$ | async as cards; else loading">
   <ng-container *ngIf="!shouldRedirect && !(isUpdated$ | async); else loading">
     <ng-container
       *ngIf="cards?.length && !addressFormOpened; else newAddressForm"
@@ -75,10 +75,10 @@
       </ng-template>
     </ng-template>
   </ng-container>
-
-  <ng-template #loading>
-    <div class="cx-spinner">
-      <cx-spinner></cx-spinner>
-    </div>
-  </ng-template>
 </ng-container>
+
+<ng-template #loading>
+  <div class="cx-spinner">
+    <cx-spinner></cx-spinner>
+  </div>
+</ng-template>

--- a/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.html
+++ b/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.html
@@ -2,7 +2,7 @@
   <h2 class="cx-checkout-title d-none d-lg-block d-xl-block">
     {{ 'checkoutAddress.shippingAddress' | cxTranslate }}
   </h2>
-  <ng-container *ngIf="!shouldRedirect && !(isLoading$ | async); else loading">
+  <ng-container *ngIf="!shouldRedirect && !(isUpdated$ | async); else loading">
     <ng-container
       *ngIf="cards?.length && !addressFormOpened; else newAddressForm"
     >

--- a/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.spec.ts
@@ -28,8 +28,8 @@ class MockActiveCartService implements Partial<ActiveCartFacade> {
 class MockCheckoutDeliveryAddressFacade
   implements Partial<CheckoutDeliveryAddressFacade>
 {
-  createAndSetAddress = createSpy();
-  setDeliveryAddress = createSpy();
+  createAndSetAddress = createSpy().and.returnValue(of());
+  setDeliveryAddress = createSpy().and.returnValue(of());
   getDeliveryAddressState = createSpy().and.returnValue(
     of({ loading: false, error: false, data: undefined })
   );
@@ -308,10 +308,8 @@ describe('CheckoutShippingAddressComponent', () => {
       expect(getCards().length).toEqual(0);
     });
 
-    it('should not display if existng addresses are loading', () => {
-      userAddressService.getAddressesLoading = createSpy().and.returnValue(
-        of(true)
-      );
+    it('should not display if existing addresses are loading', () => {
+      component.isUpdated$ = of(true);
       userAddressService.getAddresses = createSpy().and.returnValue(of([]));
       fixture.detectChanges();
       expect(getCards().length).toEqual(0);
@@ -367,9 +365,7 @@ describe('CheckoutShippingAddressComponent', () => {
     });
 
     it('should not render when existing addresses are loading', () => {
-      userAddressService.getAddressesLoading = createSpy().and.returnValue(
-        of(true)
-      );
+      component.isUpdated$ = of(true);
       userAddressService.getAddresses = createSpy().and.returnValue(of([]));
 
       fixture.detectChanges();
@@ -381,9 +377,7 @@ describe('CheckoutShippingAddressComponent', () => {
     const getSpinner = () => fixture.debugElement.query(By.css('cx-spinner'));
 
     it('should render only when existing addresses are loading', () => {
-      userAddressService.getAddressesLoading = createSpy().and.returnValue(
-        of(true)
-      );
+      component.isUpdated$ = of(true);
       userAddressService.getAddresses = createSpy().and.returnValue(of([]));
 
       fixture.detectChanges();

--- a/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
+++ b/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
@@ -120,6 +120,14 @@ export class CheckoutShippingAddressComponent implements OnInit {
     }
   }
 
+  protected onSuccess(): void {
+    this.busy$.next(false);
+  }
+
+  protected onError(): void {
+    this.busy$.next(false);
+  }
+
   getCardContent(
     address: Address,
     selected: any,
@@ -148,8 +156,15 @@ export class CheckoutShippingAddressComponent implements OnInit {
   }
 
   selectAddress(address: Address): void {
-    // TODO:#checkout - put spinner
-    this.checkoutDeliveryAddressFacade.setDeliveryAddress(address);
+    this.busy$.next(true);
+    this.checkoutDeliveryAddressFacade.setDeliveryAddress(address).subscribe({
+      complete: () => {
+        this.onSuccess();
+      },
+      error: () => {
+        this.onError();
+      },
+    });
   }
 
   addAddress(address: Address | undefined): void {
@@ -159,12 +174,12 @@ export class CheckoutShippingAddressComponent implements OnInit {
         .createAndSetAddress(address)
         .subscribe({
           complete: () => {
-            this.busy$.next(false);
+            this.onSuccess();
             this.shouldRedirect = true;
           },
           error: () => {
-            this.busy$.next(false);
-            this.shouldRedirect = true;
+            this.onError();
+            this.shouldRedirect = false;
           },
         });
     } else {

--- a/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
+++ b/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
@@ -175,17 +175,14 @@ export class CheckoutShippingAddressComponent implements OnInit {
 
   selectAddress(address: Address): void {
     this.busy$.next(true);
-    this.checkoutDeliveryAddressFacade
-      .setDeliveryAddress(address)
-      .pipe(switchMap(() => this.prepareDeliveryModes$))
-      .subscribe({
-        complete: () => {
-          this.onSuccess();
-        },
-        error: () => {
-          this.onError();
-        },
-      });
+    this.checkoutDeliveryAddressFacade.setDeliveryAddress(address).subscribe({
+      complete: () => {
+        this.onSuccess();
+      },
+      error: () => {
+        this.onError();
+      },
+    });
   }
 
   addAddress(address: Address | undefined): void {

--- a/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
+++ b/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { ActiveCartFacade, DeliveryMode } from '@spartacus/cart/main/root';
+import { ActiveCartFacade } from '@spartacus/cart/main/root';
 import {
   CheckoutDeliveryAddressFacade,
   CheckoutDeliveryModesFacade,
@@ -8,13 +8,12 @@ import {
 import {
   Address,
   getLastValueSync,
-  QueryState,
   TranslationService,
   UserAddressService,
 } from '@spartacus/core';
 import { Card } from '@spartacus/storefront';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
-import { filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
 import { CheckoutStepService } from '../services/checkout-step.service';
 
 export interface CardWithAddress {
@@ -38,19 +37,6 @@ export class CheckoutShippingAddressComponent implements OnInit {
     this.busy$,
     this.userAddressService.getAddressesLoading(),
   ]).pipe(map(([busy, loading]) => busy || loading));
-
-  protected supportedDeliveryModes$: Observable<QueryState<DeliveryMode[]>> =
-    this.checkoutDeliveryModesFacade.getSupportedDeliveryModesState().pipe(
-      filter((state) => !state.loading),
-      take(1)
-    );
-
-  protected prepareDeliveryModes$: Observable<unknown> =
-    this.supportedDeliveryModes$.pipe(
-      switchMap(() =>
-        this.checkoutDeliveryModesFacade.clearCheckoutDeliveryMode()
-      )
-    );
 
   constructor(
     protected userAddressService: UserAddressService,
@@ -196,7 +182,11 @@ export class CheckoutShippingAddressComponent implements OnInit {
 
     this.checkoutDeliveryAddressFacade
       .createAndSetAddress(address)
-      .pipe(switchMap(() => this.prepareDeliveryModes$))
+      .pipe(
+        switchMap(() =>
+          this.checkoutDeliveryModesFacade.clearCheckoutDeliveryMode()
+        )
+      )
       .subscribe({
         complete: () => {
           this.onSuccess();

--- a/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
+++ b/feature-libs/checkout/base/components/checkout-shipping-address/checkout-shipping-address.component.ts
@@ -45,6 +45,13 @@ export class CheckoutShippingAddressComponent implements OnInit {
       take(1)
     );
 
+  protected prepareDeliveryModes$: Observable<unknown> =
+    this.supportedDeliveryModes$.pipe(
+      switchMap(() =>
+        this.checkoutDeliveryModesFacade.clearCheckoutDeliveryMode()
+      )
+    );
+
   constructor(
     protected userAddressService: UserAddressService,
     protected checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
@@ -170,7 +177,7 @@ export class CheckoutShippingAddressComponent implements OnInit {
     this.busy$.next(true);
     this.checkoutDeliveryAddressFacade
       .setDeliveryAddress(address)
-      .pipe(switchMap(() => this.supportedDeliveryModes$))
+      .pipe(switchMap(() => this.prepareDeliveryModes$))
       .subscribe({
         complete: () => {
           this.onSuccess();
@@ -192,7 +199,7 @@ export class CheckoutShippingAddressComponent implements OnInit {
 
     this.checkoutDeliveryAddressFacade
       .createAndSetAddress(address)
-      .pipe(switchMap(() => this.supportedDeliveryModes$))
+      .pipe(switchMap(() => this.prepareDeliveryModes$))
       .subscribe({
         complete: () => {
           this.onSuccess();

--- a/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.spec.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.spec.ts
@@ -134,13 +134,6 @@ describe(`CheckoutDeliveryAddressService`, () => {
       );
     });
 
-    it(`should call facade's setDeliveryAddress()`, () => {
-      spyOn(service, 'setDeliveryAddress').and.stub();
-      service.createAndSetAddress(mockAddress);
-
-      expect(service.setDeliveryAddress).toHaveBeenCalledWith(mockAddress);
-    });
-
     it(`should dispatch DeliveryAddressCreatedEvent event`, () => {
       service.createAndSetAddress(mockAddress);
 

--- a/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.ts
@@ -66,8 +66,7 @@ export class CheckoutDeliveryAddressService
                     },
                     DeliveryAddressCreatedEvent
                   )
-                ),
-                switchMap((address) => this.setDeliveryAddress(address))
+                )
               );
           })
         ),

--- a/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.ts
@@ -66,7 +66,8 @@ export class CheckoutDeliveryAddressService
                     },
                     DeliveryAddressCreatedEvent
                   )
-                )
+                ),
+                switchMap((address) => this.setDeliveryAddress(address))
               );
           })
         ),

--- a/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.ts
@@ -32,7 +32,7 @@ export class CheckoutDeliveryAddressService
       (payload) =>
         this.checkoutPreconditions().pipe(
           switchMap(([userId, cartId]) => {
-            return this.checkoutDeliveryConnector
+            return this.checkoutDeliveryAddressConnector
               .createAddress(userId, cartId, payload)
               .pipe(
                 tap(() => {
@@ -66,8 +66,7 @@ export class CheckoutDeliveryAddressService
                     },
                     DeliveryAddressCreatedEvent
                   )
-                ),
-                switchMap((address) => this.setDeliveryAddress(address))
+                )
               );
           })
         ),
@@ -85,7 +84,7 @@ export class CheckoutDeliveryAddressService
             if (!addressId) {
               throw new Error('Checkout conditions not met');
             }
-            return this.checkoutDeliveryConnector
+            return this.checkoutDeliveryAddressConnector
               .setAddress(userId, cartId, addressId)
               .pipe(
                 tap(() => {
@@ -111,7 +110,7 @@ export class CheckoutDeliveryAddressService
       () =>
         this.checkoutPreconditions().pipe(
           switchMap(([userId, cartId]) =>
-            this.checkoutDeliveryConnector
+            this.checkoutDeliveryAddressConnector
               .clearCheckoutDeliveryAddress(userId, cartId)
               .pipe(
                 tap(() => {
@@ -138,7 +137,7 @@ export class CheckoutDeliveryAddressService
     protected userIdService: UserIdService,
     protected eventService: EventService,
     protected commandService: CommandService,
-    protected checkoutDeliveryConnector: CheckoutDeliveryAddressConnector,
+    protected checkoutDeliveryAddressConnector: CheckoutDeliveryAddressConnector,
     protected checkoutQueryFacade: CheckoutQueryFacade
   ) {}
 
@@ -152,11 +151,11 @@ export class CheckoutDeliveryAddressService
       this.activeCartFacade.isGuestCart(),
     ]).pipe(
       take(1),
-      map(([userId, cartId, isGustCart]) => {
+      map(([userId, cartId, isGuestCart]) => {
         if (
           !userId ||
           !cartId ||
-          (userId === OCC_USER_ID_ANONYMOUS && !isGustCart)
+          (userId === OCC_USER_ID_ANONYMOUS && !isGuestCart)
         ) {
           throw new Error('Checkout conditions not met');
         }

--- a/feature-libs/checkout/base/root/events/checkout-delivery-address-event.listener.spec.ts
+++ b/feature-libs/checkout/base/root/events/checkout-delivery-address-event.listener.spec.ts
@@ -134,6 +134,15 @@ describe(`CheckoutDeliveryAddressEventListener`, () => {
           { key: 'addressForm.userAddressAddSuccess' },
           GlobalMessageType.MSG_TYPE_CONFIRMATION
         );
+
+        expect(eventService.dispatch).toHaveBeenCalledWith(
+          {},
+          ResetDeliveryModesEvent
+        );
+        expect(eventService.dispatch).toHaveBeenCalledWith(
+          {},
+          ResetDeliveryModesEvent
+        );
       });
     });
   });

--- a/feature-libs/checkout/base/root/events/checkout-delivery-address-event.listener.ts
+++ b/feature-libs/checkout/base/root/events/checkout-delivery-address-event.listener.ts
@@ -70,6 +70,10 @@ export class CheckoutDeliveryAddressEventListener implements OnDestroy {
           { key: 'addressForm.userAddressAddSuccess' },
           GlobalMessageType.MSG_TYPE_CONFIRMATION
         );
+
+        this.eventService.dispatch({}, ResetDeliveryModesEvent);
+
+        this.eventService.dispatch({}, ResetCheckoutQueryEvent);
       })
     );
     this.subscriptions.add(

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-bulk-pricing.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-bulk-pricing.ts
@@ -1,5 +1,5 @@
 import { waitForProductPage } from '../checkout-flow';
-import { loginB2bUser as login } from './b2b-checkout';
+import * as b2bCheckout from './b2b-checkout';
 
 export function visitProduct(productCode) {
   const page = `/product/${productCode}`;
@@ -72,7 +72,7 @@ export function updateAndverifyTotal(newQuantity) {
 }
 
 export function loginB2bUser() {
-  login();
+  b2bCheckout.loginB2bUser();
 }
 
 export function placeOrder() {
@@ -87,14 +87,13 @@ export function placeOrder() {
     cy.findByText('Account').click({ force: true });
   });
 
-  cy.get('cx-payment-type .btn-primary').click();
+  b2bCheckout.selectAccountPayment();
+  b2bCheckout.selectAccountShippingAddress();
+  b2bCheckout.selectAccountDeliveryMode();
 
-  cy.get('cx-shipping-address').contains('Select your Shipping Address');
-  cy.get('cx-shipping-address .cx-checkout-btns button.btn-primary').click();
-  cy.get('cx-delivery-mode').contains('Standard Delivery');
-  cy.get('cx-delivery-mode .btn-primary').click();
   cy.get('.cx-review-title').should('contain', 'Review');
 
   cy.get('input[formcontrolname="termsAndConditions"]').check();
-  cy.get('cx-place-order button.btn-primary').click();
+
+  b2bCheckout.placeOrder('/order-confirmation');
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-bulk-pricing.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-bulk-pricing.ts
@@ -76,17 +76,11 @@ export function loginB2bUser() {
 }
 
 export function placeOrder() {
-  const checkoutSelector =
-    'cx-added-to-cart-dialog .cx-dialog-buttons a.btn.btn-secondary';
-  cy.get(checkoutSelector).click();
-  cy.get('cx-payment-type').contains(' Account ');
-  cy.get('cx-payment-type').within(() => {
-    cy.get('.form-control').clear().type('123');
-  });
-  cy.get('cx-payment-type').within(() => {
-    cy.findByText('Account').click({ force: true });
-  });
+  cy.get(
+    'cx-added-to-cart-dialog .cx-dialog-buttons a.btn.btn-secondary'
+  ).click();
 
+  b2bCheckout.enterPONumber();
   b2bCheckout.selectAccountPayment();
   b2bCheckout.selectAccountShippingAddress();
   b2bCheckout.selectAccountDeliveryMode();

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
@@ -29,18 +29,17 @@ import {
 } from '../checkout-flow';
 import { generateMail, randomString } from '../user';
 
-export const GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS =
-  'GET_CHECKOUT_SUPER_QUERY';
+export const GET_CHECKOUT_DETAILS_ENDPOINT_ALIAS = 'GET_CHECKOUT_DETAILS';
 
-export function interceptB2BCheckoutSuperQueryEndpoint() {
+export function interceptCheckoutB2BDetailsEndpoint() {
   cy.intercept(
     'GET',
     `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
       'BASE_SITE'
     )}/users/**/carts/**/*?fields=deliveryAddress(FULL),deliveryMode(FULL),paymentInfo(FULL),costCenter(FULL),purchaseOrderNumber,paymentType(FULL)*`
-  ).as(GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS);
+  ).as(GET_CHECKOUT_DETAILS_ENDPOINT_ALIAS);
 
-  return GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS;
+  return GET_CHECKOUT_DETAILS_ENDPOINT_ALIAS;
 }
 
 export function loginB2bUser() {
@@ -147,10 +146,10 @@ export function selectAccountShippingAddress() {
   cy.get('cx-card .card-header').should('contain', 'Selected');
 
   /**
-   * Delivery mode PUT intercept is not in verifyDeliveryMethod()
+   * Delivery mode PUT intercept is not in selectAccountDeliveryMode()
    * because it doesn't choose a delivery mode and the intercept might have missed timing depending on cypress's performance
    */
-  const getCheckoutSuperQueryAlias = interceptB2BCheckoutSuperQueryEndpoint();
+  const getCheckoutDetailsAlias = interceptCheckoutB2BDetailsEndpoint();
   cy.intercept({
     method: 'PUT',
     path: `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
@@ -173,7 +172,7 @@ export function selectAccountShippingAddress() {
   cy.wait(`@${deliveryPage}`).its('response.statusCode').should('eq', 200);
 
   cy.wait('@putDeliveryMode').its('response.statusCode').should('eq', 200);
-  cy.wait(`@${getCheckoutSuperQueryAlias}`)
+  cy.wait(`@${getCheckoutDetailsAlias}`)
     .its('response.statusCode')
     .should('eq', 200);
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
@@ -37,7 +37,7 @@ export function interceptB2BCheckoutSuperQueryEndpoint() {
     'GET',
     `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
       'BASE_SITE'
-    )}/users/current/carts/**/*?fields=deliveryAddress(FULL),deliveryMode(FULL),paymentInfo(FULL),costCenter(FULL),purchaseOrderNumber,paymentType(FULL)*`
+    )}/users/**/carts/**/*?fields=deliveryAddress(FULL),deliveryMode(FULL),paymentInfo(FULL),costCenter(FULL),purchaseOrderNumber,paymentType(FULL)*`
   ).as(GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS);
 
   return GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS;

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-guest.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-guest.ts
@@ -1,6 +1,6 @@
-import { SampleUser, user, getSampleUser } from '../sample-data/checkout-flow';
-import * as checkout from './checkout-flow';
+import { getSampleUser, SampleUser, user } from '../sample-data/checkout-flow';
 import { assertAddressForm } from './address-book';
+import * as checkout from './checkout-flow';
 import { validateUpdateProfileForm } from './update-profile';
 
 export let guestUser;
@@ -18,6 +18,12 @@ export function loginAsGuest(sampleUser: SampleUser = user) {
     .findByText(/Guest Checkout/i)
     .click();
   cy.wait(`@${guestLoginPage}`).its('response.statusCode').should('eq', 200);
+
+  const shippingPage = checkout.waitForPage(
+    '/checkout/shipping-address',
+    'getShippingPage'
+  );
+
   cy.get('cx-checkout-login').within(() => {
     cy.get('[formcontrolname="email"]').clear().type(sampleUser.email);
     cy.get('[formcontrolname="emailConfirmation"]')
@@ -25,17 +31,11 @@ export function loginAsGuest(sampleUser: SampleUser = user) {
       .type(sampleUser.email);
     cy.get('button[type=submit]').click();
   });
-  const shippingPage = checkout.waitForPage(
-    '/checkout/shipping-address',
-    'getShippingPage'
-  );
   cy.wait(`@${shippingPage}`).its('response.statusCode').should('eq', 200);
 }
 
 export function testCheckoutAsGuest() {
   it('should perform checkout as guest and create a user account', () => {
-    //let user = getSampleUser();
-
     checkout.goToCheapProductDetailsPage();
     checkout.addCheapProductToCartAndProceedToCheckout();
 

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -191,17 +191,10 @@ export function fillAddressForm(shippingAddressData: AddressData = user) {
     .find('.cx-summary-amount')
     .should('contain', cart.total);
 
-  const deliveryPage = waitForPage(
-    '/checkout/delivery-mode',
-    'getDeliveryPage'
-  );
-  fillShippingAddress(shippingAddressData);
-  cy.wait(`@${deliveryPage}`).its('response.statusCode').should('eq', 200);
-}
-
-export function verifyDeliveryMethod() {
-  cy.log('🛒 Selecting delivery method');
-
+  /**
+   * Delivery mode PUT intercept is not in verifyDeliveryMethod()
+   * because it doesn't choose a delivery mode and the intercept might have missed timing depending on cypress's performance
+   */
   const getCheckoutSuperQueryAlias = interceptB2CCheckoutSuperQueryEndpoint();
   cy.intercept({
     method: 'PUT',
@@ -210,12 +203,23 @@ export function verifyDeliveryMethod() {
     )}/**/deliverymode?deliveryModeId=*`,
   }).as('putDeliveryMode');
 
-  cy.get('.cx-checkout-title').should('contain', 'Shipping Method');
+  const deliveryPage = waitForPage(
+    '/checkout/delivery-mode',
+    'getDeliveryPage'
+  );
+  fillShippingAddress(shippingAddressData);
+  cy.wait(`@${deliveryPage}`).its('response.statusCode').should('eq', 200);
 
   cy.wait('@putDeliveryMode').its('response.statusCode').should('eq', 200);
   cy.wait(`@${getCheckoutSuperQueryAlias}`)
     .its('response.statusCode')
     .should('eq', 200);
+}
+
+export function verifyDeliveryMethod() {
+  cy.log('🛒 Selecting delivery method');
+
+  cy.get('.cx-checkout-title').should('contain', 'Shipping Method');
 
   cy.get('cx-delivery-mode input').first().should('be.checked');
 
@@ -381,12 +385,30 @@ export function fillAddressFormWithCheapProduct(
     .first()
     .find('.cx-summary-amount')
     .should('contain', cartData.total);
+
+  /**
+   * Delivery mode PUT intercept is not in verifyDeliveryMethod()
+   * because it doesn't choose a delivery mode and the intercept might have missed timing depending on cypress's performance
+   */
+  const getCheckoutSuperQueryAlias = interceptB2CCheckoutSuperQueryEndpoint();
+  cy.intercept({
+    method: 'PUT',
+    path: `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
+      'BASE_SITE'
+    )}/**/deliverymode?deliveryModeId=*`,
+  }).as('putDeliveryMode');
+
   const deliveryPage = waitForPage(
     '/checkout/delivery-mode',
     'getDeliveryPage'
   );
   fillShippingAddress(shippingAddressData);
   cy.wait(`@${deliveryPage}`).its('response.statusCode').should('eq', 200);
+
+  cy.wait('@putDeliveryMode').its('response.statusCode').should('eq', 200);
+  cy.wait(`@${getCheckoutSuperQueryAlias}`)
+    .its('response.statusCode')
+    .should('eq', 200);
 }
 
 export function fillPaymentFormWithCheapProduct(

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -20,18 +20,17 @@ import {
 export const ELECTRONICS_BASESITE = 'electronics-spa';
 export const ELECTRONICS_CURRENCY = 'USD';
 
-export const GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS =
-  'GET_CHECKOUT_SUPER_QUERY';
+export const GET_CHECKOUT_DETAILS_ENDPOINT_ALIAS = 'GET_CHECKOUT_DETAILS';
 
-export function interceptB2CCheckoutSuperQueryEndpoint() {
+export function interceptCheckoutB2CDetailsEndpoint() {
   cy.intercept(
     'GET',
     `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
       'BASE_SITE'
     )}/users/**/carts/**/*?fields=deliveryAddress(FULL),deliveryMode(FULL),paymentInfo(FULL)*`
-  ).as(GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS);
+  ).as(GET_CHECKOUT_DETAILS_ENDPOINT_ALIAS);
 
-  return GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS;
+  return GET_CHECKOUT_DETAILS_ENDPOINT_ALIAS;
 }
 
 /**
@@ -195,7 +194,7 @@ export function fillAddressForm(shippingAddressData: AddressData = user) {
    * Delivery mode PUT intercept is not in verifyDeliveryMethod()
    * because it doesn't choose a delivery mode and the intercept might have missed timing depending on cypress's performance
    */
-  const getCheckoutSuperQueryAlias = interceptB2CCheckoutSuperQueryEndpoint();
+  const getCheckoutDetailsAlias = interceptCheckoutB2CDetailsEndpoint();
   cy.intercept({
     method: 'PUT',
     path: `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
@@ -211,7 +210,7 @@ export function fillAddressForm(shippingAddressData: AddressData = user) {
   cy.wait(`@${deliveryPage}`).its('response.statusCode').should('eq', 200);
 
   cy.wait('@putDeliveryMode').its('response.statusCode').should('eq', 200);
-  cy.wait(`@${getCheckoutSuperQueryAlias}`)
+  cy.wait(`@${getCheckoutDetailsAlias}`)
     .its('response.statusCode')
     .should('eq', 200);
 }
@@ -390,7 +389,7 @@ export function fillAddressFormWithCheapProduct(
    * Delivery mode PUT intercept is not in verifyDeliveryMethod()
    * because it doesn't choose a delivery mode and the intercept might have missed timing depending on cypress's performance
    */
-  const getCheckoutSuperQueryAlias = interceptB2CCheckoutSuperQueryEndpoint();
+  const getCheckoutDetailsAlias = interceptCheckoutB2CDetailsEndpoint();
   cy.intercept({
     method: 'PUT',
     path: `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
@@ -406,7 +405,7 @@ export function fillAddressFormWithCheapProduct(
   cy.wait(`@${deliveryPage}`).its('response.statusCode').should('eq', 200);
 
   cy.wait('@putDeliveryMode').its('response.statusCode').should('eq', 200);
-  cy.wait(`@${getCheckoutSuperQueryAlias}`)
+  cy.wait(`@${getCheckoutDetailsAlias}`)
     .its('response.statusCode')
     .should('eq', 200);
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -28,7 +28,7 @@ export function interceptB2CCheckoutSuperQueryEndpoint() {
     'GET',
     `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
       'BASE_SITE'
-    )}/users/current/carts/**/*?fields=deliveryAddress(FULL),deliveryMode(FULL),paymentInfo(FULL)*`
+    )}/users/**/carts/**/*?fields=deliveryAddress(FULL),deliveryMode(FULL),paymentInfo(FULL)*`
   ).as(GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS);
 
   return GET_CHECKOUT_SUPER_QUERY_ENDPOINT_ALIAS;

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-forms.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-forms.ts
@@ -32,47 +32,40 @@ export function fillShippingAddress(
   submitForm: boolean = true
 ) {
   cy.get('button.btn-primary').should('be.visible');
-  cy.get('cx-page-layout').then((body) => {
-    // If the address form does not exists, shipping address has been added in previous
-    // spec attempt so we can continue
-    if (!body.find('cx-address-form').length) {
-      cy.get('button.btn-primary').click();
-    } else {
-      cy.get('cx-address-form').within(() => {
-        cy.get('.country-select[formcontrolname="isocode"]').ngSelect(
-          shippingAddress.address.country
-        );
-        cy.get('[formcontrolname="titleCode"]').ngSelect('Mr.');
-        cy.get('[formcontrolname="firstName"]')
-          .clear()
-          .type(shippingAddress.firstName);
-        cy.get('[formcontrolname="lastName"]')
-          .clear()
-          .type(shippingAddress.lastName);
-        cy.get('[formcontrolname="line1"]')
-          .clear()
-          .type(shippingAddress.address.line1);
-        if (shippingAddress.address.line2) {
-          cy.get('[formcontrolname="line2"]')
-            .clear()
-            .type(shippingAddress.address.line2);
-        }
-        cy.get('[formcontrolname="town"]')
-          .clear()
-          .type(shippingAddress.address.city);
-        if (shippingAddress.address.state) {
-          cy.get('.region-select[formcontrolname="isocode"]').ngSelect(
-            shippingAddress.address.state
-          );
-        }
-        cy.get('[formcontrolname="postalCode"]')
-          .clear()
-          .type(shippingAddress.address.postal);
-        cy.get('[formcontrolname="phone"]').clear().type(shippingAddress.phone);
-        if (submitForm) {
-          cy.get('button.btn-primary').should('be.enabled').click();
-        }
-      });
+
+  cy.get('cx-address-form').within(() => {
+    cy.get('.country-select[formcontrolname="isocode"]').ngSelect(
+      shippingAddress.address.country
+    );
+    cy.get('[formcontrolname="titleCode"]').ngSelect('Mr.');
+    cy.get('[formcontrolname="firstName"]')
+      .clear()
+      .type(shippingAddress.firstName);
+    cy.get('[formcontrolname="lastName"]')
+      .clear()
+      .type(shippingAddress.lastName);
+    cy.get('[formcontrolname="line1"]')
+      .clear()
+      .type(shippingAddress.address.line1);
+    if (shippingAddress.address.line2) {
+      cy.get('[formcontrolname="line2"]')
+        .clear()
+        .type(shippingAddress.address.line2);
+    }
+    cy.get('[formcontrolname="town"]')
+      .clear()
+      .type(shippingAddress.address.city);
+    if (shippingAddress.address.state) {
+      cy.get('.region-select[formcontrolname="isocode"]').ngSelect(
+        shippingAddress.address.state
+      );
+    }
+    cy.get('[formcontrolname="postalCode"]')
+      .clear()
+      .type(shippingAddress.address.postal);
+    cy.get('[formcontrolname="phone"]').clear().type(shippingAddress.phone);
+    if (submitForm) {
+      cy.get('button.btn-primary').should('be.enabled').click();
     }
   });
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-variants.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-variants.ts
@@ -1,20 +1,19 @@
+import {
+  cartWithTotalVariantProduct,
+  getApparelCheckoutUser,
+  products,
+  variantProduct,
+} from '../sample-data/apparel-checkout-flow';
 import { assertAddressForm } from './address-book';
 import * as guestCheckout from './checkout-as-guest';
 import * as checkout from './checkout-flow';
 import { validateUpdateProfileForm } from './update-profile';
-import { getApparelCheckoutUser } from '../sample-data/apparel-checkout-flow';
 import {
   addMutipleProductWithoutVariantToCart,
   addVariantOfSameProductToCart,
   APPAREL_CURRENCY,
   visitProductWithoutVariantPage,
 } from './variants/apparel-checkout-flow';
-
-import {
-  cartWithTotalVariantProduct,
-  products,
-  variantProduct,
-} from '../sample-data/apparel-checkout-flow';
 
 export let variantUser;
 export function generateVariantGuestUser() {
@@ -41,11 +40,7 @@ export function testCheckoutVariantAsGuest() {
 
     checkout.verifyDeliveryMethod();
 
-    checkout.fillPaymentFormWithCheapProduct(
-      variantUser,
-      undefined,
-      cartWithTotalVariantProduct
-    );
+    checkout.fillPaymentFormWithCheapProduct(variantUser, undefined);
 
     checkout.placeOrderWithCheapProduct(
       variantUser,
@@ -119,11 +114,7 @@ export function testCheckoutRegisteredUser() {
       cartWithTotalVariantProduct
     );
     checkout.verifyDeliveryMethod();
-    checkout.fillPaymentFormWithCheapProduct(
-      regVariantUser,
-      undefined,
-      cartWithTotalVariantProduct
-    );
+    checkout.fillPaymentFormWithCheapProduct(regVariantUser, undefined);
     checkout.placeOrderWithCheapProduct(
       regVariantUser,
       cartWithTotalVariantProduct,

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
@@ -3,7 +3,7 @@ import { login, register } from './auth-forms';
 import * as checkoutAsPersistentUser from './checkout-as-persistent-user';
 import * as checkout from './checkout-flow';
 import {
-  interceptB2CCheckoutSuperQueryEndpoint,
+  interceptCheckoutB2CDetailsEndpoint,
   waitForPage,
   waitForProductPage,
 } from './checkout-flow';
@@ -268,7 +268,7 @@ function fillAddressForm(shippingAddressData: AddressData = user) {
    * Delivery mode PUT intercept is not in verifyDeliveryMethod()
    * because it doesn't choose a delivery mode and the intercept might have missed timing depending on cypress's performance
    */
-  const getCheckoutSuperQueryAlias = interceptB2CCheckoutSuperQueryEndpoint();
+  const getCheckoutDetailsAlias = interceptCheckoutB2CDetailsEndpoint();
   cy.intercept({
     method: 'PUT',
     path: `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
@@ -285,7 +285,7 @@ function fillAddressForm(shippingAddressData: AddressData = user) {
   cy.wait(`@${deliveryPage}`).its('response.statusCode').should('eq', 200);
 
   cy.wait('@putDeliveryMode').its('response.statusCode').should('eq', 200);
-  cy.wait(`@${getCheckoutSuperQueryAlias}`)
+  cy.wait(`@${getCheckoutDetailsAlias}`)
     .its('response.statusCode')
     .should('eq', 200);
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
@@ -2,7 +2,11 @@ import { cheapProduct, user } from '../sample-data/checkout-flow';
 import { login, register } from './auth-forms';
 import * as checkoutAsPersistentUser from './checkout-as-persistent-user';
 import * as checkout from './checkout-flow';
-import { waitForPage, waitForProductPage } from './checkout-flow';
+import {
+  interceptB2CCheckoutSuperQueryEndpoint,
+  waitForPage,
+  waitForProductPage,
+} from './checkout-flow';
 import {
   AddressData,
   fillPaymentDetails,
@@ -260,6 +264,18 @@ function proceedToCheckout() {
 }
 
 function fillAddressForm(shippingAddressData: AddressData = user) {
+  /**
+   * Delivery mode PUT intercept is not in verifyDeliveryMethod()
+   * because it doesn't choose a delivery mode and the intercept might have missed timing depending on cypress's performance
+   */
+  const getCheckoutSuperQueryAlias = interceptB2CCheckoutSuperQueryEndpoint();
+  cy.intercept({
+    method: 'PUT',
+    path: `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
+      'BASE_SITE'
+    )}/**/deliverymode?deliveryModeId=*`,
+  }).as('putDeliveryMode');
+
   cy.get('.cx-checkout-title').should('contain', 'Shipping Address');
   const deliveryPage = waitForPage(
     '/checkout/delivery-mode',
@@ -267,6 +283,11 @@ function fillAddressForm(shippingAddressData: AddressData = user) {
   );
   fillShippingAddress(shippingAddressData);
   cy.wait(`@${deliveryPage}`).its('response.statusCode').should('eq', 200);
+
+  cy.wait('@putDeliveryMode').its('response.statusCode').should('eq', 200);
+  cy.wait(`@${getCheckoutSuperQueryAlias}`)
+    .its('response.statusCode')
+    .should('eq', 200);
 }
 
 function fillPaymentForm(

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/bulk-pricing/bulk-pricing.core-e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/bulk-pricing/bulk-pricing.core-e2e-spec.ts
@@ -1,69 +1,62 @@
-import { viewportContext } from '../../../../helpers/viewport-context';
-import * as sampleData from '../../../../sample-data/b2b-bulk-pricing';
 import * as b2bBulkPricing from '../../../../helpers/b2b/b2b-bulk-pricing';
+import * as sampleData from '../../../../sample-data/b2b-bulk-pricing';
 
 describe('B2B - Bulk Pricing', () => {
-  viewportContext(['mobile', 'desktop'], () => {
-    before(() => {
-      cy.window().then((win) => win.sessionStorage.clear());
+  before(() => {
+    cy.window().then((win) => win.sessionStorage.clear());
+  });
+
+  describe('Check bulk pricing table', () => {
+    it('should render pricing table for products that contain bulk prices', () => {
+      b2bBulkPricing.visitProduct(sampleData.PRODUCT);
+
+      const selector = 'cx-bulk-pricing-table .table';
+      sampleData.expectedData.forEach((element) => {
+        cy.get(selector).contains('td', element.quantity);
+        cy.get(selector).contains('td', element.price);
+        cy.get(selector).contains('td', element.discount);
+      });
     });
 
-    describe('Check bulk pricing table', () => {
-      it('should render pricing table for products that contain bulk prices', () => {
-        b2bBulkPricing.visitProduct(sampleData.PRODUCT);
+    it('should checkout using the proper bulk price based on quantity', () => {
+      b2bBulkPricing.visitProduct(sampleData.PRODUCT);
 
-        const selector = 'cx-bulk-pricing-table .table';
-        sampleData.expectedData.forEach((element) => {
-          cy.get(selector).contains('td', element.quantity);
-          cy.get(selector).contains('td', element.price);
-          cy.get(selector).contains('td', element.discount);
-        });
-      });
+      b2bBulkPricing.addAndverifyTotal(sampleData.TEST_QUANTITY);
+    });
 
-      it('should checkout using the proper bulk price based on quantity', () => {
-        b2bBulkPricing.visitProduct(sampleData.PRODUCT);
+    it('should NOT render pricing table for products that DO NOT contain bulk prices', () => {
+      b2bBulkPricing.visitProduct(sampleData.PRODUCT_NO_PRICING);
 
-        b2bBulkPricing.addAndverifyTotal(sampleData.TEST_QUANTITY);
-      });
+      cy.get('cx-bulk-pricing-table .container').should('not.exist');
+    });
 
-      it('should NOT render pricing table for products that DO NOT contain bulk prices', () => {
-        b2bBulkPricing.visitProduct(sampleData.PRODUCT_NO_PRICING);
+    it('should verify lowering the quantity also lowers the discount', () => {
+      b2bBulkPricing.visitProduct(sampleData.PRODUCT);
 
-        cy.get('cx-bulk-pricing-table .container').should('not.exist');
-      });
+      b2bBulkPricing.addAndverifyTotal(sampleData.QUANTITY_FOR_25_DISCOUNT);
 
-      it('should verify lowering the quantity also lowers the discount', () => {
-        b2bBulkPricing.visitProduct(sampleData.PRODUCT);
+      b2bBulkPricing.updateAndverifyTotal(sampleData.QUANTITY_FOR_13_DISCOUNT);
 
-        b2bBulkPricing.addAndverifyTotal(sampleData.QUANTITY_FOR_25_DISCOUNT);
+      b2bBulkPricing.updateAndverifyTotal(sampleData.QUANTITY_FOR_NO_DISCOUNT);
+    });
 
-        b2bBulkPricing.updateAndverifyTotal(
-          sampleData.QUANTITY_FOR_13_DISCOUNT
-        );
+    it('should verify increasing the quantity also increases the discount', () => {
+      b2bBulkPricing.visitProduct(sampleData.PRODUCT);
 
-        b2bBulkPricing.updateAndverifyTotal(
-          sampleData.QUANTITY_FOR_NO_DISCOUNT
-        );
-      });
+      b2bBulkPricing.addAndverifyTotal(sampleData.QUANTITY_FOR_8_DISCOUNT);
+      b2bBulkPricing.updateAndverifyTotal(sampleData.QUANTITY_PLUS_ONE);
+    });
 
-      it('should verify increasing the quantity also increases the discount', () => {
-        b2bBulkPricing.visitProduct(sampleData.PRODUCT);
+    it('should verify checking out a bulk priced item and a regular product', () => {
+      b2bBulkPricing.loginB2bUser();
+      b2bBulkPricing.visitProduct(sampleData.PRODUCT);
 
-        b2bBulkPricing.addAndverifyTotal(sampleData.QUANTITY_FOR_8_DISCOUNT);
-        b2bBulkPricing.updateAndverifyTotal(sampleData.QUANTITY_PLUS_ONE);
-      });
+      b2bBulkPricing.addAndverifyTotal(sampleData.QUANTITY_FOR_3_DISCOUNT);
 
-      it('should verify checking out a bulk priced item and a regular product', () => {
-        b2bBulkPricing.loginB2bUser();
-        b2bBulkPricing.visitProduct(sampleData.PRODUCT);
+      b2bBulkPricing.visitProduct(sampleData.PRODUCT_NO_PRICING);
+      b2bBulkPricing.addOneToCart();
 
-        b2bBulkPricing.addAndverifyTotal(sampleData.QUANTITY_FOR_3_DISCOUNT);
-
-        b2bBulkPricing.visitProduct(sampleData.PRODUCT_NO_PRICING);
-        b2bBulkPricing.addOneToCart();
-
-        b2bBulkPricing.placeOrder();
-      });
+      b2bBulkPricing.placeOrder();
     });
   });
 });

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/checkout/b2b-credit-card-checkout-flow.core-e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/b2b/regression/checkout/b2b-credit-card-checkout-flow.core-e2e-spec.ts
@@ -44,11 +44,7 @@ context('B2B - Credit Card Checkout flow', () => {
   });
 
   it('should enter payment method', () => {
-    checkout.fillPaymentFormWithCheapProduct(
-      user,
-      undefined,
-      cartWithB2bProduct
-    );
+    checkout.fillPaymentFormWithCheapProduct(user, undefined);
   });
 
   it('should review and place order', () => {

--- a/todo.md
+++ b/todo.md
@@ -71,6 +71,7 @@
 16. check changes to the old checkout
    1. revert the variable names from *facade to *service _in old checkout only_
 17. check the bundle size of checkout (maybe using webpack analyzer)
+18. rename `checkout-shipping-address.component` (both base and b2b) to `checkout-delivery-address.component`.
 
 ## Near the end
 

--- a/todo.md
+++ b/todo.md
@@ -72,6 +72,7 @@
    1. revert the variable names from *facade to *service _in old checkout only_
 17. check the bundle size of checkout (maybe using webpack analyzer)
 18. rename `checkout-shipping-address.component` (both base and b2b) to `checkout-delivery-address.component`.
+19. make sure in new checkout for checkout-delivery-mode template works similarly to the one in develop (look and feel) when cart-lib has updates and pulls from develop. https://github.com/SAP/spartacus/blob/develop/feature-libs/checkout/components/components/delivery-mode/delivery-mode.component.html --> specifically removing spinner from the button area.
 
 ## Near the end
 


### PR DESCRIPTION
This PR fixes the following:

1. user starts the checkout, and adds / selects an existing address
2. user navigates to delivery mode step, and selects a delivery mode
3. user wants to change an address used in the 1st step, and they navigate back to the address checkout step
4. they add an address, and press continue
5. there's an infinite spinner shown now. 

The reason for the above bug is because the checkout details (aka super query) was reset when a new address was added, and therefore the delivery mode step was waiting for it to be available. The correct fix for this is to make sure the address checkout step completes all of its operations before allowing the user to move to the next step.