### PR TITLE
feat: Allow site-context to be loaded even if static config exist

### DIFF
--- a/projects/core/src/occ/adapters/site-context/default-occ-site-context-config.ts
+++ b/projects/core/src/occ/adapters/site-context/default-occ-site-context-config.ts
@@ -10,7 +10,7 @@ export const defaultOccSiteContextConfig: OccConfig = {
         regions:
           'countries/${isoCode}/regions?fields=regions(name,isocode,isocodeShort)',
         baseSites:
-          'basesites?fields=baseSites(uid,defaultLanguage(isocode),urlEncodingAttributes,urlPatterns,stores(currencies(isocode),defaultCurrency(isocode),languages(isocode),defaultLanguage(isocode)),theme,defaultPreviewCatalogId,defaultPreviewCategoryCode,defaultPreviewProductCode)',
+          'basesites?fields=baseSites(uid,channel,defaultLanguage(isocode),urlEncodingAttributes,urlPatterns,stores(currencies(isocode),defaultCurrency(isocode),languages(isocode),defaultLanguage(isocode)),theme,defaultPreviewCatalogId,defaultPreviewCategoryCode,defaultPreviewProductCode)',
       },
     },
   },

--- a/projects/core/src/site-context/facade/base-site.service.ts
+++ b/projects/core/src/site-context/facade/base-site.service.ts
@@ -29,6 +29,18 @@ export class BaseSiteService implements SiteContext<BaseSite> {
   }
 
   /**
+   * Get active base site's details
+   */
+  getActiveData(): Observable<BaseSite> {
+    return this.store.pipe(
+      select(SiteContextSelectors.getBaseSiteData),
+      filter(
+        (baseSiteData) => baseSiteData && Object.keys(baseSiteData).length > 0
+      )
+    );
+  }
+
+  /**
    * Get all base sites data
    */
   getAll(): Observable<BaseSite[]> {

--- a/projects/core/src/site-context/site-context.module.spec.ts
+++ b/projects/core/src/site-context/site-context.module.spec.ts
@@ -4,12 +4,12 @@ import { SiteContextConfigInitializer } from './config/config-loader/site-contex
 import { SiteContextConfig } from './config/site-context-config';
 import { initSiteContextConfig } from './site-context.module';
 
-class MockSiteContextConfigInitializer implements ConfigInitializer {
+class MockSiteContextConfigInitializer implements Partial<ConfigInitializer> {
   readonly scopes = ['context'];
   readonly configFactory = async () => ({});
 }
 
-class MockSiteContextConfig {
+class MockSiteContextConfig implements Partial<SiteContextConfig> {
   context = {};
 }
 
@@ -34,17 +34,9 @@ describe('SiteContextModule', () => {
     spyOn(initializer, 'configFactory').and.callThrough();
   });
 
-  it(`should not resolve SiteContextConfig when it was already configured statically `, () => {
-    config.context = {
-      baseSite: ['electronics'],
-    };
-    const result = initSiteContextConfig(initializer, config);
-    expect(result).toEqual(null);
-  });
-
-  it(`should resolve SiteContextConfig when it was not configured statically `, () => {
+  it(`should resolve SiteContextConfig`, () => {
     config.context = {};
-    const result = initSiteContextConfig(initializer, config);
+    const result = initSiteContextConfig(initializer);
     expect(result).toEqual(initializer);
   });
 });

--- a/projects/core/src/site-context/site-context.module.ts
+++ b/projects/core/src/site-context/site-context.module.ts
@@ -9,9 +9,7 @@ import { StateModule } from '../state/index';
 import { baseSiteConfigValidator } from './config/base-site-config-validator';
 import { SiteContextConfigInitializer } from './config/config-loader/site-context-config-initializer';
 import { defaultSiteContextConfigFactory } from './config/default-site-context-config';
-import { SiteContextConfig } from './config/site-context-config';
 import { SiteContextEventModule } from './events/site-context-event.module';
-import { BASE_SITE_CONTEXT_ID } from './providers/context-ids';
 import { contextInitializerProviders } from './providers/context-initializer-providers';
 import { contextServiceMapProvider } from './providers/context-service-map';
 import { contextServiceProviders } from './providers/context-service-providers';
@@ -22,16 +20,9 @@ import { SiteContextStoreModule } from './store/site-context-store.module';
  * Initializes the site context config
  */
 export function initSiteContextConfig(
-  configInitializer: SiteContextConfigInitializer,
-  config: SiteContextConfig
+  configInitializer: SiteContextConfigInitializer
 ): ConfigInitializer | null {
-  /**
-   * Load config for `context` from backend only when there is no static config for `context.baseSite`
-   */
-  if (!config.context || !config.context[BASE_SITE_CONTEXT_ID]) {
-    return configInitializer;
-  }
-  return null;
+  return configInitializer;
 }
 
 @NgModule({
@@ -50,7 +41,7 @@ export class SiteContextModule {
         {
           provide: CONFIG_INITIALIZER,
           useFactory: initSiteContextConfig,
-          deps: [SiteContextConfigInitializer, SiteContextConfig],
+          deps: [SiteContextConfigInitializer],
           multi: true,
         },
         ...contextInitializerProviders,


### PR DESCRIPTION
closes GH-14789

to re-think as e2es are failing due to the fact that the paths are no longer persisting in the e2e test, but locally is fine.