### PR TITLE
feat: use spinner to hide delivery mode radio input when there's ongoing HTTP put request

### DIFF
--- a/projects/core/src/checkout/facade/checkout-delivery.service.ts
+++ b/projects/core/src/checkout/facade/checkout-delivery.service.ts
@@ -8,6 +8,7 @@ import {
   take,
   tap,
   withLatestFrom,
+  map,
 } from 'rxjs/operators';
 import { UserIdService } from '../../auth/user-auth/facade/user-id.service';
 import { ActiveCartService } from '../../cart/facade/active-cart.service';
@@ -26,6 +27,7 @@ import {
   StateWithCheckout,
 } from '../store/checkout-state';
 import { CheckoutSelectors } from '../store/selectors/index';
+import { CheckoutService } from './checkout.service';
 
 @Injectable({
   providedIn: 'root',
@@ -34,7 +36,8 @@ export class CheckoutDeliveryService {
   constructor(
     protected checkoutStore: Store<StateWithCheckout | StateWithProcess<void>>,
     protected activeCartService: ActiveCartService,
-    protected userIdService: UserIdService
+    protected userIdService: UserIdService,
+    protected checkoutService: CheckoutService
   ) {}
 
   /**
@@ -120,6 +123,23 @@ export class CheckoutDeliveryService {
   resetSetDeliveryModeProcess(): void {
     this.checkoutStore.dispatch(
       new CheckoutActions.ResetSetDeliveryModeProcess()
+    );
+  }
+
+  /**
+   * return info about process of setting Delivery Mode, which is done by a HTTP PUT request followed by two HTTP GET request.
+   * True means at least one quest is still in process, false means all three requests are done
+   */
+  isSetDeliveryModeBusy(): Observable<boolean> {
+    return combineLatest([
+      this.activeCartService.isStable(),
+      this.checkoutService.isLoading(),
+      this.getSetDeliveryModeProcess(),
+    ]).pipe(
+      map(
+        ([isStable, isLoading, setDeliveryProcess]) =>
+          !isStable || isLoading || (setDeliveryProcess.loading ?? false)
+      )
     );
   }
 
@@ -228,7 +248,7 @@ export class CheckoutDeliveryService {
       if (userId && cartId) {
         combineLatest([
           this.activeCartService.isStable(),
-          this.checkoutStore.pipe(select(CheckoutSelectors.getCheckoutLoading)),
+          this.checkoutService.isLoading(),
         ])
           .pipe(
             filter(([isStable, isLoading]) => isStable && !isLoading),

--- a/projects/core/src/checkout/facade/checkout-delivery.service.ts
+++ b/projects/core/src/checkout/facade/checkout-delivery.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { combineLatest, Observable } from 'rxjs';
 import {
@@ -37,8 +37,13 @@ export class CheckoutDeliveryService {
     protected checkoutStore: Store<StateWithCheckout | StateWithProcess<void>>,
     protected activeCartService: ActiveCartService,
     protected userIdService: UserIdService,
-    protected checkoutService: CheckoutService
+    @Optional() protected checkoutService?: CheckoutService
   ) {}
+
+  protected isCheckoutDetailsLoading$: Observable<boolean> = this
+    .checkoutService
+    ? this.checkoutService.isLoading()
+    : this.checkoutStore.pipe(select(CheckoutSelectors.getCheckoutLoading));
 
   /**
    * Get supported delivery modes
@@ -133,7 +138,7 @@ export class CheckoutDeliveryService {
   isSetDeliveryModeBusy(): Observable<boolean> {
     return combineLatest([
       this.activeCartService.isStable(),
-      this.checkoutService.isLoading(),
+      this.isCheckoutDetailsLoading$,
       this.getSetDeliveryModeProcess(),
     ]).pipe(
       map(
@@ -248,7 +253,7 @@ export class CheckoutDeliveryService {
       if (userId && cartId) {
         combineLatest([
           this.activeCartService.isStable(),
-          this.checkoutService.isLoading(),
+          this.isCheckoutDetailsLoading$,
         ])
           .pipe(
             filter(([isStable, isLoading]) => isStable && !isLoading),

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
@@ -164,7 +164,9 @@ export function selectAccountDeliveryMode() {
     config.deliveryMode
   );
 
-  cy.get('.cx-checkout-btns button.btn-primary').click();
+  cy.get('.cx-checkout-btns button.btn-primary')
+    .should('be.enabled')
+    .click({ force: true });
 
   cy.wait('@putDeliveryMode').its('status').should('eq', 200);
   cy.wait(`@${orderReview}`, { timeout: 30000 })

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -147,7 +147,9 @@ export function verifyDeliveryMethod() {
     '/checkout/payment-details',
     'getPaymentPage'
   );
-  cy.get('.cx-checkout-btns button.btn-primary').click();
+  cy.get('.cx-checkout-btns button.btn-primary')
+    .should('be.enabled')
+    .click({ force: true });
   cy.wait(`@${paymentPage}`).its('status').should('eq', 200);
 }
 

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/accessibility/group-skipping.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/accessibility/group-skipping.e2e-spec.ts
@@ -36,7 +36,16 @@ context('Group Skipping - Checkout', () => {
     cy.requireLoggedIn().then(() => {
       checkout.goToProductDetailsPage();
       checkout.addProductToCart();
+
+      cy.intercept({
+        method: 'PUT',
+        path: `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
+          'BASE_SITE'
+        )}/**/deliverymode?*`,
+      }).as('putDeliveryMode');
+
       checkout.fillAddressForm();
+      cy.wait('@putDeliveryMode').its('response.statusCode').should('eq', 200);
       cy.get('input[type=radio][formcontrolname=deliveryModeId]')
         .first()
         .focus()

--- a/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.html
+++ b/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.html
@@ -1,12 +1,17 @@
 <div [formGroup]="mode">
   <div class="row">
     <div class="col-md-12 col-lg-9">
-      <h3 class="cx-checkout-title d-none d-lg-block d-xl-block">
+      <h2 class="cx-checkout-title d-none d-lg-block d-xl-block">
         {{ 'checkoutShipping.shippingMethod' | cxTranslate }}
-      </h3>
+      </h2>
 
       <ng-container
-        *ngIf="(supportedDeliveryModes$ | async)?.length; else loading"
+        *ngIf="
+          (supportedDeliveryModes$ | async)?.length &&
+            !(isSetDeliveryModeBusy$ | async) &&
+            !continueButtonPressed;
+          else loading
+        "
       >
         <div
           class="form-check"
@@ -37,7 +42,7 @@
     </div>
   </div>
 
-  <ng-container *ngIf="!continueButtonPressed; else loading">
+  <ng-container>
     <div class="row cx-checkout-btns">
       <div class="col-md-12 col-lg-6">
         <button class="btn btn-block btn-action" (click)="back()">
@@ -47,7 +52,11 @@
       <div class="col-md-12 col-lg-6">
         <button
           class="btn btn-block btn-primary"
-          [disabled]="deliveryModeInvalid"
+          [disabled]="
+            deliveryModeInvalid ||
+            continueButtonPressed ||
+            (isSetDeliveryModeBusy$ | async)
+          "
           (click)="next()"
         >
           {{ 'common.continue' | cxTranslate }}

--- a/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.html
+++ b/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.html
@@ -1,9 +1,9 @@
 <div [formGroup]="mode">
   <div class="row">
     <div class="col-md-12 col-lg-9">
-      <h2 class="cx-checkout-title d-none d-lg-block d-xl-block">
+      <h3 class="cx-checkout-title d-none d-lg-block d-xl-block">
         {{ 'checkoutShipping.shippingMethod' | cxTranslate }}
-      </h2>
+      </h3>
 
       <ng-container
         *ngIf="

--- a/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.spec.ts
@@ -8,7 +8,7 @@ import {
   DeliveryMode,
   I18nTestingModule,
 } from '@spartacus/core';
-import { Observable, of } from 'rxjs';
+import { Observable, of, BehaviorSubject } from 'rxjs';
 import { LoaderState } from '../../../../../../core/src/state/utils/loader';
 import { CheckoutConfigService } from '../../services/checkout-config.service';
 import { CheckoutStepService } from '../../services/checkout-step.service';
@@ -25,13 +25,19 @@ class MockCheckoutDeliveryService {
   loadSupportedDeliveryModes = createSpy();
   setDeliveryMode = createSpy();
   getSupportedDeliveryModes(): Observable<DeliveryMode[]> {
-    return of();
+    return of(mockSupportedDeliveryModes);
   }
   getSelectedDeliveryMode(): Observable<DeliveryMode> {
-    return of();
+    return selectedDeliveryMode$.asObservable();
   }
   getLoadSupportedDeliveryModeProcess(): Observable<LoaderState<void>> {
     return of();
+  }
+  getSetDeliveryModeProcess(): Observable<LoaderState<void>> {
+    return of({});
+  }
+  isSetDeliveryModeBusy(): Observable<boolean> {
+    return isSetDeliveryModeBusy$.asObservable();
   }
 }
 
@@ -72,6 +78,10 @@ const mockSupportedDeliveryModes: DeliveryMode[] = [
   mockDeliveryMode2,
 ];
 
+const isSetDeliveryModeBusy$ = new BehaviorSubject<boolean>(false);
+
+const selectedDeliveryMode$ = new BehaviorSubject<DeliveryMode>({});
+
 describe('DeliveryModeComponent', () => {
   let component: DeliveryModeComponent;
   let fixture: ComponentFixture<DeliveryModeComponent>;
@@ -109,6 +119,8 @@ describe('DeliveryModeComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DeliveryModeComponent);
     component = fixture.componentInstance;
+    isSetDeliveryModeBusy$.next(false);
+    selectedDeliveryMode$.next({});
   });
 
   it('should be created', () => {
@@ -116,10 +128,6 @@ describe('DeliveryModeComponent', () => {
   });
 
   it('should get supported delivery modes', () => {
-    spyOn(
-      mockCheckoutDeliveryService,
-      'getSupportedDeliveryModes'
-    ).and.returnValue(of(mockSupportedDeliveryModes));
     component.ngOnInit();
 
     component.supportedDeliveryModes$.subscribe((modes) => {
@@ -128,14 +136,6 @@ describe('DeliveryModeComponent', () => {
   });
 
   it('should pre-select preferred delivery mode if not chosen before', () => {
-    spyOn(
-      mockCheckoutDeliveryService,
-      'getSupportedDeliveryModes'
-    ).and.returnValue(of(mockSupportedDeliveryModes));
-    spyOn(
-      mockCheckoutDeliveryService,
-      'getSelectedDeliveryMode'
-    ).and.returnValue(of(null));
     spyOn(
       mockCheckoutConfigService,
       'getPreferredDeliveryMode'
@@ -152,14 +152,7 @@ describe('DeliveryModeComponent', () => {
   });
 
   it('should select the delivery mode, which has been chosen before', () => {
-    spyOn(
-      mockCheckoutDeliveryService,
-      'getSupportedDeliveryModes'
-    ).and.returnValue(of(mockSupportedDeliveryModes));
-    spyOn(
-      mockCheckoutDeliveryService,
-      'getSelectedDeliveryMode'
-    ).and.returnValue(of(mockDeliveryMode2));
+    selectedDeliveryMode$.next(mockDeliveryMode2);
     spyOn(
       mockCheckoutConfigService,
       'getPreferredDeliveryMode'
@@ -201,6 +194,29 @@ describe('DeliveryModeComponent', () => {
     ).toHaveBeenCalledTimes(1);
   });
 
+  describe('Shipping method radio input', () => {
+    const getShippingMethodRadioInput = () =>
+      fixture.debugElement.query(By.css('.form-check .form-check-input'));
+
+    it('should be displayed after supported delivery modes are loaded', () => {
+      component.ngOnInit();
+      isSetDeliveryModeBusy$.next(false);
+
+      fixture.detectChanges();
+
+      expect(getShippingMethodRadioInput().nativeElement).toBeTruthy();
+    });
+
+    it('should be hidden by spinner when there is another ongoing request', () => {
+      component.ngOnInit();
+      isSetDeliveryModeBusy$.next(true);
+
+      fixture.detectChanges();
+
+      expect(getShippingMethodRadioInput()).toBeFalsy();
+    });
+  });
+
   describe('UI continue button', () => {
     const getContinueBtn = () =>
       fixture.debugElement.query(By.css('.cx-checkout-btns .btn-primary'));
@@ -209,14 +225,20 @@ describe('DeliveryModeComponent', () => {
     };
 
     it('should be disabled when delivery mode is not selected', () => {
+      selectedDeliveryMode$.next({});
       setDeliveryModeId(null);
+
       fixture.detectChanges();
 
       expect(getContinueBtn().nativeElement.disabled).toBe(true);
     });
 
     it('should be enabled when delivery mode is selected', () => {
+      component.ngOnInit();
+      component.continueButtonPressed = false;
+      isSetDeliveryModeBusy$.next(false);
       setDeliveryModeId(mockDeliveryMode1.code);
+
       fixture.detectChanges();
 
       expect(getContinueBtn().nativeElement.disabled).toBe(false);
@@ -225,9 +247,14 @@ describe('DeliveryModeComponent', () => {
     it('should call "next" function after being clicked', () => {
       spyOn(component, 'next');
 
+      component.ngOnInit();
+      isSetDeliveryModeBusy$.next(false);
       setDeliveryModeId(mockDeliveryMode1.code);
+
       fixture.detectChanges();
+
       getContinueBtn().nativeElement.click();
+
       fixture.detectChanges();
 
       expect(component.next).toHaveBeenCalled();
@@ -241,7 +268,11 @@ describe('DeliveryModeComponent', () => {
     it('should call "back" function after being clicked', () => {
       spyOn(component, 'back');
 
+      component.ngOnInit();
+      isSetDeliveryModeBusy$.next(false);
+
       fixture.detectChanges();
+
       getBackBtn().nativeElement.click();
 
       expect(component.back).toHaveBeenCalled();

--- a/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.spec.ts
@@ -226,6 +226,7 @@ describe('DeliveryModeComponent', () => {
     const enableContinueButton = () => {
       component.continueButtonPressed = false;
       isSetDeliveryModeBusy$.next(false);
+      selectedDeliveryMode$.next({ code: mockDeliveryMode1.code });
       setDeliveryModeId(mockDeliveryMode1.code);
     };
 
@@ -239,11 +240,6 @@ describe('DeliveryModeComponent', () => {
     });
 
     it('should be enabled when delivery mode is selected', () => {
-      spyOn(
-        mockCheckoutConfigService,
-        'getPreferredDeliveryMode'
-      ).and.returnValue(mockDeliveryMode1.code);
-
       component.ngOnInit();
       enableContinueButton();
 
@@ -254,10 +250,6 @@ describe('DeliveryModeComponent', () => {
 
     it('should call "next" function after being clicked', () => {
       spyOn(component, 'next');
-      spyOn(
-        mockCheckoutConfigService,
-        'getPreferredDeliveryMode'
-      ).and.returnValue(mockDeliveryMode1.code);
 
       component.ngOnInit();
       enableContinueButton();

--- a/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.spec.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.spec.ts
@@ -223,6 +223,11 @@ describe('DeliveryModeComponent', () => {
     const setDeliveryModeId = (value: string) => {
       component.mode.controls['deliveryModeId'].setValue(value);
     };
+    const enableContinueButton = () => {
+      component.continueButtonPressed = false;
+      isSetDeliveryModeBusy$.next(false);
+      setDeliveryModeId(mockDeliveryMode1.code);
+    };
 
     it('should be disabled when delivery mode is not selected', () => {
       selectedDeliveryMode$.next({});
@@ -234,10 +239,13 @@ describe('DeliveryModeComponent', () => {
     });
 
     it('should be enabled when delivery mode is selected', () => {
+      spyOn(
+        mockCheckoutConfigService,
+        'getPreferredDeliveryMode'
+      ).and.returnValue(mockDeliveryMode1.code);
+
       component.ngOnInit();
-      component.continueButtonPressed = false;
-      isSetDeliveryModeBusy$.next(false);
-      setDeliveryModeId(mockDeliveryMode1.code);
+      enableContinueButton();
 
       fixture.detectChanges();
 
@@ -246,10 +254,13 @@ describe('DeliveryModeComponent', () => {
 
     it('should call "next" function after being clicked', () => {
       spyOn(component, 'next');
+      spyOn(
+        mockCheckoutConfigService,
+        'getPreferredDeliveryMode'
+      ).and.returnValue(mockDeliveryMode1.code);
 
       component.ngOnInit();
-      isSetDeliveryModeBusy$.next(false);
-      setDeliveryModeId(mockDeliveryMode1.code);
+      enableContinueButton();
 
       fixture.detectChanges();
 

--- a/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.ts
+++ b/projects/storefrontlib/src/cms-components/checkout/components/delivery-mode/delivery-mode.component.ts
@@ -30,6 +30,8 @@ export class DeliveryModeComponent implements OnInit, OnDestroy {
 
   backBtnText = this.checkoutStepService.getBackBntText(this.activatedRoute);
 
+  isSetDeliveryModeBusy$ = this.checkoutDeliveryService.isSetDeliveryModeBusy();
+
   deliveryModeSub: Subscription;
 
   mode: FormGroup = this.fb.group({


### PR DESCRIPTION
fixes: #14710

- the delivery mode radio input control is hidden temporarily by a spinner when there's an on-going HTTP PUT request sent and executed in commerce cloud backend server. 

- We introduce a new constructor dependency, CheckoutService, in CheckoutDeliveryService. We mark it as optional to avoid potential compilation error when you upgrade to new minor version and have previously extended it by calling super() constructor with less parameters. 

- in CheckoutDeliveryService we evaluate availability of CheckoutService dependency. If it's available, use its method isLoading to return checkout loading flag, otherwise fallback to the old NgRx store approach.

- we recommend you to pass this new constructor dependency in super in case you have extended CheckoutDeliveryService.