### PR TITLE
Define services in GigyRaasComponent as protected for better extensibility

### DIFF
--- a/integration-libs/cdc/components/gigya-raas/gigya-raas.component.ts
+++ b/integration-libs/cdc/components/gigya-raas/gigya-raas.component.ts
@@ -27,12 +27,12 @@ export class GigyaRaasComponent implements OnInit {
 
   public constructor(
     public component: CmsComponentData<GigyaRaasComponentData>,
-    private baseSiteService: BaseSiteService,
-    private languageService: LanguageService,
-    private cdcConfig: CdcConfig,
-    private winRef: WindowRef,
-    private cdcJSService: CdcJsService,
-    private zone: NgZone
+    protected baseSiteService: BaseSiteService,
+    protected languageService: LanguageService,
+    protected cdcConfig: CdcConfig,
+    protected winRef: WindowRef,
+    protected cdcJSService: CdcJsService,
+    protected zone: NgZone
   ) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
As this services maybe used for customizations of the components, they should
be protected. This allows a better customization for customers.

Fixes https://github.com/SAP/spartacus/issues/14799