### PR TITLE
fix: Preserve payment details form after spinner

### DIFF
--- a/feature-libs/cart/base/components/ng-package.json
+++ b/feature-libs/cart/base/components/ng-package.json
@@ -4,7 +4,9 @@
     "entryFile": "./public_api.ts",
     "umdModuleIds": {
       "@spartacus/core": "core",
-      "@spartacus/storefront": "storefront"
+      "@spartacus/storefront": "storefront",
+      "@ng-select/ng-select": "ngSelect",
+      "@ng-bootstrap/ng-bootstrap": "ngBootstrap"
     }
   }
 }

--- a/feature-libs/cart/base/core/ng-package.json
+++ b/feature-libs/cart/base/core/ng-package.json
@@ -4,6 +4,7 @@
     "entryFile": "./public_api.ts",
     "umdModuleIds": {
       "@spartacus/core": "core",
+      "@spartacus/storefront": "storefront",
       "@ngrx/effects": "effects",
       "@ngrx/store": "store"
     }

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NgSelectModule } from '@ng-select/ng-select';
-import { CardType } from '@spartacus/cart/base/root';
+import { CardType, PaymentDetails } from '@spartacus/cart/base/root';
 import {
   CheckoutDeliveryAddressFacade,
   CheckoutPaymentFacade,
@@ -235,6 +235,28 @@ describe('CheckoutPaymentFormComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('it should patch the form if the payment details is provided', () => {
+    const mockPaymentDetails: PaymentDetails = {
+      id: 'test',
+    };
+    component.paymentDetails = mockPaymentDetails;
+    spyOn(component.paymentForm, 'patchValue').and.callThrough();
+
+    component.ngOnInit();
+
+    expect(component.paymentForm.patchValue).toHaveBeenCalledWith(
+      mockPaymentDetails
+    );
+  });
+
+  it('it should NOT patch the form if the payment details is NOT provided', () => {
+    spyOn(component.paymentForm, 'patchValue').and.callThrough();
+
+    component.ngOnInit();
+
+    expect(component.paymentForm.patchValue).not.toHaveBeenCalled();
   });
 
   it('should call ngOnInit to get billing countries', () => {

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
@@ -61,6 +61,9 @@ export class CheckoutPaymentFormComponent implements OnInit {
   @Input()
   paymentMethodsCount: number;
 
+  @Input()
+  paymentDetailsData: any;
+
   @Output()
   goBack = new EventEmitter<any>();
 
@@ -108,6 +111,8 @@ export class CheckoutPaymentFormComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    this.paymentForm.patchValue(this.paymentDetailsData);
+
     this.expMonthAndYear();
     this.countries$ = this.userPaymentService.getAllBillingCountries().pipe(
       tap((countries) => {

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
@@ -7,7 +7,7 @@ import {
   Output,
 } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { CardType } from '@spartacus/cart/base/root';
+import { CardType, PaymentDetails } from '@spartacus/cart/base/root';
 import {
   CheckoutDeliveryAddressFacade,
   CheckoutPaymentFacade,
@@ -62,7 +62,7 @@ export class CheckoutPaymentFormComponent implements OnInit {
   paymentMethodsCount: number;
 
   @Input()
-  paymentDetailsData?: any;
+  paymentDetailsData?: PaymentDetails;
 
   @Output()
   goBack = new EventEmitter<any>();

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
@@ -62,7 +62,7 @@ export class CheckoutPaymentFormComponent implements OnInit {
   paymentMethodsCount: number;
 
   @Input()
-  paymentDetailsData?: PaymentDetails;
+  paymentDetails?: PaymentDetails;
 
   @Output()
   goBack = new EventEmitter<any>();
@@ -110,9 +110,9 @@ export class CheckoutPaymentFormComponent implements OnInit {
     protected userAddressService: UserAddressService
   ) {}
 
-  ngOnInit() {
-    if (this.paymentDetailsData) {
-      this.paymentForm.patchValue(this.paymentDetailsData);
+  ngOnInit(): void {
+    if (this.paymentDetails) {
+      this.paymentForm.patchValue(this.paymentDetails);
     }
 
     this.expMonthAndYear();

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
@@ -62,7 +62,7 @@ export class CheckoutPaymentFormComponent implements OnInit {
   paymentMethodsCount: number;
 
   @Input()
-  paymentDetailsData: any;
+  paymentDetailsData?: any;
 
   @Output()
   goBack = new EventEmitter<any>();
@@ -111,7 +111,9 @@ export class CheckoutPaymentFormComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.paymentForm.patchValue(this.paymentDetailsData);
+    if (this.paymentDetailsData) {
+      this.paymentForm.patchValue(this.paymentDetailsData);
+    }
 
     this.expMonthAndYear();
     this.countries$ = this.userPaymentService.getAllBillingCountries().pipe(

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.html
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.html
@@ -72,7 +72,7 @@
       [paymentMethodsCount]="cards?.length || 0"
       [setAsDefaultField]="!isGuestCheckout"
       [loading]="isUpdating$ | async"
-      [paymentDetailsData]="paymentDetailsData"
+      [paymentDetails]="paymentDetails"
     ></cx-payment-form>
   </ng-template>
 </ng-container>

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.html
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.html
@@ -72,6 +72,7 @@
       [paymentMethodsCount]="cards?.length || 0"
       [setAsDefaultField]="!isGuestCheckout"
       [loading]="isUpdating$ | async"
+      [paymentDetailsData]="paymentDetailsData"
     ></cx-payment-form>
   </ng-template>
 </ng-container>

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
@@ -43,7 +43,7 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
   isGuestCheckout = false;
   newPaymentFormManuallyOpened = false;
   shouldRedirect: boolean = false;
-  paymentDetailsData: any;
+  paymentDetailsData?: PaymentDetails;
 
   isUpdating$: Observable<boolean> = combineLatest([
     this.busy$,

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
@@ -43,6 +43,7 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
   isGuestCheckout = false;
   newPaymentFormManuallyOpened = false;
   shouldRedirect: boolean = false;
+  paymentDetailsData: any;
 
   isUpdating$: Observable<boolean> = combineLatest([
     this.busy$,
@@ -194,6 +195,8 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
     paymentDetails: PaymentDetails;
     billingAddress?: Address;
   }): void {
+    this.paymentDetailsData = paymentDetails;
+
     const details: PaymentDetails = { ...paymentDetails };
     details.billingAddress = billingAddress || this.deliveryAddress;
     this.busy$.next(true);

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
@@ -43,7 +43,7 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
   isGuestCheckout = false;
   newPaymentFormManuallyOpened = false;
   shouldRedirect: boolean = false;
-  paymentDetailsData?: PaymentDetails;
+  paymentDetails?: PaymentDetails;
 
   isUpdating$: Observable<boolean> = combineLatest([
     this.busy$,
@@ -195,10 +195,10 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
     paymentDetails: PaymentDetails;
     billingAddress?: Address;
   }): void {
-    this.paymentDetailsData = paymentDetails;
+    this.paymentDetails = paymentDetails;
 
     const details: PaymentDetails = { ...paymentDetails };
-    details.billingAddress = billingAddress || this.deliveryAddress;
+    details.billingAddress = billingAddress ?? this.deliveryAddress;
     this.busy$.next(true);
     this.subscriptions.add(
       this.checkoutPaymentFacade.createPaymentDetails(details).subscribe({


### PR DESCRIPTION
During the checkout process, after populating the payment details form and clicking continue, the validation of the entered payment details is performed.
In case the validation fails, the form is cleared, while it should be preserved.