### PR TITLE
refactor: rename var of assistive message (#14371)

### DIFF
--- a/projects/storefrontlib/cms-components/misc/global-message/global-message.component.html
+++ b/projects/storefrontlib/cms-components/misc/global-message/global-message.component.html
@@ -1,9 +1,9 @@
 <div *ngIf="messages$ | async as messages">
   <div
     class="cx-visually-hidden"
-    *ngFor="let confMsg of messages[messageType.MSG_TYPE_ASSISTIVE]"
+    *ngFor="let assistiveMsg of messages[messageType.MSG_TYPE_ASSISTIVE]"
   >
-    <span>{{ confMsg | cxTranslate }}</span>
+    <span>{{ assistiveMsg | cxTranslate }}</span>
   </div>
   <div
     class="alert alert-success"


### PR DESCRIPTION
Rename the var used to access the iteration of assistive messages in the template of `GlobalMessage`