### PR TITLE
Fix:quantity displayed issue in item counter

### DIFF
--- a/feature-libs/cart/base/styles/components/_item-counter.scss
+++ b/feature-libs/cart/base/styles/components/_item-counter.scss
@@ -24,7 +24,7 @@
       border: none;
       cursor: text;
       @include forVersion(4.2) {
-        width: 100%;
+        width: 65px;
       }
     }
   }

--- a/feature-libs/cart/base/styles/components/_item-counter.scss
+++ b/feature-libs/cart/base/styles/components/_item-counter.scss
@@ -24,7 +24,7 @@
       border: none;
       cursor: text;
       @include forVersion(4.2) {
-        width: 35px;
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
Fix: https://github.com/SAP/spartacus/issues/15265
quantity input box had fixed width as 35px so if 4 digits value is entered then it looks bad.  fixed to 100% width