### PR TITLE
fix: i18n when using JSON in SSR - set `reloadInterval: false`

### DIFF
--- a/projects/core/src/i18n/i18next/i18next-init.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.spec.ts
@@ -5,8 +5,21 @@ import {
   TestRequest,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import {
+  ConfigInitializerService,
+  I18nConfig,
+  LanguageService,
+} from '@spartacus/core';
+import { i18n } from 'i18next';
 import { RequestCallback } from 'i18next-http-backend';
-import { getLoadPath, i18nextGetHttpClient } from './i18next-init';
+import { of } from 'rxjs';
+import {
+  getLoadPath,
+  i18nextGetHttpClient,
+  i18nextInit,
+  SiteContextI18nextSynchronizer,
+} from './i18next-init';
+import { I18NEXT_INSTANCE } from './i18next-instance';
 
 const testUrl = 'testUrl';
 
@@ -66,6 +79,60 @@ describe('i18nextGetHttpClient should return a http client that', () => {
       status,
       // a workaround for https://github.com/i18next/i18next-http-backend/issues/82
       data: null as any,
+    });
+  });
+});
+
+describe('i18nextInit', () => {
+  let i18next: i18n;
+  let configInitializerService: ConfigInitializerService;
+  let languageService: LanguageService;
+  let httpClient: HttpClient;
+  let siteContextI18nextSynchronizer: SiteContextI18nextSynchronizer;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        {
+          provide: LanguageService,
+          useValue: { getActive: () => of('en') } as Partial<LanguageService>,
+        },
+      ],
+    });
+    i18next = TestBed.inject(I18NEXT_INSTANCE);
+    configInitializerService = TestBed.inject(ConfigInitializerService);
+    languageService = TestBed.inject(LanguageService);
+    httpClient = TestBed.inject(HttpClient);
+    siteContextI18nextSynchronizer = TestBed.inject(
+      SiteContextI18nextSynchronizer
+    );
+  });
+
+  describe('when using i18next http backend', () => {
+    beforeEach(() => {
+      const config: I18nConfig = {
+        i18n: {
+          backend: {
+            loadPath: 'testPath',
+          },
+        },
+      };
+      spyOn(configInitializerService, 'getStable').and.returnValue(of(config));
+    });
+
+    fit('should set i18next config `backend.reloadInterval` to false', () => {
+      spyOn(i18next, 'init').and.callThrough();
+      i18nextInit(
+        i18next,
+        configInitializerService,
+        languageService,
+        httpClient,
+        null,
+        siteContextI18nextSynchronizer
+      )();
+      const i18nextConfig = (i18next.init as jasmine.Spy).calls.argsFor(0)[0];
+      expect(i18nextConfig.backend.reloadInterval).toBe(false);
     });
   });
 });

--- a/projects/core/src/i18n/i18next/i18next-init.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.spec.ts
@@ -121,7 +121,7 @@ describe('i18nextInit', () => {
       spyOn(configInitializerService, 'getStable').and.returnValue(of(config));
     });
 
-    fit('should set i18next config `backend.reloadInterval` to false', () => {
+    it('should set i18next config `backend.reloadInterval` to false', () => {
       spyOn(i18next, 'init').and.callThrough();
       i18nextInit(
         i18next,

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -43,7 +43,7 @@ export function i18nextInit(
               loadPath,
               request: i18nextGetHttpClient(httpClient),
 
-              // Disable the periodical reloading, because the `setInterval()` used inside `i18next-http-backend` would prevent the SSR to finish
+              // Disable the periodical reloading. Otherwise the SSR would not finish due to the pending task `setInterval()`
               // See source code: https://github.com/i18next/i18next-http-backend/blob/00b7e8f67abf8372af17529b51190a7e8b17e3d8/i18nextHttpBackend.js#L94-L95
               reloadInterval: false,
             };

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -43,8 +43,8 @@ export function i18nextInit(
               loadPath,
               request: i18nextGetHttpClient(httpClient),
 
-              // Disable the periodical reloading. Otherwise the SSR would not finish due to the pending task `setInterval()`
-              // See source code: https://github.com/i18next/i18next-http-backend/blob/00b7e8f67abf8372af17529b51190a7e8b17e3d8/i18nextHttpBackend.js#L94-L95
+              // Disable the periodical reloading. Otherwise SSR would not finish due to the pending task `setInterval()`
+              // See source code of `i18next-http-backend` : https://github.com/i18next/i18next-http-backend/blob/00b7e8f67abf8372af17529b51190a7e8b17e3d8/lib/index.js#L40-L41
               reloadInterval: false,
             };
             i18nextConfig = { ...i18nextConfig, backend };

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -42,6 +42,10 @@ export function i18nextInit(
             const backend: BackendOptions = {
               loadPath,
               request: i18nextGetHttpClient(httpClient),
+
+              // Disable the periodical reloading, because the `setInterval()` used inside `i18next-http-backend` would prevent the SSR to finish
+              // See source code: https://github.com/i18next/i18next-http-backend/blob/00b7e8f67abf8372af17529b51190a7e8b17e3d8/i18nextHttpBackend.js#L94-L95
+              reloadInterval: false,
             };
             i18nextConfig = { ...i18nextConfig, backend };
           }

--- a/projects/core/src/i18n/i18next/i18next-init.ts
+++ b/projects/core/src/i18n/i18next/i18next-init.ts
@@ -16,7 +16,7 @@ export function i18nextInit(
   configInit: ConfigInitializerService,
   languageService: LanguageService,
   httpClient: HttpClient,
-  serverRequestOrigin: string,
+  serverRequestOrigin: string | null,
   siteContextI18nextSynchronizer: SiteContextI18nextSynchronizer
 ): () => Promise<any> {
   return () =>
@@ -133,7 +133,10 @@ export function i18nextGetHttpClient(
  * - https://github.com/angular/angular/issues/19224
  * - https://github.com/angular/universal/issues/858
  */
-export function getLoadPath(path: string, serverRequestOrigin: string): string {
+export function getLoadPath(
+  path: string,
+  serverRequestOrigin: string | null
+): string {
   if (serverRequestOrigin && !path.match(/^http(s)?:\/\//)) {
     if (path.startsWith('/')) {
       path = path.slice(1);


### PR DESCRIPTION
Previously, the periodical reloading of JSON translations in SSR was enabled by default by `i18next-http-backend`. The never-ending async task `setInterval()` invoked inside `i18next-http-backend` caused the SSR to hang.

To prevent it, we're setting explicitly `reloadInterval: false` in the options of `i18next`.

fixes #14372