### PR TITLE
GH-15005 Use "totalUnitCount" over "totalItems" for Saved Cart Dialog

### DIFF
--- a/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.component.html
+++ b/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.component.html
@@ -89,7 +89,7 @@
                 {{ 'savedCartDialog.quantity' | cxTranslate }}
               </div>
               <div class="cx-saved-cart-value">
-                {{ cart?.totalItems }}
+                {{ cart?.totalUnitCount }}
               </div>
             </div>
 


### PR DESCRIPTION
Fixes https://github.com/SAP/spartacus/issues/15005

SavedCartFormDialogComponent should be using totalUnitCount rather than totalItems for displaying quantity in the cart