### PR TITLE
chore: fix pipeline on branch `release/4.3.x` 

### DIFF
--- a/.env-cmdrc
+++ b/.env-cmdrc
@@ -6,7 +6,7 @@
     "CX_BASE_URL": "https://localhost:9002"
   },
   "ci": {
-    "CX_BASE_URL": "https://20.83.184.244:9002"
+    "CX_BASE_URL": "https://20.55.1.150:9002"
   },
   "lighthouse": {
     "CX_BASE_URL": "https://api.spartacus.rocks"


### PR DESCRIPTION
- use CI server with the sample data compatible with 4.3.x

closes #15326