### PR TITLE
fix: ApproverGuard is not exported in the public api (#12840)

### DIFF
--- a/feature-libs/organization/order-approval/index.ts
+++ b/feature-libs/organization/order-approval/index.ts
@@ -1,5 +1,6 @@
 export * from './components/index';
 export * from './core/connectors/index';
+export * from './core/guards/index';
 export * from './core/model/index';
 export * from './core/services/index';
 export * from './core/store/actions/index';


### PR DESCRIPTION
closes: #12840