### PR TITLE
fix: spare part list filter input value not reset on navigation

### DIFF
--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
@@ -1,13 +1,25 @@
-import { EventEmitter, Injectable } from '@angular/core';
+import { EventEmitter, Injectable, OnDestroy } from '@angular/core';
 import { Product, ProductReference } from '@spartacus/core';
-import { combineLatest, concat, Observable, of } from 'rxjs';
+import { combineLatest, concat, Observable, of, Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
+import { Router, Event, NavigationEnd } from '@angular/router';
 
 @Injectable({
   providedIn: 'root',
 })
-export class VisualPickingProductFilterService {
-  constructor() {}
+export class VisualPickingProductFilterService implements OnDestroy {
+  constructor(protected router: Router) {
+    this.routerEventsSubscription = this.router.events.subscribe((event: Event) => { 
+      if (event instanceof NavigationEnd) {
+          this.filter = '';
+    }});
+  }
+
+  ngOnDestroy(): void {
+   this.routerEventsSubscription.unsubscribe();
+  }
+
+  protected routerEventsSubscription: Subscription;
 
   /**
    * The current filter value.


### PR DESCRIPTION
[Spare part list filter value not cleared on navigation #15232](https://github.com/SAP/spartacus/issues/15232)

- Sets the `filter` property of the VisualPickingProductFilterService to an empty string on navigation.
- Ensures that Observables used in the corresponding tests complete (to avoid interaction between tests caused by an Observable that outlives the test it relates to).