### PR TITLE
fix: spare part list filter input value not reset on navigation

### DIFF
--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.spec.ts
@@ -1,5 +1,10 @@
 import { EventEmitter } from '@angular/core';
-import { NavigationEnd, NavigationStart, Router, RouterEvent } from '@angular/router';
+import {
+  NavigationEnd,
+  NavigationStart,
+  Router,
+  RouterEvent,
+} from '@angular/router';
 import { TestBed } from '@angular/core/testing';
 import { ProductReference } from '@spartacus/core';
 import { of, Subject } from 'rxjs';
@@ -21,7 +26,9 @@ describe('VisualPickingProductFilterService', () => {
       providers: [{ provide: Router, useValue: mockRouter }],
     });
 
-    visualPickingProductFilterService = TestBed.inject(VisualPickingProductFilterService);
+    visualPickingProductFilterService = TestBed.inject(
+      VisualPickingProductFilterService
+    );
   });
   it('should match on product code', (done) => {
     const productReferences: ProductReference[] = [
@@ -72,7 +79,6 @@ describe('VisualPickingProductFilterService', () => {
 
   describe('get filter', () => {
     it('should return value that was set', () => {
-
       expect(visualPickingProductFilterService.filter).toEqual('');
       visualPickingProductFilterService.filter = 'yyyy';
       expect(visualPickingProductFilterService.filter).toEqual('yyyy');
@@ -81,7 +87,6 @@ describe('VisualPickingProductFilterService', () => {
 
   describe('getFilteredProducts', () => {
     it('should match on product description', (done) => {
-
       const productReferences: ProductReference[] = [
         {
           target: {
@@ -119,7 +124,6 @@ describe('VisualPickingProductFilterService', () => {
     });
 
     it('should match multiple', (done) => {
-
       const productReferences: ProductReference[] = [
         {
           target: {
@@ -163,7 +167,6 @@ describe('VisualPickingProductFilterService', () => {
     });
 
     it('should not filter when empty string used as filter string', (done) => {
-
       const productReferences: ProductReference[] = [
         {
           target: {

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
@@ -1,13 +1,25 @@
-import { EventEmitter, Injectable } from '@angular/core';
+import { EventEmitter, Injectable, OnDestroy } from '@angular/core';
 import { Product, ProductReference } from '@spartacus/core';
-import { combineLatest, concat, Observable, of } from 'rxjs';
+import { combineLatest, concat, Observable, of, Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
+import { Router, Event, NavigationEnd } from '@angular/router';
 
 @Injectable({
   providedIn: 'root',
 })
-export class VisualPickingProductFilterService {
-  constructor() {}
+export class VisualPickingProductFilterService implements OnDestroy {
+  constructor(protected router: Router) {
+    this.routerEventsSubscription = this.router.events.subscribe((event: Event) => {
+      if (event instanceof NavigationEnd) {
+          this.filter = '';
+    }});
+  }
+
+  ngOnDestroy(): void {
+   this.routerEventsSubscription.unsubscribe();
+  }
+
+  protected routerEventsSubscription: Subscription;
 
   /**
    * The current filter value.

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
@@ -9,14 +9,17 @@ import { Router, Event, NavigationEnd } from '@angular/router';
 })
 export class VisualPickingProductFilterService implements OnDestroy {
   constructor(protected router: Router) {
-    this.routerEventsSubscription = this.router.events.subscribe((event: Event) => {
-      if (event instanceof NavigationEnd) {
+    this.routerEventsSubscription = this.router.events.subscribe(
+      (event: Event) => {
+        if (event instanceof NavigationEnd) {
           this.filter = '';
-    }});
+        }
+      }
+    );
   }
 
   ngOnDestroy(): void {
-   this.routerEventsSubscription.unsubscribe();
+    this.routerEventsSubscription.unsubscribe();
   }
 
   protected routerEventsSubscription: Subscription;


### PR DESCRIPTION
[Spare part list filter value not cleared on navigation #15232](https://github.com/SAP/spartacus/issues/15232)

- Sets the `filter` property of the `VisualPickingProductFilterService` to an empty string on navigation.
- Ensures that Observables used in the corresponding tests complete (to avoid interaction between tests caused by an Observable that outlives the test it relates to).