### PR TITLE
fix: export I18nConfigInitializer

### DIFF
--- a/projects/core/src/i18n/index.ts
+++ b/projects/core/src/i18n/index.ts
@@ -1,4 +1,5 @@
 export * from './config/i18n-config';
+export * from './config/i18n-config-initializer';
 export * from './date.pipe';
 export * from './numeric.pipe';
 export { I18nModule } from './i18n.module';


### PR DESCRIPTION
Expose missing I18nConfigInitializer in public API

closes: #15402