### PR TITLE
feat: show conflicts as seperate issues on overviewpage

### DIFF
--- a/docs/migration/css-changes-in-version-5.md
+++ b/docs/migration/css-changes-in-version-5.md
@@ -44,7 +44,7 @@ title: Changes to Styles in 5.0
 ## Changes in \_configurator-overview-notification-banner.scss
 - flex box on root level was changed to column direction to support multiple banners placed underneath
 - `.cx-error-notification-banner` and `.cx-conflict-notification-banner` were added with flex direction row for styling the individual banners.
-- `.cx-error-notification-banner` replicates the error banner stale implemented before on root level.
+- `.cx-error-notification-banner` replicates the error banner style implemented before on root level.
 - `.cx-conflict-notification-banner` implements the new conflict banner styling.
 
 ## Changes in styles

--- a/docs/migration/css-changes-in-version-5.md
+++ b/docs/migration/css-changes-in-version-5.md
@@ -18,6 +18,10 @@ title: Changes to Styles in 5.0
 - `box-shadow` was added and set to ` 0 0 5px var(--cx-color-light)` on `%cx-configurator-add-to-cart-button`
 - `margin-top` was added and set to `0px` on `@include cx-configurator-footer-container()`
 
+## Changes in Configurator Overview Notification Banner Component
+- error banner was converted to a div, so that `cx-error-notification-banner` style could be added.
+- new conflict banner div with with style `cx-conflict-notification-banner` was added.
+
 ## Changes in Configurator Tab Bar Component
 
 - Styling is now applied only if content is not empty. Therefore, the styling is wrapped with an `&:not(:empty) {` expression.
@@ -36,6 +40,12 @@ title: Changes to Styles in 5.0
 
 - `padding-inline-start: 5px;` was removed from `cx-icon`section
 - A new section `a.cx-conflict-msg` has been introduced to style the link that allows for navigating from conflicting attributes to their original group. Its content is `cursor: pointer;`
+
+## Changes in \_configurator-overview-notification-banner.scss
+- flex box on root level was changed to column direction to support multiple banners placed underneath
+- `.cx-error-notification-banner` and `.cx-conflict-notification-banner` were added with flex direction row for styling the individual banners.
+- `.cx-error-notification-banner` replicates the error banner stale implemented before on root level.
+- `.cx-conflict-notification-banner` implements the new conflict banner styling.
 
 ## Changes in styles
 

--- a/feature-libs/product-configurator/common/assets/translations/en/configurator-common.ts
+++ b/feature-libs/product-configurator/common/assets/translations/en/configurator-common.ts
@@ -8,6 +8,7 @@ export const configurator = {
       editConfiguration: 'Edit Configuration',
       displayConfiguration: 'Display Configuration',
       resolveIssues: 'Resolve Issues',
+      resolveConflicts: 'Resolve Conflicts',
       updateMessage: 'The configuration is being updated in the background',
       showMore: 'show more',
       showLess: 'show less',
@@ -28,6 +29,9 @@ export const configurator = {
       numberOfIssues: '{{count}} issue must be resolved before checkout.',
       numberOfIssues_other:
         '{{count}} issues must be resolved before checkout.',
+      numberOfConflicts: '{{count}} conflict must be resolved before checkout.',
+      numberOfConflicts_other:
+        '{{count}} conflicts must be resolved before checkout.',
     },
     attribute: {
       id: 'ID',

--- a/feature-libs/product-configurator/common/components/service/configurator-router-data.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-data.ts
@@ -11,5 +11,6 @@ export namespace ConfiguratorRouter {
     displayOnly?: boolean;
     forceReload?: boolean;
     resolveIssues?: boolean;
+    ignoreConflicts?: boolean;
   }
 }

--- a/feature-libs/product-configurator/common/components/service/configurator-router-data.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-data.ts
@@ -11,6 +11,6 @@ export namespace ConfiguratorRouter {
     displayOnly?: boolean;
     forceReload?: boolean;
     resolveIssues?: boolean;
-    ignoreConflicts?: boolean;
+    skipConflicts?: boolean;
   }
 }

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
@@ -151,7 +151,7 @@ describe('ConfigRouterExtractorService', () => {
         .unsubscribe();
     });
 
-    it('should tell from the URL if we need to resolve issues of a configuration', () => {
+    it('should tell from the URL if we need to resolve issues without ignoring conflicts of a configuration', () => {
       mockRouterState.state.queryParams = { resolveIssues: 'true' };
       let routerData: ConfiguratorRouter.Data;
       serviceUnderTest
@@ -159,6 +159,23 @@ describe('ConfigRouterExtractorService', () => {
         .subscribe((data) => {
           routerData = data;
           expect(routerData.resolveIssues).toBe(true);
+          expect(routerData.ignoreConflicts).toBe(false);
+        })
+        .unsubscribe();
+    });
+
+    it('should tell from the URL if we need to ignore conflicts while resolving issues of a configuration', () => {
+      mockRouterState.state.queryParams = {
+        resolveIssues: 'true',
+        ignoreConflicts: 'true',
+      };
+      let routerData: ConfiguratorRouter.Data;
+      serviceUnderTest
+        .extractRouterData()
+        .subscribe((data) => {
+          routerData = data;
+          expect(routerData.resolveIssues).toBe(true);
+          expect(routerData.ignoreConflicts).toBe(true);
         })
         .unsubscribe();
     });

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
@@ -159,7 +159,7 @@ describe('ConfigRouterExtractorService', () => {
         .subscribe((data) => {
           routerData = data;
           expect(routerData.resolveIssues).toBe(true);
-          expect(routerData.ignoreConflicts).toBe(false);
+          expect(routerData.skipConflicts).toBe(false);
         })
         .unsubscribe();
     });
@@ -175,7 +175,7 @@ describe('ConfigRouterExtractorService', () => {
         .subscribe((data) => {
           routerData = data;
           expect(routerData.resolveIssues).toBe(true);
-          expect(routerData.ignoreConflicts).toBe(true);
+          expect(routerData.skipConflicts).toBe(true);
         })
         .unsubscribe();
     });

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
@@ -151,7 +151,7 @@ describe('ConfigRouterExtractorService', () => {
         .unsubscribe();
     });
 
-    it('should tell from the URL if we need to resolve issues without ignoring conflicts of a configuration', () => {
+    it('should tell from the URL if we need to resolve issues without ignoring conflicts of a configuration', (done) => {
       mockRouterState.state.queryParams = { resolveIssues: 'true' };
       let routerData: ConfiguratorRouter.Data;
       serviceUnderTest
@@ -160,11 +160,12 @@ describe('ConfigRouterExtractorService', () => {
           routerData = data;
           expect(routerData.resolveIssues).toBe(true);
           expect(routerData.skipConflicts).toBe(false);
+          done();
         })
         .unsubscribe();
     });
 
-    it('should tell from the URL if we need to ignore conflicts while resolving issues of a configuration', () => {
+    it('should tell from the URL if we need to ignore conflicts while resolving issues of a configuration', (done) => {
       mockRouterState.state.queryParams = {
         resolveIssues: 'true',
         ignoreConflicts: 'true',
@@ -176,6 +177,7 @@ describe('ConfigRouterExtractorService', () => {
           routerData = data;
           expect(routerData.resolveIssues).toBe(true);
           expect(routerData.skipConflicts).toBe(true);
+          done();
         })
         .unsubscribe();
     });

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
@@ -165,10 +165,10 @@ describe('ConfigRouterExtractorService', () => {
         .unsubscribe();
     });
 
-    it('should tell from the URL if we need to ignore conflicts while resolving issues of a configuration', (done) => {
+    it('should tell from the URL if we need to skip conflicts while resolving issues of a configuration', (done) => {
       mockRouterState.state.queryParams = {
         resolveIssues: 'true',
-        ignoreConflicts: 'true',
+        skipConflicts: 'true',
       };
       let routerData: ConfiguratorRouter.Data;
       serviceUnderTest

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
@@ -36,6 +36,8 @@ export class ConfiguratorRouterExtractorService {
           displayOnly: routingData.state.params.displayOnly,
           resolveIssues:
             routingData.state.queryParams?.resolveIssues === 'true',
+          ignoreConflicts:
+            routingData.state.queryParams?.ignoreConflicts === 'true',
           forceReload: routingData.state.queryParams?.forceReload === 'true',
           pageType:
             semanticRoute &&

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
@@ -37,7 +37,7 @@ export class ConfiguratorRouterExtractorService {
           resolveIssues:
             routingData.state.queryParams?.resolveIssues === 'true',
           skipConflicts:
-            routingData.state.queryParams?.ignoreConflicts === 'true',
+            routingData.state.queryParams?.skipConflicts === 'true',
           forceReload: routingData.state.queryParams?.forceReload === 'true',
           pageType:
             semanticRoute &&

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
@@ -36,7 +36,7 @@ export class ConfiguratorRouterExtractorService {
           displayOnly: routingData.state.params.displayOnly,
           resolveIssues:
             routingData.state.queryParams?.resolveIssues === 'true',
-          ignoreConflicts:
+          skipConflicts:
             routingData.state.queryParams?.ignoreConflicts === 'true',
           forceReload: routingData.state.queryParams?.forceReload === 'true',
           pageType:

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.spec.ts
@@ -339,6 +339,33 @@ describe('ConfigurationFormComponent', () => {
       ).toHaveBeenCalledTimes(0);
     });
 
+    it('should go to first incomplete group in case the router requires this - has conflicts, but should be ignored', () => {
+      spyOn(
+        configuratorGroupsService,
+        'navigateToConflictSolver'
+      ).and.callThrough();
+      spyOn(
+        configuratorGroupsService,
+        'navigateToFirstIncompleteGroup'
+      ).and.callThrough();
+      routerStateObservable = of({
+        ...mockRouterState,
+        state: {
+          ...mockRouterState.state,
+          queryParams: { resolveIssues: 'true', ignoreConflicts: 'true' },
+        },
+      });
+      hasConfigurationConflictsObservable = of(true);
+      createComponent().ngOnInit();
+      expect(
+        configuratorGroupsService.navigateToConflictSolver
+      ).toHaveBeenCalledTimes(0);
+      expect(
+        configuratorGroupsService.navigateToFirstIncompleteGroup
+      ).toHaveBeenCalledTimes(1);
+    });
+
+
     it('should go to first incomplete group in case the router requires this - has no conflicts', () => {
       spyOn(
         configuratorGroupsService,

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.spec.ts
@@ -365,7 +365,6 @@ describe('ConfigurationFormComponent', () => {
       ).toHaveBeenCalledTimes(1);
     });
 
-
     it('should go to first incomplete group in case the router requires this - has no conflicts', () => {
       spyOn(
         configuratorGroupsService,

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.spec.ts
@@ -339,7 +339,7 @@ describe('ConfigurationFormComponent', () => {
       ).toHaveBeenCalledTimes(0);
     });
 
-    it('should go to first incomplete group in case the router requires this - has conflicts, but should be ignored', () => {
+    it('should go to first incomplete group in case the router requires this - has conflicts, but should be skipped', () => {
       spyOn(
         configuratorGroupsService,
         'navigateToConflictSolver'
@@ -352,7 +352,7 @@ describe('ConfigurationFormComponent', () => {
         ...mockRouterState,
         state: {
           ...mockRouterState.state,
-          queryParams: { resolveIssues: 'true', ignoreConflicts: 'true' },
+          queryParams: { resolveIssues: 'true', skipConflicts: 'true' },
         },
       });
       hasConfigurationConflictsObservable = of(true);

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.ts
@@ -63,7 +63,7 @@ export class ConfiguratorFormComponent implements OnInit {
             .hasConflicts(routingData.owner)
             .pipe(take(1))
             .subscribe((hasConflicts) => {
-              if (hasConflicts) {
+              if (hasConflicts && !routingData.ignoreConflicts) {
                 this.configuratorGroupsService.navigateToConflictSolver(
                   routingData.owner
                 );

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.ts
@@ -68,7 +68,7 @@ export class ConfiguratorFormComponent implements OnInit {
                   routingData.owner
                 );
 
-                //Only check for Incomplete group when there are no conflicts
+                //Only check for Incomplete group when there are no conflicts or conflicts should be skipped
               } else {
                 this.configuratorGroupsService.navigateToFirstIncompleteGroup(
                   routingData.owner

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.ts
@@ -63,7 +63,7 @@ export class ConfiguratorFormComponent implements OnInit {
             .hasConflicts(routingData.owner)
             .pipe(take(1))
             .subscribe((hasConflicts) => {
-              if (hasConflicts && !routingData.ignoreConflicts) {
+              if (hasConflicts && !routingData.skipConflicts) {
                 this.configuratorGroupsService.navigateToConflictSolver(
                   routingData.owner
                 );

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
@@ -26,5 +26,30 @@
         </button>
       </div>
     </ng-container>
+    <ng-container *ngIf="numberOfConflicts$ | async as numberOfConflicts">
+      <cx-icon [type]="iconTypes.WARNING"></cx-icon>
+      <div class="cx-conflict-msg" id="cx-configurator-overview-conflict-msg">
+        {{
+          'configurator.notificationBanner.numberOfConflicts'
+            | cxTranslate: { count: numberOfConflicts }
+        }}
+        <button
+          class="link cx-action-link"
+          aria-describedby="cx-configurator-overview-conflict-msg"
+          [routerLink]="
+            {
+              cxRoute: 'configure' + routerData.owner.configuratorType,
+              params: {
+                entityKey: routerData.owner.id,
+                ownerType: routerData.owner.type
+              }
+            } | cxUrl          "
+          [queryParams]="{ resolveIssues: true }"
+          cxAutoFocus
+        >
+          {{ 'configurator.header.resolveConflicts' | cxTranslate }}
+        </button>
+      </div>
+    </ng-container>
   </ng-container>
 </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
@@ -24,7 +24,7 @@
           "
           [queryParams]="{
             resolveIssues: true,
-            ignoreConflicts: ignoreConflicts$ | async
+            skipConflicts: skipConflictsOnIssueNavigation$ | async
           }"
           cxAutoFocus
         >

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
@@ -1,6 +1,7 @@
 <ng-container *ngIf="routerData$ | async as routerData">
   <ng-container *ngIf="configurationOverview$ | async">
     <ng-container *ngIf="numberOfIssues$ | async as numberOfIssues">
+
       <cx-icon [type]="iconTypes.ERROR"></cx-icon>
       <div class="cx-error-msg" id="cx-configurator-overview-error-msg">
         {{
@@ -19,7 +20,7 @@
               }
             } | cxUrl
           "
-          [queryParams]="{ resolveIssues: true }"
+          [queryParams]="{ resolveIssues: true, ignoreConflicts: (numberOfConflicts$ | async)>0 }"
           cxAutoFocus
         >
           {{ 'configurator.header.resolveIssues' | cxTranslate }}

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
@@ -1,6 +1,9 @@
 <ng-container *ngIf="routerData$ | async as routerData">
   <ng-container *ngIf="configurationOverview$ | async">
-    <div class="cx-error-notification-banner" *ngIf="numberOfIssues$ | async as numberOfIssues">
+    <div
+      class="cx-error-notification-banner"
+      *ngIf="numberOfIssues$ | async as numberOfIssues"
+    >
       <cx-icon [type]="iconTypes.ERROR"></cx-icon>
       <div class="cx-error-msg" id="cx-configurator-overview-error-msg">
         {{
@@ -19,14 +22,20 @@
               }
             } | cxUrl
           "
-          [queryParams]="{ resolveIssues: true, ignoreConflicts: (numberOfConflicts$ | async)>0 }"
+          [queryParams]="{
+            resolveIssues: true,
+            ignoreConflicts: ignoreConflicts$ | async
+          }"
           cxAutoFocus
         >
           {{ 'configurator.header.resolveIssues' | cxTranslate }}
         </button>
       </div>
     </div>
-    <div class="cx-conflict-notification-banner" *ngIf="numberOfConflicts$ | async as numberOfConflicts">
+    <div
+      class="cx-conflict-notification-banner"
+      *ngIf="numberOfConflicts$ | async as numberOfConflicts"
+    >
       <cx-icon [type]="iconTypes.WARNING"></cx-icon>
       <div class="cx-conflict-msg" id="cx-configurator-overview-conflict-msg">
         {{
@@ -43,7 +52,8 @@
                 entityKey: routerData.owner.id,
                 ownerType: routerData.owner.type
               }
-            } | cxUrl          "
+            } | cxUrl
+          "
           [queryParams]="{ resolveIssues: true }"
           cxAutoFocus
         >

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
@@ -1,7 +1,6 @@
 <ng-container *ngIf="routerData$ | async as routerData">
   <ng-container *ngIf="configurationOverview$ | async">
-    <ng-container *ngIf="numberOfIssues$ | async as numberOfIssues">
-
+    <div class="cx-error-notification-banner" *ngIf="numberOfIssues$ | async as numberOfIssues">
       <cx-icon [type]="iconTypes.ERROR"></cx-icon>
       <div class="cx-error-msg" id="cx-configurator-overview-error-msg">
         {{
@@ -26,8 +25,8 @@
           {{ 'configurator.header.resolveIssues' | cxTranslate }}
         </button>
       </div>
-    </ng-container>
-    <ng-container *ngIf="numberOfConflicts$ | async as numberOfConflicts">
+    </div>
+    <div class="cx-conflict-notification-banner" *ngIf="numberOfConflicts$ | async as numberOfConflicts">
       <cx-icon [type]="iconTypes.WARNING"></cx-icon>
       <div class="cx-conflict-msg" id="cx-configurator-overview-conflict-msg">
         {{
@@ -51,6 +50,6 @@
           {{ 'configurator.header.resolveConflicts' | cxTranslate }}
         </button>
       </div>
-    </ng-container>
+    </div>
   </ng-container>
 </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
@@ -304,4 +304,15 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
       expect(skipConflicts).toBe(false)
     );
   });
+
+  it('should count zero warnings as in case overview is not available', () => {
+    configurationObs = of(productConfigurationWithConflicts);
+    initialize(routerData);
+    component.numberOfConflicts$.subscribe((numberOfConflicts) =>
+      expect(numberOfConflicts).toBe(0)
+    );
+    component.skipConflictsOnIssueNavigation$.subscribe((skipConflicts) =>
+      expect(skipConflicts).toBe(false)
+    );
+  });
 });

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
@@ -262,6 +262,20 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
     );
   });
 
+  it('should count zero issues in case detailed issue numbers are available with only conflicts', () => {
+    let config: Configurator.Configuration = {
+      ...productConfigurationWithDetailedIssuesCountedInOverview,
+    };
+    if (config.overview) {
+      config.overview.numberOfIncompleteCharacteristics = 0;
+    }
+    configurationObs = of(config);
+    initialize(routerData);
+    component.numberOfIssues$.subscribe((numberOfIssues) =>
+      expect(numberOfIssues).toBe(0)
+    );
+  });
+
   it('should count only conflicts as warnings in case detailed issue numbers are available', () => {
     configurationObs = of(
       productConfigurationWithDetailedIssuesCountedInOverview
@@ -273,8 +287,8 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
           ?.numberOfConflicts
       )
     );
-    component.ignoreConflicts$.subscribe((numberOfConflicts) =>
-      expect(numberOfConflicts).toBe(true)
+    component.ignoreConflicts$.subscribe((ignoreConflicts) =>
+      expect(ignoreConflicts).toBe(true)
     );
   });
 
@@ -286,8 +300,8 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
     component.numberOfConflicts$.subscribe((numberOfConflicts) =>
       expect(numberOfConflicts).toBe(0)
     );
-    component.ignoreConflicts$.subscribe((numberOfConflicts) =>
-      expect(numberOfConflicts).toBe(false)
+    component.ignoreConflicts$.subscribe((ignoreConflicts) =>
+      expect(ignoreConflicts).toBe(false)
     );
   });
 });

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
@@ -287,8 +287,8 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
           ?.numberOfConflicts
       )
     );
-    component.ignoreConflicts$.subscribe((ignoreConflicts) =>
-      expect(ignoreConflicts).toBe(true)
+    component.skipConflictsOnIssueNavigation$.subscribe((skipConflicts) =>
+      expect(skipConflicts).toBe(true)
     );
   });
 
@@ -300,8 +300,8 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
     component.numberOfConflicts$.subscribe((numberOfConflicts) =>
       expect(numberOfConflicts).toBe(0)
     );
-    component.ignoreConflicts$.subscribe((ignoreConflicts) =>
-      expect(ignoreConflicts).toBe(false)
+    component.skipConflictsOnIssueNavigation$.subscribe((skipConflicts) =>
+      expect(skipConflicts).toBe(false)
     );
   });
 });

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
@@ -273,6 +273,9 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
           ?.numberOfConflicts
       )
     );
+    component.ignoreConflicts$.subscribe((numberOfConflicts) =>
+      expect(numberOfConflicts).toBe(true)
+    );
   });
 
   it('should count zero warnings as in case detailed issue numbers are not available', () => {
@@ -282,6 +285,9 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
     initialize(routerData);
     component.numberOfConflicts$.subscribe((numberOfConflicts) =>
       expect(numberOfConflicts).toBe(0)
+    );
+    component.ignoreConflicts$.subscribe((numberOfConflicts) =>
+      expect(numberOfConflicts).toBe(false)
     );
   });
 });

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
@@ -35,6 +35,38 @@ class MockUrlPipe implements PipeTransform {
   transform(): any {}
 }
 
+const productConfigurationWithDetailedIssuesCountedInOverview: Configurator.Configuration =
+  {
+    ...productConfigurationWithConflicts,
+    totalNumberOfIssues: 0,
+    overview: {
+      configId: CONFIG_ID,
+      productCode: productConfigurationWithConflicts.productCode,
+      totalNumberOfIssues: 5,
+      numberOfConflicts: 3,
+      numberOfIncompleteCharacteristics: 2,
+    },
+  };
+
+const productConfigurationWithOnlyTotalIssuesCountedInOverview: Configurator.Configuration =
+  {
+    ...productConfigurationWithConflicts,
+    totalNumberOfIssues: 0,
+    overview: {
+      configId: CONFIG_ID,
+      productCode: productConfigurationWithConflicts.productCode,
+      totalNumberOfIssues: 5,
+    },
+  };
+
+const productConfigurationWithIssues: Configurator.Configuration = {
+  ...productConfigurationWithConflicts,
+  overview: {
+    configId: productConfigurationWithConflicts.configId,
+    productCode: productConfigurationWithConflicts.productCode,
+  },
+};
+
 const configuratorType = ConfiguratorType.VARIANT;
 
 const routerData: ConfiguratorRouter.Data = {
@@ -134,28 +166,15 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
       htmlElem,
       '.cx-error-msg'
     );
-  });
-
-  it('should count issues from configuration in case OV not available', () => {
-    configurationObs = of(productConfigurationWithoutIssues);
-    initialize(routerData);
-    component.numberOfIssues$.subscribe((numberOfIssues) =>
-      expect(numberOfIssues).toBe(
-        productConfigurationWithoutIssues.totalNumberOfIssues
-      )
+    CommonConfiguratorTestUtilsService.expectElementNotPresent(
+      expect,
+      htmlElem,
+      '.cx-conflict-msg'
     );
   });
 
   it('should display banner when there are issues', () => {
-    const productConfigurationWithIssuesAndConflicts: Configurator.Configuration =
-      {
-        ...productConfigurationWithConflicts,
-        overview: {
-          configId: productConfigurationWithConflicts.configId,
-          productCode: productConfigurationWithoutIssues.productCode,
-        },
-      };
-    configurationObs = of(productConfigurationWithIssuesAndConflicts);
+    configurationObs = of(productConfigurationWithIssues);
     initialize(routerData);
     CommonConfiguratorTestUtilsService.expectElementPresent(
       expect,
@@ -169,27 +188,26 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
     );
   });
 
-  it('should display banner when there are issues counted in Configurator.Overview', () => {
-    const productConfigurationWithConflictsCountedInOverview: Configurator.Configuration =
-      {
-        ...productConfigurationWithoutIssues,
-        overview: {
-          configId: CONFIG_ID,
-          productCode: productConfigurationWithoutIssues.productCode,
-          totalNumberOfIssues: 5,
-        },
-      };
-    configurationObs = of(productConfigurationWithConflictsCountedInOverview);
+  it('should display 2 banners when there are detailed issues counted', () => {
+    configurationObs = of(
+      productConfigurationWithDetailedIssuesCountedInOverview
+    );
     initialize(routerData);
-    CommonConfiguratorTestUtilsService.expectElementPresent(
+    CommonConfiguratorTestUtilsService.expectNumberOfElements(
       expect,
       htmlElem,
-      'cx-icon'
+      'cx-icon',
+      2
     );
     CommonConfiguratorTestUtilsService.expectElementPresent(
       expect,
       htmlElem,
       '.cx-error-msg'
+    );
+    CommonConfiguratorTestUtilsService.expectElementPresent(
+      expect,
+      htmlElem,
+      '.cx-conflict-msg'
     );
   });
 
@@ -205,6 +223,65 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
       expect,
       htmlElem,
       '.cx-error-msg'
+    );
+  });
+
+  it('should count issues from configuration in case OV not available', () => {
+    configurationObs = of(productConfigurationWithConflicts);
+    initialize(routerData);
+    component.numberOfIssues$.subscribe((numberOfIssues) =>
+      expect(numberOfIssues).toBe(
+        productConfigurationWithConflicts.totalNumberOfIssues
+      )
+    );
+  });
+
+  it('should count issues from OV in case OV is available', () => {
+    configurationObs = of(
+      productConfigurationWithOnlyTotalIssuesCountedInOverview
+    );
+    initialize(routerData);
+    component.numberOfIssues$.subscribe((numberOfIssues) =>
+      expect(numberOfIssues).toBe(
+        productConfigurationWithOnlyTotalIssuesCountedInOverview.overview
+          ?.totalNumberOfIssues
+      )
+    );
+  });
+
+  it('should count only missing mandatory fields as issues in case detailed issue numbers are available', () => {
+    configurationObs = of(
+      productConfigurationWithDetailedIssuesCountedInOverview
+    );
+    initialize(routerData);
+    component.numberOfIssues$.subscribe((numberOfIssues) =>
+      expect(numberOfIssues).toBe(
+        productConfigurationWithDetailedIssuesCountedInOverview.overview
+          ?.numberOfIncompleteCharacteristics
+      )
+    );
+  });
+
+  it('should count only conflicts as warnings in case detailed issue numbers are available', () => {
+    configurationObs = of(
+      productConfigurationWithDetailedIssuesCountedInOverview
+    );
+    initialize(routerData);
+    component.numberOfConflicts$.subscribe((numberOfConflicts) =>
+      expect(numberOfConflicts).toBe(
+        productConfigurationWithDetailedIssuesCountedInOverview.overview
+          ?.numberOfConflicts
+      )
+    );
+  });
+
+  it('should count zero warnings as in case detailed issue numbers are not available', () => {
+    configurationObs = of(
+      productConfigurationWithOnlyTotalIssuesCountedInOverview
+    );
+    initialize(routerData);
+    component.numberOfConflicts$.subscribe((numberOfConflicts) =>
+      expect(numberOfConflicts).toBe(0)
     );
   });
 });

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
@@ -40,11 +40,21 @@ export class ConfiguratorOverviewNotificationBannerComponent {
       //In case overview carries number of issues: We take it from there.
       //otherwise configuration's number will be accurate
       if (configuration.overview?.totalNumberOfIssues) {
-        return configuration.overview.totalNumberOfIssues;
+        return configuration.overview.numberOfIncompleteCharacteristics
+          ? configuration.overview.numberOfIncompleteCharacteristics
+          : configuration.overview.totalNumberOfIssues;
       } else
         return configuration.totalNumberOfIssues
           ? configuration.totalNumberOfIssues
           : 0;
+    })
+  );
+
+  numberOfConflicts$: Observable<number> = this.configuration$.pipe(
+    map((configuration) => {
+      //In case overview carries number of issues: We take it from there.
+      //otherwise configuration's number will be accurate
+      return configuration.overview?.numberOfConflicts ?? 0;
     })
   );
 

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
@@ -39,10 +39,11 @@ export class ConfiguratorOverviewNotificationBannerComponent {
     map((configuration) => {
       //In case overview carries number of issues: We take it from there.
       //otherwise configuration's number will be accurate
-      if (configuration.overview?.totalNumberOfIssues) {
-        return configuration.overview.numberOfIncompleteCharacteristics != null
-          ? configuration.overview.numberOfIncompleteCharacteristics
-          : configuration.overview.totalNumberOfIssues;
+      let configOv = configuration.overview;
+      if (configOv?.totalNumberOfIssues) {
+        return configOv.numberOfIncompleteCharacteristics !== undefined
+          ? configOv.numberOfIncompleteCharacteristics
+          : configOv.totalNumberOfIssues;
       } else
         return configuration.totalNumberOfIssues
           ? configuration.totalNumberOfIssues
@@ -56,11 +57,12 @@ export class ConfiguratorOverviewNotificationBannerComponent {
     })
   );
 
-  ignoreConflicts$: Observable<boolean> = this.configuration$.pipe(
-    map((configuration) => {
-      return (configuration.overview?.numberOfConflicts ?? 0) > 0;
-    })
-  );
+  skipConflictsOnIssueNavigation$: Observable<boolean> =
+    this.configuration$.pipe(
+      map((configuration) => {
+        return (configuration.overview?.numberOfConflicts ?? 0) > 0;
+      })
+    );
 
   iconTypes = ICON_TYPE;
 

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
@@ -40,7 +40,7 @@ export class ConfiguratorOverviewNotificationBannerComponent {
       //In case overview carries number of issues: We take it from there.
       //otherwise configuration's number will be accurate
       if (configuration.overview?.totalNumberOfIssues) {
-        return configuration.overview.numberOfIncompleteCharacteristics
+        return configuration.overview.numberOfIncompleteCharacteristics != null
           ? configuration.overview.numberOfIncompleteCharacteristics
           : configuration.overview.totalNumberOfIssues;
       } else

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
@@ -52,9 +52,13 @@ export class ConfiguratorOverviewNotificationBannerComponent {
 
   numberOfConflicts$: Observable<number> = this.configuration$.pipe(
     map((configuration) => {
-      //In case overview carries number of issues: We take it from there.
-      //otherwise configuration's number will be accurate
       return configuration.overview?.numberOfConflicts ?? 0;
+    })
+  );
+
+  ignoreConflicts$: Observable<boolean> = this.configuration$.pipe(
+    map((configuration) => {
+      return (configuration.overview?.numberOfConflicts ?? 0) > 0;
     })
   );
 

--- a/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
+++ b/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
@@ -100,6 +100,8 @@ export namespace Configurator {
   export interface Overview {
     configId: string;
     totalNumberOfIssues?: number;
+    numberOfIncompleteCharacteristics?: number;
+    numberOfConflicts?: number;
     groups?: GroupOverview[];
     priceSummary?: PriceSummary;
     productCode: string;

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.spec.ts
@@ -28,6 +28,8 @@ class MockTranslationService {
 const convertedOverview: Configurator.Overview = {
   configId: configId,
   totalNumberOfIssues: totalNumberOfIssues,
+  numberOfConflicts: totalNumberOfIssues - 1,
+  numberOfIncompleteCharacteristics: 1,
   priceSummary: {},
   productCode: PRODUCT_CODE,
   groups: [
@@ -117,6 +119,8 @@ Object.freeze(generalGroup);
 const overview: OccConfigurator.Overview = {
   id: configId,
   totalNumberOfIssues: totalNumberOfIssues,
+  numberOfConflicts: totalNumberOfIssues - 1,
+  numberOfIncompleteCharacteristics: 1,
   pricing: {},
   productCode: PRODUCT_CODE,
   groups: [
@@ -245,5 +249,26 @@ describe('OccConfiguratorVariantNormalizer', () => {
     const result =
       occConfiguratorVariantOverviewNormalizer.convertGroup(generalGroup);
     expect(result[0].groupDescription).toBe(generalGroupDescription);
+  });
+
+  it('should set all issue counters when running on commerce 2205 or later', () => {
+    let target: Configurator.Overview = { configId: '123', productCode: 'abc' };
+    occConfiguratorVariantOverviewNormalizer.setIssueCounters(target, overview);
+    expect(target.totalNumberOfIssues).toBe(2);
+    expect(target.numberOfIncompleteCharacteristics).toBe(1);
+    expect(target.numberOfConflicts).toBe(1);
+  });
+
+  it('should set only total number of issues when running on commerce before 2205', () => {
+    let target: Configurator.Overview = { configId: '123', productCode: 'abc' };
+    let source: OccConfigurator.Overview = {
+      id: '123',
+      productCode: 'abc',
+      totalNumberOfIssues: 2,
+    };
+    occConfiguratorVariantOverviewNormalizer.setIssueCounters(target, source);
+    expect(target.totalNumberOfIssues).toBe(2);
+    expect(target.numberOfIncompleteCharacteristics).toBeUndefined();
+    expect(target.numberOfConflicts).toBeUndefined();
   });
 });

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.spec.ts
@@ -253,7 +253,10 @@ describe('OccConfiguratorVariantNormalizer', () => {
 
   it('should set all issue counters when running on commerce 2205 or later', () => {
     let target: Configurator.Overview = { configId: '123', productCode: 'abc' };
-    occConfiguratorVariantOverviewNormalizer.setIssueCounters(target, overview);
+    occConfiguratorVariantOverviewNormalizer['setIssueCounters'](
+      target,
+      overview
+    );
     expect(target.totalNumberOfIssues).toBe(2);
     expect(target.numberOfIncompleteCharacteristics).toBe(1);
     expect(target.numberOfConflicts).toBe(1);
@@ -266,7 +269,10 @@ describe('OccConfiguratorVariantNormalizer', () => {
       productCode: 'abc',
       totalNumberOfIssues: 2,
     };
-    occConfiguratorVariantOverviewNormalizer.setIssueCounters(target, source);
+    occConfiguratorVariantOverviewNormalizer['setIssueCounters'](
+      target,
+      source
+    );
     expect(target.totalNumberOfIssues).toBe(2);
     expect(target.numberOfIncompleteCharacteristics).toBeUndefined();
     expect(target.numberOfConflicts).toBeUndefined();

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.ts
@@ -29,7 +29,6 @@ export class OccConfiguratorVariantOverviewNormalizer
     const resultTarget: Configurator.Overview = {
       ...target,
       configId: source.id,
-      totalNumberOfIssues: source.totalNumberOfIssues,
       groups: source.groups?.flatMap((group) => this.convertGroup(group)),
       priceSummary: this.converterService.convert(
         prices,
@@ -37,6 +36,7 @@ export class OccConfiguratorVariantOverviewNormalizer
       ),
       productCode: source.productCode,
     };
+    this.setIssueCounters(resultTarget, source);
     return resultTarget;
   }
 
@@ -86,5 +86,15 @@ export class OccConfiguratorVariantOverviewNormalizer
       .translate('configurator.group.general')
       .pipe(take(1))
       .subscribe((generalText) => (group.groupDescription = generalText));
+  }
+
+  setIssueCounters(
+    target: Configurator.Overview,
+    source: OccConfigurator.Overview
+  ) {
+    target.totalNumberOfIssues = source.totalNumberOfIssues;
+    target.numberOfConflicts = source.numberOfConflicts;
+    target.numberOfIncompleteCharacteristics =
+      source.numberOfIncompleteCharacteristics;
   }
 }

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.ts
@@ -88,7 +88,7 @@ export class OccConfiguratorVariantOverviewNormalizer
       .subscribe((generalText) => (group.groupDescription = generalText));
   }
 
-  setIssueCounters(
+  protected setIssueCounters(
     target: Configurator.Overview,
     source: OccConfigurator.Overview
   ) {

--- a/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.models.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.models.ts
@@ -130,6 +130,8 @@ export namespace OccConfigurator {
   export interface Overview {
     id: string;
     totalNumberOfIssues?: number;
+    numberOfIncompleteCharacteristics?: number;
+    numberOfConflicts?: number;
     groups?: GroupOverview[];
     pricing?: PriceSummary;
     productCode: string;

--- a/feature-libs/product-configurator/rulebased/styles/_configurator-overview-notification-banner.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-overview-notification-banner.scss
@@ -7,21 +7,22 @@
     justify-content: flex-start;
     max-width: 1140px;
 
-    .cx-error-notification-banner{
+    .cx-error-notification-banner {
       background-color: rgba(245, 206, 206, 1);
-      .cx-icon{
+      .cx-icon {
         color: var(--cx-color-danger);
       }
     }
-    .cx-conflict-notification-banner{
+    .cx-conflict-notification-banner {
       background-color: mix(#ffffff, theme-color('warning'), 78%);
-      .cx-icon{
+      .cx-icon {
         color: var(--cx-color-warning);
       }
     }
 
-    .cx-error-notification-banner, .cx-conflict-notification-banner{
-      width:100%;
+    .cx-error-notification-banner,
+    .cx-conflict-notification-banner {
+      width: 100%;
       display: flex;
       flex-direction: row;
       justify-content: flex-start;
@@ -51,7 +52,8 @@
       padding-block-end: 5px;
     }
 
-    .cx-error-msg, .cx-conflict-msg {
+    .cx-error-msg,
+    .cx-conflict-msg {
       padding-inline-end: 15px;
 
       button.link {

--- a/feature-libs/product-configurator/rulebased/styles/_configurator-overview-notification-banner.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-overview-notification-banner.scss
@@ -3,29 +3,47 @@
 
   &:not(:empty) {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     justify-content: flex-start;
     max-width: 1140px;
-    background-color: rgba(245, 206, 206, 1);
-    margin-block-end: 1.25rem;
-    padding-inline-start: 20px;
-    padding-inline-end: 25px;
-    padding-block-start: 5px;
-    padding-block-end: 5px;
 
-    @include media-breakpoint-up(xs) {
-      align-items: center;
+    .cx-error-notification-banner{
+      background-color: rgba(245, 206, 206, 1);
+      .cx-icon{
+        color: var(--cx-color-danger);
+      }
+    }
+    .cx-conflict-notification-banner{
+      background-color: mix(#ffffff, theme-color('warning'), 78%);
+      .cx-icon{
+        color: var(--cx-color-warning);
+      }
     }
 
-    @include media-breakpoint-down(sm) {
+    .cx-error-notification-banner, .cx-conflict-notification-banner{
+      width:100%;
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      margin-block-end: 1.25rem;
       padding-inline-start: 20px;
-      padding-inline-end: 20px;
+      padding-inline-end: 25px;
+      padding-block-start: 5px;
+      padding-block-end: 5px;
+
+      @include media-breakpoint-up(xs) {
+        align-items: center;
+      }
+
+      @include media-breakpoint-down(sm) {
+        padding-inline-start: 20px;
+        padding-inline-end: 20px;
+      }
     }
 
     cx-icon,
     .cx-icon {
       align-self: flex-start;
-      color: var(--cx-color-danger);
       font-size: 30px;
       padding-inline-start: 5px;
       padding-inline-end: 15px;
@@ -33,7 +51,7 @@
       padding-block-end: 5px;
     }
 
-    .cx-error-msg {
+    .cx-error-msg, .cx-conflict-msg {
       padding-inline-end: 15px;
 
       button.link {


### PR DESCRIPTION
Instead of having only one error banner on the overview page aggregating conflicts and missing mandatory fields, there are now two banner, one for each kind of issues. Missing mandatory fields are still visualized with an red error banner,while conflicts are shown as yellow warning type.
![image](https://user-images.githubusercontent.com/53090888/164752164-36c80b66-061e-4235-ba19-5f29ff6216ff.png)

closes #15608