### PR TITLE
feat: add migration for new constructor dependency

### DIFF
--- a/docs/migration/5_0.md
+++ b/docs/migration/5_0.md
@@ -64,6 +64,7 @@ configurations on every navigation that is not configurator related, and deletes
 
 - Added `ConfiguratorCommonsService` to constructor.
 - Added `ConfiguratorGroupsService` to constructor.
+- Added `ConfiguratorUISettingsConfig` to constructor.
 - Changed signature of `isAttributeGroup`, removed `groupType` parameter
 - Changed signature of `getConflictMessageKey`, removed `groupType` parameter
 

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-header.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-header.component.migration.ts
@@ -3,6 +3,7 @@ import {
   CONFIGURATOR_COMMONS_SERVICE,
   CONFIGURATOR_GROUPS_SERVICE,
   CONFIGURATOR_STOREFRONT_UTILS_SERVICE,
+  CONFIGURATOR_UI_SETTINGS_CONFIG,
 } from '../../../../shared/constants';
 import { SPARTACUS_PRODUCT_CONFIGURATOR_RULEBASED } from '../../../../shared/libs-constants';
 import { ConstructorDeprecation } from '../../../../shared/utils/file-utils';
@@ -25,6 +26,10 @@ export const CONFIGURATOR_ATTRIBUTE_HEADER_COMPONENT_MIGRATION: ConstructorDepre
       },
       {
         className: CONFIGURATOR_GROUPS_SERVICE,
+        importPath: SPARTACUS_PRODUCT_CONFIGURATOR_RULEBASED,
+      },
+      {
+        className: CONFIGURATOR_UI_SETTINGS_CONFIG,
         importPath: SPARTACUS_PRODUCT_CONFIGURATOR_RULEBASED,
       },
     ],


### PR DESCRIPTION
updates` configurator-attribute-header.component.migration.ts` to add dependency to `ConfiguratorUISettingsConfig` which was introduced by https://github.com/SAP/spartacus/pull/15579
test-branch: https://github.com/SAP/spartacus/tree/feature/schematicsTestForConfiguratorMigrations50
` yarn test constructor-deprecations`

closes #15657