### PR TITLE
chore: Make nested styles import available for all libraries

### DIFF
--- a/extra-webpack.config.js
+++ b/extra-webpack.config.js
@@ -42,11 +42,6 @@ module.exports = {
       '@spartacus/asm': path.join(__dirname, 'feature-libs/asm'),
       '@spartacus/smartedit': path.join(__dirname, 'feature-libs/smartedit'),
       '@spartacus/qualtrics': path.join(__dirname, 'feature-libs/qualtrics'),
-      '@spartacus/cdc': path.join(__dirname, 'feature-libs/cdc'),
-      '@spartacus/digital-payments': path.join(
-        __dirname,
-        'feature-libs/digital-payments'
-      ),
       '@spartacus/tracking': path.join(__dirname, 'feature-libs/tracking'),
       '@spartacus/cart': path.join(__dirname, 'feature-libs/cart'),
       '@spartacus/order': path.join(__dirname, 'feature-libs/order'),

--- a/extra-webpack.config.js
+++ b/extra-webpack.config.js
@@ -45,7 +45,6 @@ module.exports = {
       '@spartacus/tracking': path.join(__dirname, 'feature-libs/tracking'),
       '@spartacus/cart': path.join(__dirname, 'feature-libs/cart'),
       '@spartacus/order': path.join(__dirname, 'feature-libs/order'),
-      '@spartacus/setup': path.join(__dirname, 'feature-libs/setup'),
       '@spartacus/epd-visualization': path.join(
         __dirname,
         'integration-libs/epd-visualization'

--- a/extra-webpack.config.js
+++ b/extra-webpack.config.js
@@ -24,6 +24,37 @@ module.exports = {
   resolve: {
     alias: {
       '@spartacus/styles': path.join(__dirname, 'projects/storefrontstyles'),
+      '@spartacus/user': path.join(__dirname, 'feature-libs/user'),
+      '@spartacus/organization': path.join(
+        __dirname,
+        'feature-libs/organization'
+      ),
+      '@spartacus/product': path.join(__dirname, 'feature-libs/product'),
+      '@spartacus/product-configurator': path.join(
+        __dirname,
+        'feature-libs/product-configurator'
+      ),
+      '@spartacus/storefinder': path.join(
+        __dirname,
+        'feature-libs/storefinder'
+      ),
+      '@spartacus/checkout': path.join(__dirname, 'feature-libs/checkout'),
+      '@spartacus/asm': path.join(__dirname, 'feature-libs/asm'),
+      '@spartacus/smartedit': path.join(__dirname, 'feature-libs/smartedit'),
+      '@spartacus/qualtrics': path.join(__dirname, 'feature-libs/qualtrics'),
+      '@spartacus/cdc': path.join(__dirname, 'feature-libs/cdc'),
+      '@spartacus/digital-payments': path.join(
+        __dirname,
+        'feature-libs/digital-payments'
+      ),
+      '@spartacus/tracking': path.join(__dirname, 'feature-libs/tracking'),
+      '@spartacus/cart': path.join(__dirname, 'feature-libs/cart'),
+      '@spartacus/order': path.join(__dirname, 'feature-libs/order'),
+      '@spartacus/setup': path.join(__dirname, 'feature-libs/setup'),
+      '@spartacus/epd-visualization': path.join(
+        __dirname,
+        'integration-libs/epd-visualization'
+      ),
     },
   },
 };

--- a/feature-libs/asm/schematics/add-asm/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/asm/schematics/add-asm/__snapshots__/index_spec.ts.snap
@@ -94,7 +94,12 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/asm.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -163,7 +168,12 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/asm.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/cart/schematics/add-cart/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/cart/schematics/add-cart/__snapshots__/index_spec.ts.snap
@@ -104,7 +104,12 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -173,7 +178,12 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -277,7 +287,12 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature Cart Import Expor
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -346,7 +361,12 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature Cart Import Expor
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -450,7 +470,12 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -519,7 +544,12 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -623,7 +653,12 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -692,7 +727,12 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -801,7 +841,12 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -870,7 +915,12 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/cart.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/checkout/schematics/add-checkout/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/checkout/schematics/add-checkout/__snapshots__/index_spec.ts.snap
@@ -148,7 +148,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/checkout.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -217,7 +222,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/checkout.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -321,7 +331,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/checkout.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -390,7 +405,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/checkout.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -562,7 +582,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/checkout.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -631,7 +656,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/checkout.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/order/schematics/add-order/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/order/schematics/add-order/__snapshots__/index_spec.ts.snap
@@ -94,7 +94,12 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/order.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -163,7 +168,12 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/order.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/order/styles/components/order-history/_index.scss
+++ b/feature-libs/order/styles/components/order-history/_index.scss
@@ -1,3 +1,4 @@
+@import '@spartacus/cart/base/styles/components/cart-item-list';
 @import './amend-order-actions';
 @import './amend-order-items';
 @import './order-history';
@@ -8,7 +9,6 @@
 @import './return-request-totals';
 @import './cancel-order';
 @import './consignment-tracking';
-@import 'cart';
 
 $order-history-allowlist: cx-amend-order-actions, cx-amend-order-items,
   cx-cancel-order, cx-consignment-tracking, cx-tracking-events, cx-order-history,

--- a/feature-libs/organization/schematics/add-organization/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/organization/schematics/add-organization/__snapshots__/index_spec.ts.snap
@@ -132,7 +132,12 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/organization.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -201,7 +206,12 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/organization.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -343,7 +353,12 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/organization.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -412,7 +427,12 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/organization.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/product-configurator/schematics/add-product-configurator/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product-configurator/schematics/add-product-configurator/__snapshots__/index_spec.ts.snap
@@ -148,7 +148,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product-configurator.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -217,7 +222,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product-configurator.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -361,7 +371,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product-configurator.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -430,7 +445,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product-configurator.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -571,7 +591,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product-configurator.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -640,7 +665,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product-configurator.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -744,7 +774,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product-configurator.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -813,7 +848,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product-configurator.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/product/schematics/add-product/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product/schematics/add-product/__snapshots__/index_spec.ts.snap
@@ -132,7 +132,12 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -201,7 +206,12 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -305,7 +315,12 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -374,7 +389,12 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -478,7 +498,12 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -547,7 +572,12 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/product.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/qualtrics/schematics/add-qualtrics/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/qualtrics/schematics/add-qualtrics/__snapshots__/index_spec.ts.snap
@@ -78,7 +78,12 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/qualtrics-embedded-feedback.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -147,7 +152,12 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/qualtrics-embedded-feedback.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/smartedit/schematics/add-smartedit/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/smartedit/schematics/add-smartedit/__snapshots__/index_spec.ts.snap
@@ -57,7 +57,12 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
             \\"styles\\": [
               \\"src/styles.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -130,7 +135,12 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
             \\"styles\\": [
               \\"src/styles.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/storefinder/schematics/add-storefinder/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/storefinder/schematics/add-storefinder/__snapshots__/index_spec.ts.snap
@@ -94,7 +94,12 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/storefinder.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -163,7 +168,12 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/storefinder.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/feature-libs/user/schematics/add-user/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/user/schematics/add-user/__snapshots__/index_spec.ts.snap
@@ -94,7 +94,12 @@ exports[`Spartacus User schematics: ng-add Account feature general setup styling
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/user.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -163,7 +168,12 @@ exports[`Spartacus User schematics: ng-add Account feature general setup styling
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/user.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -267,7 +277,12 @@ exports[`Spartacus User schematics: ng-add Profile feature general setup styling
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/user.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -336,7 +351,12 @@ exports[`Spartacus User schematics: ng-add Profile feature general setup styling
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/user.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
@@ -153,7 +153,12 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/epd-visualization.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -222,7 +227,12 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/epd-visualization.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -213,6 +213,83 @@ function increaseBudgets(): Rule {
   };
 }
 
+function createStylePreprocessorOptions(): Rule {
+  return (tree: Tree): Tree => {
+    const { path, workspace: angularJson } = getWorkspace(tree);
+    const projectName = getDefaultProjectNameFromWorkspace(tree);
+    const project = angularJson.projects[projectName];
+    const architect = project.architect;
+
+    // `build` architect section
+    const architectBuild = architect?.build;
+    const buildStylePreprocessorOptions = createStylePreprocessorOptionsArray(
+      (architectBuild?.options as any)?.stylePreprocessorOptions
+    );
+    const buildOptions = {
+      ...architectBuild?.options,
+      stylePreprocessorOptions: buildStylePreprocessorOptions,
+    };
+
+    // `test` architect section
+    const architectTest = architect?.test;
+    const testStylePreprocessorOptions = createStylePreprocessorOptionsArray(
+      (architectBuild?.options as any)?.stylePreprocessorOptions
+    );
+    const testOptions = {
+      ...architectTest?.options,
+      stylePreprocessorOptions: testStylePreprocessorOptions,
+    };
+
+    const updatedAngularJson = {
+      ...angularJson,
+      projects: {
+        ...angularJson.projects,
+        [projectName]: {
+          ...project,
+          architect: {
+            ...architect,
+            build: {
+              ...architectBuild,
+              options: buildOptions,
+            },
+            test: {
+              ...architectTest,
+              options: testOptions,
+            },
+          },
+        },
+      },
+    };
+
+    tree.overwrite(path, JSON.stringify(updatedAngularJson, null, 2));
+    return tree;
+  };
+}
+
+function createStylePreprocessorOptionsArray(angularJsonStylePreprocessorOptions: {
+  includePaths: string[];
+}): { includePaths: string[] } {
+  if (!angularJsonStylePreprocessorOptions) {
+    angularJsonStylePreprocessorOptions = {
+      includePaths: ['node_modules/'],
+    };
+  } else {
+    if (!angularJsonStylePreprocessorOptions.includePaths) {
+      angularJsonStylePreprocessorOptions.includePaths = ['node_modules/'];
+    } else {
+      if (
+        !angularJsonStylePreprocessorOptions.includePaths.includes(
+          'node_modules/'
+        )
+      ) {
+        angularJsonStylePreprocessorOptions.includePaths.push('node_modules/');
+      }
+    }
+  }
+
+  return angularJsonStylePreprocessorOptions;
+}
+
 function prepareDependencies(): NodeDependency[] {
   const spartacusDependencies = prepareSpartacusDependencies();
   return spartacusDependencies.concat(prepare3rdPartyDependencies());
@@ -317,6 +394,7 @@ export function addSpartacus(options: SpartacusOptions): Rule {
       updateMainComponent(project, options),
       options.useMetaTags ? updateIndexFile(tree, options) : noop(),
       increaseBudgets(),
+      createStylePreprocessorOptions(),
 
       addSpartacusFeatures(options),
     ])(tree, context);

--- a/projects/schematics/src/shared/utils/__snapshots__/lib-utils_spec.ts.snap
+++ b/projects/schematics/src/shared/utils/__snapshots__/lib-utils_spec.ts.snap
@@ -36,7 +36,12 @@ exports[`Lib utils addLibraryFeature assets options should update angular.json f
             \\"styles\\": [
               \\"src/styles.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -104,7 +109,12 @@ exports[`Lib utils addLibraryFeature assets options should update angular.json f
             \\"styles\\": [
               \\"src/styles.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }
@@ -156,7 +166,12 @@ exports[`Lib utils addLibraryFeature assets options should update angular.json f
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/xxx.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           },
           \\"configurations\\": {
             \\"production\\": {
@@ -230,7 +245,12 @@ exports[`Lib utils addLibraryFeature assets options should update angular.json f
               \\"src/styles.scss\\",
               \\"src/styles/spartacus/xxx.scss\\"
             ],
-            \\"scripts\\": []
+            \\"scripts\\": [],
+            \\"stylePreprocessorOptions\\": {
+              \\"includePaths\\": [
+                \\"node_modules/\\"
+              ]
+            }
           }
         }
       }

--- a/projects/schematics/src/shared/utils/__snapshots__/workspace-utils_spec.ts.snap
+++ b/projects/schematics/src/shared/utils/__snapshots__/workspace-utils_spec.ts.snap
@@ -48,6 +48,11 @@ Object {
         "outputPath": "dist/schematics-test",
         "polyfills": "src/polyfills.ts",
         "scripts": Array [],
+        "stylePreprocessorOptions": Object {
+          "includePaths": Array [
+            "node_modules/",
+          ],
+        },
         "styles": Array [
           "src/styles.scss",
         ],
@@ -84,6 +89,11 @@ Object {
         "main": "src/test.ts",
         "polyfills": "src/polyfills.ts",
         "scripts": Array [],
+        "stylePreprocessorOptions": Object {
+          "includePaths": Array [
+            "node_modules/",
+          ],
+        },
         "styles": Array [
           "src/styles.scss",
         ],
@@ -153,6 +163,11 @@ Object {
       "outputPath": "dist/schematics-test",
       "polyfills": "src/polyfills.ts",
       "scripts": Array [],
+      "stylePreprocessorOptions": Object {
+        "includePaths": Array [
+          "node_modules/",
+        ],
+      },
       "styles": Array [
         "src/styles.scss",
       ],
@@ -189,6 +204,11 @@ Object {
       "main": "src/test.ts",
       "polyfills": "src/polyfills.ts",
       "scripts": Array [],
+      "stylePreprocessorOptions": Object {
+        "includePaths": Array [
+          "node_modules/",
+        ],
+      },
       "styles": Array [
         "src/styles.scss",
       ],


### PR DESCRIPTION
closes https://jira.tools.sap/browse/CXSPA-238

1. configuring custom webpack in order to alias and resolve to the proper library for import awareness
2. updated schematics for the shellapp to include node_modules to the styles preprocessor in order to access nested styles within packages