### PR TITLE
test: fix notification preference e2e by specifying button

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/notification.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/notification.ts
@@ -94,7 +94,7 @@ export function updateEmail(): String {
   cy.get('cx-update-email [formcontrolname="email"]').type(newUid);
   cy.get('cx-update-email [formcontrolname="confirmEmail"]').type(newUid);
   cy.get('cx-update-email [formcontrolname="password"]').type(password);
-  cy.get('cx-update-email button').click();
+  cy.get('cx-update-email button').contains('Save').click();
   login(newUid, password);
   return newUid;
 }


### PR DESCRIPTION
closes: https://jira.tools.sap/secure/RapidBoard.jspa?rapidView=33203&projectKey=CXSPA&selectedIssue=CXSPA-391

With the introduction of password visibility, there is an additional button so we specify which to fix it