### PR TITLE
feat: Include a message to Slack through the pipeline when develop breaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,7 @@ jobs:
           echo "test"
           echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
           echo "abc ${{ secrets.SLACK_TOKEN }}"
+          echo "fake secret is still *** ?: ${{ secrets.FAKE_SECRET }}"
         # if: |
         #   needs.build_conclusion.result == 'failure' || 
         #   needs.build_conclusion.result == 'cancelled' || 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: 'test-spa-channel-message'
-          slack-message: "Hello world from slackapi - raw message: ${{ job.status }}\n${{ github.base_ref }}\n${{ github.event.head_commit.url }}"
+          slack-message: "Hello world from slackapi - raw message: a${{ needs.build_conclusion.result }}b\n${{ github.base_ref }}c\n${{ github.event.head_commit.url }}"
         # if: |
         #   needs.build_conclusion.result == 'failure'
   # slackapi
@@ -280,13 +280,13 @@ jobs:
           channel-id: 'test-spa-channel-message'
           payload: |
             {
-              "text": "Hello world from slackapi - raw message: ${{ job.status }}\n${{ github.base_ref }}\n${{ github.event.head_commit.url }}"
+              "text": "using blocks - Hello world from slackapi - raw message: a${{ needs.build_conclusion.result }}b\n${{ github.base_ref }}c\n${{ github.event.head_commit.url }}"
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    "text": "real blocks - Hello world from slackapi - raw message: a${{ needs.build_conclusion.result }}b\n${{ github.base_ref }}c\n${{ github.event.head_commit.url }}"
                   }
                 }
               ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,81 +47,81 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # - name: Setup node
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: ${{ env.NODE_VERSION }}
-      # - name: Cache node_modules
-      #   id: cache-node-modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: | 
-      #       node_modules
-      #       projects/storefrontapp-e2e-cypress/node_modules
-      #       ~/.cache/Cypress
-      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
-      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      # - name: Install angular CLI
-      #   run: npm install -g @angular/cli@latest
-      # - name: Package installation
-      #   run: yarn --frozen-lockfile
-      # - name: Run unit tests for Spartacus libs
-      #   run: |
-      #     ci-scripts/unit-tests-core-lib.sh
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Install angular CLI
+        run: npm install -g @angular/cli@latest
+      - name: Package installation
+        run: yarn --frozen-lockfile
+      - name: Run unit tests for Spartacus libs
+        run: |
+          ci-scripts/unit-tests-core-lib.sh
   unit_tests_libs:
     needs: no_retries
     name: Unit tests for integration libs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # - name: Setup node
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: ${{ env.NODE_VERSION }}
-      # - name: Cache node_modules
-      #   id: cache-node-modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: | 
-      #       node_modules
-      #       projects/storefrontapp-e2e-cypress/node_modules
-      #       ~/.cache/Cypress
-      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
-      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      # - name: Install angular CLI
-      #   run: npm install -g @angular/cli@latest
-      # - name: Package installation
-      #   run: yarn --frozen-lockfile
-      # - name: Run unit tests for integration libs
-      #   run: |
-      #     ci-scripts/unit-tests.sh
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Install angular CLI
+        run: npm install -g @angular/cli@latest
+      - name: Package installation
+        run: yarn --frozen-lockfile
+      - name: Run unit tests for integration libs
+        run: |
+          ci-scripts/unit-tests.sh
   linting:
     needs: no_retries
     name: Validation checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # - name: Setup node
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: ${{ env.NODE_VERSION }}
-      # - name: Cache node_modules
-      #   id: cache-node-modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: | 
-      #       node_modules
-      #       projects/storefrontapp-e2e-cypress/node_modules
-      #       ~/.cache/Cypress
-      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
-      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      # - name: Install angular CLI
-      #   run: npm install -g @angular/cli@latest
-      # - name: Package installation
-      #   run: yarn --frozen-lockfile
-      # - name: Run linting validation
-      #   run: |
-      #     ci-scripts/validate-lint.sh
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Install angular CLI
+        run: npm install -g @angular/cli@latest
+      - name: Package installation
+        run: yarn --frozen-lockfile
+      - name: Run linting validation
+        run: |
+          ci-scripts/validate-lint.sh
   b2c_e2e_tests:
     needs: [no_retries, validate_e2e_execution]
     name: E2E tests for B2C
@@ -132,21 +132,21 @@ jobs:
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v2
-      # - name: Cache node_modules
-      #   id: cache-node-modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: | 
-      #       node_modules
-      #       projects/storefrontapp-e2e-cypress/node_modules
-      #       ~/.cache/Cypress
-      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
-      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      # - name: Run e2es
-      #   env: 
-      #     SPA_ENV: ci,b2c
-      #   run: |
-      #     ci-scripts/e2e-cypress.sh
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Run e2es
+        env: 
+          SPA_ENV: ci,b2c
+        run: |
+          ci-scripts/e2e-cypress.sh
   b2c_ssr_e2e_tests:
     needs: [no_retries, validate_e2e_execution]
     name: E2E tests for SSR B2C
@@ -154,21 +154,21 @@ jobs:
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v2
-      # - name: Cache node_modules
-      #   id: cache-node-modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: | 
-      #       node_modules
-      #       projects/storefrontapp-e2e-cypress/node_modules
-      #       ~/.cache/Cypress
-      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
-      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      # - name: Run e2es
-      #   env: 
-      #     SPA_ENV: ci,b2c
-      #   run: |
-      #     ci-scripts/e2e-cypress.sh --ssr
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Run e2es
+        env: 
+          SPA_ENV: ci,b2c
+        run: |
+          ci-scripts/e2e-cypress.sh --ssr
   b2b_e2e_tests:
     needs: [no_retries, validate_e2e_execution]
     name: E2E tests for B2B
@@ -179,21 +179,21 @@ jobs:
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v2
-      # - name: Cache node_modules
-      #   id: cache-node-modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: | 
-      #       node_modules
-      #       projects/storefrontapp-e2e-cypress/node_modules
-      #       ~/.cache/Cypress
-      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
-      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      # - name: Run e2es
-      #   env:
-      #     SPA_ENV: ci,b2b
-      #   run: |     
-      #     ci-scripts/e2e-cypress.sh -s b2b
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Run e2es
+        env:
+          SPA_ENV: ci,b2b
+        run: |     
+          ci-scripts/e2e-cypress.sh -s b2b
   build_conclusion:
     needs: [no_retries, unit_tests_core, unit_tests_libs, linting, b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests]
     name: Build Conclusion
@@ -213,34 +213,11 @@ jobs:
           needs.b2c_e2e_tests.result == 'failure' || needs.b2c_e2e_tests.result == 'cancelled' ||
           needs.b2c_ssr_e2e_tests.result == 'failure' || needs.b2c_ssr_e2e_tests.result == 'cancelled' || 
           needs.b2b_e2e_tests.result == 'failure' || needs.b2b_e2e_tests.result == 'cancelled'
-  # # abinoda
-  # send_slack_message_v1:
-  #   needs: build_conclusion
-  #   name: Slack message for failed develop CI build in Spartacus
-  #   runs-on: ubuntu-latest
-  #   # if: ${{ github.event_name == 'push' && github.base_ref == 'develop' }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: test values
-  #       run: |
-  #         echo "test"
-  #         echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
-  #         echo "abc ${{ secrets.SLACK_TOKEN }}"
-  #         echo "fake secret is still *** ?: ${{ secrets.FAKE_SECRET }}"
-  #     - name: Send Slack message when build conclusion failed
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
-  #       uses: pullreminders/slack-action@master
-  #       with:
-  #         args: '{\"channel\":\"test-spa-channel-message\",\"text\":\"Hello world\"}'
-  #       # if: |
-  #       #   needs.build_conclusion.result == 'failure'
-    # slackapi
-  send_slack_message_v2:
+  send_slack_message:
     needs: build_conclusion
     name: Slack message for failed develop CI build in Spartacus
     runs-on: ubuntu-latest
-    # if: ${{ github.event_name == 'push' && github.base_ref == 'develop' }}
+    if: ${{ always() }}
     steps:
       - uses: actions/checkout@v2
       - name: test values
@@ -254,30 +231,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
         uses: slackapi/slack-github-action@v1.19.0
         with:
-          channel-id: 'test-spa-channel-message'
-          slack-message: "Hello world from slackapi - raw message: a${{ needs.build_conclusion.result }}b\n${{ github.base_ref }}c\n${{ github.event.head_commit.url }}"
-        # if: |
-        #   needs.build_conclusion.result == 'failure'
-  # slackapi
-  send_slack_message_v2-1:
-    needs: build_conclusion
-    name: Slack message for failed develop CI build in Spartacus
-    runs-on: ubuntu-latest
-    # if: ${{ github.event_name == 'push' && github.base_ref == 'develop' }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: test values
-        run: |
-          echo "test"
-          echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
-          echo "abc ${{ secrets.SLACK_TOKEN }}"
-          echo "fake secret is still *** ?: ${{ secrets.FAKE_SECRET }}"
-      - name: Send Slack message when build conclusion failed
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        uses: slackapi/slack-github-action@v1.19.0
-        with:
-          channel-id: 'test-spa-channel-message'
+          channel-id: ${{ secrets.SLACK_NOTIFICATION_CHANNEL }}
           payload: |
             {
               "blocks": [
@@ -285,10 +239,11 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "real blocks - Hello world from slackapi - raw message: a${{ needs.build_conclusion.result }}b\n${{ github.base_ref }}c\n${{ github.event.head_commit.url }}"
+                    "text": "some text that I will have to put \n result: ${{ needs.build_conclusion.result }} \n branch: ${{ github.base_ref }} \n the commit url: ${{ github.event.head_commit.url }}"
                   }
                 }
               ]
             }
-        # if: |
-        #   needs.build_conclusion.result == 'failure'
+        if: |
+          ${{ github.event_name == 'push' && github.ref_name == 'develop' }} && needs.build_conclusion.result == 'failure'
+        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
     needs: build_conclusion
     name: Slack message for failed develop CI build in Spartacus
     runs-on: ubuntu-latest
+    # if: ${{ github.event_name == 'push' && github.base_ref == 'develop' }}
     steps:
       - uses: actions/checkout@v2
       - name: Send Slack message when build conclusion failed
@@ -224,7 +225,7 @@ jobs:
           echo "test"
           echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
           echo "abc ${{ secrets.SLACK_TOKEN }}"
-        if: |
-          needs.build_conclusion.result == 'failure' || 
-          needs.build_conclusion.result == 'cancelled' || 
-          needs.build_conclusion.result == 'skipped'
+        # if: |
+        #   needs.build_conclusion.result == 'failure' || 
+        #   needs.build_conclusion.result == 'cancelled' || 
+        #   needs.build_conclusion.result == 'skipped'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,30 @@ jobs:
           needs.b2c_e2e_tests.result == 'failure' || needs.b2c_e2e_tests.result == 'cancelled' ||
           needs.b2c_ssr_e2e_tests.result == 'failure' || needs.b2c_ssr_e2e_tests.result == 'cancelled' || 
           needs.b2b_e2e_tests.result == 'failure' || needs.b2b_e2e_tests.result == 'cancelled'
-  send_slack_message:
+  # # abinoda
+  # send_slack_message_v1:
+  #   needs: build_conclusion
+  #   name: Slack message for failed develop CI build in Spartacus
+  #   runs-on: ubuntu-latest
+  #   # if: ${{ github.event_name == 'push' && github.base_ref == 'develop' }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: test values
+  #       run: |
+  #         echo "test"
+  #         echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
+  #         echo "abc ${{ secrets.SLACK_TOKEN }}"
+  #         echo "fake secret is still *** ?: ${{ secrets.FAKE_SECRET }}"
+  #     - name: Send Slack message when build conclusion failed
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
+  #       uses: pullreminders/slack-action@master
+  #       with:
+  #         args: '{\"channel\":\"test-spa-channel-message\",\"text\":\"Hello world\"}'
+  #       # if: |
+  #       #   needs.build_conclusion.result == 'failure'
+    # slackapi
+  send_slack_message_v2:
     needs: build_conclusion
     name: Slack message for failed develop CI build in Spartacus
     runs-on: ubuntu-latest
@@ -229,10 +252,44 @@ jobs:
       - name: Send Slack message when build conclusion failed
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        uses: pullreminders/slack-action@master
+        uses: slackapi/slack-github-action@v1.19.0
         with:
-          args: '{\"channel\":\"test-spa-channel-message\",\"text\":\"Hello world\"}'
+          channel-id: 'test-spa-channel-message'
+          slack-message: "Hello world from slackapi - raw message: ${{ job.status }}\n${{ github.base_ref }}\n${{ github.event.head_commit.url }}"
         # if: |
-        #   needs.build_conclusion.result == 'failure' || 
-        #   needs.build_conclusion.result == 'cancelled' || 
-        #   needs.build_conclusion.result == 'skipped'
+        #   needs.build_conclusion.result == 'failure'
+  # slackapi
+  send_slack_message_v2-1:
+    needs: build_conclusion
+    name: Slack message for failed develop CI build in Spartacus
+    runs-on: ubuntu-latest
+    # if: ${{ github.event_name == 'push' && github.base_ref == 'develop' }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: test values
+        run: |
+          echo "test"
+          echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
+          echo "abc ${{ secrets.SLACK_TOKEN }}"
+          echo "fake secret is still *** ?: ${{ secrets.FAKE_SECRET }}"
+      - name: Send Slack message when build conclusion failed
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        uses: slackapi/slack-github-action@v1.19.0
+        with:
+          channel-id: 'test-spa-channel-message'
+          payload: |
+            {
+              "text": "Hello world from slackapi - raw message: ${{ job.status }}\n${{ github.base_ref }}\n${{ github.event.head_commit.url }}"
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                }
+              ]
+            }
+        # if: |
+        #   needs.build_conclusion.result == 'failure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
           channel-id: 'test-spa-channel-message'
           payload: |
             {
-              "text": "using blocks - Hello world from slackapi - raw message: a${{ needs.build_conclusion.result }}b\n${{ github.base_ref }}c\n${{ github.event.head_commit.url }}"
+              "text": "using blocks - Hello world from slackapi - raw message: a${{ needs.build_conclusion.result }}b\n${{ github.base_ref }}c\n${{ github.event.head_commit.url }}",
               "blocks": [
                 {
                   "type": "section",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,14 +219,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
-      - uses: actions/checkout@v2
-      - name: test values
-        run: |
-          echo "test"
-          echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
-          echo "abc ${{ secrets.SLACK_TOKEN }}"
-          echo "fake secret is still *** ?: ${{ secrets.FAKE_SECRET }}"
-      - name: Send Slack message when build conclusion failed
+      - name: Notify the channel of broken end-to-end tests
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
         uses: slackapi/slack-github-action@v1.19.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":nuclear-bomb: :fireduck: **Broken build in develop**"
+                    "text": ":nuclear-bomb: :fireduck: *Broken build in develop*"
                   }
                 },
                 {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,10 +245,10 @@ jobs:
                       "type": "button",
                       "text": {
                         "type": "plain_text",
-                        "text": "The actual build",
+                        "text": "Failed build",
                         "emoji": true
                       },
-                      "value": "actual_build",
+                      "value": "failed_build",
                       "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                     },
                     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
-      - name: Notify the channel of broken end-to-end tests
+      - name: Notify the slack channel of when build conclusion failed
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
         uses: slackapi/slack-github-action@v1.19.0
@@ -275,6 +275,8 @@ jobs:
                 }
               ]
             }
-        if: |
-          ${{ github.event_name == 'push' && github.ref_name == 'develop' }} && needs.build_conclusion.result == 'failure'
+        if: | 
+          needs.build_conclusion.result == 'failure' &&
+          github.event_name == 'push' && 
+          github.ref_name == 'develop'
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,8 +232,36 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "some text that I will have to put \n result: ${{ needs.build_conclusion.result }} \n branch: ${{ github.base_ref }} \n the commit url: ${{ github.event.head_commit.url }}"
+                    "text": ":fire: :fireduck: :fire: \n\n Hello Tribe! \n *Our e2es in develop are failing*. Please take a look at the problem! Help keep our CI in develop green! \n\n :fire: :fireduck: :fire:"
                   }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Build history",
+                        "emoji": true
+                      },
+                      "value": "buid_history",
+                      "url": "https://github.com/SAP/spartacus/actions/workflows/ci.yml?query=branch%3Adevelop"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "What was committed?",
+                        "emoji": true
+                      },
+                      "value": "recent_merged_commit",
+                      "url": "${{ github.event.head_commit.url }}"
+                    }
+                  ]
                 }
               ]
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,81 +47,81 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
-      - name: Package installation
-        run: yarn --frozen-lockfile
-      - name: Run unit tests for Spartacus libs
-        run: |
-          ci-scripts/unit-tests-core-lib.sh
+      # - name: Setup node
+      #   uses: actions/setup-node@v2
+      #   with:
+      #     node-version: ${{ env.NODE_VERSION }}
+      # - name: Cache node_modules
+      #   id: cache-node-modules
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: | 
+      #       node_modules
+      #       projects/storefrontapp-e2e-cypress/node_modules
+      #       ~/.cache/Cypress
+      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
+      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      # - name: Install angular CLI
+      #   run: npm install -g @angular/cli@latest
+      # - name: Package installation
+      #   run: yarn --frozen-lockfile
+      # - name: Run unit tests for Spartacus libs
+      #   run: |
+      #     ci-scripts/unit-tests-core-lib.sh
   unit_tests_libs:
     needs: no_retries
     name: Unit tests for integration libs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
-      - name: Package installation
-        run: yarn --frozen-lockfile
-      - name: Run unit tests for integration libs
-        run: |
-          ci-scripts/unit-tests.sh
+      # - name: Setup node
+      #   uses: actions/setup-node@v2
+      #   with:
+      #     node-version: ${{ env.NODE_VERSION }}
+      # - name: Cache node_modules
+      #   id: cache-node-modules
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: | 
+      #       node_modules
+      #       projects/storefrontapp-e2e-cypress/node_modules
+      #       ~/.cache/Cypress
+      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
+      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      # - name: Install angular CLI
+      #   run: npm install -g @angular/cli@latest
+      # - name: Package installation
+      #   run: yarn --frozen-lockfile
+      # - name: Run unit tests for integration libs
+      #   run: |
+      #     ci-scripts/unit-tests.sh
   linting:
     needs: no_retries
     name: Validation checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
-      - name: Package installation
-        run: yarn --frozen-lockfile
-      - name: Run linting validation
-        run: |
-          ci-scripts/validate-lint.sh
+      # - name: Setup node
+      #   uses: actions/setup-node@v2
+      #   with:
+      #     node-version: ${{ env.NODE_VERSION }}
+      # - name: Cache node_modules
+      #   id: cache-node-modules
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: | 
+      #       node_modules
+      #       projects/storefrontapp-e2e-cypress/node_modules
+      #       ~/.cache/Cypress
+      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
+      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      # - name: Install angular CLI
+      #   run: npm install -g @angular/cli@latest
+      # - name: Package installation
+      #   run: yarn --frozen-lockfile
+      # - name: Run linting validation
+      #   run: |
+      #     ci-scripts/validate-lint.sh
   b2c_e2e_tests:
     needs: [no_retries, validate_e2e_execution]
     name: E2E tests for B2C
@@ -132,21 +132,21 @@ jobs:
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v2
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Run e2es
-        env: 
-          SPA_ENV: ci,b2c
-        run: |
-          ci-scripts/e2e-cypress.sh
+      # - name: Cache node_modules
+      #   id: cache-node-modules
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: | 
+      #       node_modules
+      #       projects/storefrontapp-e2e-cypress/node_modules
+      #       ~/.cache/Cypress
+      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
+      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      # - name: Run e2es
+      #   env: 
+      #     SPA_ENV: ci,b2c
+      #   run: |
+      #     ci-scripts/e2e-cypress.sh
   b2c_ssr_e2e_tests:
     needs: [no_retries, validate_e2e_execution]
     name: E2E tests for SSR B2C
@@ -154,21 +154,21 @@ jobs:
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v2
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Run e2es
-        env: 
-          SPA_ENV: ci,b2c
-        run: |
-          ci-scripts/e2e-cypress.sh --ssr
+      # - name: Cache node_modules
+      #   id: cache-node-modules
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: | 
+      #       node_modules
+      #       projects/storefrontapp-e2e-cypress/node_modules
+      #       ~/.cache/Cypress
+      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
+      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      # - name: Run e2es
+      #   env: 
+      #     SPA_ENV: ci,b2c
+      #   run: |
+      #     ci-scripts/e2e-cypress.sh --ssr
   b2b_e2e_tests:
     needs: [no_retries, validate_e2e_execution]
     name: E2E tests for B2B
@@ -179,21 +179,21 @@ jobs:
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v2
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Run e2es
-        env:
-          SPA_ENV: ci,b2b
-        run: |     
-          ci-scripts/e2e-cypress.sh -s b2b
+      # - name: Cache node_modules
+      #   id: cache-node-modules
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: | 
+      #       node_modules
+      #       projects/storefrontapp-e2e-cypress/node_modules
+      #       ~/.cache/Cypress
+      #     key: nodemodules-${{ github.event.pull_request.base.sha }}
+      #     restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      # - name: Run e2es
+      #   env:
+      #     SPA_ENV: ci,b2b
+      #   run: |     
+      #     ci-scripts/e2e-cypress.sh -s b2b
   build_conclusion:
     needs: [no_retries, unit_tests_core, unit_tests_libs, linting, b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests]
     name: Build Conclusion
@@ -213,3 +213,18 @@ jobs:
           needs.b2c_e2e_tests.result == 'failure' || needs.b2c_e2e_tests.result == 'cancelled' ||
           needs.b2c_ssr_e2e_tests.result == 'failure' || needs.b2c_ssr_e2e_tests.result == 'cancelled' || 
           needs.b2b_e2e_tests.result == 'failure' || needs.b2b_e2e_tests.result == 'cancelled'
+  send_slack_message:
+    needs: build_conclusion
+    name: Slack message for failed develop CI build in Spartacus
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Send Slack message when build conclusion failed
+        run: |
+          echo "test"
+          echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
+          echo "abc ${{ secrets.SLACK_TOKEN }}"
+        if: |
+          needs.build_conclusion.result == 'failure' || 
+          needs.build_conclusion.result == 'cancelled' || 
+          needs.build_conclusion.result == 'skipped'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,6 @@ jobs:
           channel-id: 'test-spa-channel-message'
           payload: |
             {
-              "text": "using blocks - Hello world from slackapi - raw message: a${{ needs.build_conclusion.result }}b\n${{ github.base_ref }}c\n${{ github.event.head_commit.url }}",
               "blocks": [
                 {
                   "type": "section",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":fire: :fireduck: :fire: \n\n Hello Tribe! \n *Our e2es in develop are failing*. Please take a look at the problem! Help keep our CI in develop green! \n\n :fire: :fireduck: :fire:"
+                    "text": ":nuclear-bomb: :fireduck: **Broken build in develop**"
                   }
                 },
                 {
@@ -245,11 +245,11 @@ jobs:
                       "type": "button",
                       "text": {
                         "type": "plain_text",
-                        "text": "Build history",
+                        "text": "The actual build",
                         "emoji": true
                       },
-                      "value": "buid_history",
-                      "url": "https://github.com/SAP/spartacus/actions/workflows/ci.yml?query=branch%3Adevelop"
+                      "value": "actual_build",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                     },
                     {
                       "type": "button",
@@ -260,6 +260,16 @@ jobs:
                       },
                       "value": "recent_merged_commit",
                       "url": "${{ github.event.head_commit.url }}"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Build history",
+                        "emoji": true
+                      },
+                      "value": "buid_history",
+                      "url": "https://github.com/SAP/spartacus/actions/workflows/ci.yml?query=branch%3Adevelop"
                     }
                   ]
                 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
     # if: ${{ github.event_name == 'push' && github.base_ref == 'develop' }}
     steps:
       - uses: actions/checkout@v2
-      - name: test
+      - name: test values
         run: |
           echo "test"
           echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
@@ -229,6 +229,7 @@ jobs:
       - name: Send Slack message when build conclusion failed
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        uses: pullreminders/slack-action@master
         with:
           args: '{\"channel\":\"test-spa-channel-message\",\"text\":\"Hello world\"}'
         # if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,12 +220,17 @@ jobs:
     # if: ${{ github.event_name == 'push' && github.base_ref == 'develop' }}
     steps:
       - uses: actions/checkout@v2
-      - name: Send Slack message when build conclusion failed
+      - name: test
         run: |
           echo "test"
           echo "hmm can it be  seen ${{ secrets.GITHUB_TOKEN }}"
           echo "abc ${{ secrets.SLACK_TOKEN }}"
           echo "fake secret is still *** ?: ${{ secrets.FAKE_SECRET }}"
+      - name: Send Slack message when build conclusion failed
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        with:
+          args: '{\"channel\":\"test-spa-channel-message\",\"text\":\"Hello world\"}'
         # if: |
         #   needs.build_conclusion.result == 'failure' || 
         #   needs.build_conclusion.result == 'cancelled' || 


### PR DESCRIPTION
- tests are done to simulate the `develop` branch from [here](https://github.com/SAP/spartacus/tree/epic/simulate-branch-for-slack-verify-values) 
- test on pull request to the 'simulated' `develop` branch can be found [here](https://github.com/SAP/spartacus/pull/15738) and [here](https://github.com/SAP/spartacus/pull/15752). Basically, skipping sending of message because it's a pull_request event and not a 'push'

closes https://jira.tools.sap/browse/CXSPA-425