### PR TITLE
chore: Block overall retries of pipeline AND retries of failed e2e jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,10 @@ concurrency:
 name: Spartacus build pipeline
 jobs:
   no_retries: 
-    name: Verify retries
+    name: Verify re-run of all jobs
     runs-on: ubuntu-latest
     steps:
-      - name: test
-        run: |
-          echo "hello attempt ${{ github.run_attempt }}"
-          echo "test id ${{ github.run_id }}"
-          echo "abc number ${{ github.run_number }}"
-      - name: Forcefully fail build if retried
+      - name: Forcefully fail build if jobs are all retried
         uses: actions/github-script@v5
         with:
           script: |
@@ -136,11 +131,12 @@ jobs:
         containers: [1, 2, 3, 4, 5]
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - name: test
-        run: |
-          echo "b2c attempt ${{ github.run_attempt }}"
-          echo "test id ${{ github.run_id }}"
-          echo "abc number ${{ github.run_number }}"
+      - name: Forcefully fail build if e2e job is retried
+        uses: actions/github-script@v5
+        with:
+          script: |
+            core.setFailed('Please push a commit to trigger the build. To push an empty commit you can use `git commit --allow-empty -m "Trigger Build"`') 
+        if: ${{ github.run_attempt > 1 }}
       - uses: actions/checkout@v2
       - name: Cache node_modules
         id: cache-node-modules
@@ -163,11 +159,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - name: test
-        run: |
-          echo "ssr ${{ github.run_attempt }}"
-          echo "test id ${{ github.run_id }}"
-          echo "abc number ${{ github.run_number }}"
+      - name: Forcefully fail build if e2e job is retried
+        uses: actions/github-script@v5
+        with:
+          script: |
+            core.setFailed('Please push a commit to trigger the build. To push an empty commit you can use `git commit --allow-empty -m "Trigger Build"`') 
+        if: ${{ github.run_attempt > 1 }}
       - uses: actions/checkout@v2
       - name: Cache node_modules
         id: cache-node-modules
@@ -193,11 +190,12 @@ jobs:
         containers: [1, 2]
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - name: test
-        run: |
-          echo "b2b attempt ${{ github.run_attempt }}"
-          echo "test id ${{ github.run_id }}"
-          echo "abc number ${{ github.run_number }}"
+      - name: Forcefully fail build if e2e job is retried
+        uses: actions/github-script@v5
+        with:
+          script: |
+            core.setFailed('Please push a commit to trigger the build. To push an empty commit you can use `git commit --allow-empty -m "Trigger Build"`') 
+        if: ${{ github.run_attempt > 1 }}
       - uses: actions/checkout@v2
       - name: Cache node_modules
         id: cache-node-modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,11 @@ jobs:
         containers: [1, 2, 3, 4, 5]
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
+      - name: test
+        run: |
+          echo "b2c attempt ${{ github.run_attempt }}"
+          echo "test id ${{ github.run_id }}"
+          echo "abc number ${{ github.run_number }}"
       - uses: actions/checkout@v2
       - name: Cache node_modules
         id: cache-node-modules
@@ -158,6 +163,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
+      - name: test
+        run: |
+          echo "ssr ${{ github.run_attempt }}"
+          echo "test id ${{ github.run_id }}"
+          echo "abc number ${{ github.run_number }}"
       - uses: actions/checkout@v2
       - name: Cache node_modules
         id: cache-node-modules
@@ -183,6 +193,11 @@ jobs:
         containers: [1, 2]
     if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
+      - name: test
+        run: |
+          echo "b2b attempt ${{ github.run_attempt }}"
+          echo "test id ${{ github.run_id }}"
+          echo "abc number ${{ github.run_number }}"
       - uses: actions/checkout@v2
       - name: Cache node_modules
         id: cache-node-modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,189 +32,189 @@ jobs:
           script: |
             core.setFailed('Please push a commit to trigger the build. To push an empty commit you can use `git commit --allow-empty -m "Trigger Build"`') 
         if: ${{ github.run_attempt > 1 }}
-  # validate_e2e_execution:
-  #   name: Validate pull_request files
-  #   runs-on: ubuntu-latest
-  #   outputs: 
-  #     SHOULD_RUN_E2E: ${{ steps.save-e2e-output-result.outputs.SHOULD_RUN_E2E }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Determine whether to run e2es
-  #       id: save-e2e-output-result
-  #       run: |         
-  #         source ci-scripts/validate-e2e-execution.sh
-  #         echo "::set-output name=SHOULD_RUN_E2E::$(echo $RUN_E2E)"
-  # unit_tests_core:
-  #   needs: no_retries
-  #   name: Unit tests for core Spartacus libs
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Setup node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: ${{ env.NODE_VERSION }}
-  #     - name: Cache node_modules
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: | 
-  #           node_modules
-  #           projects/storefrontapp-e2e-cypress/node_modules
-  #           ~/.cache/Cypress
-  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
-  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-  #     - name: Install angular CLI
-  #       run: npm install -g @angular/cli@latest
-  #     - name: Package installation
-  #       run: yarn --frozen-lockfile
-  #     - name: Run unit tests for Spartacus libs
-  #       run: |
-  #         ci-scripts/unit-tests-core-lib.sh
-  # unit_tests_libs:
-  #   needs: no_retries
-  #   name: Unit tests for integration libs
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Setup node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: ${{ env.NODE_VERSION }}
-  #     - name: Cache node_modules
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: | 
-  #           node_modules
-  #           projects/storefrontapp-e2e-cypress/node_modules
-  #           ~/.cache/Cypress
-  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
-  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-  #     - name: Install angular CLI
-  #       run: npm install -g @angular/cli@latest
-  #     - name: Package installation
-  #       run: yarn --frozen-lockfile
-  #     - name: Run unit tests for integration libs
-  #       run: |
-  #         ci-scripts/unit-tests.sh
-  # linting:
-  #   needs: no_retries
-  #   name: Validation checks
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Setup node
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: ${{ env.NODE_VERSION }}
-  #     - name: Cache node_modules
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: | 
-  #           node_modules
-  #           projects/storefrontapp-e2e-cypress/node_modules
-  #           ~/.cache/Cypress
-  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
-  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-  #     - name: Install angular CLI
-  #       run: npm install -g @angular/cli@latest
-  #     - name: Package installation
-  #       run: yarn --frozen-lockfile
-  #     - name: Run linting validation
-  #       run: |
-  #         ci-scripts/validate-lint.sh
-  # b2c_e2e_tests:
-  #   needs: [no_retries, validate_e2e_execution]
-  #   name: E2E tests for B2C
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       containers: [1, 2, 3, 4, 5]
-  #   if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Cache node_modules
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: | 
-  #           node_modules
-  #           projects/storefrontapp-e2e-cypress/node_modules
-  #           ~/.cache/Cypress
-  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
-  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-  #     - name: Run e2es
-  #       env: 
-  #         SPA_ENV: ci,b2c
-  #       run: |
-  #         ci-scripts/e2e-cypress.sh
-  # b2c_ssr_e2e_tests:
-  #   needs: [no_retries, validate_e2e_execution]
-  #   name: E2E tests for SSR B2C
-  #   runs-on: ubuntu-latest
-  #   if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Cache node_modules
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: | 
-  #           node_modules
-  #           projects/storefrontapp-e2e-cypress/node_modules
-  #           ~/.cache/Cypress
-  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
-  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-  #     - name: Run e2es
-  #       env: 
-  #         SPA_ENV: ci,b2c
-  #       run: |
-  #         ci-scripts/e2e-cypress.sh --ssr
-  # b2b_e2e_tests:
-  #   needs: [no_retries, validate_e2e_execution]
-  #   name: E2E tests for B2B
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       containers: [1, 2]
-  #   if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Cache node_modules
-  #       id: cache-node-modules
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: | 
-  #           node_modules
-  #           projects/storefrontapp-e2e-cypress/node_modules
-  #           ~/.cache/Cypress
-  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
-  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-  #     - name: Run e2es
-  #       env:
-  #         SPA_ENV: ci,b2b
-  #       run: |     
-  #         ci-scripts/e2e-cypress.sh -s b2b
-  # build_conclusion:
-  #   needs: [no_retries, unit_tests_core, unit_tests_libs, linting, b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests]
-  #   name: Build Conclusion
-  #   runs-on: ubuntu-latest
-  #   if: ${{ always() }}
-  #   steps:
-  #     - name: Required build failed
-  #       uses: actions/github-script@v5
-  #       with:
-  #         script: |
-  #           core.setFailed('Build failed')
-  #       if: |
-  #         needs.no_retries.result == 'failure' || needs.no_retries.result == 'cancelled' ||
-  #         needs.unit_tests_core.result == 'failure' || needs.unit_tests_core.result == 'cancelled' ||
-  #         needs.unit_tests_libs.result == 'failure' || needs.unit_tests_libs.result == 'cancelled' ||
-  #         needs.linting.result == 'failure' || needs.linting.result == 'cancelled' ||
-  #         needs.b2c_e2e_tests.result == 'failure' || needs.b2c_e2e_tests.result == 'cancelled' ||
-  #         needs.b2c_ssr_e2e_tests.result == 'failure' || needs.b2c_ssr_e2e_tests.result == 'cancelled' || 
-  #         needs.b2b_e2e_tests.result == 'failure' || needs.b2b_e2e_tests.result == 'cancelled'
+  validate_e2e_execution:
+    name: Validate pull_request files
+    runs-on: ubuntu-latest
+    outputs: 
+      SHOULD_RUN_E2E: ${{ steps.save-e2e-output-result.outputs.SHOULD_RUN_E2E }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Determine whether to run e2es
+        id: save-e2e-output-result
+        run: |         
+          source ci-scripts/validate-e2e-execution.sh
+          echo "::set-output name=SHOULD_RUN_E2E::$(echo $RUN_E2E)"
+  unit_tests_core:
+    needs: no_retries
+    name: Unit tests for core Spartacus libs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Install angular CLI
+        run: npm install -g @angular/cli@latest
+      - name: Package installation
+        run: yarn --frozen-lockfile
+      - name: Run unit tests for Spartacus libs
+        run: |
+          ci-scripts/unit-tests-core-lib.sh
+  unit_tests_libs:
+    needs: no_retries
+    name: Unit tests for integration libs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Install angular CLI
+        run: npm install -g @angular/cli@latest
+      - name: Package installation
+        run: yarn --frozen-lockfile
+      - name: Run unit tests for integration libs
+        run: |
+          ci-scripts/unit-tests.sh
+  linting:
+    needs: no_retries
+    name: Validation checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Install angular CLI
+        run: npm install -g @angular/cli@latest
+      - name: Package installation
+        run: yarn --frozen-lockfile
+      - name: Run linting validation
+        run: |
+          ci-scripts/validate-lint.sh
+  b2c_e2e_tests:
+    needs: [no_retries, validate_e2e_execution]
+    name: E2E tests for B2C
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        containers: [1, 2, 3, 4, 5]
+    if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Run e2es
+        env: 
+          SPA_ENV: ci,b2c
+        run: |
+          ci-scripts/e2e-cypress.sh
+  b2c_ssr_e2e_tests:
+    needs: [no_retries, validate_e2e_execution]
+    name: E2E tests for SSR B2C
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Run e2es
+        env: 
+          SPA_ENV: ci,b2c
+        run: |
+          ci-scripts/e2e-cypress.sh --ssr
+  b2b_e2e_tests:
+    needs: [no_retries, validate_e2e_execution]
+    name: E2E tests for B2B
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        containers: [1, 2]
+    if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: | 
+            node_modules
+            projects/storefrontapp-e2e-cypress/node_modules
+            ~/.cache/Cypress
+          key: nodemodules-${{ github.event.pull_request.base.sha }}
+          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+      - name: Run e2es
+        env:
+          SPA_ENV: ci,b2b
+        run: |     
+          ci-scripts/e2e-cypress.sh -s b2b
+  build_conclusion:
+    needs: [no_retries, unit_tests_core, unit_tests_libs, linting, b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests]
+    name: Build Conclusion
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Required build failed
+        uses: actions/github-script@v5
+        with:
+          script: |
+            core.setFailed('Build failed')
+        if: |
+          needs.no_retries.result == 'failure' || needs.no_retries.result == 'cancelled' ||
+          needs.unit_tests_core.result == 'failure' || needs.unit_tests_core.result == 'cancelled' ||
+          needs.unit_tests_libs.result == 'failure' || needs.unit_tests_libs.result == 'cancelled' ||
+          needs.linting.result == 'failure' || needs.linting.result == 'cancelled' ||
+          needs.b2c_e2e_tests.result == 'failure' || needs.b2c_e2e_tests.result == 'cancelled' ||
+          needs.b2c_ssr_e2e_tests.result == 'failure' || needs.b2c_ssr_e2e_tests.result == 'cancelled' || 
+          needs.b2b_e2e_tests.result == 'failure' || needs.b2b_e2e_tests.result == 'cancelled'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,195 +21,200 @@ jobs:
     name: Verify retries
     runs-on: ubuntu-latest
     steps:
+      - name: test
+        run: |
+          echo "hello attempt ${{ github.run_attempt }}"
+          echo "test id ${{ github.run_id }}"
+          echo "abc number ${{ github.run_number }}"
       - name: Forcefully fail build if retried
         uses: actions/github-script@v5
         with:
           script: |
             core.setFailed('Please push a commit to trigger the build. To push an empty commit you can use `git commit --allow-empty -m "Trigger Build"`') 
         if: ${{ github.run_attempt > 1 }}
-  validate_e2e_execution:
-    name: Validate pull_request files
-    runs-on: ubuntu-latest
-    outputs: 
-      SHOULD_RUN_E2E: ${{ steps.save-e2e-output-result.outputs.SHOULD_RUN_E2E }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Determine whether to run e2es
-        id: save-e2e-output-result
-        run: |         
-          source ci-scripts/validate-e2e-execution.sh
-          echo "::set-output name=SHOULD_RUN_E2E::$(echo $RUN_E2E)"
-  unit_tests_core:
-    needs: no_retries
-    name: Unit tests for core Spartacus libs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
-      - name: Package installation
-        run: yarn --frozen-lockfile
-      - name: Run unit tests for Spartacus libs
-        run: |
-          ci-scripts/unit-tests-core-lib.sh
-  unit_tests_libs:
-    needs: no_retries
-    name: Unit tests for integration libs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
-      - name: Package installation
-        run: yarn --frozen-lockfile
-      - name: Run unit tests for integration libs
-        run: |
-          ci-scripts/unit-tests.sh
-  linting:
-    needs: no_retries
-    name: Validation checks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
-      - name: Package installation
-        run: yarn --frozen-lockfile
-      - name: Run linting validation
-        run: |
-          ci-scripts/validate-lint.sh
-  b2c_e2e_tests:
-    needs: [no_retries, validate_e2e_execution]
-    name: E2E tests for B2C
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        containers: [1, 2, 3, 4, 5]
-    if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Run e2es
-        env: 
-          SPA_ENV: ci,b2c
-        run: |
-          ci-scripts/e2e-cypress.sh
-  b2c_ssr_e2e_tests:
-    needs: [no_retries, validate_e2e_execution]
-    name: E2E tests for SSR B2C
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Run e2es
-        env: 
-          SPA_ENV: ci,b2c
-        run: |
-          ci-scripts/e2e-cypress.sh --ssr
-  b2b_e2e_tests:
-    needs: [no_retries, validate_e2e_execution]
-    name: E2E tests for B2B
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        containers: [1, 2]
-    if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: | 
-            node_modules
-            projects/storefrontapp-e2e-cypress/node_modules
-            ~/.cache/Cypress
-          key: nodemodules-${{ github.event.pull_request.base.sha }}
-          restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
-      - name: Run e2es
-        env:
-          SPA_ENV: ci,b2b
-        run: |     
-          ci-scripts/e2e-cypress.sh -s b2b
-  build_conclusion:
-    needs: [no_retries, unit_tests_core, unit_tests_libs, linting, b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests]
-    name: Build Conclusion
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    steps:
-      - name: Required build failed
-        uses: actions/github-script@v5
-        with:
-          script: |
-            core.setFailed('Build failed')
-        if: |
-          needs.no_retries.result == 'failure' || needs.no_retries.result == 'cancelled' ||
-          needs.unit_tests_core.result == 'failure' || needs.unit_tests_core.result == 'cancelled' ||
-          needs.unit_tests_libs.result == 'failure' || needs.unit_tests_libs.result == 'cancelled' ||
-          needs.linting.result == 'failure' || needs.linting.result == 'cancelled' ||
-          needs.b2c_e2e_tests.result == 'failure' || needs.b2c_e2e_tests.result == 'cancelled' ||
-          needs.b2c_ssr_e2e_tests.result == 'failure' || needs.b2c_ssr_e2e_tests.result == 'cancelled' || 
-          needs.b2b_e2e_tests.result == 'failure' || needs.b2b_e2e_tests.result == 'cancelled'
+  # validate_e2e_execution:
+  #   name: Validate pull_request files
+  #   runs-on: ubuntu-latest
+  #   outputs: 
+  #     SHOULD_RUN_E2E: ${{ steps.save-e2e-output-result.outputs.SHOULD_RUN_E2E }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Determine whether to run e2es
+  #       id: save-e2e-output-result
+  #       run: |         
+  #         source ci-scripts/validate-e2e-execution.sh
+  #         echo "::set-output name=SHOULD_RUN_E2E::$(echo $RUN_E2E)"
+  # unit_tests_core:
+  #   needs: no_retries
+  #   name: Unit tests for core Spartacus libs
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Setup node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: ${{ env.NODE_VERSION }}
+  #     - name: Cache node_modules
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: | 
+  #           node_modules
+  #           projects/storefrontapp-e2e-cypress/node_modules
+  #           ~/.cache/Cypress
+  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
+  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+  #     - name: Install angular CLI
+  #       run: npm install -g @angular/cli@latest
+  #     - name: Package installation
+  #       run: yarn --frozen-lockfile
+  #     - name: Run unit tests for Spartacus libs
+  #       run: |
+  #         ci-scripts/unit-tests-core-lib.sh
+  # unit_tests_libs:
+  #   needs: no_retries
+  #   name: Unit tests for integration libs
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Setup node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: ${{ env.NODE_VERSION }}
+  #     - name: Cache node_modules
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: | 
+  #           node_modules
+  #           projects/storefrontapp-e2e-cypress/node_modules
+  #           ~/.cache/Cypress
+  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
+  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+  #     - name: Install angular CLI
+  #       run: npm install -g @angular/cli@latest
+  #     - name: Package installation
+  #       run: yarn --frozen-lockfile
+  #     - name: Run unit tests for integration libs
+  #       run: |
+  #         ci-scripts/unit-tests.sh
+  # linting:
+  #   needs: no_retries
+  #   name: Validation checks
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Setup node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: ${{ env.NODE_VERSION }}
+  #     - name: Cache node_modules
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: | 
+  #           node_modules
+  #           projects/storefrontapp-e2e-cypress/node_modules
+  #           ~/.cache/Cypress
+  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
+  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+  #     - name: Install angular CLI
+  #       run: npm install -g @angular/cli@latest
+  #     - name: Package installation
+  #       run: yarn --frozen-lockfile
+  #     - name: Run linting validation
+  #       run: |
+  #         ci-scripts/validate-lint.sh
+  # b2c_e2e_tests:
+  #   needs: [no_retries, validate_e2e_execution]
+  #   name: E2E tests for B2C
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       containers: [1, 2, 3, 4, 5]
+  #   if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Cache node_modules
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: | 
+  #           node_modules
+  #           projects/storefrontapp-e2e-cypress/node_modules
+  #           ~/.cache/Cypress
+  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
+  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+  #     - name: Run e2es
+  #       env: 
+  #         SPA_ENV: ci,b2c
+  #       run: |
+  #         ci-scripts/e2e-cypress.sh
+  # b2c_ssr_e2e_tests:
+  #   needs: [no_retries, validate_e2e_execution]
+  #   name: E2E tests for SSR B2C
+  #   runs-on: ubuntu-latest
+  #   if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Cache node_modules
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: | 
+  #           node_modules
+  #           projects/storefrontapp-e2e-cypress/node_modules
+  #           ~/.cache/Cypress
+  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
+  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+  #     - name: Run e2es
+  #       env: 
+  #         SPA_ENV: ci,b2c
+  #       run: |
+  #         ci-scripts/e2e-cypress.sh --ssr
+  # b2b_e2e_tests:
+  #   needs: [no_retries, validate_e2e_execution]
+  #   name: E2E tests for B2B
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       containers: [1, 2]
+  #   if: ${{ github.event_name == 'push' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Cache node_modules
+  #       id: cache-node-modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: | 
+  #           node_modules
+  #           projects/storefrontapp-e2e-cypress/node_modules
+  #           ~/.cache/Cypress
+  #         key: nodemodules-${{ github.event.pull_request.base.sha }}
+  #         restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
+  #     - name: Run e2es
+  #       env:
+  #         SPA_ENV: ci,b2b
+  #       run: |     
+  #         ci-scripts/e2e-cypress.sh -s b2b
+  # build_conclusion:
+  #   needs: [no_retries, unit_tests_core, unit_tests_libs, linting, b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests]
+  #   name: Build Conclusion
+  #   runs-on: ubuntu-latest
+  #   if: ${{ always() }}
+  #   steps:
+  #     - name: Required build failed
+  #       uses: actions/github-script@v5
+  #       with:
+  #         script: |
+  #           core.setFailed('Build failed')
+  #       if: |
+  #         needs.no_retries.result == 'failure' || needs.no_retries.result == 'cancelled' ||
+  #         needs.unit_tests_core.result == 'failure' || needs.unit_tests_core.result == 'cancelled' ||
+  #         needs.unit_tests_libs.result == 'failure' || needs.unit_tests_libs.result == 'cancelled' ||
+  #         needs.linting.result == 'failure' || needs.linting.result == 'cancelled' ||
+  #         needs.b2c_e2e_tests.result == 'failure' || needs.b2c_e2e_tests.result == 'cancelled' ||
+  #         needs.b2c_ssr_e2e_tests.result == 'failure' || needs.b2c_ssr_e2e_tests.result == 'cancelled' || 
+  #         needs.b2b_e2e_tests.result == 'failure' || needs.b2b_e2e_tests.result == 'cancelled'


### PR DESCRIPTION
current job `no_retries` from the build pipeline workflow allows for overall retries, but only blocks retries of jobs