### PR TITLE
CXINT-78 Adding parameters jsSDKUrl, baseSite and sessionExpiration in CDC schematics

### DIFF
--- a/integration-libs/cdc/schematics/add-cdc/index.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index.ts
@@ -29,7 +29,7 @@ import {
 } from '../constants';
 
 export function addCdcFeature(options: SpartacusCdcOptions): Rule {
-  return (tree: Tree, _context: SchematicContext): Rule => {
+  return (tree: Tree, context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
 
@@ -37,20 +37,20 @@ export function addCdcFeature(options: SpartacusCdcOptions): Rule {
       addPackageJsonDependenciesForLibrary(peerDependencies, options),
 
       shouldAddFeature(CLI_CDC_FEATURE, options.features)
-        ? addCdc(options, _context)
+        ? addCdc(options, context)
         : noop(),
     ]);
   };
 }
 
 function addCdc(options: SpartacusCdcOptions, context: SchematicContext): Rule {
-  if (!options.jsSDKUrl) {
+  if (!options.javascriptUrl) {
     context.logger.warn(
-      `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the jsSDKUrl.`
+      `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the javascriptUrl.`
     );
   }
 
-  let jsSDKUrl = options.jsSDKUrl? options.jsSDKUrl: "<url-to-cdc-script>";
+  const JS_SDK_URL_PLACEHOLDER = '<url-to-cdc-script>';
 
   return addLibraryFeature(options, {
     folderName: CDC_FOLDER_NAME,
@@ -79,7 +79,9 @@ function addCdc(options: SpartacusCdcOptions, context: SchematicContext): Rule {
           cdc: [
             {
               baseSite: '${options.baseSite}',
-              javascriptUrl: '${jsSDKUrl}',
+              javascriptUrl: '${
+                options.javascriptUrl ?? JS_SDK_URL_PLACEHOLDER
+              }',
               sessionExpiration: ${options.sessionExpiration}
             },
           ],

--- a/integration-libs/cdc/schematics/add-cdc/index.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index.ts
@@ -12,13 +12,13 @@ import {
   CDC_ROOT_MODULE,
   CLI_CDC_FEATURE,
   CLI_USER_PROFILE_FEATURE,
-  LibraryOptions as SpartacusCdcOptions,
   readPackageJson,
   shouldAddFeature,
   SPARTACUS_CDC,
   SPARTACUS_USER,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
+import { Schema as SpartacusCdcOptions } from './schema';
 import { peerDependencies } from '../../package.json';
 import {
   CDC_CONFIG,
@@ -37,13 +37,21 @@ export function addCdcFeature(options: SpartacusCdcOptions): Rule {
       addPackageJsonDependenciesForLibrary(peerDependencies, options),
 
       shouldAddFeature(CLI_CDC_FEATURE, options.features)
-        ? addCdc(options)
+        ? addCdc(options, _context)
         : noop(),
     ]);
   };
 }
 
-function addCdc(options: SpartacusCdcOptions): Rule {
+function addCdc(options: SpartacusCdcOptions, context: SchematicContext): Rule {
+  if (!options.jsSDKUrl) {
+    context.logger.warn(
+      `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the jsSDKUrl.`
+    );
+  }
+
+  let jsSDKUrl = options.jsSDKUrl? options.jsSDKUrl: "<url-to-cdc-script>";
+
   return addLibraryFeature(options, {
     folderName: CDC_FOLDER_NAME,
     moduleName: CDC_MODULE_NAME,
@@ -70,9 +78,9 @@ function addCdc(options: SpartacusCdcOptions): Rule {
       content: `<${CDC_CONFIG}>{
           cdc: [
             {
-              baseSite: 'electronics-spa',
-              javascriptUrl: '<url-to-cdc-script>',
-              sessionExpiration: 3600
+              baseSite: '${options.baseSite}',
+              javascriptUrl: '${jsSDKUrl}',
+              sessionExpiration: ${options.sessionExpiration}
             },
           ],
         }`,

--- a/integration-libs/cdc/schematics/add-cdc/index_spec.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index_spec.ts
@@ -132,29 +132,23 @@ describe('Spartacus CDC schematics: ng-add', () => {
         });
 
         appTree = await schematicRunner
-          .runSchematicAsync(
-            'ng-add',
-            { ...cdcFeatureOptions},
-            appTree
-          )
+          .runSchematicAsync('ng-add', { ...cdcFeatureOptions }, appTree)
           .toPromise();
       });
 
       it('show the warning', () => {
         expect(firstMessage).toEqual(
-          `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the jsSDKUrl.`
+          `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the javascriptUrl.`
         );
       });
-
     });
 
     describe('validation of jsSDKUrl', () => {
       beforeEach(async () => {
-
         appTree = await schematicRunner
           .runSchematicAsync(
             'ng-add',
-            { ...cdcFeatureOptions, jsSDKUrl: '<dc>.gigya.com/<api-key>' },
+            { ...cdcFeatureOptions, javascriptUrl: '<dc>.gigya.com/<api-key>' },
             appTree
           )
           .toPromise();
@@ -162,11 +156,8 @@ describe('Spartacus CDC schematics: ng-add', () => {
 
       it('should set the given javascriptUrl', () => {
         const module = appTree.readContent(featureModulePath);
-        expect(module).toContain<string>(
-          `<dc>.gigya.com/<api-key>`
-        );
+        expect(module).toContain<string>(`<dc>.gigya.com/<api-key>`);
       });
-
     });
 
     describe('general setup', () => {
@@ -175,7 +166,6 @@ describe('Spartacus CDC schematics: ng-add', () => {
           .runSchematicAsync('ng-add', cdcFeatureOptions, appTree)
           .toPromise();
       });
-
 
       it('should install necessary Spartacus libraries', () => {
         const packageJson = JSON.parse(appTree.readContent('package.json'));

--- a/integration-libs/cdc/schematics/add-cdc/index_spec.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index_spec.ts
@@ -122,12 +122,60 @@ describe('Spartacus CDC schematics: ng-add', () => {
   });
 
   describe('CDC feature', () => {
+    describe('warning for missing jsSDKUrl', () => {
+      let firstMessage: string | undefined;
+      beforeEach(async () => {
+        schematicRunner.logger.subscribe((log) => {
+          if (!firstMessage) {
+            firstMessage = log.message;
+          }
+        });
+
+        appTree = await schematicRunner
+          .runSchematicAsync(
+            'ng-add',
+            { ...cdcFeatureOptions},
+            appTree
+          )
+          .toPromise();
+      });
+
+      it('show the warning', () => {
+        expect(firstMessage).toEqual(
+          `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the jsSDKUrl.`
+        );
+      });
+
+    });
+
+    describe('validation of jsSDKUrl', () => {
+      beforeEach(async () => {
+
+        appTree = await schematicRunner
+          .runSchematicAsync(
+            'ng-add',
+            { ...cdcFeatureOptions, jsSDKUrl: '<dc>.gigya.com/<api-key>' },
+            appTree
+          )
+          .toPromise();
+      });
+
+      it('should set the given javascriptUrl', () => {
+        const module = appTree.readContent(featureModulePath);
+        expect(module).toContain<string>(
+          `<dc>.gigya.com/<api-key>`
+        );
+      });
+
+    });
+
     describe('general setup', () => {
       beforeEach(async () => {
         appTree = await schematicRunner
           .runSchematicAsync('ng-add', cdcFeatureOptions, appTree)
           .toPromise();
       });
+
 
       it('should install necessary Spartacus libraries', () => {
         const packageJson = JSON.parse(appTree.readContent('package.json'));
@@ -197,7 +245,10 @@ describe('Spartacus CDC schematics: ng-add', () => {
         appTree = await schematicRunner
           .runSchematicAsync(
             'ng-add',
-            { ...cdcFeatureOptions, lazy: false },
+            {
+              ...cdcFeatureOptions,
+              lazy: false,
+            },
             appTree
           )
           .toPromise();

--- a/integration-libs/cdc/schematics/add-cdc/schema.json
+++ b/integration-libs/cdc/schematics/add-cdc/schema.json
@@ -26,7 +26,7 @@
       "uniqueItems": true,
       "default": ["CDC"]
     },
-    "jsSDKUrl": {
+    "javascriptUrl": {
       "type": "string",
       "description": "Location of the CDC Java Script SDK in Customer Data Cloud",
       "x-prompt": "[CDC] What is the CDC JS SDK URL?"
@@ -34,13 +34,13 @@
     "baseSite": {
       "type": "string",
       "description": "Name of the Spartcus base site",
-      "x-prompt": "[CDC] What is the base site? (optional)",
+      "x-prompt": "[CDC] What is the base site?",
       "default": "electronics-spa"
     },
     "sessionExpiration": {
       "type": "number",
       "description": "Session Expiration time in seconds",
-      "x-prompt": "[CDC] What is the CDC Session expiration time (in seconds)? (optional)",
+      "x-prompt": "[CDC] What is the CDC Session expiration time (in seconds)?",
       "default": 3600
     }
   },

--- a/integration-libs/cdc/schematics/add-cdc/schema.json
+++ b/integration-libs/cdc/schematics/add-cdc/schema.json
@@ -25,6 +25,23 @@
       "type": "array",
       "uniqueItems": true,
       "default": ["CDC"]
+    },
+    "jsSDKUrl": {
+      "type": "string",
+      "description": "Location of the CDC Java Script SDK in Customer Data Cloud",
+      "x-prompt": "[CDC] What is the CDC JS SDK URL?"
+    },
+    "baseSite": {
+      "type": "string",
+      "description": "Name of the Spartcus base site",
+      "x-prompt": "[CDC] What is the base site? (optional)",
+      "default": "electronics-spa"
+    },
+    "sessionExpiration": {
+      "type": "number",
+      "description": "Session Expiration time in seconds",
+      "x-prompt": "[CDC] What is the CDC Session expiration time (in seconds)? (optional)",
+      "default": 3600
     }
   },
   "required": []

--- a/integration-libs/cdc/schematics/add-cdc/schema.ts
+++ b/integration-libs/cdc/schematics/add-cdc/schema.ts
@@ -1,7 +1,7 @@
 import { LibraryOptions } from '@spartacus/schematics';
 
 export interface Schema extends LibraryOptions {
-  baseSite?: string;
-  jsSDKUrl?: string;
-  sessionExpiration?: number;
+  baseSite: string;
+  javascriptUrl: string;
+  sessionExpiration: number;
 }

--- a/integration-libs/cdc/schematics/add-cdc/schema.ts
+++ b/integration-libs/cdc/schematics/add-cdc/schema.ts
@@ -1,0 +1,7 @@
+import { LibraryOptions } from '@spartacus/schematics';
+
+export interface Schema extends LibraryOptions {
+  baseSite?: string;
+  jsSDKUrl?: string;
+  sessionExpiration?: number;
+}


### PR DESCRIPTION
- Provided configurable parameters for CDC schematics to allow build pipelines to generate Spartacus modules
- Allows a new Angular project to add CDC schematics like -
 `ng add @spartacus/cdc@latest --interactive false  --javascriptUrl="https://eu1.gigya.com/API-KEY" --baseSite="electroncis-spa" --sessionExpiration=7200`
