### PR TITLE
CXINT-78 Adding parameters jsSDKUrl, baseSite and sessionExpiration In CDC schematics

### DIFF
--- a/integration-libs/cdc/schematics/add-cdc/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/cdc/schematics/add-cdc/__snapshots__/index_spec.ts.snap
@@ -93,51 +93,67 @@ export class CdcFeatureModule { }
 `;
 
 exports[`Spartacus CDC schematics: ng-add CDC feature warning for blank jsSDKUrl should set the default JS_SDK_URL_PLACEHOLDER 1`] = `
-Object {
-  "children": Array [],
-  "exports": Object {},
-  "filename": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/index_spec.ts",
-  "id": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/index_spec.ts",
-  "loaded": true,
-  "main": [Circular],
-  "parent": null,
-  "path": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc",
-  "paths": Array [
-    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/node_modules",
-    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/node_modules",
-    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/node_modules",
-    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/node_modules",
-    "/Users/i323558/CX/spacdcconfig/spartacus/node_modules",
-    "/Users/i323558/CX/spacdcconfig/node_modules",
-    "/Users/i323558/CX/node_modules",
-    "/Users/i323558/node_modules",
-    "/Users/node_modules",
-    "/node_modules",
+"import { NgModule } from '@angular/core';
+import { CdcConfig, CdcRootModule, CDC_FEATURE } from \\"@spartacus/cdc/root\\";
+import { CmsConfig, provideConfig } from \\"@spartacus/core\\";
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CdcRootModule
   ],
-}
+  providers: [provideConfig(<CmsConfig>{
+    featureModules: {
+      [CDC_FEATURE]: {
+        module: () =>
+          import('@spartacus/cdc').then((m) => m.CdcModule),
+      },
+    }
+  }),
+  provideConfig(<CdcConfig>{
+    cdc: [
+      {
+        baseSite: 'electronics-spa',
+        javascriptUrl: 'JS_SDK_URL_PLACEHOLDER',
+        sessionExpiration: 3600
+      },
+    ],
+  })
+  ]
+})
+export class CdcFeatureModule { }
+"
 `;
 
 exports[`Spartacus CDC schematics: ng-add CDC feature warning for missing jsSDKUrl should set the default JS_SDK_URL_PLACEHOLDER 1`] = `
-Object {
-  "children": Array [],
-  "exports": Object {},
-  "filename": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/index_spec.ts",
-  "id": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/index_spec.ts",
-  "loaded": true,
-  "main": [Circular],
-  "parent": null,
-  "path": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc",
-  "paths": Array [
-    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/node_modules",
-    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/node_modules",
-    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/node_modules",
-    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/node_modules",
-    "/Users/i323558/CX/spacdcconfig/spartacus/node_modules",
-    "/Users/i323558/CX/spacdcconfig/node_modules",
-    "/Users/i323558/CX/node_modules",
-    "/Users/i323558/node_modules",
-    "/Users/node_modules",
-    "/node_modules",
+"import { NgModule } from '@angular/core';
+import { CdcConfig, CdcRootModule, CDC_FEATURE } from \\"@spartacus/cdc/root\\";
+import { CmsConfig, provideConfig } from \\"@spartacus/core\\";
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CdcRootModule
   ],
-}
+  providers: [provideConfig(<CmsConfig>{
+    featureModules: {
+      [CDC_FEATURE]: {
+        module: () =>
+          import('@spartacus/cdc').then((m) => m.CdcModule),
+      },
+    }
+  }),
+  provideConfig(<CdcConfig>{
+    cdc: [
+      {
+        baseSite: 'electronics-spa',
+        javascriptUrl: 'JS_SDK_URL_PLACEHOLDER',
+        sessionExpiration: 3600
+      },
+    ],
+  })
+  ]
+})
+export class CdcFeatureModule { }
+"
 `;

--- a/integration-libs/cdc/schematics/add-cdc/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/cdc/schematics/add-cdc/__snapshots__/index_spec.ts.snap
@@ -16,7 +16,7 @@ import { provideConfig } from \\"@spartacus/core\\";
     cdc: [
       {
         baseSite: 'electronics-spa',
-        javascriptUrl: '<url-to-cdc-script>',
+        javascriptUrl: 'JS_SDK_URL_PLACEHOLDER',
         sessionExpiration: 3600
       },
     ],
@@ -48,7 +48,7 @@ import { CmsConfig, provideConfig } from \\"@spartacus/core\\";
     cdc: [
       {
         baseSite: 'electronics-spa',
-        javascriptUrl: '<url-to-cdc-script>',
+        javascriptUrl: 'JS_SDK_URL_PLACEHOLDER',
         sessionExpiration: 3600
       },
     ],
@@ -57,4 +57,87 @@ import { CmsConfig, provideConfig } from \\"@spartacus/core\\";
 })
 export class CdcFeatureModule { }
 "
+`;
+
+exports[`Spartacus CDC schematics: ng-add CDC feature validation of jsSDKUrl should set the given javascriptUrl 1`] = `
+"import { NgModule } from '@angular/core';
+import { CdcConfig, CdcRootModule, CDC_FEATURE } from \\"@spartacus/cdc/root\\";
+import { CmsConfig, provideConfig } from \\"@spartacus/core\\";
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CdcRootModule
+  ],
+  providers: [provideConfig(<CmsConfig>{
+    featureModules: {
+      [CDC_FEATURE]: {
+        module: () =>
+          import('@spartacus/cdc').then((m) => m.CdcModule),
+      },
+    }
+  }),
+  provideConfig(<CdcConfig>{
+    cdc: [
+      {
+        baseSite: 'electronics-spa',
+        javascriptUrl: '<dc>.gigya.com/<api-key>',
+        sessionExpiration: 3600
+      },
+    ],
+  })
+  ]
+})
+export class CdcFeatureModule { }
+"
+`;
+
+exports[`Spartacus CDC schematics: ng-add CDC feature warning for blank jsSDKUrl should set the default JS_SDK_URL_PLACEHOLDER 1`] = `
+Object {
+  "children": Array [],
+  "exports": Object {},
+  "filename": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/index_spec.ts",
+  "id": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/index_spec.ts",
+  "loaded": true,
+  "main": [Circular],
+  "parent": null,
+  "path": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc",
+  "paths": Array [
+    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/node_modules",
+    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/node_modules",
+    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/node_modules",
+    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/node_modules",
+    "/Users/i323558/CX/spacdcconfig/spartacus/node_modules",
+    "/Users/i323558/CX/spacdcconfig/node_modules",
+    "/Users/i323558/CX/node_modules",
+    "/Users/i323558/node_modules",
+    "/Users/node_modules",
+    "/node_modules",
+  ],
+}
+`;
+
+exports[`Spartacus CDC schematics: ng-add CDC feature warning for missing jsSDKUrl should set the default JS_SDK_URL_PLACEHOLDER 1`] = `
+Object {
+  "children": Array [],
+  "exports": Object {},
+  "filename": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/index_spec.ts",
+  "id": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/index_spec.ts",
+  "loaded": true,
+  "main": [Circular],
+  "parent": null,
+  "path": "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc",
+  "paths": Array [
+    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/add-cdc/node_modules",
+    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/schematics/node_modules",
+    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/cdc/node_modules",
+    "/Users/i323558/CX/spacdcconfig/spartacus/integration-libs/node_modules",
+    "/Users/i323558/CX/spacdcconfig/spartacus/node_modules",
+    "/Users/i323558/CX/spacdcconfig/node_modules",
+    "/Users/i323558/CX/node_modules",
+    "/Users/i323558/node_modules",
+    "/Users/node_modules",
+    "/node_modules",
+  ],
+}
 `;

--- a/integration-libs/cdc/schematics/add-cdc/index.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index.ts
@@ -50,8 +50,6 @@ function addCdc(options: SpartacusCdcOptions, context: SchematicContext): Rule {
     );
   }
 
-  const JS_SDK_URL_PLACEHOLDER = '<url-to-cdc-script>';
-
   return addLibraryFeature(options, {
     folderName: CDC_FOLDER_NAME,
     moduleName: CDC_MODULE_NAME,
@@ -80,7 +78,7 @@ function addCdc(options: SpartacusCdcOptions, context: SchematicContext): Rule {
             {
               baseSite: '${options.baseSite}',
               javascriptUrl: '${
-                options.javascriptUrl ?? JS_SDK_URL_PLACEHOLDER
+                options.javascriptUrl || 'JS_SDK_URL_PLACEHOLDER'
               }',
               sessionExpiration: ${options.sessionExpiration}
             },

--- a/integration-libs/cdc/schematics/add-cdc/index.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index.ts
@@ -12,13 +12,13 @@ import {
   CDC_ROOT_MODULE,
   CLI_CDC_FEATURE,
   CLI_USER_PROFILE_FEATURE,
-  LibraryOptions as SpartacusCdcOptions,
   readPackageJson,
   shouldAddFeature,
   SPARTACUS_CDC,
   SPARTACUS_USER,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
+import { Schema as SpartacusCdcOptions } from './schema';
 import { peerDependencies } from '../../package.json';
 import {
   CDC_CONFIG,
@@ -29,7 +29,7 @@ import {
 } from '../constants';
 
 export function addCdcFeature(options: SpartacusCdcOptions): Rule {
-  return (tree: Tree, _context: SchematicContext): Rule => {
+  return (tree: Tree, context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
 
@@ -37,13 +37,21 @@ export function addCdcFeature(options: SpartacusCdcOptions): Rule {
       addPackageJsonDependenciesForLibrary(peerDependencies, options),
 
       shouldAddFeature(CLI_CDC_FEATURE, options.features)
-        ? addCdc(options)
+        ? addCdc(options, context)
         : noop(),
     ]);
   };
 }
 
-function addCdc(options: SpartacusCdcOptions): Rule {
+function addCdc(options: SpartacusCdcOptions, context: SchematicContext): Rule {
+  if (!options.javascriptUrl) {
+    context.logger.warn(
+      `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the javascriptUrl.`
+    );
+  }
+
+  const JS_SDK_URL_PLACEHOLDER = '<url-to-cdc-script>';
+
   return addLibraryFeature(options, {
     folderName: CDC_FOLDER_NAME,
     moduleName: CDC_MODULE_NAME,
@@ -70,9 +78,11 @@ function addCdc(options: SpartacusCdcOptions): Rule {
       content: `<${CDC_CONFIG}>{
           cdc: [
             {
-              baseSite: 'electronics-spa',
-              javascriptUrl: '<url-to-cdc-script>',
-              sessionExpiration: 3600
+              baseSite: '${options.baseSite}',
+              javascriptUrl: '${
+                options.javascriptUrl ?? JS_SDK_URL_PLACEHOLDER
+              }',
+              sessionExpiration: ${options.sessionExpiration}
             },
           ],
         }`,

--- a/integration-libs/cdc/schematics/add-cdc/index_spec.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index_spec.ts
@@ -136,10 +136,43 @@ describe('Spartacus CDC schematics: ng-add', () => {
           .toPromise();
       });
 
-      it('show the warning', () => {
+      it('should show the warning', () => {
         expect(firstMessage).toEqual(
           `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the javascriptUrl.`
         );
+      });
+
+      it('should set the default JS_SDK_URL_PLACEHOLDER', () => {
+        expect(module).toMatchSnapshot();
+      });
+    });
+
+    describe('warning for blank jsSDKUrl', () => {
+      let firstMessage: string | undefined;
+      beforeEach(async () => {
+        schematicRunner.logger.subscribe((log) => {
+          if (!firstMessage) {
+            firstMessage = log.message;
+          }
+        });
+
+        appTree = await schematicRunner
+          .runSchematicAsync(
+            'ng-add',
+            { ...cdcFeatureOptions, javascriptUrl: '' },
+            appTree
+          )
+          .toPromise();
+      });
+
+      it('should show the warning', () => {
+        expect(firstMessage).toEqual(
+          `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the javascriptUrl.`
+        );
+      });
+
+      it('should set the default JS_SDK_URL_PLACEHOLDER', () => {
+        expect(module).toMatchSnapshot();
       });
     });
 
@@ -156,7 +189,7 @@ describe('Spartacus CDC schematics: ng-add', () => {
 
       it('should set the given javascriptUrl', () => {
         const module = appTree.readContent(featureModulePath);
-        expect(module).toContain<string>(`<dc>.gigya.com/<api-key>`);
+        expect(module).toMatchSnapshot();
       });
     });
 

--- a/integration-libs/cdc/schematics/add-cdc/index_spec.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index_spec.ts
@@ -122,6 +122,44 @@ describe('Spartacus CDC schematics: ng-add', () => {
   });
 
   describe('CDC feature', () => {
+    describe('warning for missing jsSDKUrl', () => {
+      let firstMessage: string | undefined;
+      beforeEach(async () => {
+        schematicRunner.logger.subscribe((log) => {
+          if (!firstMessage) {
+            firstMessage = log.message;
+          }
+        });
+
+        appTree = await schematicRunner
+          .runSchematicAsync('ng-add', { ...cdcFeatureOptions }, appTree)
+          .toPromise();
+      });
+
+      it('show the warning', () => {
+        expect(firstMessage).toEqual(
+          `CDC JS SDK URL is not provided. Please run the schematic again, or make sure you update the javascriptUrl.`
+        );
+      });
+    });
+
+    describe('validation of jsSDKUrl', () => {
+      beforeEach(async () => {
+        appTree = await schematicRunner
+          .runSchematicAsync(
+            'ng-add',
+            { ...cdcFeatureOptions, javascriptUrl: '<dc>.gigya.com/<api-key>' },
+            appTree
+          )
+          .toPromise();
+      });
+
+      it('should set the given javascriptUrl', () => {
+        const module = appTree.readContent(featureModulePath);
+        expect(module).toContain<string>(`<dc>.gigya.com/<api-key>`);
+      });
+    });
+
     describe('general setup', () => {
       beforeEach(async () => {
         appTree = await schematicRunner

--- a/integration-libs/cdc/schematics/add-cdc/index_spec.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index_spec.ts
@@ -142,7 +142,8 @@ describe('Spartacus CDC schematics: ng-add', () => {
         );
       });
 
-      it('should set the default JS_SDK_URL_PLACEHOLDER', () => {
+      it('should set the default JS_SDK_URL_PLACEHOLDER', async () => {
+        const module = appTree.readContent(featureModulePath);
         expect(module).toMatchSnapshot();
       });
     });
@@ -171,7 +172,8 @@ describe('Spartacus CDC schematics: ng-add', () => {
         );
       });
 
-      it('should set the default JS_SDK_URL_PLACEHOLDER', () => {
+      it('should set the default JS_SDK_URL_PLACEHOLDER', async () => {
+        const module = appTree.readContent(featureModulePath);
         expect(module).toMatchSnapshot();
       });
     });
@@ -187,7 +189,7 @@ describe('Spartacus CDC schematics: ng-add', () => {
           .toPromise();
       });
 
-      it('should set the given javascriptUrl', () => {
+      it('should set the given javascriptUrl', async () => {
         const module = appTree.readContent(featureModulePath);
         expect(module).toMatchSnapshot();
       });

--- a/integration-libs/cdc/schematics/add-cdc/schema.json
+++ b/integration-libs/cdc/schematics/add-cdc/schema.json
@@ -25,6 +25,23 @@
       "type": "array",
       "uniqueItems": true,
       "default": ["CDC"]
+    },
+    "javascriptUrl": {
+      "type": "string",
+      "description": "Location of the CDC Java Script SDK in Customer Data Cloud",
+      "x-prompt": "[CDC] What is the CDC JS SDK URL?"
+    },
+    "baseSite": {
+      "type": "string",
+      "description": "Name of the Spartcus base site",
+      "x-prompt": "[CDC] What is the base site?",
+      "default": "electronics-spa"
+    },
+    "sessionExpiration": {
+      "type": "number",
+      "description": "Session Expiration time in seconds",
+      "x-prompt": "[CDC] What is the CDC Session expiration time (in seconds)?",
+      "default": 3600
     }
   },
   "required": []

--- a/integration-libs/cdc/schematics/add-cdc/schema.ts
+++ b/integration-libs/cdc/schematics/add-cdc/schema.ts
@@ -1,0 +1,7 @@
+import { LibraryOptions } from '@spartacus/schematics';
+
+export interface Schema extends LibraryOptions {
+  baseSite: string;
+  javascriptUrl: string;
+  sessionExpiration: number;
+}


### PR DESCRIPTION
- Provided configurable parameters for CDC schematics to allow build pipelines to generate Spartacus modules
- Allows a new Angular project to add CDC schematics like -
```ng add @spartacus/cdc@latest --interactive false --javascriptUrl="https://eu1.gigya.com/API-KEY" --baseSite="electroncis-spa" --sessionExpiration=7200```