### PR TITLE
fix: Lock CI jobs to use angular 13 instead of the latest tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           key: nodemodules-${{ github.event.pull_request.base.sha }}
           restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
       - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
+        run: npm install -g @angular/cli@v13-lts
       - name: Package installation
         run: yarn --frozen-lockfile
       - name: Run unit tests for Spartacus libs
@@ -89,7 +89,7 @@ jobs:
           key: nodemodules-${{ github.event.pull_request.base.sha }}
           restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
       - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
+        run: npm install -g @angular/cli@v13-lts
       - name: Package installation
         run: yarn --frozen-lockfile
       - name: Run unit tests for integration libs
@@ -116,7 +116,7 @@ jobs:
           key: nodemodules-${{ github.event.pull_request.base.sha }}
           restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
       - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
+        run: npm install -g @angular/cli@v13-lts
       - name: Package installation
         run: yarn --frozen-lockfile
       - name: Run linting validation

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -37,7 +37,7 @@ jobs:
           key: nodemodules-${{ github.event.pull_request.base.sha }}
           restore-keys: nodemodules-${{ github.event.pull_request.base.sha }}
       - name: Install angular CLI
-        run: npm install -g @angular/cli@latest
+        run: npm install -g @angular/cli@v13-lts
       - name: Package installation
         run: yarn --frozen-lockfile
       - name: Run lighthouse score validation


### PR DESCRIPTION
closes https://jira.tools.sap/browse/CXSPA-565


context:
- the ci workflow contained some jobs that needed angular to be installed such as lighthouse, unit test lib, and unit core. However, they downloaded the angular/cli with the @latest tag. Reason being, we wanted the pipeline to run with the latest angular and not a specific angular 13 minor/patch.
- 5 days ago the latest tag was set to 14.0.0, therefore causing issues to our pipeline.