### PR TITLE
fix: wait with bootstraping the app until OAuth params are checked in the URL #15831 [backport to 4.3.x]

### DIFF
--- a/projects/core/src/auth/user-auth/user-auth.module.spec.ts
+++ b/projects/core/src/auth/user-auth/user-auth.module.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
+import { AuthService } from './facade/auth.service';
+import { checkOAuthParamsInUrl } from './user-auth.module';
+
+class MockAuthService implements Partial<AuthService> {
+  checkOAuthParamsInUrl() {
+    return Promise.resolve();
+  }
+}
+
+class MockConfigInitializerService
+  implements Partial<ConfigInitializerService>
+{
+  getStable() {
+    return of({});
+  }
+}
+
+describe(`checkOAuthParamsInUrl APP_INITIALIZER`, () => {
+  let authService: AuthService;
+  let configInitializerService: ConfigInitializerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
+        },
+        {
+          provide: ConfigInitializerService,
+          useClass: MockConfigInitializerService,
+        },
+      ],
+    });
+    authService = TestBed.inject(AuthService);
+    configInitializerService = TestBed.inject(ConfigInitializerService);
+  });
+
+  it(`should check OAuth params in the URL`, (done) => {
+    spyOn(authService, 'checkOAuthParamsInUrl').and.callThrough();
+
+    checkOAuthParamsInUrl(authService, configInitializerService)().then(() => {
+      expect(authService.checkOAuthParamsInUrl).toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it(`should resolve only after checking of the URL params completes`, (done) => {
+    let checkingUrlParamsCompleted = false;
+
+    spyOn(authService, 'checkOAuthParamsInUrl').and.callFake(() => {
+      // simulate a delay in checking URL params
+      // (which can normally happen due to a long OAuth authorization_code handshake):
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          checkingUrlParamsCompleted = true;
+          resolve();
+        }, 1);
+      });
+    });
+
+    checkOAuthParamsInUrl(authService, configInitializerService)().then(() => {
+      expect(checkingUrlParamsCompleted).toBe(true);
+      done();
+    });
+  });
+});

--- a/projects/core/src/auth/user-auth/user-auth.module.ts
+++ b/projects/core/src/auth/user-auth/user-auth.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
-import { tap } from 'rxjs/operators';
+import { switchMap } from 'rxjs/operators';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { provideDefaultConfig } from '../../config/config-providers';
 import { provideConfigValidator } from '../../config/config-validator/config-validator';
@@ -24,10 +24,10 @@ export function checkOAuthParamsInUrl(
     configInit
       .getStable()
       .pipe(
-        tap(() => {
+        switchMap(() =>
           // Wait for stable config is used, because with auth redirect would kick so quickly that the page would not be loaded correctly
-          authService.checkOAuthParamsInUrl();
-        })
+          authService.checkOAuthParamsInUrl()
+        )
       )
       .toPromise();
 


### PR DESCRIPTION
(It's a backport of https://github.com/SAP/spartacus/pull/15831 to 4.3.x)

### Context
When OAuth implicit or code flow is configured, on page start (especially when returing from the external auth server to Spartacus), we attempt to retrieve the access token from the URL, with the method `authService.checkOAuthParamsInUrl()`. During the execution of this method, the long OAuth authorization_code handshake can happen. Therefore the access token might be retireved with a delay.

### Before fix
Previously we didn’t wait until the access token is retireved, but started bootstrapping the application right away, including running of the route guards. Especially it was possible to run the AuthGuard, before we retireved the access token by the method `authService.checkOAuthParamsInUrl()`. This could result in AuthGuard blocking the navigaiton becasue the user was **not yet** logged in (however awaiting the access token in the background).

### After fix
Now we wait for `authService.checkOAuthParamsInUrl()` to resolve, and only then we proceed with bootstrapping the application and running the guards, including `AuthGuard`.

fixes #13622
fixes CXSPA-405