### PR TITLE
chore: lint integration libs with i18n-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "generate:changelog": "ts-node ./scripts/changelog.ts",
     "generate:docs": "npx @compodoc/compodoc@1.1.13 -p tsconfig.compodoc.json && ./scripts/zip-docs.sh",
     "generate:publish:docs": "yarn generate:docs && yarn publish:docs",
-    "i18n-lint": "i18n-lint -t \"{{,}}\" **/*.html --exclude **/node_modules/**/*.html,projects/storefrontapp/**/*.html -a alt,title,placeholder,aria-label",
+    "i18n-lint": "i18n-lint -t \"{{,}}\" projects/storefrontlib/**/*.html feature-libs/**/*.html integration-libs/**/*.html -a alt,title,placeholder,aria-label",
     "lint": "ng lint",
     "lint:styles": "stylelint \"{projects,feature-libs}/**/*.scss\"",
     "prettier": "prettier --config ./.prettierrc --list-different \"{projects,feature-libs,core-libs,integration-libs}/**/*{.ts,.js,.json,.scss,.html}\"",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "generate:changelog": "ts-node ./scripts/changelog.ts",
     "generate:docs": "npx @compodoc/compodoc@1.1.13 -p tsconfig.compodoc.json && ./scripts/zip-docs.sh",
     "generate:publish:docs": "yarn generate:docs && yarn publish:docs",
-    "i18n-lint": "i18n-lint -t \"{{,}}\" projects/storefrontlib/**/*.html feature-libs/**/*.html --exclude **/node_modules/**/*.html -a alt,title,placeholder,aria-label",
+    "i18n-lint": "i18n-lint -t \"{{,}}\" **/*.html --exclude **/node_modules/**/*.html,projects/storefrontapp/**/*.html -a alt,title,placeholder,aria-label",
     "lint": "ng lint",
     "lint:styles": "stylelint \"{projects,feature-libs}/**/*.scss\"",
     "prettier": "prettier --config ./.prettierrc --list-different \"{projects,feature-libs,core-libs,integration-libs}/**/*{.ts,.js,.json,.scss,.html}\"",

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -81,6 +81,14 @@ if (!environment.production) {
         level: '4.2',
       },
     }),
+    provideConfig({
+      authentication: {
+        client_id: 'client4kyma',
+        OAuthLibConfig: {
+          responseType: 'code',
+        },
+      },
+    }),
   ],
   bootstrap: [StorefrontComponent],
 })

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -81,14 +81,6 @@ if (!environment.production) {
         level: '4.2',
       },
     }),
-    provideConfig({
-      authentication: {
-        client_id: 'client4kyma',
-        OAuthLibConfig: {
-          responseType: 'code',
-        },
-      },
-    }),
   ],
   bootstrap: [StorefrontComponent],
 })


### PR DESCRIPTION
`i18n-lint` checks if no hardcoded texts appear in the HTML templates

Previously integration-libs were not linted, but only feature-libs and the storefrontlib. Now integration libs are also linted.

Btw. removed the `--exclude` of node_modules folder, as being redundant - node_modules don't overlap with any allowlisted files.

fixes https://jira.tools.sap/browse/CXSPA-627