### PR TITLE
chore: use fixed version of @microsoft/api-extractor@7.23.2 in the github api-extractor-action

### DIFF
--- a/.github/api-extractor-action/src/setup.ts
+++ b/.github/api-extractor-action/src/setup.ts
@@ -21,7 +21,7 @@ export async function prepareRepositoryForApiExtractor(
   // Create directory for reports
   await io.mkdirP(`${REPORT_DIR}`);
 
-  await exec.exec('npm', ['i', '-g', '@microsoft/api-extractor@^7.12.0']);
+  await exec.exec('npm', ['i', '-g', '@microsoft/api-extractor@7.23.2']);
 
   // Clone base branch
   await exec.exec('sh', [


### PR DESCRIPTION
In our CI script for API Extractor (Breaking changes detection bot) we've been installing the latest minor of API Extractor 7.x (@microsoft/api-extractor@^7.12.0). See
https://github.com/SAP/spartacus/blob/b8d8c3a01998dd5e73d888a41f2a6750a63fbd3b/.github/api-extractor-action/src/setup.ts#L24

Since api-extractor version v7.24.0 (released 2022-05-14) it throws an error if it processes other files than in the d.ts format. See changelog https://github.com/microsoft/rushstack/blob/main/apps/api-extractor/CHANGELOG.md#7240

This made our CI script to fail.

So now I'm freezing the version of api-extractor to the latest working, which is v7.23.2.

**Future work:**
According to https://api-extractor.com/pages/messages/ae-wrong-input-file-type/ , it seems that we're using the API extractor tool not in a way that the tool's authors assumed. We analyze TS files, but they expect us to analyze d.ts. So to be able to use higher version of api-extractor in the future, >=7.24.0, we will need to first adapt our api-extractor script to use the d.ts files (in /dist folder) instead of the source code TS files of libraries.

closes https://jira.tools.sap/browse/CXSPA-436