### PR TITLE
fix: Allow placing a replenishment order when local time is midnight

### DIFF
--- a/feature-libs/order/occ/adapters/converters/occ-scheduled-replenishment-order-form-serializer.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-scheduled-replenishment-order-form-serializer.ts
@@ -35,7 +35,7 @@ export class OccScheduledReplenishmentOrderFormSerializer
     const localTime = new Date().toLocaleTimeString([], {
       hour: '2-digit',
       minute: '2-digit',
-      hour12: false,
+      hourCycle: 'h23',
     });
     return `${date}T${localTime}:00${TimeUtils.getLocalTimezoneOffset()}`;
   }


### PR DESCRIPTION
- remove date bug, where 24h time for midnight translates to 24:xx instead of 00:xx. Basically, backend for the replenishment endpoint does not accept 24 for midnight, but 00 / reference to fix conversion https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle

part of https://jira.tools.sap/browse/CXSPA-530