### PR TITLE
test: Improve currency checkout page core e2e

### DIFF
--- a/feature-libs/qualtrics/components/qualtrics-loader/qualtrics.component.ts
+++ b/feature-libs/qualtrics/components/qualtrics-loader/qualtrics.component.ts
@@ -16,7 +16,7 @@ export class QualtricsComponent {
     protected config: QualtricsConfig,
     protected globalConfigType: Config
   ) {
-    console.log('find me', this.globalConfigType);
+    console.log('find me', this.globalConfigType.v);
 
     if (this.config.qualtrics?.scriptSource) {
       this.qualtricsLoader.addScript(this.config.qualtrics.scriptSource);

--- a/feature-libs/qualtrics/components/qualtrics-loader/qualtrics.component.ts
+++ b/feature-libs/qualtrics/components/qualtrics-loader/qualtrics.component.ts
@@ -1,5 +1,4 @@
 import { Component, isDevMode } from '@angular/core';
-import { Config } from '@spartacus/core';
 import { QualtricsConfig } from './config/qualtrics-config';
 import { QualtricsLoaderService } from './qualtrics-loader.service';
 /**
@@ -13,11 +12,8 @@ import { QualtricsLoaderService } from './qualtrics-loader.service';
 export class QualtricsComponent {
   constructor(
     protected qualtricsLoader: QualtricsLoaderService,
-    protected config: QualtricsConfig,
-    protected globalConfigType: Config
+    protected config: QualtricsConfig
   ) {
-    console.log('find me', this.globalConfigType.v);
-
     if (this.config.qualtrics?.scriptSource) {
       this.qualtricsLoader.addScript(this.config.qualtrics.scriptSource);
     } else if (isDevMode()) {

--- a/feature-libs/qualtrics/components/qualtrics-loader/qualtrics.component.ts
+++ b/feature-libs/qualtrics/components/qualtrics-loader/qualtrics.component.ts
@@ -1,4 +1,5 @@
 import { Component, isDevMode } from '@angular/core';
+import { Config } from '@spartacus/core';
 import { QualtricsConfig } from './config/qualtrics-config';
 import { QualtricsLoaderService } from './qualtrics-loader.service';
 /**
@@ -12,8 +13,11 @@ import { QualtricsLoaderService } from './qualtrics-loader.service';
 export class QualtricsComponent {
   constructor(
     protected qualtricsLoader: QualtricsLoaderService,
-    protected config: QualtricsConfig
+    protected config: QualtricsConfig,
+    protected globalConfigType: Config
   ) {
+    console.log('find me', this.globalConfigType);
+
     if (this.config.qualtrics?.scriptSource) {
       this.qualtricsLoader.addScript(this.config.qualtrics.scriptSource);
     } else if (isDevMode()) {

--- a/projects/storefrontapp-e2e-cypress/cypress/plugins/index.js
+++ b/projects/storefrontapp-e2e-cypress/cypress/plugins/index.js
@@ -3,16 +3,6 @@ const fs = require('fs');
 
 module.exports = (on, config) => {
   on('file:preprocessor', cypressTypeScriptPreprocessor);
-
-  /* Set exact timestamp to be shared in all spec files */
-  config.env.TIMESTAMP = Date.now() - 1535535333333;
-  return config;
-};
-
-/**
- * Read file but return null if no file found (instead of failing the test).
- */
-module.exports = (on, config) => {
   on('task', {
     readFile(filename) {
       if (fs.existsSync(filename)) {
@@ -22,4 +12,8 @@ module.exports = (on, config) => {
       return null;
     },
   });
+
+  /* Set exact timestamp to be shared in all spec files */
+  config.env.TIMESTAMP = Date.now() - 1535535333333;
+  return config;
 };


### PR DESCRIPTION
2 things fixed:

1. fixed the plugin.js, where we had 2 module.export (should only have 1 and it took the latest export). This caused e2es using `cy.requireLoggedIn()` without an input param to have an undefined email, which can cause e2es to overlap. Basically, how it was before, the email that was generated when using `cy.requireLoggedIn() -> without input param` is `cypress_user_somethingsomething_undefined@sapcx.com`
- merging the module.export, it now displays the current timestamp instead of `_undefined`

2. Put the tests in one assertion instead of depending on cy.restoreStorage AND cy.saveStorage as each `it` should not depend on the previous states.


dashboard showing the failure for currency checkout page https://dashboard.cypress.io/projects/k3nmep/runs/31645/test-results/69c9dcc2-81d7-48c8-8fd3-6bde37e5670e

closes https://jira.tools.sap/browse/CXSPA-656