### PR TITLE
chore: fix "Public API Changes" bot (#15883) [backport to 4.3.x]

### DIFF
--- a/.github/api-extractor-action/api-extractor.json
+++ b/.github/api-extractor-action/api-extractor.json
@@ -305,8 +305,19 @@
      */
     "extractorMessageReporting": {
       "default": {
-        "logLevel": "warning"
-        // "addToApiReportFile": false
+        "logLevel": "warning",
+        "addToApiReportFile": false
+      },
+
+      // Spartaus: currently we don't use the release tags @alpha/@beta/@internal/@public in our JSDocs:
+      "ae-missing-release-tag": {
+        "logLevel": "none"
+      },
+
+      // Spartacus: disabled due to false-positive warnings e.g. when an interface is exported, but from a different library
+      "ae-forgotten-export": {
+        "logLevel": "none",
+        "addToApiReportFile": false
       }
 
       // "ae-extra-release-tag": {
@@ -326,7 +337,7 @@
      */
     "tsdocMessageReporting": {
       "default": {
-        "logLevel": "warning"
+        "logLevel": "none"
         // "addToApiReportFile": false
       }
 

--- a/feature-libs/asm/core/asm-core.module.ts
+++ b/feature-libs/asm/core/asm-core.module.ts
@@ -8,7 +8,7 @@ import { AsmStoreModule } from './store/asm-store.module';
 
 export function asmStatePersistenceFactory(
   asmStatePersistenceService: AsmStatePersistenceService
-) {
+): () => void {
   const result = () => asmStatePersistenceService.initSync();
   return result;
 }

--- a/feature-libs/asm/root/asm-loader.module.ts
+++ b/feature-libs/asm/root/asm-loader.module.ts
@@ -26,7 +26,7 @@ export class AsmLoaderModule {}
  * to a real component; the router and state aren't available in an optimized
  * way during the APP_INITIALIZER.
  */
-export function asmFactory(asmEnablerService: AsmEnablerService) {
+export function asmFactory(asmEnablerService: AsmEnablerService): () => void {
   const isReady = () => {
     asmEnablerService.load();
   };

--- a/feature-libs/smartedit/root/smart-edit-root.module.ts
+++ b/feature-libs/smartedit/root/smart-edit-root.module.ts
@@ -6,7 +6,7 @@ import { SmartEditLauncherService } from './services/smart-edit-launcher.service
 
 export function smartEditFactory(
   smartEditLauncherService: SmartEditLauncherService
-) {
+): () => void {
   const isReady = () => {
     smartEditLauncherService.load();
   };

--- a/integration-libs/cdc/root/cdc-root.module.ts
+++ b/integration-libs/cdc/root/cdc-root.module.ts
@@ -1,6 +1,7 @@
 import { APP_INITIALIZER, NgModule } from '@angular/core';
 import {
   CmsConfig,
+  Config,
   ConfigInitializerService,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
@@ -13,7 +14,7 @@ import { CdcJsService } from './service/cdc-js.service';
 export function cdcJsFactory(
   cdcJsService: CdcJsService,
   configInit: ConfigInitializerService
-) {
+): () => Promise<Config> {
   const func = () =>
     configInit
       .getStable('context', 'cdc')

--- a/projects/core/src/auth/user-auth/user-auth.module.ts
+++ b/projects/core/src/auth/user-auth/user-auth.module.ts
@@ -19,7 +19,7 @@ import { AuthStorageService } from './services/auth-storage.service';
 export function checkOAuthParamsInUrl(
   authService: AuthService,
   configInit: ConfigInitializerService
-) {
+): () => Promise<void> {
   const result = () =>
     configInit
       .getStable()

--- a/projects/core/src/cart/cart-persistence.module.ts
+++ b/projects/core/src/cart/cart-persistence.module.ts
@@ -2,13 +2,14 @@ import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
 import { ActionReducer, MetaReducer, META_REDUCERS } from '@ngrx/store';
 import { tap } from 'rxjs/operators';
 import { ConfigInitializerService } from '../config/config-initializer/config-initializer.service';
+import { Config } from '../config/config-tokens';
 import { MultiCartStatePersistenceService } from './services/multi-cart-state-persistence.service';
 import { activeCartInitialState } from './store/reducers/multi-cart.reducer';
 
 export function cartStatePersistenceFactory(
   cartStatePersistenceService: MultiCartStatePersistenceService,
   configInit: ConfigInitializerService
-) {
+): () => Promise<Config> {
   const result = () =>
     configInit
       .getStable('context')

--- a/projects/core/src/config/config-initializer/config-initializer.module.ts
+++ b/projects/core/src/config/config-initializer/config-initializer.module.ts
@@ -1,28 +1,29 @@
+import { LOCATION_INITIALIZED } from '@angular/common';
 import {
   APP_INITIALIZER,
   ModuleWithProviders,
   NgModule,
   Optional,
 } from '@angular/core';
-import { ConfigInitializerService } from './config-initializer.service';
+import { Config } from '../config-tokens';
 import {
+  ConfigInitializer,
   CONFIG_INITIALIZER,
   CONFIG_INITIALIZER_FORROOT_GUARD,
-  ConfigInitializer,
 } from './config-initializer';
-import { LOCATION_INITIALIZED } from '@angular/common';
+import { ConfigInitializerService } from './config-initializer.service';
 
 export function configInitializerFactory(
   configInitializer: ConfigInitializerService,
   initializers: ConfigInitializer[]
-) {
+): () => Promise<void> {
   const isReady = () => configInitializer.initialize(initializers);
   return isReady;
 }
 
 export function locationInitializedFactory(
   configInitializer: ConfigInitializerService
-) {
+): Promise<Config> {
   return configInitializer.getStable().toPromise();
 }
 

--- a/projects/core/src/config/config-validator/config-validator.module.ts
+++ b/projects/core/src/config/config-validator/config-validator.module.ts
@@ -15,7 +15,7 @@ import {
 export function configValidatorFactory(
   configInitializer: ConfigInitializerService,
   validators: ConfigValidator[]
-) {
+): () => void {
   const validate = () => {
     if (isDevMode()) {
       configInitializer

--- a/projects/core/src/occ/occ-models/occ.models.ts
+++ b/projects/core/src/occ/occ-models/occ.models.ts
@@ -4,13 +4,8 @@ export namespace Occ {
    * An interface representing Country.
    */
   export interface Country {
-    /**
-     * @member {string} [isocode]
-     */
     isocode?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
   }
 
@@ -19,21 +14,12 @@ export namespace Occ {
    * An interface representing Region.
    */
   export interface Region {
-    /**
-     * @member {string} [countryIso]
-     */
     countryIso?: string;
-    /**
-     * @member {string} [isocode]
-     */
+
     isocode?: string;
-    /**
-     * @member {string} [isocodeShort]
-     */
+
     isocodeShort?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
   }
 
@@ -42,9 +28,6 @@ export namespace Occ {
    * An interface representing RegionList.
    */
   export interface RegionList {
-    /**
-     * @member {Region[]} [regions]
-     */
     regions?: Region[];
   }
 
@@ -57,85 +40,44 @@ export namespace Occ {
    * An interface representing Address.
    */
   export interface Address {
-    /**
-     * @member {string} [companyName]
-     */
     companyName?: string;
-    /**
-     * @member {Country} [country]
-     */
+
     country?: Country;
-    /**
-     * @member {boolean} [defaultAddress]
-     */
+
     defaultAddress?: boolean;
-    /**
-     * @member {string} [email]
-     */
+
     email?: string;
-    /**
-     * @member {string} [firstName]
-     */
+
     firstName?: string;
-    /**
-     * @member {string} [formattedAddress]
-     */
+
     formattedAddress?: string;
-    /**
-     * @member {string} [id]
-     */
+
     id?: string;
-    /**
-     * @member {string} [lastName]
-     */
+
     lastName?: string;
-    /**
-     * @member {string} [line1]
-     */
+
     line1?: string;
-    /**
-     * @member {string} [line2]
-     */
+
     line2?: string;
-    /**
-     * @member {string} [phone]
-     */
+
     phone?: string;
-    /**
-     * @member {string} [town]
-     */
+
     cellphone?: string;
-    /**
-     * @member {string} [postalCode]
-     */
+
     postalCode?: string;
-    /**
-     * @member {Region} [region]
-     */
+
     region?: Region;
-    /**
-     * @member {string} [town]
-     */
+
     district?: string;
-    /**
-     * @member {boolean} [shippingAddress]
-     */
+
     shippingAddress?: boolean;
-    /**
-     * @member {string} [title]
-     */
+
     title?: string;
-    /**
-     * @member {string} [titleCode]
-     */
+
     titleCode?: string;
-    /**
-     * @member {string} [town]
-     */
+
     town?: string;
-    /**
-     * @member {boolean} [visibleInAddressBook]
-     */
+
     visibleInAddressBook?: boolean;
   }
 
@@ -144,9 +86,6 @@ export namespace Occ {
    * An interface representing AddressList.
    */
   export interface AddressList {
-    /**
-     * @member {Address[]} [addresses]
-     */
     addresses?: Address[];
   }
 
@@ -158,25 +97,25 @@ export namespace Occ {
    */
   export interface ErrorModel {
     /**
-     * @member {string} [message] Descriptive, human readable error message.
+     * Descriptive, human readable error message.
      */
     message?: string;
     /**
-     * @member {string} [reason] Additional classification specific for each
+     * Additional classification specific for each
      * error type e.g. 'noStock'.
      */
     reason?: string;
     /**
-     * @member {string} [subject] Identifier of the related object e.g. '1'.
+     * Identifier of the related object e.g. '1'.
      */
     subject?: string;
     /**
-     * @member {string} [subjectType] Type of the object related to the error
+     * Type of the object related to the error
      * e.g. 'entry'.
      */
     subjectType?: string;
     /**
-     * @member {string} [type] Type of the error e.g. 'LowStockError'.
+     * Type of the error e.g. 'LowStockError'.
      */
     type?: string;
   }
@@ -188,9 +127,6 @@ export namespace Occ {
    *
    */
   export interface ErrorList {
-    /**
-     * @member {ErrorModel[]} [errors]
-     */
     errors?: ErrorModel[];
   }
 
@@ -199,17 +135,10 @@ export namespace Occ {
    * An interface representing AddressValidation.
    */
   export interface AddressValidation {
-    /**
-     * @member {string} [decision]
-     */
     decision?: string;
-    /**
-     * @member {ErrorList} [errors]
-     */
+
     errors?: ErrorList;
-    /**
-     * @member {Address[]} [suggestedAddresses]
-     */
+
     suggestedAddresses?: Address[];
   }
 
@@ -218,29 +147,18 @@ export namespace Occ {
    * An interface representing Price.
    */
   export interface Price {
-    /**
-     * @member {string} [currencyIso]
-     */
     currencyIso?: string;
-    /**
-     * @member {string} [formattedValue]
-     */
+
     formattedValue?: string;
-    /**
-     * @member {number} [maxQuantity]
-     */
+
     maxQuantity?: number;
-    /**
-     * @member {number} [minQuantity]
-     */
+
     minQuantity?: number;
     /**
-     * @member {PriceType} [priceType] Possible values include: 'BUY', 'FROM'
+     * Possible values include: 'BUY', 'FROM'
      */
     priceType?: PriceType;
-    /**
-     * @member {number} [value]
-     */
+
     value?: number;
   }
 
@@ -249,13 +167,8 @@ export namespace Occ {
    * An interface representing Stock.
    */
   export interface Stock {
-    /**
-     * @member {number} [stockLevel]
-     */
     stockLevel?: number;
-    /**
-     * @member {string} [stockLevelStatus]
-     */
+
     stockLevelStatus?: string;
   }
 
@@ -264,26 +177,17 @@ export namespace Occ {
    * An interface representing Image.
    */
   export interface Image {
-    /**
-     * @member {string} [altText]
-     */
     altText?: string;
-    /**
-     * @member {string} [format]
-     */
+
     format?: string;
-    /**
-     * @member {number} [galleryIndex]
-     */
+
     galleryIndex?: number;
     /**
-     * @member {ImageType} [imageType] Possible values include: 'PRIMARY',
+     * Possible values include: 'PRIMARY',
      * 'GALLERY'
      */
     imageType?: ImageType;
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
   }
 
@@ -292,21 +196,12 @@ export namespace Occ {
    * An interface representing VariantOptionQualifier.
    */
   export interface VariantOptionQualifier {
-    /**
-     * @member {Image} [image]
-     */
     image?: Image;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {string} [qualifier]
-     */
+
     qualifier?: string;
-    /**
-     * @member {string} [value]
-     */
+
     value?: string;
   }
 
@@ -315,25 +210,14 @@ export namespace Occ {
    * An interface representing VariantOption.
    */
   export interface VariantOption {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {Price} [priceData]
-     */
+
     priceData?: Price;
-    /**
-     * @member {Stock} [stock]
-     */
+
     stock?: Stock;
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
-    /**
-     * @member {VariantOptionQualifier[]} [variantOptionQualifiers]
-     */
+
     variantOptionQualifiers?: VariantOptionQualifier[];
   }
 
@@ -342,17 +226,10 @@ export namespace Occ {
    * An interface representing BaseOption.
    */
   export interface BaseOption {
-    /**
-     * @member {VariantOption[]} [options]
-     */
     options?: VariantOption[];
-    /**
-     * @member {VariantOption} [selected]
-     */
+
     selected?: VariantOption;
-    /**
-     * @member {string} [variantType]
-     */
+
     variantType?: string;
   }
 
@@ -361,9 +238,6 @@ export namespace Occ {
    * An interface representing SearchQuery.
    */
   export interface SearchQuery {
-    /**
-     * @member {string} [value]
-     */
     value?: string;
   }
 
@@ -372,13 +246,8 @@ export namespace Occ {
    * An interface representing SearchState.
    */
   export interface SearchState {
-    /**
-     * @member {SearchQuery} [query]
-     */
     query?: SearchQuery;
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
   }
 
@@ -387,29 +256,16 @@ export namespace Occ {
    * An interface representing Breadcrumb.
    */
   export interface Breadcrumb {
-    /**
-     * @member {string} [facetCode]
-     */
     facetCode?: string;
-    /**
-     * @member {string} [facetName]
-     */
+
     facetName?: string;
-    /**
-     * @member {string} [facetValueCode]
-     */
+
     facetValueCode?: string;
-    /**
-     * @member {string} [facetValueName]
-     */
+
     facetValueName?: string;
-    /**
-     * @member {SearchState} [removeQuery]
-     */
+
     removeQuery?: SearchState;
-    /**
-     * @member {SearchState} [truncateQuery]
-     */
+
     truncateQuery?: SearchState;
   }
 
@@ -418,25 +274,14 @@ export namespace Occ {
    * An interface representing Component.
    */
   export interface Component {
-    /**
-     * @member {Date} [modifiedTime]
-     */
     modifiedTime?: Date;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {any} [otherProperties]
-     */
+
     otherProperties?: any;
-    /**
-     * @member {string} [typeCode]
-     */
+
     typeCode?: string;
-    /**
-     * @member {string} [uid]
-     */
+
     uid?: string;
   }
 
@@ -445,9 +290,6 @@ export namespace Occ {
    * An interface representing ComponentList.
    */
   export interface ComponentList {
-    /**
-     * @member {Component[]} [component]
-     */
     component?: Component[] | any[];
   }
 
@@ -456,33 +298,18 @@ export namespace Occ {
    * An interface representing ContentSlot.
    */
   export interface ContentSlot {
-    /**
-     * @member {ComponentList} [components]
-     */
     components?: ComponentList;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {string} [position]
-     */
+
     position?: string;
-    /**
-     * @member {string} [slotId]
-     */
+
     slotId?: string;
-    /**
-     * @member {boolean} [slotShared]
-     */
+
     slotShared?: boolean;
-    /**
-     * @member {string} [slotStatus]
-     */
+
     slotStatus?: string;
-    /**
-     * @member {any} [properties]
-     */
+
     properties?: any;
   }
 
@@ -491,9 +318,6 @@ export namespace Occ {
    * An interface representing ContentSlotList.
    */
   export interface ContentSlotList {
-    /**
-     * @member {ContentSlot[]} [contentSlot]
-     */
     contentSlot?: ContentSlot[];
   }
 
@@ -502,45 +326,24 @@ export namespace Occ {
    * An interface representing CMSPage.
    */
   export interface CMSPage {
-    /**
-     * @member {ContentSlotList} [contentSlots]
-     */
     contentSlots?: ContentSlotList;
-    /**
-     * @member {boolean} [defaultPage]
-     */
+
     defaultPage?: boolean;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {string} [template]
-     */
+
     template?: string;
-    /**
-     * @member {string} [title]
-     */
+
     title?: string;
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {string} [typeCode]
-     */
+
     typeCode?: string;
-    /**
-     * @member {string} [uid]
-     */
+
     uid?: string;
-    /**
-     * @member {string} [label]
-     */
+
     label?: string;
-    /**
-     * @member {any} [properties]
-     */
+
     properties?: any;
 
     robotTag?: PageRobots;
@@ -561,13 +364,8 @@ export namespace Occ {
    * An interface representing CardType.
    */
   export interface CardType {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
   }
 
@@ -576,9 +374,6 @@ export namespace Occ {
    * An interface representing CardTypeList.
    */
   export interface CardTypeList {
-    /**
-     * @member {CardType[]} [cardTypes]
-     */
     cardTypes?: CardType[];
   }
 
@@ -587,13 +382,8 @@ export namespace Occ {
    * An interface representing PaymentType.
    */
   export interface PaymentType {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {string} [displayName]
-     */
+
     displayName?: string;
   }
 
@@ -602,9 +392,6 @@ export namespace Occ {
    * An interface representing PaymentTypeList.
    */
   export interface PaymentTypeList {
-    /**
-     * @member {PaymentType[]} [paymentTypes]
-     */
     paymentTypes?: PaymentType[];
   }
 
@@ -613,21 +400,12 @@ export namespace Occ {
    * An interface representing PromotionOrderEntryConsumed.
    */
   export interface PromotionOrderEntryConsumed {
-    /**
-     * @member {number} [adjustedUnitPrice]
-     */
     adjustedUnitPrice?: number;
-    /**
-     * @member {string} [code]
-     */
+
     code?: string;
-    /**
-     * @member {number} [orderEntryNumber]
-     */
+
     orderEntryNumber?: number;
-    /**
-     * @member {number} [quantity]
-     */
+
     quantity?: number;
   }
 
@@ -636,13 +414,8 @@ export namespace Occ {
    * An interface representing PromotionRestriction.
    */
   export interface PromotionRestriction {
-    /**
-     * @member {string} [description]
-     */
     description?: string;
-    /**
-     * @member {string} [restrictionType]
-     */
+
     restrictionType?: string;
   }
 
@@ -651,57 +424,30 @@ export namespace Occ {
    * An interface representing Promotion.
    */
   export interface Promotion {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {string[]} [couldFireMessages]
-     */
+
     couldFireMessages?: string[];
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {boolean} [enabled]
-     */
+
     enabled?: boolean;
-    /**
-     * @member {Date} [endDate]
-     */
+
     endDate?: Date;
-    /**
-     * @member {string[]} [firedMessages]
-     */
+
     firedMessages?: string[];
-    /**
-     * @member {number} [priority]
-     */
+
     priority?: number;
-    /**
-     * @member {Image} [productBanner]
-     */
+
     productBanner?: Image;
-    /**
-     * @member {string} [promotionGroup]
-     */
+
     promotionGroup?: string;
-    /**
-     * @member {string} [promotionType]
-     */
+
     promotionType?: string;
-    /**
-     * @member {PromotionRestriction[]} [restrictions]
-     */
+
     restrictions?: PromotionRestriction[];
-    /**
-     * @member {Date} [startDate]
-     */
+
     startDate?: Date;
-    /**
-     * @member {string} [title]
-     */
+
     title?: string;
   }
 
@@ -710,17 +456,10 @@ export namespace Occ {
    * An interface representing PromotionResult.
    */
   export interface PromotionResult {
-    /**
-     * @member {PromotionOrderEntryConsumed[]} [consumedEntries]
-     */
     consumedEntries?: PromotionOrderEntryConsumed[];
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {Promotion} [promotion]
-     */
+
     promotion?: Promotion;
   }
 
@@ -729,21 +468,12 @@ export namespace Occ {
    * An interface representing Currency.
    */
   export interface Currency {
-    /**
-     * @member {boolean} [active]
-     */
     active?: boolean;
-    /**
-     * @member {string} [isocode]
-     */
+
     isocode?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {string} [symbol]
-     */
+
     symbol?: string;
   }
 
@@ -752,45 +482,24 @@ export namespace Occ {
    * An interface representing Voucher.
    */
   export interface Voucher {
-    /**
-     * @member {Price} [appliedValue]
-     */
     appliedValue?: Price;
-    /**
-     * @member {string} [code]
-     */
+
     code?: string;
-    /**
-     * @member {Currency} [currency]
-     */
+
     currency?: Currency;
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {boolean} [freeShipping]
-     */
+
     freeShipping?: boolean;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {number} [value]
-     */
+
     value?: number;
-    /**
-     * @member {string} [valueFormatted]
-     */
+
     valueFormatted?: string;
-    /**
-     * @member {string} [valueString]
-     */
+
     valueString?: string;
-    /**
-     * @member {string} [voucherCode]
-     */
+
     voucherCode?: string;
   }
 
@@ -799,21 +508,12 @@ export namespace Occ {
    * An interface representing DeliveryMode.
    */
   export interface DeliveryMode {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {Price} [deliveryCost]
-     */
+
     deliveryCost?: Price;
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
   }
 
@@ -822,13 +522,8 @@ export namespace Occ {
    * An interface representing GeoPoint.
    */
   export interface GeoPoint {
-    /**
-     * @member {number} [latitude]
-     */
     latitude?: number;
-    /**
-     * @member {number} [longitude]
-     */
+
     longitude?: number;
   }
 
@@ -837,17 +532,10 @@ export namespace Occ {
    * An interface representing Time.
    */
   export interface Time {
-    /**
-     * @member {string} [formattedHour]
-     */
     formattedHour?: string;
-    /**
-     * @member {number} [hour]
-     */
+
     hour?: number;
-    /**
-     * @member {number} [minute]
-     */
+
     minute?: number;
   }
 
@@ -856,33 +544,18 @@ export namespace Occ {
    * An interface representing SpecialOpeningDay.
    */
   export interface SpecialOpeningDay {
-    /**
-     * @member {boolean} [closed]
-     */
     closed?: boolean;
-    /**
-     * @member {Time} [closingTime]
-     */
+
     closingTime?: Time;
-    /**
-     * @member {string} [comment]
-     */
+
     comment?: string;
-    /**
-     * @member {Date} [date]
-     */
+
     date?: Date;
-    /**
-     * @member {string} [formattedDate]
-     */
+
     formattedDate?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {Time} [openingTime]
-     */
+
     openingTime?: Time;
   }
 
@@ -891,21 +564,12 @@ export namespace Occ {
    * An interface representing WeekdayOpeningDay.
    */
   export interface WeekdayOpeningDay {
-    /**
-     * @member {boolean} [closed]
-     */
     closed?: boolean;
-    /**
-     * @member {Time} [closingTime]
-     */
+
     closingTime?: Time;
-    /**
-     * @member {Time} [openingTime]
-     */
+
     openingTime?: Time;
-    /**
-     * @member {string} [weekDay]
-     */
+
     weekDay?: string;
   }
 
@@ -914,21 +578,12 @@ export namespace Occ {
    * An interface representing OpeningSchedule.
    */
   export interface OpeningSchedule {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {SpecialOpeningDay[]} [specialDayOpeningList]
-     */
+
     specialDayOpeningList?: SpecialOpeningDay[];
-    /**
-     * @member {WeekdayOpeningDay[]} [weekDayOpeningList]
-     */
+
     weekDayOpeningList?: WeekdayOpeningDay[];
   }
 
@@ -937,57 +592,30 @@ export namespace Occ {
    * An interface representing PointOfService.
    */
   export interface PointOfService {
-    /**
-     * @member {Address} [address]
-     */
     address?: Address;
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {string} [displayName]
-     */
+
     displayName?: string;
-    /**
-     * @member {number} [distanceKm]
-     */
+
     distanceKm?: number;
-    /**
-     * @member {{ [propertyName: string]: string }} [features]
-     */
+
     features?: { [propertyName: string]: string };
-    /**
-     * @member {string} [formattedDistance]
-     */
+
     formattedDistance?: string;
-    /**
-     * @member {GeoPoint} [geoPoint]
-     */
+
     geoPoint?: GeoPoint;
-    /**
-     * @member {Image} [mapIcon]
-     */
+
     mapIcon?: Image;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {OpeningSchedule} [openingHours]
-     */
+
     openingHours?: OpeningSchedule;
-    /**
-     * @member {string} [storeContent]
-     */
+
     storeContent?: string;
-    /**
-     * @member {Image[]} [storeImages]
-     */
+
     storeImages?: Image[];
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
   }
 
@@ -996,21 +624,12 @@ export namespace Occ {
    * An interface representing Category.
    */
   export interface Category {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {string} [code]
-     */
+
     name?: string;
-    /**
-     * @member {Image} [image]
-     */
+
     image?: Image;
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
   }
 
@@ -1019,17 +638,10 @@ export namespace Occ {
    * An interface representing FeatureUnit.
    */
   export interface FeatureUnit {
-    /**
-     * @member {string} [name]
-     */
     name?: string;
-    /**
-     * @member {string} [symbol]
-     */
+
     symbol?: string;
-    /**
-     * @member {string} [unitType]
-     */
+
     unitType?: string;
   }
 
@@ -1038,9 +650,6 @@ export namespace Occ {
    * An interface representing FeatureValue.
    */
   export interface FeatureValue {
-    /**
-     * @member {string} [value]
-     */
     value?: string;
   }
 
@@ -1049,37 +658,20 @@ export namespace Occ {
    * An interface representing Feature.
    */
   export interface Feature {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {boolean} [comparable]
-     */
+
     comparable?: boolean;
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {FeatureUnit} [featureUnit]
-     */
+
     featureUnit?: FeatureUnit;
-    /**
-     * @member {FeatureValue[]} [featureValues]
-     */
+
     featureValues?: FeatureValue[];
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {boolean} [range]
-     */
+
     range?: boolean;
-    /**
-     * @member {string} [type]
-     */
+
     type?: string;
   }
 
@@ -1088,17 +680,10 @@ export namespace Occ {
    * An interface representing Classification.
    */
   export interface Classification {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {Feature[]} [features]
-     */
+
     features?: Feature[];
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
   }
 
@@ -1107,17 +692,10 @@ export namespace Occ {
    * An interface representing FutureStock.
    */
   export interface FutureStock {
-    /**
-     * @member {Date} [date]
-     */
     date?: Date;
-    /**
-     * @member {string} [formattedDate]
-     */
+
     formattedDate?: string;
-    /**
-     * @member {Stock} [stock]
-     */
+
     stock?: Stock;
   }
 
@@ -1126,13 +704,8 @@ export namespace Occ {
    * An interface representing PriceRange.
    */
   export interface PriceRange {
-    /**
-     * @member {Price} [maxPrice]
-     */
     maxPrice?: Price;
-    /**
-     * @member {Price} [minPrice]
-     */
+
     minPrice?: Price;
   }
 
@@ -1141,25 +714,14 @@ export namespace Occ {
    * An interface representing ProductReference.
    */
   export interface ProductReference {
-    /**
-     * @member {string} [description]
-     */
     description?: string;
-    /**
-     * @member {boolean} [preselected]
-     */
+
     preselected?: boolean;
-    /**
-     * @member {number} [quantity]
-     */
+
     quantity?: number;
-    /**
-     * @member {string} [referenceType]
-     */
+
     referenceType?: string;
-    /**
-     * @member {Product} [target]
-     */
+
     target?: Product;
   }
 
@@ -1168,21 +730,12 @@ export namespace Occ {
    * An interface representing Language.
    */
   export interface Language {
-    /**
-     * @member {boolean} [active]
-     */
     active?: boolean;
-    /**
-     * @member {string} [isocode]
-     */
+
     isocode?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {string} [nativeName]
-     */
+
     nativeName?: string;
   }
 
@@ -1191,53 +744,28 @@ export namespace Occ {
    * An interface representing User.
    */
   export interface User {
-    /**
-     * @member {Currency} [currency]
-     */
     currency?: Currency;
-    /**
-     * @member {string} [customerId]
-     */
+
     customerId?: string;
-    /**
-     * @member {Date} [deactivationDate]
-     */
+
     deactivationDate?: Date;
-    /**
-     * @member {Address} [defaultAddress]
-     */
+
     defaultAddress?: Address;
-    /**
-     * @member {string} [displayUid]
-     */
+
     displayUid?: string;
-    /**
-     * @member {string} [firstName]
-     */
+
     firstName?: string;
-    /**
-     * @member {Language} [language]
-     */
+
     language?: Language;
-    /**
-     * @member {string} [lastName]
-     */
+
     lastName?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {string} [title]
-     */
+
     title?: string;
-    /**
-     * @member {string} [titleCode]
-     */
+
     titleCode?: string;
-    /**
-     * @member {string} [uid]
-     */
+
     uid?: string;
   }
 
@@ -1246,33 +774,18 @@ export namespace Occ {
    * An interface representing Review.
    */
   export interface Review {
-    /**
-     * @member {string} [alias]
-     */
     alias?: string;
-    /**
-     * @member {string} [comment]
-     */
+
     comment?: string;
-    /**
-     * @member {Date} [date]
-     */
+
     date?: Date;
-    /**
-     * @member {string} [headline]
-     */
+
     headline?: string;
-    /**
-     * @member {string} [id]
-     */
+
     id?: string;
-    /**
-     * @member {User} [principal]
-     */
+
     principal?: User;
-    /**
-     * @member {number} [rating]
-     */
+
     rating?: number;
   }
 
@@ -1281,17 +794,10 @@ export namespace Occ {
    * An interface representing VariantCategory.
    */
   export interface VariantCategory {
-    /**
-     * @member {boolean} [hasImage]
-     */
     hasImage?: boolean;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {number} [priority]
-     */
+
     priority?: number;
   }
 
@@ -1300,17 +806,10 @@ export namespace Occ {
    * An interface representing VariantValueCategory.
    */
   export interface VariantValueCategory {
-    /**
-     * @member {string} [name]
-     */
     name?: string;
-    /**
-     * @member {number} [sequence]
-     */
+
     sequence?: number;
-    /**
-     * @member {VariantCategory[]} [superCategories]
-     */
+
     superCategories?: VariantCategory[];
   }
 
@@ -1319,25 +818,14 @@ export namespace Occ {
    * An interface representing VariantMatrixElement.
    */
   export interface VariantMatrixElement {
-    /**
-     * @member {VariantMatrixElement[]} [elements]
-     */
     elements?: VariantMatrixElement[];
-    /**
-     * @member {boolean} [isLeaf]
-     */
+
     isLeaf?: boolean;
-    /**
-     * @member {VariantCategory} [parentVariantCategory]
-     */
+
     parentVariantCategory?: VariantCategory;
-    /**
-     * @member {VariantOption} [variantOption]
-     */
+
     variantOption?: VariantOption;
-    /**
-     * @member {VariantValueCategory} [variantValueCategory]
-     */
+
     variantValueCategory?: VariantValueCategory;
   }
 
@@ -1346,117 +834,60 @@ export namespace Occ {
    * An interface representing Product.
    */
   export interface Product {
-    /**
-     * @member {boolean} [availableForPickup]
-     */
     availableForPickup?: boolean;
-    /**
-     * @member {number} [averageRating]
-     */
+
     averageRating?: number;
-    /**
-     * @member {BaseOption[]} [baseOptions]
-     */
+
     baseOptions?: BaseOption[];
-    /**
-     * @member {string} [baseProduct]
-     */
+
     baseProduct?: string;
-    /**
-     * @member {Category[]} [categories]
-     */
+
     categories?: Category[];
-    /**
-     * @member {Classification[]} [classifications]
-     */
+
     classifications?: Classification[];
-    /**
-     * @member {string} [code]
-     */
+
     code?: string;
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {FutureStock[]} [futureStocks]
-     */
+
     futureStocks?: FutureStock[];
-    /**
-     * @member {Image[]} [images]
-     */
+
     images?: Image[];
-    /**
-     * @member {string} [manufacturer]
-     */
+
     manufacturer?: string;
-    /**
-     * @member {boolean} [multidimensional]
-     */
+
     multidimensional?: boolean;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {number} [numberOfReviews]
-     */
+
     numberOfReviews?: number;
-    /**
-     * @member {Promotion[]} [potentialPromotions]
-     */
+
     potentialPromotions?: Promotion[];
-    /**
-     * @member {Price} [price]
-     */
+
     price?: Price;
-    /**
-     * @member {PriceRange} [priceRange]
-     */
+
     priceRange?: PriceRange;
-    /**
-     * @member {ProductReference[]} [productReferences]
-     */
+
     productReferences?: ProductReference[];
-    /**
-     * @member {boolean} [purchasable]
-     */
+
     purchasable?: boolean;
-    /**
-     * @member {Review[]} [reviews]
-     */
+
     reviews?: Review[];
-    /**
-     * @member {Stock} [stock]
-     */
+
     stock?: Stock;
-    /**
-     * @member {string} [summary]
-     */
+
     summary?: string;
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
-    /**
-     * @member {VariantMatrixElement[]} [variantMatrix]
-     */
+
     variantMatrix?: VariantMatrixElement[];
-    /**
-     * @member {VariantOption[]} [variantOptions]
-     */
+
     variantOptions?: VariantOption[];
-    /**
-     * @member {string} [variantType]
-     */
+
     variantType?: string;
-    /**
-     * @member {Price[]} [volumePrices]
-     */
+
     volumePrices?: Price[];
-    /**
-     * @member {boolean} [volumePricesFlag]
-     */
+
     volumePricesFlag?: boolean;
   }
 
@@ -1465,45 +896,24 @@ export namespace Occ {
    * An interface representing OrderEntry.
    */
   export interface OrderEntry {
-    /**
-     * @member {Price} [basePrice]
-     */
     basePrice?: Price;
-    /**
-     * @member {DeliveryMode} [deliveryMode]
-     */
+
     deliveryMode?: DeliveryMode;
-    /**
-     * @member {PointOfService} [deliveryPointOfService]
-     */
+
     deliveryPointOfService?: PointOfService;
-    /**
-     * @member {number} [entryNumber]
-     */
+
     entryNumber?: number;
-    /**
-     * @member {Product} [product]
-     */
+
     product?: Product;
-    /**
-     * @member {number} [quantity]
-     */
+
     quantity?: number;
-    /**
-     * @member {Price} [totalPrice]
-     */
+
     totalPrice?: Price;
-    /**
-     * @member {boolean} [updateable]
-     */
+
     updateable?: boolean;
-    /**
-     * @member {StatusSummary[]} [statusSummaryList]
-     */
+
     statusSummaryList?: StatusSummary[];
-    /**
-     * @member {ConfigurationInfo[]} [configurationInfos]
-     */
+
     configurationInfos?: ConfigurationInfo[];
   }
 
@@ -1513,21 +923,12 @@ export namespace Occ {
    * Provides information about configuration values of the entry.
    */
   export interface ConfigurationInfo {
-    /**
-     * @member {string} [configurationLabel]
-     */
     configurationLabel?: string;
-    /**
-     * @member {string} [configurationValue]
-     */
+
     configurationValue?: string;
-    /**
-     * @member {string} [configuratorType]
-     */
+
     configuratorType?: string;
-    /**
-     * @member {string} [status]
-     */
+
     status?: string;
   }
 
@@ -1547,13 +948,8 @@ export namespace Occ {
    * Provides status including number of issues for configurable entry.
    */
   export interface StatusSummary {
-    /**
-     * @member {number} [numberOfIssues]
-     */
     numberOfIssues?: number;
-    /**
-     * @member {string} [status]
-     */
+
     status?: OrderEntryStatus;
   }
 
@@ -1562,21 +958,12 @@ export namespace Occ {
    * An interface representing DeliveryOrderEntryGroup.
    */
   export interface DeliveryOrderEntryGroup {
-    /**
-     * @member {Address} [deliveryAddress]
-     */
     deliveryAddress?: Address;
-    /**
-     * @member {OrderEntry[]} [entries]
-     */
+
     entries?: OrderEntry[];
-    /**
-     * @member {number} [quantity]
-     */
+
     quantity?: number;
-    /**
-     * @member {Price} [totalPriceWithTax]
-     */
+
     totalPriceWithTax?: Price;
   }
 
@@ -1585,61 +972,32 @@ export namespace Occ {
    * An interface representing PaymentDetails.
    */
   export interface PaymentDetails {
-    /**
-     * @member {string} [accountHolderName]
-     */
     accountHolderName?: string;
-    /**
-     * @member {Address} [billingAddress]
-     */
+
     billingAddress?: Address;
-    /**
-     * @member {string} [cardNumber]
-     */
+
     cardNumber?: string;
-    /**
-     * @member {CardType} [cardType]
-     */
+
     cardType?: CardType;
-    /**
-     * @member {string} [cvn]
-     */
+
     cvn?: string;
-    /**
-     * @member {boolean} [defaultPayment]
-     */
+
     defaultPayment?: boolean;
-    /**
-     * @member {string} [expiryMonth]
-     */
+
     expiryMonth?: string;
-    /**
-     * @member {string} [expiryYear]
-     */
+
     expiryYear?: string;
-    /**
-     * @member {string} [id]
-     */
+
     id?: string;
-    /**
-     * @member {string} [issueNumber]
-     */
+
     issueNumber?: string;
-    /**
-     * @member {boolean} [saved]
-     */
+
     saved?: boolean;
-    /**
-     * @member {string} [startMonth]
-     */
+
     startMonth?: string;
-    /**
-     * @member {string} [startYear]
-     */
+
     startYear?: string;
-    /**
-     * @member {string} [subscriptionId]
-     */
+
     subscriptionId?: string;
   }
 
@@ -1648,25 +1006,14 @@ export namespace Occ {
    * An interface representing PickupOrderEntryGroup.
    */
   export interface PickupOrderEntryGroup {
-    /**
-     * @member {PointOfService} [deliveryPointOfService]
-     */
     deliveryPointOfService?: PointOfService;
-    /**
-     * @member {number} [distance]
-     */
+
     distance?: number;
-    /**
-     * @member {OrderEntry[]} [entries]
-     */
+
     entries?: OrderEntry[];
-    /**
-     * @member {number} [quantity]
-     */
+
     quantity?: number;
-    /**
-     * @member {Price} [totalPriceWithTax]
-     */
+
     totalPriceWithTax?: Price;
   }
 
@@ -1675,13 +1022,8 @@ export namespace Occ {
    * An interface representing Principal.
    */
   export interface Principal {
-    /**
-     * @member {string} [name]
-     */
     name?: string;
-    /**
-     * @member {string} [uid]
-     */
+
     uid?: string;
   }
 
@@ -1690,145 +1032,74 @@ export namespace Occ {
    * An interface representing Cart.
    */
   export interface Cart {
-    /**
-     * @member {PromotionResult[]} [appliedOrderPromotions]
-     */
     appliedOrderPromotions?: PromotionResult[];
-    /**
-     * @member {PromotionResult[]} [appliedProductPromotions]
-     */
+
     appliedProductPromotions?: PromotionResult[];
-    /**
-     * @member {Voucher[]} [appliedVouchers]
-     */
+
     appliedVouchers?: Voucher[];
-    /**
-     * @member {boolean} [calculated]
-     */
+
     calculated?: boolean;
-    /**
-     * @member {string} [code]
-     */
+
     code?: string;
-    /**
-     * @member {Address} [deliveryAddress]
-     */
+
     deliveryAddress?: Address;
-    /**
-     * @member {Price} [deliveryCost]
-     */
+
     deliveryCost?: Price;
-    /**
-     * @member {number} [deliveryItemsQuantity]
-     */
+
     deliveryItemsQuantity?: number;
-    /**
-     * @member {DeliveryMode} [deliveryMode]
-     */
+
     deliveryMode?: DeliveryMode;
-    /**
-     * @member {DeliveryOrderEntryGroup[]} [deliveryOrderGroups]
-     */
+
     deliveryOrderGroups?: DeliveryOrderEntryGroup[];
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {OrderEntry[]} [entries]
-     */
+
     entries?: OrderEntry[];
-    /**
-     * @member {Date} [expirationTime]
-     */
+
     expirationTime?: Date;
-    /**
-     * @member {string} [guid]
-     */
+
     guid?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {boolean} [net]
-     */
+
     net?: boolean;
-    /**
-     * @member {Price} [orderDiscounts]
-     */
+
     orderDiscounts?: Price;
-    /**
-     * @member {PaymentDetails} [paymentInfo]
-     */
+
     paymentInfo?: PaymentDetails;
-    /**
-     * @member {number} [pickupItemsQuantity]
-     */
+
     pickupItemsQuantity?: number;
-    /**
-     * @member {PickupOrderEntryGroup[]} [pickupOrderGroups]
-     */
+
     pickupOrderGroups?: PickupOrderEntryGroup[];
-    /**
-     * @member {PromotionResult[]} [potentialOrderPromotions]
-     */
+
     potentialOrderPromotions?: PromotionResult[];
-    /**
-     * @member {PromotionResult[]} [potentialProductPromotions]
-     */
+
     potentialProductPromotions?: PromotionResult[];
-    /**
-     * @member {Price} [productDiscounts]
-     */
+
     productDiscounts?: Price;
-    /**
-     * @member {Date} [saveTime]
-     */
+
     saveTime?: Date;
-    /**
-     * @member {Principal} [savedBy]
-     */
+
     savedBy?: Principal;
-    /**
-     * @member {string} [site]
-     */
+
     site?: string;
-    /**
-     * @member {string} [store]
-     */
+
     store?: string;
-    /**
-     * @member {Price} [subTotal]
-     */
+
     subTotal?: Price;
-    /**
-     * @member {Price} [totalDiscounts]
-     */
+
     totalDiscounts?: Price;
-    /**
-     * @member {number} [totalItems]
-     */
+
     totalItems?: number;
-    /**
-     * @member {Price} [totalPrice]
-     */
+
     totalPrice?: Price;
-    /**
-     * @member {Price} [totalPriceWithTax]
-     */
+
     totalPriceWithTax?: Price;
-    /**
-     * @member {Price} [totalTax]
-     */
+
     totalTax?: Price;
-    /**
-     * @member {number} [totalUnitCount]
-     */
+
     totalUnitCount?: number;
-    /**
-     * @member {Principal} [user]
-     */
+
     user?: Principal;
   }
 
@@ -1837,9 +1108,6 @@ export namespace Occ {
    * An interface representing CartList.
    */
   export interface CartList {
-    /**
-     * @member {Cart[]} [carts]
-     */
     carts?: Cart[];
   }
 
@@ -1848,29 +1116,16 @@ export namespace Occ {
    * An interface representing CartModification.
    */
   export interface CartModification {
-    /**
-     * @member {boolean} [deliveryModeChanged]
-     */
     deliveryModeChanged?: boolean;
-    /**
-     * @member {OrderEntry} [entry]
-     */
+
     entry?: OrderEntry;
-    /**
-     * @member {number} [quantity]
-     */
+
     quantity?: number;
-    /**
-     * @member {number} [quantityAdded]
-     */
+
     quantityAdded?: number;
-    /**
-     * @member {string} [statusCode]
-     */
+
     statusCode?: string;
-    /**
-     * @member {string} [statusMessage]
-     */
+
     statusMessage?: string;
   }
 
@@ -1879,25 +1134,14 @@ export namespace Occ {
    * An interface representing CategoryHierarchy.
    */
   export interface CategoryHierarchy {
-    /**
-     * @member {string} [id]
-     */
     id?: string;
-    /**
-     * @member {Date} [lastModified]
-     */
+
     lastModified?: Date;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {CategoryHierarchy[]} [subcategories]
-     */
+
     subcategories?: CategoryHierarchy[];
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
   }
 
@@ -1906,25 +1150,14 @@ export namespace Occ {
    * An interface representing CatalogVersion.
    */
   export interface CatalogVersion {
-    /**
-     * @member {CategoryHierarchy[]} [categories]
-     */
     categories?: CategoryHierarchy[];
-    /**
-     * @member {string} [id]
-     */
+
     id?: string;
-    /**
-     * @member {Date} [lastModified]
-     */
+
     lastModified?: Date;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
   }
 
@@ -1933,25 +1166,14 @@ export namespace Occ {
    * An interface representing Catalog.
    */
   export interface Catalog {
-    /**
-     * @member {CatalogVersion[]} [catalogVersions]
-     */
     catalogVersions?: CatalogVersion[];
-    /**
-     * @member {string} [id]
-     */
+
     id?: string;
-    /**
-     * @member {Date} [lastModified]
-     */
+
     lastModified?: Date;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
   }
 
@@ -1960,9 +1182,6 @@ export namespace Occ {
    * An interface representing CatalogList.
    */
   export interface CatalogList {
-    /**
-     * @member {Catalog[]} [catalogs]
-     */
     catalogs?: Catalog[];
   }
 
@@ -1971,9 +1190,6 @@ export namespace Occ {
    * An interface representing ComponentIDList.
    */
   export interface ComponentIDList {
-    /**
-     * @member {string[]} [idList]
-     */
     idList?: string[];
   }
 
@@ -1982,17 +1198,10 @@ export namespace Occ {
    * An interface representing ConsignmentEntry.
    */
   export interface ConsignmentEntry {
-    /**
-     * @member {OrderEntry} [orderEntry]
-     */
     orderEntry?: OrderEntry;
-    /**
-     * @member {number} [quantity]
-     */
+
     quantity?: number;
-    /**
-     * @member {number} [shippedQuantity]
-     */
+
     shippedQuantity?: number;
   }
 
@@ -2001,33 +1210,18 @@ export namespace Occ {
    * An interface representing Consignment.
    */
   export interface Consignment {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {PointOfService} [deliveryPointOfService]
-     */
+
     deliveryPointOfService?: PointOfService;
-    /**
-     * @member {ConsignmentEntry[]} [entries]
-     */
+
     entries?: ConsignmentEntry[];
-    /**
-     * @member {Address} [shippingAddress]
-     */
+
     shippingAddress?: Address;
-    /**
-     * @member {string} [status]
-     */
+
     status?: string;
-    /**
-     * @member {Date} [statusDate]
-     */
+
     statusDate?: Date;
-    /**
-     * @member {string} [trackingID]
-     */
+
     trackingID?: string;
   }
 
@@ -2036,9 +1230,6 @@ export namespace Occ {
    * An interface representing CountryList.
    */
   export interface CountryList {
-    /**
-     * @member {Country[]} [countries]
-     */
     countries?: Country[];
   }
 
@@ -2047,9 +1238,6 @@ export namespace Occ {
    * An interface representing CurrencyList.
    */
   export interface CurrencyList {
-    /**
-     * @member {Currency[]} [currencies]
-     */
     currencies?: Currency[];
   }
 
@@ -2057,37 +1245,20 @@ export namespace Occ {
    * An interface representing CustomerCoupon
    */
   export interface CustomerCoupon {
-    /**
-     * @member {string} [couponId]
-     */
     couponId?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {string} [startDate]
-     */
+
     startDate?: string;
-    /**
-     * @member {string} [endDate]
-     */
+
     endDate?: string;
-    /**
-     * @member {string} [endDate]
-     */
+
     status?: string;
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {boolean} [notificationOn]
-     */
+
     notificationOn?: boolean;
-    /**
-     * @member {boolean} [allProductsApplicable]
-     */
+
     allProductsApplicable?: boolean;
   }
 
@@ -2095,17 +1266,10 @@ export namespace Occ {
    * An interface representing CustomerCouponSearchResult
    */
   export interface CustomerCouponSearchResult {
-    /**
-     * @member {CustomerCoupon[]} [coupons]
-     */
     coupons?: CustomerCoupon[];
-    /**
-     * @member {Sort[]} [sorts]
-     */
+
     sorts?: Sort[];
-    /**
-     * @member {Pagination} [pagination]
-     */
+
     pagination?: Pagination;
   }
 
@@ -2114,9 +1278,6 @@ export namespace Occ {
    * An interface representing DeliveryModeList.
    */
   export interface DeliveryModeList {
-    /**
-     * @member {DeliveryMode[]} [deliveryModes]
-     */
     deliveryModes?: DeliveryMode[];
   }
 
@@ -2125,21 +1286,12 @@ export namespace Occ {
    * An interface representing FacetValue.
    */
   export interface FacetValue {
-    /**
-     * @member {number} [count]
-     */
     count?: number;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {SearchState} [query]
-     */
+
     query?: SearchState;
-    /**
-     * @member {boolean} [selected]
-     */
+
     selected?: boolean;
   }
 
@@ -2148,33 +1300,18 @@ export namespace Occ {
    * An interface representing Facet.
    */
   export interface Facet {
-    /**
-     * @member {boolean} [category]
-     */
     category?: boolean;
-    /**
-     * @member {boolean} [multiSelect]
-     */
+
     multiSelect?: boolean;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {number} [priority]
-     */
+
     priority?: number;
-    /**
-     * @member {FacetValue[]} [topValues]
-     */
+
     topValues?: FacetValue[];
-    /**
-     * @member {FacetValue[]} [values]
-     */
+
     values?: FacetValue[];
-    /**
-     * @member {boolean} [visible]
-     */
+
     visible?: boolean;
   }
 
@@ -2183,9 +1320,6 @@ export namespace Occ {
    * An interface representing LanguageList.
    */
   export interface LanguageList {
-    /**
-     * @member {Language[]} [languages]
-     */
     languages?: Language[];
   }
 
@@ -2197,19 +1331,19 @@ export namespace Occ {
    */
   export interface Pagination {
     /**
-     * @member {number} [count] Number of elements on this page
+     * Number of elements on this page
      */
     count?: number;
     /**
-     * @member {number} [page] Current page number
+     * Current page number
      */
     page?: number;
     /**
-     * @member {number} [totalCount] Total number of elements
+     * Total number of elements
      */
     totalCount?: number;
     /**
-     * @member {number} [totalPages] Total number of pages
+     * Total number of pages
      */
     totalPages?: number;
   }
@@ -2221,13 +1355,8 @@ export namespace Occ {
    *
    */
   export interface Sort {
-    /**
-     * @member {boolean} [asc]
-     */
     asc?: boolean;
-    /**
-     * @member {string} [code]
-     */
+
     code?: string;
   }
 
@@ -2236,17 +1365,10 @@ export namespace Occ {
    * An interface representing ListAdaptedComponents.
    */
   export interface ListAdaptedComponents {
-    /**
-     * @member {any[]} [components]
-     */
     components?: any[];
-    /**
-     * @member {Pagination} [pagination]
-     */
+
     pagination?: Pagination;
-    /**
-     * @member {Sort[]} [sorts]
-     */
+
     sorts?: Sort[];
   }
 
@@ -2255,9 +1377,6 @@ export namespace Occ {
    * An interface representing MemberList.
    */
   export interface MemberList {
-    /**
-     * @member {Principal[]} [members]
-     */
     members?: Principal[];
   }
 
@@ -2266,9 +1385,6 @@ export namespace Occ {
    * An interface representing OrderEntryList.
    */
   export interface OrderEntryList {
-    /**
-     * @member {OrderEntry[]} [orderEntries]
-     */
     orderEntries?: OrderEntry[];
   }
 
@@ -2277,29 +1393,16 @@ export namespace Occ {
    * An interface representing OrderHistory.
    */
   export interface OrderHistory {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {string} [guid]
-     */
+
     guid?: string;
-    /**
-     * @member {Date} [placed]
-     */
+
     placed?: Date;
-    /**
-     * @member {string} [status]
-     */
+
     status?: string;
-    /**
-     * @member {string} [statusDisplay]
-     */
+
     statusDisplay?: string;
-    /**
-     * @member {Price} [total]
-     */
+
     total?: Price;
   }
 
@@ -2308,25 +1411,14 @@ export namespace Occ {
    * An interface representing PaginationModel.
    */
   export interface PaginationModel {
-    /**
-     * @member {number} [currentPage]
-     */
     currentPage?: number;
-    /**
-     * @member {number} [pageSize]
-     */
+
     pageSize?: number;
-    /**
-     * @member {string} [sort]
-     */
+
     sort?: string;
-    /**
-     * @member {number} [totalPages]
-     */
+
     totalPages?: number;
-    /**
-     * @member {number} [totalResults]
-     */
+
     totalResults?: number;
   }
 
@@ -2335,17 +1427,10 @@ export namespace Occ {
    * An interface representing SortModel.
    */
   export interface SortModel {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {boolean} [selected]
-     */
+
     selected?: boolean;
   }
 
@@ -2354,17 +1439,10 @@ export namespace Occ {
    * An interface representing OrderHistoryList.
    */
   export interface OrderHistoryList {
-    /**
-     * @member {OrderHistory[]} [orders]
-     */
     orders?: OrderHistory[];
-    /**
-     * @member {PaginationModel} [pagination]
-     */
+
     pagination?: PaginationModel;
-    /**
-     * @member {SortModel[]} [sorts]
-     */
+
     sorts?: SortModel[];
   }
 
@@ -2373,17 +1451,10 @@ export namespace Occ {
    * An interface representing OrderStatusUpdateElement.
    */
   export interface OrderStatusUpdateElement {
-    /**
-     * @member {string} [baseSiteId]
-     */
     baseSiteId?: string;
-    /**
-     * @member {string} [code]
-     */
+
     code?: string;
-    /**
-     * @member {string} [status]
-     */
+
     status?: string;
   }
 
@@ -2392,9 +1463,6 @@ export namespace Occ {
    * An interface representing OrderStatusUpdateElementList.
    */
   export interface OrderStatusUpdateElementList {
-    /**
-     * @member {OrderStatusUpdateElement[]} [orderStatusUpdateElements]
-     */
     orderStatusUpdateElements?: OrderStatusUpdateElement[];
   }
 
@@ -2403,145 +1471,74 @@ export namespace Occ {
    * An interface representing Order.
    */
   export interface Order {
-    /**
-     * @member {PromotionResult[]} [appliedOrderPromotions]
-     */
     appliedOrderPromotions?: PromotionResult[];
-    /**
-     * @member {PromotionResult[]} [appliedProductPromotions]
-     */
+
     appliedProductPromotions?: PromotionResult[];
-    /**
-     * @member {Voucher[]} [appliedVouchers]
-     */
+
     appliedVouchers?: Voucher[];
-    /**
-     * @member {boolean} [calculated]
-     */
+
     calculated?: boolean;
-    /**
-     * @member {string} [code]
-     */
+
     code?: string;
-    /**
-     * @member {Consignment[]} [consignments]
-     */
+
     consignments?: Consignment[];
-    /**
-     * @member {Date} [created]
-     */
+
     created?: Date;
-    /**
-     * @member {Address} [deliveryAddress]
-     */
+
     deliveryAddress?: Address;
-    /**
-     * @member {Price} [deliveryCost]
-     */
+
     deliveryCost?: Price;
-    /**
-     * @member {number} [deliveryItemsQuantity]
-     */
+
     deliveryItemsQuantity?: number;
-    /**
-     * @member {DeliveryMode} [deliveryMode]
-     */
+
     deliveryMode?: DeliveryMode;
-    /**
-     * @member {DeliveryOrderEntryGroup[]} [deliveryOrderGroups]
-     */
+
     deliveryOrderGroups?: DeliveryOrderEntryGroup[];
-    /**
-     * @member {string} [deliveryStatus]
-     */
+
     deliveryStatus?: string;
-    /**
-     * @member {string} [deliveryStatusDisplay]
-     */
+
     deliveryStatusDisplay?: string;
-    /**
-     * @member {OrderEntry[]} [entries]
-     */
+
     entries?: OrderEntry[];
-    /**
-     * @member {boolean} [guestCustomer]
-     */
+
     guestCustomer?: boolean;
-    /**
-     * @member {string} [guid]
-     */
+
     guid?: string;
-    /**
-     * @member {boolean} [net]
-     */
+
     net?: boolean;
-    /**
-     * @member {Price} [orderDiscounts]
-     */
+
     orderDiscounts?: Price;
-    /**
-     * @member {PaymentDetails} [paymentInfo]
-     */
+
     paymentInfo?: PaymentDetails;
-    /**
-     * @member {number} [pickupItemsQuantity]
-     */
+
     pickupItemsQuantity?: number;
-    /**
-     * @member {PickupOrderEntryGroup[]} [pickupOrderGroups]
-     */
+
     pickupOrderGroups?: PickupOrderEntryGroup[];
-    /**
-     * @member {Price} [productDiscounts]
-     */
+
     productDiscounts?: Price;
-    /**
-     * @member {string} [site]
-     */
+
     site?: string;
-    /**
-     * @member {string} [status]
-     */
+
     status?: string;
-    /**
-     * @member {string} [statusDisplay]
-     */
+
     statusDisplay?: string;
-    /**
-     * @member {string} [store]
-     */
+
     store?: string;
-    /**
-     * @member {Price} [subTotal]
-     */
+
     subTotal?: Price;
-    /**
-     * @member {Price} [totalDiscounts]
-     */
+
     totalDiscounts?: Price;
-    /**
-     * @member {number} [totalItems]
-     */
+
     totalItems?: number;
-    /**
-     * @member {Price} [totalPrice]
-     */
+
     totalPrice?: Price;
-    /**
-     * @member {Price} [totalPriceWithTax]
-     */
+
     totalPriceWithTax?: Price;
-    /**
-     * @member {Price} [totalTax]
-     */
+
     totalTax?: Price;
-    /**
-     * @member {OrderEntry[]} [unconsignedEntries]
-     */
+
     unconsignedEntries?: OrderEntry[];
-    /**
-     * @member {Principal} [user]
-     */
+
     user?: Principal;
   }
 
@@ -2550,53 +1547,28 @@ export namespace Occ {
    * An interface representing ReturnRequest.
    */
   export interface ReturnRequest {
-    /**
-     * @member {boolean} [cancellable]
-     */
     cancellable?: boolean;
-    /**
-     * @member {string} [code]
-     */
+
     code?: string;
-    /**
-     * @member {Date} [creationTime]
-     */
+
     creationTime?: Date;
-    /**
-     * @member {Price} [deliveryCost]
-     */
+
     deliveryCost?: Price;
-    /**
-     * @member {order} [order]
-     */
+
     order?: Order;
-    /**
-     * @member {boolean} [refundDeliveryCost]
-     */
+
     refundDeliveryCost?: boolean;
-    /**
-     * @member {ReturnRequestEntry[]} [returnEntries]
-     */
+
     returnEntries?: ReturnRequestEntry[];
-    /**
-     * @member {string} [returnLabelDownloadUrl]
-     */
+
     returnLabelDownloadUrl?: string;
-    /**
-     * @member {string} [rma]
-     */
+
     rma?: string;
-    /**
-     * @member {string} [status]
-     */
+
     status?: string;
-    /**
-     * @member {Price} [subTotal]
-     */
+
     subTotal?: Price;
-    /**
-     * @member {Price} [totalPrice]
-     */
+
     totalPrice?: Price;
   }
 
@@ -2605,17 +1577,10 @@ export namespace Occ {
    * An interface representing ReturnRequestEntry.
    */
   export interface ReturnRequestEntry {
-    /**
-     * @member {OrderEntry} [orderEntry]
-     */
     orderEntry?: OrderEntry;
-    /**
-     * @member {number} [expectedQuantity]
-     */
+
     expectedQuantity?: number;
-    /**
-     * @member {Price} [refundAmount]
-     */
+
     refundAmount?: Price;
   }
 
@@ -2624,9 +1589,6 @@ export namespace Occ {
    * An interface representing PaymentDetailsList.
    */
   export interface PaymentDetailsList {
-    /**
-     * @member {PaymentDetails[]} [payments]
-     */
     payments?: PaymentDetails[];
   }
 
@@ -2635,61 +1597,32 @@ export namespace Occ {
    * An interface representing PointOfServiceStock.
    */
   export interface PointOfServiceStock {
-    /**
-     * @member {Address} [address]
-     */
     address?: Address;
-    /**
-     * @member {string} [description]
-     */
+
     description?: string;
-    /**
-     * @member {string} [displayName]
-     */
+
     displayName?: string;
-    /**
-     * @member {number} [distanceKm]
-     */
+
     distanceKm?: number;
-    /**
-     * @member {{ [propertyName: string]: string }} [features]
-     */
+
     features?: { [propertyName: string]: string };
-    /**
-     * @member {string} [formattedDistance]
-     */
+
     formattedDistance?: string;
-    /**
-     * @member {GeoPoint} [geoPoint]
-     */
+
     geoPoint?: GeoPoint;
-    /**
-     * @member {Image} [mapIcon]
-     */
+
     mapIcon?: Image;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {OpeningSchedule} [openingHours]
-     */
+
     openingHours?: OpeningSchedule;
-    /**
-     * @member {Stock} [stockInfo]
-     */
+
     stockInfo?: Stock;
-    /**
-     * @member {string} [storeContent]
-     */
+
     storeContent?: string;
-    /**
-     * @member {Image[]} [storeImages]
-     */
+
     storeImages?: Image[];
-    /**
-     * @member {string} [url]
-     */
+
     url?: string;
   }
 
@@ -2698,17 +1631,10 @@ export namespace Occ {
    * An interface representing ProductExpressUpdateElement.
    */
   export interface ProductExpressUpdateElement {
-    /**
-     * @member {string} [catalogId]
-     */
     catalogId?: string;
-    /**
-     * @member {string} [catalogVersion]
-     */
+
     catalogVersion?: string;
-    /**
-     * @member {string} [code]
-     */
+
     code?: string;
   }
 
@@ -2717,9 +1643,6 @@ export namespace Occ {
    * An interface representing ProductExpressUpdateElementList.
    */
   export interface ProductExpressUpdateElementList {
-    /**
-     * @member {ProductExpressUpdateElement[]} [productExpressUpdateElements]
-     */
     productExpressUpdateElements?: ProductExpressUpdateElement[];
   }
 
@@ -2728,29 +1651,16 @@ export namespace Occ {
    * An interface representing ProductList.
    */
   export interface ProductList {
-    /**
-     * @member {string} [catalog]
-     */
     catalog?: string;
-    /**
-     * @member {number} [currentPage]
-     */
+
     currentPage?: number;
-    /**
-     * @member {Product[]} [products]
-     */
+
     products?: Product[];
-    /**
-     * @member {number} [totalPageCount]
-     */
+
     totalPageCount?: number;
-    /**
-     * @member {number} [totalProductCount]
-     */
+
     totalProductCount?: number;
-    /**
-     * @member {string} [version]
-     */
+
     version?: string;
   }
 
@@ -2759,9 +1669,6 @@ export namespace Occ {
    * An interface representing ProductReferenceList.
    */
   export interface ProductReferenceList {
-    /**
-     * @member {ProductReference[]} [references]
-     */
     references?: ProductReference[];
   }
 
@@ -2770,13 +1677,8 @@ export namespace Occ {
    * An interface representing SpellingSuggestion.
    */
   export interface SpellingSuggestion {
-    /**
-     * @member {string} [query]
-     */
     query?: string;
-    /**
-     * @member {string} [suggestion]
-     */
+
     suggestion?: string;
   }
 
@@ -2785,45 +1687,24 @@ export namespace Occ {
    * An interface representing ProductSearchPage.
    */
   export interface ProductSearchPage {
-    /**
-     * @member {Breadcrumb[]} [breadcrumbs]
-     */
     breadcrumbs?: Breadcrumb[];
-    /**
-     * @member {string} [categoryCode]
-     */
+
     categoryCode?: string;
-    /**
-     * @member {SearchState} [currentQuery]
-     */
+
     currentQuery?: SearchState;
-    /**
-     * @member {Facet[]} [facets]
-     */
+
     facets?: Facet[];
-    /**
-     * @member {string} [freeTextSearch]
-     */
+
     freeTextSearch?: string;
-    /**
-     * @member {string} [keywordRedirectUrl]
-     */
+
     keywordRedirectUrl?: string;
-    /**
-     * @member {PaginationModel} [pagination]
-     */
+
     pagination?: PaginationModel;
-    /**
-     * @member {Product[]} [products]
-     */
+
     products?: Product[];
-    /**
-     * @member {SortModel[]} [sorts]
-     */
+
     sorts?: SortModel[];
-    /**
-     * @member {SpellingSuggestion} [spellingSuggestion]
-     */
+
     spellingSuggestion?: SpellingSuggestion;
   }
 
@@ -2832,9 +1713,6 @@ export namespace Occ {
    * An interface representing PromotionList.
    */
   export interface PromotionList {
-    /**
-     * @member {Promotion[]} [promotions]
-     */
     promotions?: Promotion[];
   }
 
@@ -2843,9 +1721,6 @@ export namespace Occ {
    * An interface representing PromotionResultList.
    */
   export interface PromotionResultList {
-    /**
-     * @member {PromotionResult[]} [promotions]
-     */
     promotions?: PromotionResult[];
   }
 
@@ -2854,9 +1729,6 @@ export namespace Occ {
    * An interface representing ReviewList.
    */
   export interface ReviewList {
-    /**
-     * @member {Review[]} [reviews]
-     */
     reviews?: Review[];
   }
 
@@ -2865,9 +1737,6 @@ export namespace Occ {
    * An interface representing SaveCartResult.
    */
   export interface SaveCartResult {
-    /**
-     * @member {Cart} [savedCartData]
-     */
     savedCartData?: Cart;
   }
 
@@ -2876,45 +1745,24 @@ export namespace Occ {
    * An interface representing StoreFinderSearchPage.
    */
   export interface StoreFinderSearchPage {
-    /**
-     * @member {number} [boundEastLongitude]
-     */
     boundEastLongitude?: number;
-    /**
-     * @member {number} [boundNorthLatitude]
-     */
+
     boundNorthLatitude?: number;
-    /**
-     * @member {number} [boundSouthLatitude]
-     */
+
     boundSouthLatitude?: number;
-    /**
-     * @member {number} [boundWestLongitude]
-     */
+
     boundWestLongitude?: number;
-    /**
-     * @member {string} [locationText]
-     */
+
     locationText?: string;
-    /**
-     * @member {PaginationModel} [pagination]
-     */
+
     pagination?: PaginationModel;
-    /**
-     * @member {SortModel[]} [sorts]
-     */
+
     sorts?: SortModel[];
-    /**
-     * @member {number} [sourceLatitude]
-     */
+
     sourceLatitude?: number;
-    /**
-     * @member {number} [sourceLongitude]
-     */
+
     sourceLongitude?: number;
-    /**
-     * @member {PointOfService[]} [stores]
-     */
+
     stores?: PointOfService[];
   }
 
@@ -2923,49 +1771,26 @@ export namespace Occ {
    * An interface representing StoreFinderStockSearchPage.
    */
   export interface StoreFinderStockSearchPage {
-    /**
-     * @member {number} [boundEastLongitude]
-     */
     boundEastLongitude?: number;
-    /**
-     * @member {number} [boundNorthLatitude]
-     */
+
     boundNorthLatitude?: number;
-    /**
-     * @member {number} [boundSouthLatitude]
-     */
+
     boundSouthLatitude?: number;
-    /**
-     * @member {number} [boundWestLongitude]
-     */
+
     boundWestLongitude?: number;
-    /**
-     * @member {string} [locationText]
-     */
+
     locationText?: string;
-    /**
-     * @member {PaginationModel} [pagination]
-     */
+
     pagination?: PaginationModel;
-    /**
-     * @member {Product} [product]
-     */
+
     product?: Product;
-    /**
-     * @member {SortModel[]} [sorts]
-     */
+
     sorts?: SortModel[];
-    /**
-     * @member {number} [sourceLatitude]
-     */
+
     sourceLatitude?: number;
-    /**
-     * @member {number} [sourceLongitude]
-     */
+
     sourceLongitude?: number;
-    /**
-     * @member {PointOfServiceStock[]} [stores]
-     */
+
     stores?: PointOfServiceStock[];
   }
 
@@ -2974,9 +1799,6 @@ export namespace Occ {
    * An interface representing Suggestion.
    */
   export interface Suggestion {
-    /**
-     * @member {string} [value]
-     */
     value?: string;
   }
 
@@ -2985,9 +1807,6 @@ export namespace Occ {
    * An interface representing SuggestionList.
    */
   export interface SuggestionList {
-    /**
-     * @member {Suggestion[]} [suggestions]
-     */
     suggestions?: Suggestion[];
   }
 
@@ -2996,13 +1815,8 @@ export namespace Occ {
    * An interface representing Title.
    */
   export interface Title {
-    /**
-     * @member {string} [code]
-     */
     code?: string;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
   }
 
@@ -3011,9 +1825,6 @@ export namespace Occ {
    * An interface representing TitleList.
    */
   export interface TitleList {
-    /**
-     * @member {Title[]} [titles]
-     */
     titles?: Title[];
   }
 
@@ -3022,25 +1833,14 @@ export namespace Occ {
    * An interface representing UserGroup.
    */
   export interface UserGroup {
-    /**
-     * @member {Principal[]} [members]
-     */
     members?: Principal[];
-    /**
-     * @member {number} [membersCount]
-     */
+
     membersCount?: number;
-    /**
-     * @member {string} [name]
-     */
+
     name?: string;
-    /**
-     * @member {UserGroup[]} [subGroups]
-     */
+
     subGroups?: UserGroup[];
-    /**
-     * @member {string} [uid]
-     */
+
     uid?: string;
   }
 
@@ -3060,9 +1860,6 @@ export namespace Occ {
    * An interface representing VoucherList.
    */
   export interface VoucherList {
-    /**
-     * @member {Voucher[]} [vouchers]
-     */
     vouchers?: Voucher[];
   }
 

--- a/projects/core/src/routing/external-routes/external-routes.providers.ts
+++ b/projects/core/src/routing/external-routes/external-routes.providers.ts
@@ -1,6 +1,8 @@
 import { ExternalRoutesService } from './external-routes.service';
 
-export function addExternalRoutesFactory(service: ExternalRoutesService) {
+export function addExternalRoutesFactory(
+  service: ExternalRoutesService
+): () => void {
   const result = () => {
     service.addRoutes();
   };

--- a/projects/core/src/site-context/providers/context-initializer-providers.ts
+++ b/projects/core/src/site-context/providers/context-initializer-providers.ts
@@ -3,20 +3,26 @@ import { BaseSiteInitializer } from '../services/base-site-initializer';
 import { CurrencyInitializer } from '../services/currency-initializer';
 import { LanguageInitializer } from '../services/language-initializer';
 
-export function initializeCurrency(currencyInitializer: CurrencyInitializer) {
+export function initializeCurrency(
+  currencyInitializer: CurrencyInitializer
+): () => void {
   const result = () => {
     currencyInitializer.initialize();
   };
   return result;
 }
-export function initializeLanguage(languageInitializer: LanguageInitializer) {
+export function initializeLanguage(
+  languageInitializer: LanguageInitializer
+): () => void {
   const result = () => {
     languageInitializer.initialize();
   };
   return result;
 }
 
-export function initializeBaseSite(baseSiteInitializer: BaseSiteInitializer) {
+export function initializeBaseSite(
+  baseSiteInitializer: BaseSiteInitializer
+): () => void {
   const result = () => {
     baseSiteInitializer.initialize();
   };

--- a/projects/core/src/site-context/providers/context-service-providers.ts
+++ b/projects/core/src/site-context/providers/context-service-providers.ts
@@ -1,6 +1,7 @@
 import { APP_INITIALIZER, Provider } from '@angular/core';
 import { tap } from 'rxjs/operators';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
+import { Config } from '../../config/config-tokens';
 import { BaseSiteService } from '../facade/base-site.service';
 import { CurrencyService } from '../facade/currency.service';
 import { LanguageService } from '../facade/language.service';
@@ -9,7 +10,7 @@ import { SiteContextRoutesHandler } from '../services/site-context-routes-handle
 export function initializeContext(
   configInit: ConfigInitializerService,
   siteContextRoutesHandler: SiteContextRoutesHandler
-) {
+): () => Promise<Config> {
   return () => {
     return configInit
       .getStable('context')

--- a/projects/storefrontlib/cms-structure/outlet/outlet.module.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet.module.ts
@@ -23,7 +23,7 @@ export function registerOutletsFactory(
   providedOutletOptions: ProvideOutletOptions[],
   componentFactoryResolver: ComponentFactoryResolver,
   outletService: OutletService<ComponentFactory<Type<any>>>
-) {
+): () => void {
   const result = () => {
     (providedOutletOptions ?? []).forEach((options) => {
       const factory = componentFactoryResolver.resolveComponentFactory(

--- a/projects/storefrontlib/cms-structure/routing/cms-route/add-cms-route.ts
+++ b/projects/storefrontlib/cms-structure/routing/cms-route/add-cms-route.ts
@@ -9,7 +9,7 @@ const cmsRoute: Route = {
   component: PageLayoutComponent,
 };
 
-export function addCmsRoute(injector: Injector) {
+export function addCmsRoute(injector: Injector): () => void {
   const result = () => {
     const router = injector.get(Router);
     router.config.push(cmsRoute);

--- a/projects/storefrontlib/cms-structure/seo/html-lang-provider.ts
+++ b/projects/storefrontlib/cms-structure/seo/html-lang-provider.ts
@@ -14,7 +14,7 @@ export const htmlLangProvider: Provider = {
 export function setHtmlLangAttribute(
   winRef: WindowRef,
   languageService: LanguageService
-) {
+): () => void {
   const result = () => {
     languageService.getActive().subscribe((lang) => {
       winRef.document.documentElement.lang = lang.replace(/_/g, '-');

--- a/projects/storefrontlib/cms-structure/seo/seo.module.ts
+++ b/projects/storefrontlib/cms-structure/seo/seo.module.ts
@@ -5,7 +5,7 @@ import { htmlLangProvider } from './html-lang-provider';
 import { SeoMetaService } from './seo-meta.service';
 import { StructuredDataModule } from './structured-data/structured-data.module';
 
-export function initSeoService(injector: Injector) {
+export function initSeoService(injector: Injector): () => void {
   const result = () => {
     const service = injector.get(SeoMetaService);
     service.init();

--- a/projects/storefrontlib/cms-structure/seo/structured-data/structured-data.module.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/structured-data.module.ts
@@ -7,7 +7,7 @@ import { StructuredDataFactory } from './structured-data.factory';
  * Factory to build the structure data
  * without any interaction with the UI.
  */
-export function getStructuredDataFactory(injector: Injector) {
+export function getStructuredDataFactory(injector: Injector): () => void {
   const result = () => {
     const factory = injector.get(StructuredDataFactory);
     factory.build();

--- a/projects/storefrontlib/layout/a11y/skip-link/skip-link.module.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/skip-link.module.ts
@@ -43,7 +43,7 @@ export class SkipLinkModule {}
 export function skipLinkFactory(
   componentFactoryResolver: ComponentFactoryResolver,
   outletService: OutletService
-) {
+): () => void {
   const isReady = () => {
     const factory =
       componentFactoryResolver.resolveComponentFactory(SkipLinkComponent);

--- a/projects/storefrontlib/layout/direction/direction.module.ts
+++ b/projects/storefrontlib/layout/direction/direction.module.ts
@@ -6,7 +6,7 @@ import { DirectionService } from './direction.service';
 export function initHtmlDirAttribute(
   directionService: DirectionService,
   featureConfigService: FeatureConfigService
-) {
+): () => void {
   const result = () => {
     if (featureConfigService.isLevel('2.1')) {
       return directionService.initialize();

--- a/projects/storefrontlib/router/app-routing.module.ts
+++ b/projects/storefrontlib/router/app-routing.module.ts
@@ -24,7 +24,9 @@ import { OnNavigateService } from './on-navigate.service';
 })
 export class AppRoutingModule {}
 
-export function onNavigateFactory(onNavigateService: OnNavigateService) {
+export function onNavigateFactory(
+  onNavigateService: OnNavigateService
+): () => void {
   const isReady = () => onNavigateService.initializeWithConfig();
   return isReady;
 }

--- a/tsconfig.api-extractor.json
+++ b/tsconfig.api-extractor.json
@@ -1,6 +1,6 @@
 {
   //TODO: Remove file and reference to it when everything is adjusted to strict mode
-  "extends": "./tsconfig.json",
+  "extends": "./projects/storefrontapp/tsconfig.app.prod.json",
   "compilerOptions": {
     "strict": false,
     "typeRoots": ["node_modules/@types/!(jest/jasmine)"]


### PR DESCRIPTION
**Improvements**:
- make the "Public API changes" bot back working in CI (get rid of all the errors in the script)
  - side effect: reduce the time of executing "Public API changes" bot from 2h back to ~30min (see [test PR](https://github.com/SAP/spartacus/actions/runs/2580268027))
- reduced the warnings noise in logs:
  - disabled API-extractor warnings not relevant in our project, e.g. [warning for missing release tags like alpha/beta/internal/public in our TSDocs](https://api-extractor.com/pages/messages/ae-missing-release-tag/),
  - disabled API-extractor warnings about missing exports, because sometimes caused false-positive warnings e.g. when an interface is exported, but from a different library
  - disabled all warnings from TSDocs parser (checking the syntax of TSDocs is not in scope of our breaking changes detection bot; generated ~30k warnings per script execution before)
- reduced the warnings noise in the report comment:
  - API Extractor warnings are not printed to the report comment, but only in the console of the script - to avoid fake reports because of a different file path, for example:
     ```diff
     -// /github/workspace/branch-clone/dist/<...file path> - <warning message>
     +// /github/workspace/dist/<...file path> - <warning message>
    ```

**Changes**:
- analyze d.ts instead of TS files in dependent libraries (e.g. when finding `import {X} from '@spartacus/core'`, analyze `dist/core/.../.d.ts` instead of `/projects/core/.../.ts`)
- disable api-extractor warning of type `ae-missing-release-tag` and `ae-forgotten-export`
- disable all TSDoc warnings (of type `tsdocMessageReporting`)
- disable reporting warnings in the markdown report, but leave them in the script console output
- add explicit return type for `APP_INITIALIZER`s that returned `()=>Promise<Config>` - to avoid api-extractor error `ERROR: Failed to fetch entity for import() type node: import("@spartacus/core").Config`
  - by the way, I added also missing return types for other `APP_INITIALIZER`s, which was not essential for this PR
- by the way, removed some redundant JSDoc notices `@member` from `occ-models.ts` - which caused warnings in api-extractor and were redundant

**Implementation notes**:
Previously for API Extractor tool we used the tsconfig with path mappings to source code (e.g. for resolving an import from `@spartacus/core` it looked up the source code TS files in `projects/core/*`).

According to https://api-extractor.com/pages/messages/ae-wrong-input-file-type/ , it seems that we were using the api-extractor tool not in a way that the tool's authors assumed. We analyzed TS files (only in dependency packages), but api-extractor expects to analyze d.ts

Moreover, since API Extractor v7.24.0 (released 2022-05-14), analyzing TS files throws an error (see [changelog](https://github.com/microsoft/rushstack/blob/main/apps/api-extractor/CHANGELOG.md#7240) and [troubleshooting page](https://api-extractor.com/pages/messages/ae-wrong-input-file-type/)), which caused our CI script for api-extractor to fail since 2022-05-14.

In this PR, we start using the "production" version of `tsconfig` (`tsconfig.app.prod.json` instead of `tsconfig.json`), which uses `"paths"` mapping to the `/dist` folder, which contains d.ts files.