### PR TITLE
chore: Add additional notes to new releases for including sample data in the assets

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -49,6 +49,11 @@ assignees: ''
 
 Do the following steps to keep track of spartacussampledata releases:
 
+- Important note:
+  - If the release is a 4.3.x
+    - make sure the downloaded sample data is using the `release/2105/4dot4` for the 2105 sample release
+  - If the release is a 5.x.x
+    - make sure the downloaded sample data is using the `release/2105/deploy` for the 2105 sample release
 - [ ] Tag sample data branches for each version (1905, 2005, 2011, 2105):
   - [ ] `git clone https://github.tools.sap/cx-commerce/spartacussampledata` (if already present `cd spartacussampledata && git fetch origin`)
   - [ ] tag the final commit on [release/1905/next](https://github.tools.sap/cx-commerce/spartacussampledata/commits/release/1905/next) branch: `git tag 1905-*.*.* HEAD-COMMIT-HASH-FROM-release/1905/next`


### PR DESCRIPTION
Currently, `release/2105/next` or `release/2105/deploy` contains breaking changes for our current application as those branch can only be used for `develop` or `5.x.x`.

If we're releasing a new minor/patch for `4.x.x`, then the asset should be taken from the branch `release/2105/4dot4`.

-----
I have manually updated the core-4.3.5 to use the downloaded zip of the branch `release/2105/4dot4` to fix the new deployed versions on ccv2.