### PR TITLE
fix: don't throw in `SupplementHashAnchorsPipe`, when given an empty `html` argument

### DIFF
--- a/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.pipe.spec.ts
+++ b/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.pipe.spec.ts
@@ -95,5 +95,9 @@ describe('AnchorPipe', () => {
         `${currentUrlWithoutFragment}#`
       );
     });
+
+    it('should return empty string for undefined html', () => {
+      expect(pipe.transform(undefined)).toBe('');
+    });
   });
 });

--- a/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.pipe.ts
+++ b/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.pipe.ts
@@ -24,7 +24,7 @@ export class SupplementHashAnchorsPipe implements PipeTransform {
     return `${currentUrlWithoutFragment}${anchorId}`;
   }
 
-  public transform(html: string): string {
+  public transform(html: string = ''): string {
     const template = this.renderer.createElement('template');
     template.innerHTML = html.trim();
     const linkNodes: NodeListOf<HTMLAnchorElement> =


### PR DESCRIPTION
closes https://jira.tools.sap/browse/CXSPA-743