### PR TITLE
chore: disable Public API Changes bot

### DIFF
--- a/.github/workflows/breaking-changes-detection-bot.yml
+++ b/.github/workflows/breaking-changes-detection-bot.yml
@@ -1,18 +1,20 @@
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-name: API extractor
-jobs:
-  breakingChangeDetectionBot:
-    name: Breaking change detection bot
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@master
-      - name: Breaking change detection bot
-        uses: ./.github/api-extractor-action
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# Disable the Public API Changes bot, until it's fixed https://jira.tools.sap/browse/CXSPA-745
+
+# on:
+#   pull_request:
+#     types: [opened, synchronize, reopened]
+# name: API extractor
+# jobs:
+#   breakingChangeDetectionBot:
+#     name: Breaking change detection bot
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Cancel Previous Runs
+#         uses: styfle/cancel-workflow-action@0.8.0
+#         with:
+#           access_token: ${{ secrets.GITHUB_TOKEN }}
+#       - uses: actions/checkout@master
+#       - name: Breaking change detection bot
+#         uses: ./.github/api-extractor-action
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
disabling the Public API Changes bot, until it's fixed
related to https://jira.tools.sap/browse/CXSPA-745