### PR TITLE
CXSPA-22 [BOPIS] Store the consumer's preferred store in the browser

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,4 @@
-(A) identify the consent template to use
-(B) integrate with the consent service to check if the user has consented to the template
-(C) expand tests to cover consents
+x (A) identify the consent template to use
+x (B) integrate with the consent service to check if the user has consented to the template
+x (C) expand tests to cover consents
 (D) check sample data for uniqueness of point of service `name` fields

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,4 @@
+(A) identify the consent template to use
+(B) integrate with the consent service to check if the user has consented to the template
+(C) expand tests to cover consents
+(D) check sample data for uniqueness of point of service `name` fields

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,0 @@
-x (A) identify the consent template to use
-x (B) integrate with the consent service to check if the user has consented to the template
-x (C) expand tests to cover consents
-(D) check sample data for uniqueness of point of service `name` fields

--- a/feature-libs/pickup-in-store/components/pickup-delivery-option-dialog/pickup-delivery-option-dialog.component.spec.ts
+++ b/feature-libs/pickup-in-store/components/pickup-delivery-option-dialog/pickup-delivery-option-dialog.component.spec.ts
@@ -4,12 +4,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { I18nTestingModule } from '@spartacus/core';
+import { PreferredStoreService } from '@spartacus/pickup-in-store/core';
 import {
   LocationSearchParams,
   PickupInStoreFacade,
 } from '@spartacus/pickup-in-store/root';
 import { IconTestingModule, LaunchDialogService } from '@spartacus/storefront';
 import { MockPickupInStoreService } from 'feature-libs/pickup-in-store/core/facade/pickup-in-store.service.spec';
+import { MockPreferredStoreService } from 'feature-libs/pickup-in-store/core/services/preferred-store.service.spec';
 import { Observable, of } from 'rxjs';
 import { StoreListModule } from '../store-list/index';
 import { StoreSearchModule } from '../store-search/store-search.module';
@@ -44,6 +46,7 @@ describe('PickupDeliveryOptionDialogComponent', () => {
       providers: [
         { provide: LaunchDialogService, useClass: MockLaunchDialogService },
         { provide: PickupInStoreFacade, useClass: MockPickupInStoreService },
+        { provide: PreferredStoreService, useClass: MockPreferredStoreService },
       ],
     }).compileComponents();
 

--- a/feature-libs/pickup-in-store/components/store-list/store-list.component.html
+++ b/feature-libs/pickup-in-store/components/store-list/store-list.component.html
@@ -12,8 +12,12 @@
     </div>
   </div>
 
-  <div *ngIf="stores.length">
-    <cx-store *ngFor="let store of stores" [storeDetails]="store"></cx-store>
+  <div class="container" *ngIf="stores.length">
+    <cx-store
+      *ngFor="let store of stores"
+      [storeDetails]="store"
+      (storeSelected)="onSelectStore($event)"
+    ></cx-store>
   </div>
 </div>
 <ng-template #loading>

--- a/feature-libs/pickup-in-store/components/store-list/store-list.component.spec.ts
+++ b/feature-libs/pickup-in-store/components/store-list/store-list.component.spec.ts
@@ -4,15 +4,18 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { I18nTestingModule } from '@spartacus/core';
+import { PreferredStoreService } from '@spartacus/pickup-in-store/core';
 import { PickupInStoreFacade } from '@spartacus/pickup-in-store/root';
 import { SpinnerModule } from '@spartacus/storefront';
 import { MockPickupInStoreService } from 'feature-libs/pickup-in-store/core/facade/pickup-in-store.service.spec';
+import { MockPreferredStoreService } from 'feature-libs/pickup-in-store/core/services/preferred-store.service.spec';
 import { StoreListComponent } from './store-list.component';
 
 describe('StoreListComponent', () => {
   let component: StoreListComponent;
   let fixture: ComponentFixture<StoreListComponent>;
   let pickupInStoreService: PickupInStoreFacade;
+  let preferredStoreService: PreferredStoreService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -27,12 +30,14 @@ describe('StoreListComponent', () => {
       declarations: [StoreListComponent],
       providers: [
         { provide: PickupInStoreFacade, useClass: MockPickupInStoreService },
+        { provide: PreferredStoreService, useClass: MockPreferredStoreService },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(StoreListComponent);
     component = fixture.componentInstance;
     pickupInStoreService = TestBed.inject(PickupInStoreFacade);
+    preferredStoreService = TestBed.inject(PreferredStoreService);
 
     fixture.detectChanges();
   });
@@ -49,5 +54,13 @@ describe('StoreListComponent', () => {
     expect(pickupInStoreService.getStores).toHaveBeenCalled();
     expect(pickupInStoreService.getStockLoading).toHaveBeenCalled();
     expect(pickupInStoreService.getSearchHasBeenPerformed).toHaveBeenCalled();
+  });
+
+  it('should set the preferred store when a store is selected', () => {
+    spyOn(preferredStoreService, 'setPreferredStore');
+    component.onSelectStore('storeName');
+    expect(preferredStoreService.setPreferredStore).toHaveBeenCalledWith(
+      'storeName'
+    );
   });
 });

--- a/feature-libs/pickup-in-store/components/store-list/store-list.component.ts
+++ b/feature-libs/pickup-in-store/components/store-list/store-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { PointOfServiceStock } from '@spartacus/core';
+import { PreferredStoreService } from '@spartacus/pickup-in-store/core';
 import { PickupInStoreFacade } from '@spartacus/pickup-in-store/root';
 import { Observable } from 'rxjs';
 
@@ -12,12 +13,19 @@ export class StoreListComponent implements OnInit {
   stores$: Observable<PointOfServiceStock[]>;
   searchHasBeenPerformed$: Observable<boolean>;
 
-  constructor(private readonly pickupInStoreService: PickupInStoreFacade) {}
+  constructor(
+    private readonly pickupInStoreService: PickupInStoreFacade,
+    private readonly preferredStoreService: PreferredStoreService
+  ) {}
 
   ngOnInit() {
     this.stores$ = this.pickupInStoreService.getStores();
     this.isLoading$ = this.pickupInStoreService.getStockLoading();
     this.searchHasBeenPerformed$ =
       this.pickupInStoreService.getSearchHasBeenPerformed();
+  }
+
+  onSelectStore(storeName: string) {
+    this.preferredStoreService.setPreferredStore(storeName);
   }
 }

--- a/feature-libs/pickup-in-store/components/store-list/store/store.component.ts
+++ b/feature-libs/pickup-in-store/components/store-list/store/store.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { PointOfServiceStock } from '@spartacus/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 
@@ -9,12 +9,15 @@ import { ICON_TYPE } from '@spartacus/storefront';
 export class StoreComponent {
   @Input()
   storeDetails: PointOfServiceStock = {};
+  @Output()
+  storeSelected: EventEmitter<string> = new EventEmitter<string>();
 
   iconTypes = ICON_TYPE;
 
   openHoursOpen = false;
 
   selectStore(): boolean {
+    this.storeSelected.emit(this.storeDetails.name);
     // return false to prevent this button adding to cart
     return false;
   }

--- a/feature-libs/pickup-in-store/core/config/default-pickup-in-store-config.ts
+++ b/feature-libs/pickup-in-store/core/config/default-pickup-in-store-config.ts
@@ -1,0 +1,7 @@
+import { PickupInStoreConfig } from './pickup-in-store-config';
+
+export const defaultPickupInStoreConfig: PickupInStoreConfig = {
+  pickupInStore: {
+    consentTemplateId: 'STORE_USER_INFORMATION',
+  },
+};

--- a/feature-libs/pickup-in-store/core/config/index.ts
+++ b/feature-libs/pickup-in-store/core/config/index.ts
@@ -1,0 +1,2 @@
+export * from './default-pickup-in-store-config';
+export * from './pickup-in-store-config';

--- a/feature-libs/pickup-in-store/core/config/pickup-in-store-config.ts
+++ b/feature-libs/pickup-in-store/core/config/pickup-in-store-config.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Config } from '@spartacus/core';
+
+@Injectable({
+  providedIn: 'root',
+  useExisting: Config,
+})
+export abstract class PickupInStoreConfig {
+  pickupInStore?: {
+    consentTemplateId?: string;
+  };
+}
+
+declare module '@spartacus/core' {
+  interface Config extends PickupInStoreConfig {}
+}

--- a/feature-libs/pickup-in-store/core/index.ts
+++ b/feature-libs/pickup-in-store/core/index.ts
@@ -1,3 +1,4 @@
+export * from './config/index';
 export * from './connectors/index';
 export * from './facade/index';
 export * from './model/index';

--- a/feature-libs/pickup-in-store/core/index.ts
+++ b/feature-libs/pickup-in-store/core/index.ts
@@ -2,3 +2,4 @@ export * from './connectors/index';
 export * from './facade/index';
 export * from './model/index';
 export * from './pickup-in-store-core.module';
+export * from './services/index';

--- a/feature-libs/pickup-in-store/core/pickup-in-store-core.module.ts
+++ b/feature-libs/pickup-in-store/core/pickup-in-store-core.module.ts
@@ -1,4 +1,6 @@
 import { NgModule } from '@angular/core';
+import { provideDefaultConfig } from '@spartacus/core';
+import { defaultPickupInStoreConfig } from './config/index';
 import { StockConnector } from './connectors/index';
 import { facadeProviders } from './facade/index';
 import { PreferredStoreService } from './services/index';
@@ -6,6 +8,11 @@ import { StockStoreModule } from './store';
 
 @NgModule({
   imports: [StockStoreModule],
-  providers: [StockConnector, PreferredStoreService, ...facadeProviders],
+  providers: [
+    provideDefaultConfig(defaultPickupInStoreConfig),
+    StockConnector,
+    PreferredStoreService,
+    ...facadeProviders,
+  ],
 })
 export class PickupInStoreCoreModule {}

--- a/feature-libs/pickup-in-store/core/pickup-in-store-core.module.ts
+++ b/feature-libs/pickup-in-store/core/pickup-in-store-core.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { StockConnector } from './connectors/index';
 import { facadeProviders } from './facade/index';
+import { PreferredStoreService } from './services/index';
 import { StockStoreModule } from './store';
 
 @NgModule({
   imports: [StockStoreModule],
-  providers: [StockConnector, ...facadeProviders],
+  providers: [StockConnector, PreferredStoreService, ...facadeProviders],
 })
 export class PickupInStoreCoreModule {}

--- a/feature-libs/pickup-in-store/core/services/index.ts
+++ b/feature-libs/pickup-in-store/core/services/index.ts
@@ -1,0 +1,1 @@
+export * from './preferred-store.service';

--- a/feature-libs/pickup-in-store/core/services/preferred-store.service.spec.ts
+++ b/feature-libs/pickup-in-store/core/services/preferred-store.service.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import { WindowRef } from '@spartacus/core';
+import { PreferredStoreService } from './preferred-store.service';
+
+const MockWindowRef = () => {
+  const store: { [key: string]: string | null } = {};
+  return {
+    localStorage: {
+      getItem: (key: string): string | null => {
+        return key in store ? store[key] : null;
+      },
+      setItem: (key: string, value: string) => {
+        store[key] = `${value}`;
+      },
+      removeItem: (key: string): void => {
+        if (key in store) {
+          delete store[key];
+        }
+      },
+    },
+  };
+};
+
+describe('PreferredStoreService', () => {
+  let preferredStoreService: PreferredStoreService;
+  let windowRef: WindowRef;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PreferredStoreService,
+        { provide: WindowRef, useValue: MockWindowRef() },
+      ],
+    });
+
+    preferredStoreService = TestBed.inject(PreferredStoreService);
+    windowRef = TestBed.inject(WindowRef);
+  });
+
+  it('should be created', () => {
+    expect(preferredStoreService).toBeDefined();
+  });
+
+  describe('getPreferredStore', () => {
+    it('should return the preferred store', () => {
+      const preferredStore = 'preferredStore';
+      windowRef.localStorage?.setItem('preferred_store', preferredStore);
+      expect(preferredStoreService.getPreferredStore()).toEqual(preferredStore);
+    });
+  });
+
+  describe('setPreferredStore', () => {
+    it('should set the preferred store', () => {
+      const preferredStore = 'preferredStore';
+      preferredStoreService.setPreferredStore(preferredStore);
+      expect(windowRef.localStorage?.getItem('preferred_store')).toEqual(
+        preferredStore
+      );
+    });
+  });
+
+  describe('clearPreferredStore', () => {
+    it('should clear the preferred store', () => {
+      windowRef.localStorage?.setItem('preferred_store', 'preferredStore');
+      preferredStoreService.clearPreferredStore();
+      expect(windowRef.localStorage?.getItem('preferred_store')).toBeNull();
+    });
+  });
+});

--- a/feature-libs/pickup-in-store/core/services/preferred-store.service.spec.ts
+++ b/feature-libs/pickup-in-store/core/services/preferred-store.service.spec.ts
@@ -1,6 +1,24 @@
 import { TestBed } from '@angular/core/testing';
-import { WindowRef } from '@spartacus/core';
+import { ConsentService, WindowRef } from '@spartacus/core';
+import { Observable, of } from 'rxjs';
+import { PickupInStoreConfig } from '../config';
 import { PreferredStoreService } from './preferred-store.service';
+
+class MockConsentService {
+  checkConsentGivenByTemplateId(_templateId: string): Observable<boolean> {
+    return of(true);
+  }
+}
+
+const MockPickupInStoreConfig = (withConfig = true): PickupInStoreConfig => {
+  return withConfig
+    ? {
+        pickupInStore: {
+          consentTemplateId: 'STORE_USER_INFORMATION',
+        },
+      }
+    : {};
+};
 
 const MockWindowRef = () => {
   const store: { [key: string]: string | null } = {};
@@ -23,47 +41,111 @@ const MockWindowRef = () => {
 
 describe('PreferredStoreService', () => {
   let preferredStoreService: PreferredStoreService;
+  let consentService: ConsentService;
   let windowRef: WindowRef;
 
-  beforeEach(() => {
+  const configureTestingModule = (withConfig = true) => {
     TestBed.configureTestingModule({
       providers: [
         PreferredStoreService,
+        { provide: ConsentService, useClass: MockConsentService },
+        {
+          provide: PickupInStoreConfig,
+          useValue: MockPickupInStoreConfig(withConfig),
+        },
         { provide: WindowRef, useValue: MockWindowRef() },
       ],
     });
 
     preferredStoreService = TestBed.inject(PreferredStoreService);
+    consentService = TestBed.inject(ConsentService);
     windowRef = TestBed.inject(WindowRef);
-  });
+  };
 
-  it('should be created', () => {
-    expect(preferredStoreService).toBeDefined();
-  });
+  describe('with pickup in store config', () => {
+    beforeEach(() => {
+      configureTestingModule();
+    });
 
-  describe('getPreferredStore', () => {
-    it('should return the preferred store', () => {
-      const preferredStore = 'preferredStore';
-      windowRef.localStorage?.setItem('preferred_store', preferredStore);
-      expect(preferredStoreService.getPreferredStore()).toEqual(preferredStore);
+    it('should be created', () => {
+      expect(preferredStoreService).toBeDefined();
+    });
+
+    describe('getPreferredStore', () => {
+      it('should return the preferred store', () => {
+        const preferredStore = 'preferredStore';
+        windowRef.localStorage?.setItem('preferred_store', preferredStore);
+        expect(preferredStoreService.getPreferredStore()).toEqual(
+          preferredStore
+        );
+      });
+    });
+
+    describe('setPreferredStore', () => {
+      it('should set the preferred store if consent is given', () => {
+        spyOn(consentService, 'checkConsentGivenByTemplateId').and.returnValue(
+          of(true)
+        );
+        const preferredStore = 'preferredStore';
+        preferredStoreService.setPreferredStore(preferredStore);
+        expect(windowRef.localStorage?.getItem('preferred_store')).toEqual(
+          preferredStore
+        );
+      });
+
+      it('should not set the preferred store if consent is not', () => {
+        spyOn(consentService, 'checkConsentGivenByTemplateId').and.returnValue(
+          of(false)
+        );
+        const preferredStore = 'preferredStore';
+        preferredStoreService.setPreferredStore(preferredStore);
+        expect(windowRef.localStorage?.getItem('preferred_store')).toBeNull();
+      });
+    });
+
+    describe('clearPreferredStore', () => {
+      it('should clear the preferred store', () => {
+        windowRef.localStorage?.setItem('preferred_store', 'preferredStore');
+        preferredStoreService.clearPreferredStore();
+        expect(windowRef.localStorage?.getItem('preferred_store')).toBeNull();
+      });
+    });
+
+    describe('onDestroy', () => {
+      it('should unsubscribe onDestroy', () => {
+        preferredStoreService.setPreferredStore('preferredStore');
+        spyOn(preferredStoreService.subscription, 'unsubscribe');
+        preferredStoreService.ngOnDestroy();
+        expect(
+          preferredStoreService.subscription.unsubscribe
+        ).toHaveBeenCalled();
+      });
     });
   });
 
-  describe('setPreferredStore', () => {
-    it('should set the preferred store', () => {
+  describe('without pickup in store config', () => {
+    beforeEach(() => {
+      configureTestingModule(false);
+    });
+
+    it('setPreferredStore should not set preferred store if consent template config is not set', () => {
+      spyOn(consentService, 'checkConsentGivenByTemplateId').and.returnValue(
+        of(false)
+      );
       const preferredStore = 'preferredStore';
       preferredStoreService.setPreferredStore(preferredStore);
-      expect(windowRef.localStorage?.getItem('preferred_store')).toEqual(
-        preferredStore
+      expect(consentService.checkConsentGivenByTemplateId).toHaveBeenCalledWith(
+        ''
       );
-    });
-  });
-
-  describe('clearPreferredStore', () => {
-    it('should clear the preferred store', () => {
-      windowRef.localStorage?.setItem('preferred_store', 'preferredStore');
-      preferredStoreService.clearPreferredStore();
       expect(windowRef.localStorage?.getItem('preferred_store')).toBeNull();
     });
   });
 });
+
+export class MockPreferredStoreService {
+  getPreferredStore(): string {
+    return 'preferredStore';
+  }
+  setPreferredStore(_preferredStore: string): void {}
+  clearPreferredStore(): void {}
+}

--- a/feature-libs/pickup-in-store/core/services/preferred-store.service.ts
+++ b/feature-libs/pickup-in-store/core/services/preferred-store.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { WindowRef } from '@spartacus/core';
+import { PREFERRED_STORE_LOCAL_STORAGE_KEY } from '@spartacus/pickup-in-store/root';
+
+/**
+ * Service to store the user's preferred store for Pickup in Store in local storage.
+ */
+@Injectable()
+export class PreferredStoreService {
+  constructor(protected readonly winRef: WindowRef) {}
+
+  /**
+   * Gets the user's preferred store for Pickup in Store.
+   * @returns the preferred store from local storage
+   */
+  getPreferredStore(): string | null | undefined {
+    return this.winRef.localStorage?.getItem(PREFERRED_STORE_LOCAL_STORAGE_KEY);
+  }
+
+  /**
+   * Sets the user's preferred store for Pickup in Store.
+   * @param preferredStore the preferred store to set
+   */
+  setPreferredStore(preferredStore: string): void {
+    this.winRef.localStorage?.setItem(
+      PREFERRED_STORE_LOCAL_STORAGE_KEY,
+      preferredStore
+    );
+  }
+
+  /**
+   * Clears the user's preferred store for Pickup in Store.
+   */
+  clearPreferredStore(): void {
+    this.winRef.localStorage?.removeItem(PREFERRED_STORE_LOCAL_STORAGE_KEY);
+  }
+}

--- a/feature-libs/pickup-in-store/root/index.ts
+++ b/feature-libs/pickup-in-store/root/index.ts
@@ -1,4 +1,5 @@
 export * from './facade/index';
 export * from './feature-name';
 export * from './model/index';
+export * from './pickup-in-store-constants';
 export * from './pickup-in-store-root.module';

--- a/feature-libs/pickup-in-store/root/pickup-in-store-constants.ts
+++ b/feature-libs/pickup-in-store/root/pickup-in-store-constants.ts
@@ -1,0 +1,1 @@
+export const PREFERRED_STORE_LOCAL_STORAGE_KEY = 'preferred_store';

--- a/projects/core/src/user/facade/consent.service.ts
+++ b/projects/core/src/user/facade/consent.service.ts
@@ -16,7 +16,7 @@ export class ConsentService {
   ) {}
 
   /**
-   * Returns either anonymous consent or registered consent as they are emmited.
+   * Returns either anonymous consent or registered consent as they are emitted.
    * @param templateCode for which to return either anonymous or registered consent.
    */
   getConsent(


### PR DESCRIPTION
## User story
As a consumer, when I return to an online shop, I want the last store I picked up from to be remembered to save me time in the future.

## Description
When the user selects a store, we should save that choice in the browser. There will be a future journey for a more feature rich implementation of favourite stores.

## Acceptance Criteria
1. Save the latest store in localstorage for all users (known and unknown)
2. Only save the information if the user has given consent to use cookies