### PR TITLE
fix: checkmarx-CXSPA-665: add rel attribute to anchors

### DIFF
--- a/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.html
+++ b/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.html
@@ -12,6 +12,7 @@
           [routerLink]="{ cxRoute: 'termsAndConditions' } | cxUrl"
           class="cx-tc-link"
           target="_blank"
+          rel="noopener noreferrer"
         >
           {{ 'checkoutReview.termsAndConditions' | cxTranslate }}
         </a>

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.html
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.html
@@ -12,6 +12,7 @@
           [routerLink]="{ cxRoute: 'termsAndConditions' } | cxUrl"
           class="cx-tc-link"
           target="_blank"
+          rel="noopener noreferrer"
         >
           {{ 'checkoutReview.termsAndConditions' | cxTranslate }}
         </a>

--- a/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/tracking-events/tracking-events.component.html
+++ b/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/tracking-events/tracking-events.component.html
@@ -67,9 +67,12 @@
             </div>
             <div class="shipment-content">
               <ng-container *ngIf="consignmentTracking?.trackingUrl">
-                <a target="_blank" [href]="consignmentTracking.trackingUrl">{{
-                  consignmentTracking?.trackingID
-                }}</a>
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  [href]="consignmentTracking.trackingUrl"
+                  >{{ consignmentTracking?.trackingID }}</a
+                >
               </ng-container>
               <ng-container *ngIf="!consignmentTracking?.trackingUrl">
                 <label>

--- a/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.html
+++ b/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.html
@@ -42,6 +42,7 @@
       aria-hidden="true"
       href="{{ getDirections(location) }}"
       target="_blank"
+      rel="noopener noreferrer"
       class="btn btn-sm btn-action btn-block cx-button"
       (click)="$event.stopPropagation()"
       [attr.aria-label]="'storeFinder.ariaLabelGetDirections' | cxTranslate"

--- a/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.html
+++ b/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.html
@@ -22,6 +22,7 @@
                 class="cx-link"
                 [href]="getDirections(location)"
                 target="_blank"
+                rel="noopener noreferrer"
                 [attr.aria-label]="
                   'storeFinder.ariaLabelGetDirections' | cxTranslate
                 "

--- a/feature-libs/user/profile/components/register/register.component.html
+++ b/feature-libs/user/profile/components/register/register.component.html
@@ -173,6 +173,7 @@
                   <a
                     [routerLink]="{ cxRoute: 'termsAndConditions' } | cxUrl"
                     target="_blank"
+                    rel="noopener noreferrer"
                   >
                     {{ 'register.termsAndConditions' | cxTranslate }}
                   </a>

--- a/projects/storefrontlib/cms-components/content/pdf/pdf.component.html
+++ b/projects/storefrontlib/cms-components/content/pdf/pdf.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="data$ | async as data">
   <div class="pdf-container">
-    <a [href]="url" target="_blank">
+    <a [href]="url" target="_blank" rel="noopener noreferrer">
       <span>{{
         addPdfExtension(
           data?.title ||


### PR DESCRIPTION
This PR target 5.0.x branch.
It is the same PR that was merged into 'develop': https://github.com/SAP/spartacus/pull/15932
----------------
see https://jira.tools.sap/browse/CXSPA-665 for details
this fix: add rel="noopener noreferrer" attribute to the 7 anchors that are using using target _blank.
tested with pdf and 'terms and conditions' links, and AMP.
those change enforce security:
'noopener' -> new tab page does not have access to document obj of launcher page
'noreferrer' -> (referrer property not set in header)
see details on https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types