### PR TITLE
Remove depreciated entryComponents of EPD-Visualization module files

### DIFF
--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.module.ts
@@ -10,7 +10,6 @@ import { VisualPickingProductFilterService } from './visual-picking-product-filt
   imports: [CommonModule, FormsModule, IconModule, UrlModule, I18nModule],
   providers: [VisualPickingProductFilterService],
   declarations: [VisualPickingProductFilterComponent],
-  entryComponents: [VisualPickingProductFilterComponent],
   exports: [VisualPickingProductFilterComponent],
 })
 export class VisualPickingProductFilterModule {}

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.module.ts
@@ -27,6 +27,5 @@ import { VisualPickingProductListComponent } from './visual-picking-product-list
   ],
   declarations: [VisualPickingProductListComponent],
   exports: [VisualPickingProductListComponent],
-  entryComponents: [VisualPickingProductListComponent],
 })
 export class VisualPickingProductListModule {}

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.module.ts
@@ -27,6 +27,5 @@ import { VisualPickingTabComponent } from './visual-picking-tab.component';
   ],
   declarations: [VisualPickingTabComponent],
   exports: [VisualPickingTabComponent],
-  entryComponents: [VisualPickingTabComponent],
 })
 export class VisualPickingTabModule {}

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.module.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.module.ts
@@ -7,6 +7,5 @@ import { VisualViewerAnimationSliderComponent } from './visual-viewer-animation-
   imports: [CommonModule, I18nModule],
   declarations: [VisualViewerAnimationSliderComponent],
   exports: [VisualViewerAnimationSliderComponent],
-  entryComponents: [VisualViewerAnimationSliderComponent],
 })
 export class VisualViewerAnimationSliderModule {}

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.module.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.module.ts
@@ -7,6 +7,5 @@ import { VisualViewerToolbarButtonComponent } from './visual-viewer-toolbar-butt
   imports: [CommonModule, IconModule],
   declarations: [VisualViewerToolbarButtonComponent],
   exports: [VisualViewerToolbarButtonComponent],
-  entryComponents: [VisualViewerToolbarButtonComponent],
 })
 export class VisualViewerToolbarButtonModule {}

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.module.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.module.ts
@@ -18,6 +18,5 @@ import { VisualViewerComponent } from './visual-viewer.component';
   ],
   declarations: [VisualViewerComponent],
   exports: [VisualViewerComponent],
-  entryComponents: [VisualViewerComponent],
 })
 export class VisualViewerModule {}


### PR DESCRIPTION
6 Low vulnerabilities of type Angular_Deprecated_API can be fix by removing
'entryComponents' property in module files.

'entryComponents' is not needed anymore since ivy, see https://angular.io/guide/deprecations#entrycomponents-and-analyze_for_entry_components-no-longer-required

The rest was already removed in May 2021 with this PR: https://github.com/SAP/spartacus/pull/12263/files
6 'entryComponents' from EPD-Visualization module files is still present, which can now be removed.

 