### PR TITLE
refactor: class properties as readonly to enforce xss security

### DIFF
--- a/projects/storefrontlib/layout/launch-dialog/services/launch-render.strategy.ts
+++ b/projects/storefrontlib/layout/launch-dialog/services/launch-render.strategy.ts
@@ -26,29 +26,29 @@ export abstract class LaunchRenderStrategy implements Applicable {
   /**
    * Classes to apply to the component when the dialog is a DIALOG
    */
-  protected dialogClasses = ['d-block', 'fade', 'modal', 'show'];
+  protected readonly dialogClasses = ['d-block', 'fade', 'modal', 'show'];
   /**
    * Classes to apply to the component when the dialog is a POPOVER
    */
-  protected popoverClasses = ['cx-dialog-popover'];
+  protected readonly popoverClasses = ['cx-dialog-popover'];
   /**
    * Classes to apply to the component when the dialog is a POPOVER_CENTER
    */
-  protected popoverCenterClasses = ['cx-dialog-popover-center'];
+  protected readonly popoverCenterClasses = ['cx-dialog-popover-center'];
   /**
    * Classes to apply to the component when the dialog is a POPOVER_CENTER with a backdrop
    */
-  protected popoverCenterBackdropClasses = [
+  protected readonly popoverCenterBackdropClasses = [
     'cx-dialog-popover-center-backdrop',
   ];
   /**
    * Classes to apply to the component when the dialog is a SIDEBAR_END
    */
-  protected sidebarEndClasses = ['cx-sidebar-end'];
+  protected readonly sidebarEndClasses = ['cx-sidebar-end'];
   /**
    * Classes to apply to the component when the dialog is a SIDEBAR_START
    */
-  protected sidebarStartClasses = ['cx-sidebar-start'];
+  protected readonly sidebarStartClasses = ['cx-sidebar-start'];
 
   protected renderer: Renderer2;
 


### PR DESCRIPTION
This PR is similar of https://github.com/SAP/spartacus/pull/16013 targeting 5.0.x release.

To enforce security about xss attack.
see https://jira.tools.sap/browse/CXSPA-658 last comment.

The idea is to set the class variable as readonly so base classes cannot mutate them.
In this case those variable values are injected in DOM using addClass, it is an extra security feature.