### PR TITLE
chore: change console message from warn to error in case of inconsistent setup

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.spec.ts
@@ -828,14 +828,14 @@ describe('ConfigAttributeHeaderComponent', () => {
       component.attribute.groupId = undefined;
 
       spyOn(configurationGroupsService, 'navigateToGroup');
-      spyOn<any>(component, 'logWarning');
+      spyOn<any>(component, 'logError');
       fixture.detectChanges();
 
       component.navigateToGroup();
       expect(configurationGroupsService.navigateToGroup).toHaveBeenCalledTimes(
         0
       );
-      expect(component['logWarning']).toHaveBeenCalled();
+      expect(component['logError']).toHaveBeenCalled();
     });
   });
 

--- a/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.ts
@@ -175,7 +175,9 @@ export class ConfiguratorAttributeHeaderComponent
           this.focusValue(this.attribute);
           this.scrollToAttribute(this.attribute.name);
         } else {
-          this.logWarning('Attribute was not found in any conflict group');
+          this.logError(
+            'Attribute was not found in any conflict group. Note that for this navigation, commerce 22.05 or later is required. Consider to disable setting "enableNavigationToConflict"'
+          );
         }
       });
   }
@@ -208,9 +210,9 @@ export class ConfiguratorAttributeHeaderComponent
       })?.id;
   }
 
-  protected logWarning(text: string): void {
+  protected logError(text: string): void {
     if (isDevMode()) {
-      console.warn(text);
+      console.error(text);
     }
   }
 


### PR DESCRIPTION


In case the conflict navigation feature is enabled, but the backend does not allow it, we write an error console message in dev mode.