### PR TITLE
CXSPA-1114 [BOPIS] Add copyright headers

### DIFF
--- a/feature-libs/pickup-in-store/assets/public_api.ts
+++ b/feature-libs/pickup-in-store/assets/public_api.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './translations/translations';

--- a/feature-libs/pickup-in-store/assets/translations/en/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/en/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { pickupInStore } from './pickup-in-store.i18n';
 
 /** English language translations for pickup in store strings. */

--- a/feature-libs/pickup-in-store/assets/translations/en/pickup-in-store.i18n.ts
+++ b/feature-libs/pickup-in-store/assets/translations/en/pickup-in-store.i18n.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export const pickupInStoreDialog = {
   close: 'Close',
   modalHeader: 'Pickup in Store',

--- a/feature-libs/pickup-in-store/assets/translations/translations.ts
+++ b/feature-libs/pickup-in-store/assets/translations/translations.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { TranslationChunksConfig, TranslationResources } from '@spartacus/core';
 import { en } from './en/index';
 

--- a/feature-libs/pickup-in-store/cart/facade/pickup-in-store-active-cart.service.ts
+++ b/feature-libs/pickup-in-store/cart/facade/pickup-in-store-active-cart.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import {
   ActiveCartService,

--- a/feature-libs/pickup-in-store/cart/index.ts
+++ b/feature-libs/pickup-in-store/cart/index.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './pickup-in-store-cart.module';

--- a/feature-libs/pickup-in-store/cart/pickup-in-store-cart.module.ts
+++ b/feature-libs/pickup-in-store/cart/pickup-in-store-cart.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NgModule } from '@angular/core';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import { PickupInStoreActiveCartService } from './facade/pickup-in-store-active-cart.service';

--- a/feature-libs/pickup-in-store/cart/public_api.ts
+++ b/feature-libs/pickup-in-store/cart/public_api.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './index';

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Component, OnInit, Optional } from '@angular/core';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import {

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
@@ -24,7 +24,9 @@ export class CartPickupOptionsContainerComponent implements OnInit {
   constructor(
     @Optional() protected outlet: OutletContextData<OrderEntry>,
     protected storeDetails: PickupLocationsSearchFacade
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   ngOnInit() {
     this.pickupOption$ = this.outlet?.context$.pipe(

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
@@ -38,7 +38,6 @@ export class CartPickupOptionsContainerComponent implements OnInit {
 
     this.displayName$ = this.outlet?.context$.pipe(
       map((entry) => entry?.deliveryPointOfService?.name),
-      tap((storeName) => console.log('Debug: storeName: ', storeName)),
       filter((name): name is string => !!name),
       tap((storeName) => this.storeDetails.loadStoreDetails(storeName)),
       switchMap((storeName) => this.storeDetails.getStoreDetails(storeName)),

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.module.ts
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { CartOutlets } from '@spartacus/cart/base/root';

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/index.ts
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './cart-pickup-options-container.component';
 export * from './cart-pickup-options-container.module';

--- a/feature-libs/pickup-in-store/components/container/index.ts
+++ b/feature-libs/pickup-in-store/components/container/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './cart-pickup-options-container/index';
 export * from './pdp-pickup-options-container/index';
 export * from './pickup-delivery-option-dialog/index';

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/index.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './pdp-pickup-options-container.component';
 export * from './pdp-pickup-options-container.module';

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
@@ -67,7 +67,9 @@ export class PdpPickupOptionsContainerComponent implements OnInit, OnDestroy {
     protected currentLocationService: CurrentLocationService,
     protected pickupLocationsSearchService: PickupLocationsSearchFacade,
     protected preferredStoreService: PreferredStoreService
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   ngOnInit() {
     const productCode$ = this.currentProductService.getProduct().pipe(

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   Component,
   ElementRef,

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.module.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { CartOutlets } from '@spartacus/cart/base/root';

--- a/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/index.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './pickup-delivery-option-dialog-layout.config';
 export * from './pickup-delivery-option-dialog.component';
 export * from './pickup-delivery-option-dialog.module';

--- a/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/pickup-delivery-option-dialog-layout.config.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/pickup-delivery-option-dialog-layout.config.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { DIALOG_TYPE, LayoutConfig } from '@spartacus/storefront';
 import { PickupDeliveryOptionDialogComponent } from './pickup-delivery-option-dialog.component';
 

--- a/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/pickup-delivery-option-dialog.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/pickup-delivery-option-dialog.component.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Component, OnInit } from '@angular/core';
 import {
   IntendedPickupLocationFacade,

--- a/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/pickup-delivery-option-dialog.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/pickup-delivery-option-dialog.component.ts
@@ -32,7 +32,9 @@ export class PickupDeliveryOptionDialogComponent implements OnInit {
     protected readonly launchDialogService: LaunchDialogService,
     protected readonly pickupLocationsSearchService: PickupLocationsSearchFacade,
     protected readonly intendedPickupLocationService: IntendedPickupLocationFacade
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   ngOnInit() {
     this.launchDialogService.data$.subscribe(({ productCode }) => {

--- a/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/pickup-delivery-option-dialog.module.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-delivery-option-dialog/pickup-delivery-option-dialog.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { I18nModule } from '@spartacus/core';

--- a/feature-libs/pickup-in-store/components/container/store-list/index.ts
+++ b/feature-libs/pickup-in-store/components/container/store-list/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './store-list.component';
 export * from './store-list.module';

--- a/feature-libs/pickup-in-store/components/container/store-list/store-list.component.ts
+++ b/feature-libs/pickup-in-store/components/container/store-list/store-list.component.ts
@@ -31,7 +31,9 @@ export class StoreListComponent implements OnInit {
     private readonly pickupLocationsSearchService: PickupLocationsSearchFacade,
     private readonly preferredStoreService: PreferredStoreService,
     private readonly intendedPickupLocationService: IntendedPickupLocationFacade
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   ngOnInit() {
     this.stores$ = this.pickupLocationsSearchService.getSearchResults(

--- a/feature-libs/pickup-in-store/components/container/store-list/store-list.component.ts
+++ b/feature-libs/pickup-in-store/components/container/store-list/store-list.component.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { PointOfServiceStock } from '@spartacus/core';
 import { PreferredStoreService } from '@spartacus/pickup-in-store/core';

--- a/feature-libs/pickup-in-store/components/container/store-list/store-list.module.ts
+++ b/feature-libs/pickup-in-store/components/container/store-list/store-list.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { I18nModule } from '@spartacus/core';

--- a/feature-libs/pickup-in-store/components/container/store-search/index.ts
+++ b/feature-libs/pickup-in-store/components/container/store-search/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './store-search.component';
 export * from './store-search.module';

--- a/feature-libs/pickup-in-store/components/container/store-search/store-search.component.ts
+++ b/feature-libs/pickup-in-store/components/container/store-search/store-search.component.ts
@@ -19,7 +19,9 @@ export class StoreSearchComponent {
 
   @Input() hideOutOfStock: boolean = false;
 
-  constructor(protected currentLocationService: CurrentLocationService) {}
+  constructor(protected currentLocationService: CurrentLocationService) {
+    // Intentional empty constructor
+  }
 
   onFindStores(location: string): boolean {
     this.findStores.emit({ location });

--- a/feature-libs/pickup-in-store/components/container/store-search/store-search.component.ts
+++ b/feature-libs/pickup-in-store/components/container/store-search/store-search.component.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { LocationSearchParams } from '@spartacus/pickup-in-store/root';
 import { CurrentLocationService } from '../../services/current-location.service';

--- a/feature-libs/pickup-in-store/components/container/store-search/store-search.module.ts
+++ b/feature-libs/pickup-in-store/components/container/store-search/store-search.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { I18nModule } from '@spartacus/core';

--- a/feature-libs/pickup-in-store/components/index.ts
+++ b/feature-libs/pickup-in-store/components/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './container/index';
 export * from './pickup-in-store-components.module';
 export * from './presentational/index';

--- a/feature-libs/pickup-in-store/components/pickup-in-store-components.module.ts
+++ b/feature-libs/pickup-in-store/components/pickup-in-store-components.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { provideDefaultConfig } from '@spartacus/core';

--- a/feature-libs/pickup-in-store/components/presentational/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './pickup-options/index';
 export * from './store/index';

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './pickup-options.component';
 export * from './pickup-options.module';

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   Component,
   EventEmitter,

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.module.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';

--- a/feature-libs/pickup-in-store/components/presentational/store/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './store-schedule/index';
 export * from './store.component';
 export * from './store.module';

--- a/feature-libs/pickup-in-store/components/presentational/store/store-schedule/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store-schedule/index.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './store-schedule.component';

--- a/feature-libs/pickup-in-store/components/presentational/store/store-schedule/store-schedule.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store-schedule/store-schedule.component.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Component, Input, OnInit } from '@angular/core';
 import { PointOfService } from '@spartacus/core';
 

--- a/feature-libs/pickup-in-store/components/presentational/store/store-schedule/store-schedule.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store-schedule/store-schedule.component.ts
@@ -23,8 +23,6 @@ export class StoreScheduleComponent implements OnInit {
 
   openingTimes: OpeningTime[] = [];
 
-  constructor() {}
-
   ngOnInit() {
     this.openingTimes =
       this.storeDetails?.openingHours?.weekDayOpeningList?.map(

--- a/feature-libs/pickup-in-store/components/presentational/store/store.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store.component.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { PointOfServiceStock } from '@spartacus/core';
 import { storeHasStock } from '@spartacus/pickup-in-store/core';

--- a/feature-libs/pickup-in-store/components/presentational/store/store.module.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { I18nModule } from '@spartacus/core';

--- a/feature-libs/pickup-in-store/components/public_api.ts
+++ b/feature-libs/pickup-in-store/components/public_api.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './index';

--- a/feature-libs/pickup-in-store/components/services/current-location.service.ts
+++ b/feature-libs/pickup-in-store/components/services/current-location.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { WindowRef } from '@spartacus/core';
 

--- a/feature-libs/pickup-in-store/components/services/current-location.service.ts
+++ b/feature-libs/pickup-in-store/components/services/current-location.service.ts
@@ -14,7 +14,9 @@ import { WindowRef } from '@spartacus/core';
   providedIn: 'root',
 })
 export class CurrentLocationService {
-  constructor(protected windowRef: WindowRef) {}
+  constructor(protected windowRef: WindowRef) {
+    // Intentional empty constructor
+  }
 
   /**
    * Obtains the user's current position for the browser and calls the provided callback with it.

--- a/feature-libs/pickup-in-store/core/config/default-pickup-in-store-config.ts
+++ b/feature-libs/pickup-in-store/core/config/default-pickup-in-store-config.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { PickupInStoreConfig } from './pickup-in-store-config';
 
 export const defaultPickupInStoreConfig: PickupInStoreConfig = {

--- a/feature-libs/pickup-in-store/core/config/index.ts
+++ b/feature-libs/pickup-in-store/core/config/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './default-pickup-in-store-config';
 export * from './pickup-in-store-config';

--- a/feature-libs/pickup-in-store/core/config/pickup-in-store-config.ts
+++ b/feature-libs/pickup-in-store/core/config/pickup-in-store-config.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { Config } from '@spartacus/core';
 

--- a/feature-libs/pickup-in-store/core/connectors/index.ts
+++ b/feature-libs/pickup-in-store/core/connectors/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './stock.adapter';
 export * from './stock.connector';
 export * from './pickup-location.adapter';

--- a/feature-libs/pickup-in-store/core/connectors/pickup-location.adapter.ts
+++ b/feature-libs/pickup-in-store/core/connectors/pickup-location.adapter.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { PointOfService } from '@spartacus/core';
 import { Observable } from 'rxjs';
 

--- a/feature-libs/pickup-in-store/core/connectors/pickup-location.connector.ts
+++ b/feature-libs/pickup-in-store/core/connectors/pickup-location.connector.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { PointOfService } from '@spartacus/core';
 import { Observable } from 'rxjs';

--- a/feature-libs/pickup-in-store/core/connectors/pickup-location.connector.ts
+++ b/feature-libs/pickup-in-store/core/connectors/pickup-location.connector.ts
@@ -14,7 +14,9 @@ import { PickupLocationAdapter } from './pickup-location.adapter';
  */
 @Injectable({ providedIn: 'root' })
 export class PickupLocationConnector {
-  constructor(protected adapter: PickupLocationAdapter) {}
+  constructor(protected adapter: PickupLocationAdapter) {
+    // Intentional empty constructor
+  }
 
   /**
    * Get the store details by store name.

--- a/feature-libs/pickup-in-store/core/connectors/stock.adapter.ts
+++ b/feature-libs/pickup-in-store/core/connectors/stock.adapter.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Stock, StoreFinderStockSearchPage } from '@spartacus/core';
 import { LocationSearchParams } from '@spartacus/pickup-in-store/root';
 import { Observable } from 'rxjs';

--- a/feature-libs/pickup-in-store/core/connectors/stock.connector.ts
+++ b/feature-libs/pickup-in-store/core/connectors/stock.connector.ts
@@ -15,7 +15,9 @@ import { StockAdapter } from './stock.adapter';
  */
 @Injectable({ providedIn: 'root' })
 export class StockConnector {
-  constructor(protected adapter: StockAdapter) {}
+  constructor(protected adapter: StockAdapter) {
+    // Intentional empty constructor
+  }
 
   /**
    * Finds stock levels of a product at stores near a location.

--- a/feature-libs/pickup-in-store/core/connectors/stock.connector.ts
+++ b/feature-libs/pickup-in-store/core/connectors/stock.connector.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { Stock, StoreFinderStockSearchPage } from '@spartacus/core';
 import { LocationSearchParams } from '@spartacus/pickup-in-store/root';

--- a/feature-libs/pickup-in-store/core/facade/cart.service.ts
+++ b/feature-libs/pickup-in-store/core/facade/cart.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { CartFacade } from '@spartacus/pickup-in-store/root';
 

--- a/feature-libs/pickup-in-store/core/facade/facade-providers.ts
+++ b/feature-libs/pickup-in-store/core/facade/facade-providers.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Provider } from '@angular/core';
 import {
   CartFacade,

--- a/feature-libs/pickup-in-store/core/facade/index.ts
+++ b/feature-libs/pickup-in-store/core/facade/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './facade-providers';
 export * from './pickup-locations-search.service';

--- a/feature-libs/pickup-in-store/core/facade/intended-pickup-location.service.ts
+++ b/feature-libs/pickup-in-store/core/facade/intended-pickup-location.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import {

--- a/feature-libs/pickup-in-store/core/facade/intended-pickup-location.service.ts
+++ b/feature-libs/pickup-in-store/core/facade/intended-pickup-location.service.ts
@@ -23,7 +23,9 @@ import { StateWithPickupLocations } from '../store/pickup-location-state';
 export class IntendedPickupLocationService
   implements IntendedPickupLocationFacade
 {
-  constructor(protected readonly store: Store<StateWithPickupLocations>) {}
+  constructor(protected readonly store: Store<StateWithPickupLocations>) {
+    // Intentional empty constructor
+  }
 
   getIntendedLocation(
     productCode: string

--- a/feature-libs/pickup-in-store/core/facade/pickup-locations-search.service.spec.ts
+++ b/feature-libs/pickup-in-store/core/facade/pickup-locations-search.service.spec.ts
@@ -24,7 +24,9 @@ import { PickupLocationsSearchService } from './pickup-locations-search.service'
 export class MockPickupLocationsSearchService
   implements PickupLocationsSearchFacade
 {
-  constructor(protected store: Store<StateWithStock>) {}
+  constructor(protected store: Store<StateWithStock>) {
+    // Intentional empty constructor
+  }
 
   stockLevelAtStore(_productCode: string, _storeName: string): void {}
 

--- a/feature-libs/pickup-in-store/core/facade/pickup-locations-search.service.ts
+++ b/feature-libs/pickup-in-store/core/facade/pickup-locations-search.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { PointOfService, PointOfServiceStock, Stock } from '@spartacus/core';

--- a/feature-libs/pickup-in-store/core/facade/pickup-locations-search.service.ts
+++ b/feature-libs/pickup-in-store/core/facade/pickup-locations-search.service.ts
@@ -32,7 +32,9 @@ export class PickupLocationsSearchService
 {
   constructor(
     protected readonly store: Store<StateWithStock & StateWithPickupLocations>
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   stockLevelAtStore(productCode: string, storeName: string): void {
     this.store.dispatch(

--- a/feature-libs/pickup-in-store/core/index.ts
+++ b/feature-libs/pickup-in-store/core/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './config/index';
 export * from './connectors/index';
 export * from './facade/index';

--- a/feature-libs/pickup-in-store/core/pickup-in-store-core.module.ts
+++ b/feature-libs/pickup-in-store/core/pickup-in-store-core.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NgModule } from '@angular/core';
 import { provideDefaultConfig } from '@spartacus/core';
 import { defaultPickupInStoreConfig } from './config/index';

--- a/feature-libs/pickup-in-store/core/public_api.ts
+++ b/feature-libs/pickup-in-store/core/public_api.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './index';

--- a/feature-libs/pickup-in-store/core/services/index.ts
+++ b/feature-libs/pickup-in-store/core/services/index.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './preferred-store.service';

--- a/feature-libs/pickup-in-store/core/services/preferred-store.service.ts
+++ b/feature-libs/pickup-in-store/core/services/preferred-store.service.ts
@@ -31,7 +31,9 @@ export class PreferredStoreService implements OnDestroy {
     protected readonly consentService: ConsentService,
     protected config: PickupInStoreConfig,
     protected readonly winRef: WindowRef
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   /**
    * Gets the user's preferred store for Pickup in Store.

--- a/feature-libs/pickup-in-store/core/services/preferred-store.service.ts
+++ b/feature-libs/pickup-in-store/core/services/preferred-store.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable, OnDestroy } from '@angular/core';
 import {
   ConsentService,

--- a/feature-libs/pickup-in-store/core/store/actions/browser-location.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/browser-location.action.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createAction, props } from '@ngrx/store';
 
 export const ADD_BROWSER_LOCATION = '[Pickup Locations] Add Browser Location';

--- a/feature-libs/pickup-in-store/core/store/actions/hide-out-of-stock.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/hide-out-of-stock.action.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createAction } from '@ngrx/store';
 
 export const TOGGLE_HIDE_OUT_OF_STOCK_OPTIONS =

--- a/feature-libs/pickup-in-store/core/store/actions/index.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './hide-out-of-stock.action';
 import * as PickupLocationActions from './pickup-location.action';
 import * as StockLevelActions from './stock.action';

--- a/feature-libs/pickup-in-store/core/store/actions/pickup-location.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/pickup-location.action.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createAction, props } from '@ngrx/store';
 import { PointOfService } from '@spartacus/core';
 import {

--- a/feature-libs/pickup-in-store/core/store/actions/stock.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/stock.action.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createAction, props } from '@ngrx/store';
 import { StateUtils, Stock, StoreFinderStockSearchPage } from '@spartacus/core';
 import { StockLocationSearchParams } from '@spartacus/pickup-in-store/root';

--- a/feature-libs/pickup-in-store/core/store/effects/index.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { PickupLocationEffect } from './pickup-location.effect';
 import { StockEffect } from './stock.effect';
 

--- a/feature-libs/pickup-in-store/core/store/effects/pickup-location.effect.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/pickup-location.effect.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { normalizeHttpError } from '@spartacus/core';

--- a/feature-libs/pickup-in-store/core/store/effects/pickup-location.effect.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/pickup-location.effect.ts
@@ -8,7 +8,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { normalizeHttpError } from '@spartacus/core';
 import { of } from 'rxjs';
-import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 import { PickupLocationConnector } from '../../connectors';
 import * as PickupLocationActions from '../actions/pickup-location.action';
 
@@ -31,7 +31,6 @@ export class PickupLocationEffect {
       ),
       switchMap((storeName) =>
         this.pickupLocationConnector.getStoreDetails(storeName).pipe(
-          tap((storeDetails) => console.log('Debugg effect :', storeDetails)),
           map((storeDetails) =>
             PickupLocationActions.SetStoreDetailsSuccess({
               payload: storeDetails,

--- a/feature-libs/pickup-in-store/core/store/effects/pickup-location.effect.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/pickup-location.effect.ts
@@ -17,7 +17,9 @@ export class PickupLocationEffect {
   constructor(
     private readonly actions$: Actions,
     private readonly pickupLocationConnector: PickupLocationConnector
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   storeDetails$ = createEffect(() =>
     this.actions$.pipe(

--- a/feature-libs/pickup-in-store/core/store/effects/stock.effect.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/stock.effect.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { normalizeHttpError } from '@spartacus/core';

--- a/feature-libs/pickup-in-store/core/store/effects/stock.effect.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/stock.effect.ts
@@ -17,7 +17,9 @@ export class StockEffect {
   constructor(
     private readonly actions$: Actions,
     private readonly stockConnector: StockConnector
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   loadStockLevels$ = createEffect(() =>
     this.actions$.pipe(

--- a/feature-libs/pickup-in-store/core/store/index.ts
+++ b/feature-libs/pickup-in-store/core/store/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './actions/index';
 export * from './effects/index';
 export * from './reducers/index';

--- a/feature-libs/pickup-in-store/core/store/pickup-in-store-store.module.ts
+++ b/feature-libs/pickup-in-store/core/store/pickup-in-store-store.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 

--- a/feature-libs/pickup-in-store/core/store/pickup-location-state.ts
+++ b/feature-libs/pickup-in-store/core/store/pickup-location-state.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { PointOfService } from '@spartacus/core';
 import { AugmentedPointOfService } from '@spartacus/pickup-in-store/root';
 

--- a/feature-libs/pickup-in-store/core/store/reducers/index.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './pickup-locations/index';
 export * from './stock/index';

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/index.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { InjectionToken, Provider } from '@angular/core';
 import { ActionReducerMap, MetaReducer } from '@ngrx/store';
 

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/pickup-locations.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/pickup-locations.reducer.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createReducer, on } from '@ngrx/store';
 import { PickupLocationActions } from '../../actions';
 import { PickupLocationsState } from '../../pickup-location-state';

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/store-details.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/store-details.reducer.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createReducer, on } from '@ngrx/store';
 import { PickupLocationActions } from '../../actions';
 import { PickupLocationsState } from '../../pickup-location-state';

--- a/feature-libs/pickup-in-store/core/store/reducers/stock/browser-location.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/stock/browser-location.reducer.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createReducer, on } from '@ngrx/store';
 import { BrowserLocationActions } from '../../actions/index';
 import { StockState } from '../../stock-state';

--- a/feature-libs/pickup-in-store/core/store/reducers/stock/hide-out-of-stock.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/stock/hide-out-of-stock.reducer.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createReducer, on } from '@ngrx/store';
 import { ToggleHideOutOfStockOptionsAction } from '../../actions/index';
 import { StockState } from '../../stock-state';

--- a/feature-libs/pickup-in-store/core/store/reducers/stock/index.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/stock/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { InjectionToken, Provider } from '@angular/core';
 import {
   Action,

--- a/feature-libs/pickup-in-store/core/store/reducers/stock/stock-level.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/stock/stock-level.reducer.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Action, createAction, createReducer, on, props } from '@ngrx/store';
 import { StockLevelActions } from '../../actions/index';
 import { StockLevelSuccessPayload } from '../../actions/stock.action';

--- a/feature-libs/pickup-in-store/core/store/selectors/feature.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/feature.selectors.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createFeatureSelector, MemoizedSelector } from '@ngrx/store';
 import {
   PickupLocationsState,

--- a/feature-libs/pickup-in-store/core/store/selectors/hide-out-of-stock.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/hide-out-of-stock.selectors.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createSelector, MemoizedSelector } from '@ngrx/store';
 import { StateWithStock, StockState } from '../stock-state';
 import { getStockState } from './feature.selectors';

--- a/feature-libs/pickup-in-store/core/store/selectors/index.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as HideOutOfStockSelectors from './hide-out-of-stock.selectors';
 import * as PickupLocationsSelectors from './pickup-locations.selectors';
 import * as StockSelectors from './stock.selectors';

--- a/feature-libs/pickup-in-store/core/store/selectors/pickup-locations.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/pickup-locations.selectors.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createSelector, MemoizedSelector } from '@ngrx/store';
 import { PointOfService } from '@spartacus/core';
 import {

--- a/feature-libs/pickup-in-store/core/store/selectors/stock.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/stock.selectors.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createSelector, MemoizedSelector } from '@ngrx/store';
 import { PointOfServiceStock, StateUtils, Stock } from '@spartacus/core';
 import { storeHasStock } from '../../utils';

--- a/feature-libs/pickup-in-store/core/store/stock-state.ts
+++ b/feature-libs/pickup-in-store/core/store/stock-state.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { StateUtils, Stock, StoreFinderStockSearchPage } from '@spartacus/core';
 
 export const STOCK_FEATURE = 'stock';

--- a/feature-libs/pickup-in-store/core/utils/index.ts
+++ b/feature-libs/pickup-in-store/core/utils/index.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './utils';

--- a/feature-libs/pickup-in-store/core/utils/utils.ts
+++ b/feature-libs/pickup-in-store/core/utils/utils.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { PointOfServiceStock } from '@spartacus/core';
 
 export function storeHasStock({ stockInfo }: PointOfServiceStock): boolean {

--- a/feature-libs/pickup-in-store/occ/adapters/default-occ-pickup-location-config.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/default-occ-pickup-location-config.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { OccConfig } from '@spartacus/core';
 
 /**

--- a/feature-libs/pickup-in-store/occ/adapters/default-occ-stock-config.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/default-occ-stock-config.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { OccConfig } from '@spartacus/core';
 
 /**

--- a/feature-libs/pickup-in-store/occ/adapters/index.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './default-occ-stock-config';
 export * from './occ-stock.adapter';
 export * from './occ-pickup-location.adapter';

--- a/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
@@ -15,7 +15,9 @@ export class OccPickupLocationAdapter implements PickupLocationAdapter {
   constructor(
     protected http: HttpClient,
     protected occEndpointsService: OccEndpointsService
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   getStoreDetails(storeName: string): Observable<PointOfService> {
     return this.http.get<PointOfService>(

--- a/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { OccEndpointsService, PointOfService } from '@spartacus/core';

--- a/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {

--- a/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
@@ -23,7 +23,9 @@ export class OccStockAdapter implements StockAdapter {
   constructor(
     protected http: HttpClient,
     protected occEndpointsService: OccEndpointsService
-  ) {}
+  ) {
+    // Intentional empty constructor
+  }
 
   loadStockLevels(
     productCode: string,

--- a/feature-libs/pickup-in-store/occ/index.ts
+++ b/feature-libs/pickup-in-store/occ/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './adapters/index';
 export * from './pickup-in-store-occ.module';
 export * from './model/index';

--- a/feature-libs/pickup-in-store/occ/model/index.ts
+++ b/feature-libs/pickup-in-store/occ/model/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Imported for side effects (module augmentation)
 import './occ-stock-endpoints.model';
 import './occ-pickup-location-endpoints.model';

--- a/feature-libs/pickup-in-store/occ/model/occ-pickup-location-endpoints.model.ts
+++ b/feature-libs/pickup-in-store/occ/model/occ-pickup-location-endpoints.model.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { OccEndpoint } from '@spartacus/core';
 
 declare module '@spartacus/core' {

--- a/feature-libs/pickup-in-store/occ/model/occ-stock-endpoints.model.ts
+++ b/feature-libs/pickup-in-store/occ/model/occ-stock-endpoints.model.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { OccEndpoint } from '@spartacus/core';
 
 declare module '@spartacus/core' {

--- a/feature-libs/pickup-in-store/occ/pickup-in-store-occ.module.ts
+++ b/feature-libs/pickup-in-store/occ/pickup-in-store-occ.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NgModule } from '@angular/core';
 import { provideDefaultConfig } from '@spartacus/core';
 import {

--- a/feature-libs/pickup-in-store/occ/public_api.ts
+++ b/feature-libs/pickup-in-store/occ/public_api.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './index';

--- a/feature-libs/pickup-in-store/pickup-in-store.module.ts
+++ b/feature-libs/pickup-in-store/pickup-in-store.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NgModule } from '@angular/core';
 import { PickupInStoreComponentsModule } from '@spartacus/pickup-in-store/components';
 import { PickupInStoreCoreModule } from '@spartacus/pickup-in-store/core';

--- a/feature-libs/pickup-in-store/public_api.ts
+++ b/feature-libs/pickup-in-store/public_api.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /**
  * Public API surface of pickup-in-store
  */

--- a/feature-libs/pickup-in-store/root/facade/cart.facade.ts
+++ b/feature-libs/pickup-in-store/root/facade/cart.facade.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { facadeFactory } from '@spartacus/core';
 import { PICKUP_IN_STORE_CORE_FEATURE } from '../feature-name';

--- a/feature-libs/pickup-in-store/root/facade/index.ts
+++ b/feature-libs/pickup-in-store/root/facade/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './intended-pickup-location.facade';
 export * from './pickup-locations-search.facade';
 export * from './cart.facade';

--- a/feature-libs/pickup-in-store/root/facade/intended-pickup-location.facade.ts
+++ b/feature-libs/pickup-in-store/root/facade/intended-pickup-location.facade.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { facadeFactory } from '@spartacus/core';
 import { Observable } from 'rxjs';

--- a/feature-libs/pickup-in-store/root/facade/pickup-locations-search.facade.ts
+++ b/feature-libs/pickup-in-store/root/facade/pickup-locations-search.facade.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import {
   facadeFactory,

--- a/feature-libs/pickup-in-store/root/feature-name.ts
+++ b/feature-libs/pickup-in-store/root/feature-name.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /** pickup-in-store feature name. */
 export const PICKUP_IN_STORE_FEATURE = 'pickupInStore';
 /** pickup-in-store core feature name. */

--- a/feature-libs/pickup-in-store/root/index.ts
+++ b/feature-libs/pickup-in-store/root/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './facade/index';
 export * from './feature-name';
 export * from './model/index';

--- a/feature-libs/pickup-in-store/root/model/augmented-core.model.ts
+++ b/feature-libs/pickup-in-store/root/model/augmented-core.model.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import '@spartacus/storefront';
 
 declare module '@spartacus/storefront' {

--- a/feature-libs/pickup-in-store/root/model/index.ts
+++ b/feature-libs/pickup-in-store/root/model/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './augmented-core.model';
 export * from './pickup-option.model';
 export * from './stock-location-search-params.model';

--- a/feature-libs/pickup-in-store/root/model/pickup-option.model.ts
+++ b/feature-libs/pickup-in-store/root/model/pickup-option.model.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { PointOfService } from '@spartacus/core';
 
 /** The options for receiving a product, either 'delivery' or 'pickup'. */

--- a/feature-libs/pickup-in-store/root/model/stock-location-search-params.model.ts
+++ b/feature-libs/pickup-in-store/root/model/stock-location-search-params.model.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /** The latitude and longitude of the user for searching for a location. */
 type BrowserLocationSearchParameters = {
   latitude: number;

--- a/feature-libs/pickup-in-store/root/pickup-in-store-constants.ts
+++ b/feature-libs/pickup-in-store/root/pickup-in-store-constants.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /** The used for storing the name of the user's preferred store in browser local storage. */
 export const PREFERRED_STORE_LOCAL_STORAGE_KEY = 'preferred_store';

--- a/feature-libs/pickup-in-store/root/pickup-in-store-root.module.ts
+++ b/feature-libs/pickup-in-store/root/pickup-in-store-root.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NgModule } from '@angular/core';
 import { CmsConfig, provideDefaultConfigFactory } from '@spartacus/core';
 

--- a/feature-libs/pickup-in-store/root/public_api.ts
+++ b/feature-libs/pickup-in-store/root/public_api.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './index';

--- a/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index.ts
+++ b/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   chain,
   Rule,

--- a/feature-libs/pickup-in-store/test-jest.ts
+++ b/feature-libs/pickup-in-store/test-jest.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import 'zone.js/fesm2015/zone-testing-bundle.min.js';
 import { getTestBed } from '@angular/core/testing';
 import {

--- a/feature-libs/pickup-in-store/test.ts
+++ b/feature-libs/pickup-in-store/test.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 // Zone.js and zone.js/testing should be imported as FIRST and in this ORDER:

--- a/pre-push checklist.md
+++ b/pre-push checklist.md
@@ -1,6 +1,7 @@
 # Pre-push checklist
 
 - [ ] `yarn install`
+- [ ] `./ci-scripts/prepend-license.sh`
 - [ ] `yarn prettier:fix`
 - [ ] `yarn lint:styles`
 - [ ] `yarn i18n-lint`
@@ -11,4 +12,11 @@
 - [ ] `./ci-scripts/lhci.sh` (warning: slow, ~12 minutes)
 - [ ] If schematics have been updated: `yarn --cwd feature-libs/pickup-in-store run test:schematics --coverage=true`
 
-N.B. If we have changed other feature libraries we should run the unit tests for those in a similar fashion. i.e. `ng test <library>` etc.
+## `./ci-scripts/prepend-license.sh` prerequisites
+
+1. Install pipx - <https://pypa.github.io/pipx/>
+2. Install reuse - `pipx install reuse` (<https://github.com/fsfe/reuse-tool>)
+
+## Unit Tests
+
+If we have changed other feature libraries we should run the unit tests for those in a similar fashion. i.e. `ng test <library>` etc.

--- a/projects/schematics/src/shared/lib-configs/pickup-in-store-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/pickup-in-store-schematics-config.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   CART_BASE_FEATURE_NAME,
   PICKUP_IN_STORE_FEATURE_NAME,

--- a/projects/storefrontapp/src/app/spartacus/features/cart/cart-base-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cart/cart-base-wrapper.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NgModule, Type } from '@angular/core';
 import { CartBaseModule } from '@spartacus/cart/base';
 import { PickupInStoreCartModule } from '@spartacus/pickup-in-store/cart';

--- a/projects/storefrontapp/src/app/spartacus/features/pickup-in-store/pickup-in-store-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/pickup-in-store/pickup-in-store-feature.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NgModule } from '@angular/core';
 import { provideConfig } from '@spartacus/core';
 import { PickupInStoreModule } from '@spartacus/pickup-in-store';


### PR DESCRIPTION
To ensure that we have no SonarQube issues relating to licences, we need copyright headers for all our `ts` files. These are generated with the `./ci-scripts/prepend-license.sh` script.

Additionally, SonarQube highlights empty constructors as a code smell, so we are adding comments to them to indicate we intend for them to be empty.

Finally, remove some debug statements.