### PR TITLE
CXSPA-12 [BOPIS] Correct item count in mini cart

### DIFF
--- a/feature-libs/cart/base/components/mini-cart/mini-cart-component.service.spec.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart-component.service.spec.ts
@@ -314,7 +314,7 @@ describe('MiniCartComponentService', () => {
         cold('(t|)', booleanValues)
       );
       const mockActiveCart = {
-        deliveryItemsQuantity: 7,
+        totalUnitCount: 7,
       } as Partial<Cart>;
 
       spyOn(activeCartFacade, 'getActive').and.returnValue(

--- a/feature-libs/cart/base/components/mini-cart/mini-cart-component.service.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart-component.service.ts
@@ -36,7 +36,7 @@ export class MiniCartComponentService {
   ) {}
 
   /**
-   * This function supports lazy loading of the cart functoinality's code. We only call
+   * This function supports lazy loading of the cart functionality's code. We only call
    * the activeCartFacade if we know there is actually a cart.
    * Without a cart, we can return a default value and
    * avoid loading the cart library code.
@@ -46,8 +46,8 @@ export class MiniCartComponentService {
       switchMap((activeCartRequired) => {
         if (activeCartRequired) {
           return this.activeCartFacade.getActive().pipe(
-            startWith({ deliveryItemsQuantity: 0 }),
-            map((cart) => cart.deliveryItemsQuantity || 0)
+            startWith({ totalUnitCount: 0 }),
+            map((cart) => cart.totalUnitCount || 0)
           );
         } else {
           return of(0);
@@ -57,7 +57,7 @@ export class MiniCartComponentService {
   }
 
   /**
-   * This function supports lazy loading of the cart functoinality's code. We only call
+   * This function supports lazy loading of the cart functionality's code. We only call
    * the activeCartFacade if we know there is actually a cart.
    * Without a cart, we can return a default value and
    * avoid loading the cart library code.


### PR DESCRIPTION
The original implementation of the mini-cart component only counted
products being delivered. Using the total unit count also includes items
being picked up too.

CXSPA-12