### PR TITLE
Converted Webpack aliases to fallbacks and fixed the module type of storefinder

### DIFF
--- a/extra-webpack.config.js
+++ b/extra-webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
     }),
   ],
   resolve: {
-    alias: {
+    fallback: {
       '@spartacus/styles': path.join(__dirname, 'projects/storefrontstyles'),
       '@spartacus/user': path.join(__dirname, 'feature-libs/user'),
       '@spartacus/organization': path.join(

--- a/feature-libs/storefinder/assets/ng-package.json
+++ b/feature-libs/storefinder/assets/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
     "entryFile": "./public_api.ts"
   }

--- a/feature-libs/storefinder/components/ng-package.json
+++ b/feature-libs/storefinder/components/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
     "entryFile": "./public_api.ts"
   }

--- a/feature-libs/storefinder/core/ng-package.json
+++ b/feature-libs/storefinder/core/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
     "entryFile": "./public_api.ts"
   }

--- a/feature-libs/storefinder/occ/ng-package.json
+++ b/feature-libs/storefinder/occ/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
     "entryFile": "./public_api.ts"
   }

--- a/feature-libs/storefinder/root/ng-package.json
+++ b/feature-libs/storefinder/root/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
     "entryFile": "./public_api.ts"
   }

--- a/feature-libs/storefinder/tsconfig.lib.json
+++ b/feature-libs/storefinder/tsconfig.lib.json
@@ -4,7 +4,7 @@
     "outDir": "../../out-tsc/lib",
     "declarationMap": true,
     "target": "es2020",
-    "module": "NodeNext",
+    "module": "es2020",
     "moduleResolution": "node",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
The custom Webpack configuration included some resolution aliases for style imports. These aliases were causing module resolution errors. Converting them to fallbacks make them still available, but only when normal resolution fails. You may read about it [here](https://webpack.js.org/configuration/resolve/#resolvefallback).

The compiler was not able to load any storefinder modules because the module type was set to`NodeNext`. Setting it back to `es2020` fixes that.

The ng-package.json schema paths are just bonus. 🙂