### PR TITLE
Feature/cxspa 827 - SanityCheck to prevent wrong angular cli version

### DIFF
--- a/scripts/install/functions.sh
+++ b/scripts/install/functions.sh
@@ -392,7 +392,6 @@ function run_sanity_check {
     else
         printh "Run config sanity check"
         ng_sanity_check
-        basesite_sanity_check
     fi
 }
 

--- a/scripts/install/run.sh
+++ b/scripts/install/run.sh
@@ -46,13 +46,16 @@ fi
 
 CLONE_DIR="${BASE_DIR}/${CLONE_DIR}"
 INSTALLATION_DIR="${BASE_DIR}/${INSTALLATION_DIR}"
+SKIP_SANITY=false
 
 for current_command in $(echo "${commands}" | tr "+" "\n"); do
 
     case "${current_command}" in
         'install' )
+            parseInstallArgs $@
             install_from_sources;;
         'install_npm' )
+            parseInstallArgs $@
             install_from_npm;;
         'start' )
             start_apps;;


### PR DESCRIPTION
A sanity check of the install configuration runs before the installation to check if specified spartacus version and angular cli version are compatible. 