### PR TITLE
fix(CDC): handle error states in forms

### DIFF
--- a/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.ts
+++ b/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.ts
@@ -26,6 +26,11 @@ export class CdcLoginFormComponentService
   protected subscription: Subscription = new Subscription();
 
   login() {
+    if (!this.form.valid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
     this.busy$.next(true);
     this.subscription.add(
       this.cdcJsService.didLoad().subscribe((cdcLoaded) => {

--- a/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.ts
+++ b/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.ts
@@ -42,7 +42,10 @@ export class CdcLoginFormComponentService
               this.form.value.password,
               true
             )
-            .subscribe(() => this.busy$.next(false));
+            .subscribe({
+              next: () => this.busy$.next(false),
+              error: () => this.busy$.next(false),
+            });
         } else {
           // CDC Gigya SDK not loaded, show error to the user
           this.globalMessageService.add(

--- a/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.ts
+++ b/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.ts
@@ -49,11 +49,14 @@ export class CDCForgotPasswordComponentService
           // Reset password using CDC Gigya SDK
           this.cdcJsService
             .resetPasswordWithoutScreenSet(this.form.value.userEmail)
-            .subscribe((response) => {
-              this.busy$.next(false);
-              if (response.status === 'OK') {
-                this.redirect();
-              }
+            .subscribe({
+              next: (response) => {
+                this.busy$.next(false);
+                if (response.status === 'OK') {
+                  this.redirect();
+                }
+              },
+              error: () => this.busy$.next(false),
             });
         } else {
           this.busy$.next(false);


### PR DESCRIPTION
- prevent submitting the login form when the form is invalid
- enable form back, after unsuccessful login
- enable form back, after unsuccessful forgot-password

sub-PR for https://github.com/SAP/spartacus/pull/15785