### PR TITLE
docs: Update link for wrapper modules

### DIFF
--- a/projects/schematics/README.md
+++ b/projects/schematics/README.md
@@ -44,7 +44,7 @@ Here are some terms you might hear or find in the code:
 
 - Spartacus library vs. Spartacus feature - a library is a top-level Spartacus library (e.g. `@spartacus/checkout`). A feature is contained withing that library, and it could have its own secondary entry-point (e.g. `@spartacus/checkout/base`). Feature usually have their own menu item in the schematics prompt.
 
-- "wrapper" modules - refers to our feature extension mechanism, as described [here](https://github.com/SAP/spartacus/pull/15237) (_note_: the link might be moved to the Wiki, so please check there by searching for "wrapper module". Additionally, please notify us to update the link in this file).
+- "wrapper" modules - refers to our feature extension mechanism, as described [here](https://wiki.one.int.sap/wiki/x/bwAfsw) and [here](https://wiki.one.int.sap/wiki/x/PJhbsQ).
 
 ### Preparing setup
 

--- a/projects/schematics/README.md
+++ b/projects/schematics/README.md
@@ -44,7 +44,7 @@ Here are some terms you might hear or find in the code:
 
 - Spartacus library vs. Spartacus feature - a library is a top-level Spartacus library (e.g. `@spartacus/checkout`). A feature is contained withing that library, and it could have its own secondary entry-point (e.g. `@spartacus/checkout/base`). Feature usually have their own menu item in the schematics prompt.
 
-- "wrapper" modules - refers to our feature extension mechanism, as described [here](https://wiki.one.int.sap/wiki/x/bwAfsw) and [here](https://wiki.one.int.sap/wiki/x/PJhbsQ).
+- "wrapper" modules - refers to our feature extension mechanism, as described [here](https://wiki.one.int.sap/wiki/x/bwAfsw) and mentioned [in schematics ADR](https://wiki.one.int.sap/wiki/x/PJhbsQ).
 
 ### Preparing setup
 


### PR DESCRIPTION
Updated schematics README to include the links to:
- wrapper schematics
- a guide about installing extensions for lazy loaded features