### PR TITLE
feat: automate the process of bumping package versions for publishing

### DIFF
--- a/tools/config/const.ts
+++ b/tools/config/const.ts
@@ -10,3 +10,4 @@ export const SPARTACUS_SCOPE = '@spartacus';
 export const SAP_SCOPE = 'sap';
 export const SAPUI5_TYPES = '@sapui5/ts-types-esm';
 export const SPARTACUS_SCHEMATICS = `${SPARTACUS_SCOPE}/schematics`;
+export const PUBLISHING_VERSION = '';

--- a/tools/config/manage-dependencies.ts
+++ b/tools/config/manage-dependencies.ts
@@ -222,6 +222,7 @@ export function manageDependencies(
       return acc;
     }, {});
 
+    // If publishing version is defined, update the publishing versions of packages
     if (PUBLISHING_VERSION) {
       updatePublishingVersions(libraries, PUBLISHING_VERSION);
     }
@@ -1073,6 +1074,7 @@ function updateDependenciesVersions(
   Object.values(libraries).forEach((lib) => {
     const pathToPackageJson = `${lib.directory}/${PACKAGE_JSON}`;
     const packageJson = lib.packageJsonContent;
+    // If publishing version is defined, update the publishing versions of packages
     packageJson.version = PUBLISHING_VERSION ? PUBLISHING_VERSION : packageJson.version;
     const types = [
       'dependencies',

--- a/tools/config/manage-dependencies.ts
+++ b/tools/config/manage-dependencies.ts
@@ -222,10 +222,10 @@ export function manageDependencies(
       return acc;
     }, {});
 
-    // If publishing version is defined, update the publishing versions of packages
-    if (PUBLISHING_VERSION) {
-      updatePublishingVersions(libraries, PUBLISHING_VERSION);
-    }
+  // If publishing version is defined, update the publishing versions of packages
+  if (PUBLISHING_VERSION) {
+    updatePublishingVersions(libraries, PUBLISHING_VERSION);
+  }
 
   // Check where imports are used (spec, lib, schematics, schematics spec)
   categorizeUsageOfDependencies(libraries);

--- a/tools/config/manage-dependencies.ts
+++ b/tools/config/manage-dependencies.ts
@@ -28,6 +28,7 @@ import semver from 'semver';
 import ts from 'typescript';
 import {
   PACKAGE_JSON,
+  PUBLISHING_VERSION,
   SAPUI5_TYPES,
   SAP_SCOPE,
   SPARTACUS_SCHEMATICS,
@@ -220,6 +221,10 @@ export function manageDependencies(
       acc[curr.name] = curr;
       return acc;
     }, {});
+
+    if (PUBLISHING_VERSION) {
+      updatePublishingVersions(libraries, PUBLISHING_VERSION);
+    }
 
   // Check where imports are used (spec, lib, schematics, schematics spec)
   categorizeUsageOfDependencies(libraries);
@@ -476,6 +481,18 @@ function filterLocalAbsolutePathFiles(
       success();
     }
   }
+}
+
+/**
+ * Update the publishing versions for packages
+ */
+ function updatePublishingVersions(
+  libraries: Record<string, LibraryWithDependencies>,
+  version: string
+): void{
+  Object.values(libraries).map((library) => {
+    library.version = version;
+  });
 }
 
 /**
@@ -1056,6 +1073,7 @@ function updateDependenciesVersions(
   Object.values(libraries).forEach((lib) => {
     const pathToPackageJson = `${lib.directory}/${PACKAGE_JSON}`;
     const packageJson = lib.packageJsonContent;
+    packageJson.version = PUBLISHING_VERSION ? PUBLISHING_VERSION : packageJson.version;
     const types = [
       'dependencies',
       'peerDependencies',


### PR DESCRIPTION
closes: https://jira.tools.sap/browse/CXSPA-853

**Basic test cases**

Test 1:

1. Set a value for PUBLISHING_VERSION in spartacus/tools/config/const.ts
2. Run yarn config:update -> it should update the publishing version as well as dependency versions to the value you set

Test 2:

1. Keep the value empty for PUBLISHING_VERSION in spartacus/tools/config/const.ts
2. Run yarn config:update -> it should not update the publishing version or dependency versions

Test 3:

1. Update the publishing version for @spartacus/core in its package.json (update line 3 to any different number)
2. Run yarn config:update -> it should update @spartacus/core in other package.jsons such as checkout (this makes sure the previous feature still works)