### PR TITLE
prevent xss attacks on JSon-LD by escaping html tags

### DIFF
--- a/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.spec.ts
@@ -14,7 +14,7 @@ function createTestComponent(
   }).createComponent(TestComponent);
 }
 
-describe('JsonLdDirective', () => {
+fdescribe('JsonLdDirective', () => {
   let fixture: ComponentFixture<any>;
 
   afterEach(() => {
@@ -51,14 +51,19 @@ describe('JsonLdDirective', () => {
     expect(fixture.nativeElement.innerHTML).not.toContain('<script');
   });
 
-  // a single test for sanitization as more tests are created in the json-ld script factort
-  it('should sanitize malicious code', () => {
+  it('should encode malicious html code', () => {
     const template = `<span [cxJsonLd]="{foo: 'bar<script>alert(1)</script>'}">hello</span>`;
     spyOn(console, 'warn').and.stub();
     fixture = createTestComponent(template);
     fixture.detectChanges();
-    expect(fixture.nativeElement.innerHTML).toContain(
-      '<script type="application/ld+json">{"foo":"bar"}</script>'
-    );
+    expect(fixture.nativeElement.innerHTML).toContain('&lt;script&gt;');
+  });
+
+  it('should encode deep nested malicious html code', () => {
+    const template = `<span [cxJsonLd]="[{ foo: { bar: { deep: 'before <script>alert()</script>and after' } }},]"></span>`;
+    spyOn(console, 'warn').and.stub();
+    fixture = createTestComponent(template);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerHTML).toContain('&lt;script&gt;');
   });
 });

--- a/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.spec.ts
@@ -14,7 +14,7 @@ function createTestComponent(
   }).createComponent(TestComponent);
 }
 
-fdescribe('JsonLdDirective', () => {
+describe('JsonLdDirective', () => {
   let fixture: ComponentFixture<any>;
 
   afterEach(() => {

--- a/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Directive, HostBinding, Input } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
 import { JsonLdScriptFactory } from './json-ld-script.factory';
 
 /**
@@ -27,25 +26,27 @@ export class JsonLdDirective {
    * Writes the schema data to a json-ld script element.
    */
   @Input() set cxJsonLd(schema: string | {}) {
-    this.jsonLD = this.generateJsonLdScript(schema);
+    this.generateJsonLdScript(schema);
   }
 
-  @HostBinding('innerHTML') jsonLD: SafeHtml | undefined;
-
   constructor(
+    private renderer: Renderer2,
     protected jsonLdScriptFactory: JsonLdScriptFactory,
-    protected sanitizer: DomSanitizer
+    private element: ElementRef
   ) {}
 
   /**
-   * Returns the json-ld script tag with the schema data. The script is
-   * _bypassing_ sanitization explicitly.
+   * attach the json-ld script tag to DOM with the schema data. To avoid xss attacks, HTMl tags within schema data are encoded (aka escaping)
    */
-  protected generateJsonLdScript(schema: string | {}): SafeHtml | undefined {
+  protected generateJsonLdScript(schema: string | {}) {
     if (schema && this.jsonLdScriptFactory.isJsonLdRequired()) {
-      const sanitizedSchema = this.jsonLdScriptFactory.sanitize(schema);
-      const html = `<script type="application/ld+json">${sanitizedSchema}</script>`;
-      return this.sanitizer.bypassSecurityTrustHtml(html);
+      const div: HTMLDivElement = this.renderer.createElement('div');
+      const script: HTMLScriptElement = this.renderer.createElement('script');
+      script.type = 'application/ld+json';
+      div.textContent = JSON.stringify(schema);
+      script.textContent = div.innerHTML;
+      this.renderer.appendChild(div, script);
+      this.renderer.appendChild(this.element.nativeElement, script);
     }
   }
 }


### PR DESCRIPTION
XSS attacks are prevented by escaping HTML code.
JSON-LD standard recommends 'escaping', see https://www.w3.org/TR/json-ld/#restrictions-for-contents-of-json-ld-script-elements
Same technic was used on similar issue for icon-loader: https://github.com/SAP/spartacus/pull/16190