### PR TITLE
fix: prevent two forms to be rendered at same time

### DIFF
--- a/projects/storefrontlib/cms-components/myaccount/address-book/address-book.component.html
+++ b/projects/storefrontlib/cms-components/myaccount/address-book/address-book.component.html
@@ -43,7 +43,12 @@
     </div>
   </ng-container>
 
-  <ng-container *ngIf="!(addresses$ | async)?.length || showAddAddressForm">
+  <ng-container
+    *ngIf="
+      (!(addresses$ | async)?.length || showAddAddressForm) &&
+      !showEditAddressForm
+    "
+  >
     <section>
       <p class="cx-section-msg">
         {{ 'addressBook.addNewDeliveryAddress' | cxTranslate }}


### PR DESCRIPTION
Same as PR https://github.com/SAP/spartacus/pull/16256 for 5.0 branch

Jira: [CXSPA-1325](https://jira.tools.sap/browse/CXSPA-1325)
issue:
App frozen after logout during address edition in address book view
reason:
Issue was caused by the 2 forms (add and edit address) were rendered at the same time when logout, creating infinite loop in address-service.
fix:
	• Adjusted a condition in template to prevent 'Add address' form to be rendered at same time as 'Edit address
tests:
	• login, edit address, logout -> ok
login, add address, logout -> ok