### PR TITLE
v3 POC #15566 cxCartItemContext, fixed styling

### DIFF
--- a/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.ts
@@ -5,16 +5,10 @@
  */
 
 import { Component } from '@angular/core';
-import { CartItemContext } from '@spartacus/cart/base/root';
 import { CartItemComponent } from '../cart-item/cart-item.component';
-import { CartItemContextSource } from '../cart-item/model/cart-item-context-source.model';
 
 @Component({
   selector: '[cx-cart-item-list-row], cx-cart-item-list-row',
   templateUrl: './cart-item-list-row.component.html',
-  providers: [
-    CartItemContextSource,
-    { provide: CartItemContext, useExisting: CartItemContextSource },
-  ],
 })
 export class CartItemListRowComponent extends CartItemComponent {}

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info-row.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info-row.component.ts
@@ -10,11 +10,10 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'cx-configurator-cart-entry-bundle-info-row',
   template: `
-    <tr>
-      <td colspan="4">
-        <cx-configurator-cart-entry-bundle-info></cx-configurator-cart-entry-bundle-info>
-      </td>
-    </tr>
+    <td colspan="4">
+      <cx-configurator-cart-entry-bundle-info></cx-configurator-cart-entry-bundle-info>
+    </td>
   `,
+  host: { role: 'row' },
 })
 export class ConfiguratorCartEntryBundleInfoRowComponent {}

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
@@ -28,38 +28,24 @@
           <div class="cx-item-name" aria-hidden="true">
             {{ lineItem?.name }}
           </div>
-          <ng-container *ngIf="isDesktop() | async; else mobile">
-            <div class="cx-item-price" aria-hidden="true">
-              <span class="cx-item" *ngIf="lineItem?.formattedPrice">{{
-                lineItem?.formattedPrice
+          <div class="cx-item-quantity" aria-hidden="true">
+            <ng-container *ngIf="lineItem?.formattedQuantity">
+              <span class="cx-identifier">{{
+                'configurator.attribute.quantity' | cxTranslate
               }}</span>
-            </div>
-            <div class="cx-item-quantity" aria-hidden="true">
-              <span class="cx-item" *ngIf="lineItem?.formattedQuantity">{{
+              <span class="cx-item">{{
                 lineItem?.formattedQuantity | cxNumeric
               }}</span>
-            </div>
-          </ng-container>
-          <ng-template #mobile>
-            <div class="cx-item-quantity" aria-hidden="true">
-              <ng-container *ngIf="lineItem?.formattedQuantity">
-                <span class="cx-identifier">{{
-                  'configurator.attribute.quantity' | cxTranslate
-                }}</span>
-                <span class="cx-item">{{
-                  lineItem?.formattedQuantity | cxNumeric
-                }}</span>
-              </ng-container>
-            </div>
-            <div class="cx-item-price" aria-hidden="true">
-              <ng-container *ngIf="lineItem?.formattedPrice">
-                <span class="cx-identifier">{{
-                  'configurator.overviewForm.itemPrice' | cxTranslate
-                }}</span>
-                <span class="cx-item">{{ lineItem?.formattedPrice }}</span>
-              </ng-container>
-            </div>
-          </ng-template>
+            </ng-container>
+          </div>
+          <div class="cx-item-price" aria-hidden="true">
+            <ng-container *ngIf="lineItem?.formattedPrice">
+              <span class="cx-identifier">{{
+                'configurator.overviewForm.itemPrice' | cxTranslate
+              }}</span>
+              <span class="cx-item">{{ lineItem?.formattedPrice }}</span>
+            </ng-container>
+          </div>
         </div>
       </div>
     </ng-container>

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
@@ -82,6 +82,7 @@ export class ConfiguratorCartEntryBundleInfoComponent {
       : false;
   }
 
+  // SPIKE TODO: REMOVE:
   /**
    * Verifies whether the current screen size equals or is larger than breakpoint `BREAKPOINT.md`.
    *

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.module.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.module.ts
@@ -26,14 +26,7 @@ import { ConfiguratorCartEntryBundleInfoComponent } from './configurator-cart-en
 
   providers: [
     provideOutlet({
-      id: CartOutlets.LIST_ITEM,
-      position: OutletPosition.AFTER,
-      component: ConfiguratorCartEntryBundleInfoRowComponent,
-    }),
-
-    // SPIKE TODO: reuse the same component and outlet in added-to-cart.modal
-    provideOutlet({
-      id: CartOutlets.ITEM,
+      id: CartOutlets.ITEM_BUNDLE_DETAILS,
       position: OutletPosition.AFTER,
       component: ConfiguratorCartEntryBundleInfoComponent,
     }),

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification-row.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification-row.component.ts
@@ -10,11 +10,10 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'cx-configurator-issues-notification-row',
   template: `
-    <tr>
-      <td colspan="4">
-        <cx-configurator-issues-notification></cx-configurator-issues-notification>
-      </td>
-    </tr>
+    <td colspan="4">
+      <cx-configurator-issues-notification></cx-configurator-issues-notification>
+    </td>
   `,
+  host: { role: 'row' },
 })
 export class ConfiguratorIssuesNotificationRowComponent {}

--- a/feature-libs/product-configurator/common/styles/_configurator-cart-entry-bundle-info.scss
+++ b/feature-libs/product-configurator/common/styles/_configurator-cart-entry-bundle-info.scss
@@ -1,6 +1,10 @@
 // SPIKE NEW:
 cx-configurator-cart-entry-bundle-info-row {
-  display: contents;
+  display: table-row;
+
+  @include media-breakpoint-down(md) {
+    display: block;
+  }
 
   tr > td:nth-of-type(1) {
     padding: 0;

--- a/feature-libs/product-configurator/common/styles/_configurator-cart-entry-bundle-info.scss
+++ b/feature-libs/product-configurator/common/styles/_configurator-cart-entry-bundle-info.scss
@@ -58,17 +58,7 @@ cx-configurator-cart-entry-bundle-info-row {
       .cx-item-name {
         overflow-wrap: break-word;
 
-        @include media-breakpoint-down(sm) {
-          width: 100%;
-        }
-
-        @include media-breakpoint-up(md) {
-          width: 24%;
-        }
-
-        @include media-breakpoint-only(xl) {
-          width: 41.6%;
-        }
+        width: 100%;
       }
 
       .cx-item-price,
@@ -80,42 +70,17 @@ cx-configurator-cart-entry-bundle-info-row {
         }
 
         .cx-item {
-          @include media-breakpoint-only(xs) {
-            width: 55%;
-          }
-
-          @include media-breakpoint-only(sm) {
-            width: 85%;
-          }
+          // width: 100%
         }
 
-        @include media-breakpoint-down(sm) {
-          display: flex;
-          flex-direction: row;
-          width: 100%;
-        }
-
-        @include media-breakpoint-up(md) {
-          width: 26%;
-          text-align: center;
-        }
-      }
-
-      .cx-item-price {
-        @include media-breakpoint-only(xl) {
-          width: 17%;
-          text-align: center;
-        }
-      }
-
-      .cx-item-quantity {
-        @include media-breakpoint-only(xl) {
-          width: 26%;
-        }
+        display: flex;
+        flex-direction: row;
+        width: 100%;
       }
     }
   }
 
+  // SPIKE NEW:
   cx-cart-item & {
     padding-inline-start: 65px;
 

--- a/feature-libs/product-configurator/common/styles/_configurator-issues-notification.scss
+++ b/feature-libs/product-configurator/common/styles/_configurator-issues-notification.scss
@@ -1,8 +1,12 @@
 // SPIKE NEW:
 cx-configurator-issues-notification-row {
-  display: contents;
+  display: table-row;
 
-  tr > td:nth-of-type(1) {
+  @include media-breakpoint-down(md) {
+    display: block;
+  }
+
+  & > td:nth-of-type(1) {
     padding: 0;
   }
 }


### PR DESCRIPTION
Same as [v1 POC](https://github.com/SAP/spartacus/pull/16269/) plus:
- replace <tr> with actual outlet components, having CSS `display:table-row` and attribute `role='row'`

related to #15566 

Result:
> ![image](https://user-images.githubusercontent.com/4001059/196159343-33b7a52d-fe13-4cce-a5e3-dae35fdcd4a1.png)
