### PR TITLE
v4 POC #15566 cxCartItemContext, fixed styling 

### DIFF
--- a/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.html
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.html
@@ -40,7 +40,10 @@
         [options]="options"
       >
         <tbody>
-          <ng-template [cxOutlet]="CartOutlets.LIST_ITEM">
+          <ng-template
+            [cxOutlet]="CartOutlets.LIST_ITEM"
+            [cxOutletHtmlTag]="'tr'"
+          >
             <tr
               cx-cart-item-list-row
               role="row"

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification-row.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification-row.component.ts
@@ -14,6 +14,5 @@ import { Component } from '@angular/core';
       <cx-configurator-issues-notification></cx-configurator-issues-notification>
     </td>
   `,
-  host: { role: 'row' },
 })
 export class ConfiguratorIssuesNotificationRowComponent {}

--- a/feature-libs/product-configurator/common/styles/_configurator-issues-notification.scss
+++ b/feature-libs/product-configurator/common/styles/_configurator-issues-notification.scss
@@ -1,16 +1,3 @@
-// SPIKE NEW:
-cx-configurator-issues-notification-row {
-  display: table-row;
-
-  @include media-breakpoint-down(md) {
-    display: block;
-  }
-
-  & > td:nth-of-type(1) {
-    padding: 0;
-  }
-}
-
 %cx-configurator-issues-notification {
   display: none;
   width: 100%;
@@ -29,6 +16,10 @@ cx-configurator-issues-notification-row {
 
     margin-block-start: 1.25rem;
     margin-block-end: 1.25rem;
+
+    td > & {
+      margin: 0;
+    }
 
     cx-icon {
       align-self: flex-start;


### PR DESCRIPTION
Same as [v3 POC](https://github.com/SAP/spartacus/pull/16272/) plus:
- outlet components instantiated as `<tr>` elements (we need no more: CSS `display: table-row` and role=row)
- OutletDirective suport for instantiating compponents with a custom html tag - input `[cxOutletHtmlTag]="'tr'"`

related to #15566 