### PR TITLE
feature/cxspa-1474 add email address to the unit-level order history list

### DIFF
--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
@@ -116,8 +116,9 @@ const mockOrder: Order = {
     },
   } as CostCenter,
   orgCustomer: {
-    uid: 'gi.sun@rustic-hw.com',
+    uid: 'gi.sun@rustic-hw.com|powertools-standalone',
     name: 'Gi Sun',
+    email: 'gi.sun@rustic-hw.com',
   } as B2BUser,
   orgUnit: {
     name: 'Rustic',
@@ -125,8 +126,9 @@ const mockOrder: Order = {
 };
 
 const mockUnitOrderViewer: B2BUser = {
-  uid: 'gi.sun@rustic-hw.com',
+  uid: 'gi.sun@rustic-hw.com|powertools-standalone',
   name: 'Gi Sun',
+  email: 'gi.sun@rustic-hw.com',
   roles: [B2BUserRole.CUSTOMER, B2BUserRole.UNIT_LEVEL_ORDERS_VIEWER],
 };
 
@@ -538,7 +540,7 @@ describe('OrderOverviewComponent', () => {
           expect(data.title).toEqual('test');
           expect(data.text).toEqual([
             mockOrder.orgCustomer?.name,
-            '(' + mockOrder.orgCustomer?.uid + ')',
+            '(' + mockOrder.orgCustomer?.email + ')',
           ]);
         })
         .unsubscribe();

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
@@ -264,7 +264,7 @@ export class OrderOverviewComponent implements OnInit {
         (textTitle) =>
           ({
             title: textTitle,
-            text: [customer?.name, `(${customer?.uid})`],
+            text: [customer?.name, `(${customer?.email})`],
           } as Card)
       )
     );

--- a/feature-libs/organization/unit-order/_index.scss
+++ b/feature-libs/organization/unit-order/_index.scss
@@ -1,2 +1,2 @@
-@import '~@spartacus/styles/scss/core';
+@import '@spartacus/styles/scss/core';
 @import './styles/index';

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.html
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.html
@@ -129,7 +129,10 @@
                     "
                     class="cx-unit-level-order-history-value"
                   >
-                    {{ order?.orgCustomer?.name }}</a
+                    {{ order?.orgCustomer?.name }}
+                    <span>
+                      {{ order?.orgCustomer?.email }}</span
+                    ></a
                   >
                 </td>
                 <td class="cx-unit-level-order-history-unit">

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.html
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.html
@@ -130,9 +130,7 @@
                     class="cx-unit-level-order-history-value"
                   >
                     {{ order?.orgCustomer?.name }}
-                    <span>
-                      {{ order?.orgCustomer?.email }}</span
-                    ></a
+                    <span> {{ order?.orgCustomer?.email }}</span></a
                   >
                 </td>
                 <td class="cx-unit-level-order-history-unit">

--- a/feature-libs/organization/unit-order/styles/_unit-order.scss
+++ b/feature-libs/organization/unit-order/styles/_unit-order.scss
@@ -23,7 +23,7 @@
 
     td {
       width: 16.6%;
-      padding: 1.625rem 0;
+      padding: 1rem 0;
 
       @include media-breakpoint-up(md) {
         text-align: start;
@@ -46,6 +46,11 @@
         &:last-child {
           padding-bottom: 1.25rem;
         }
+      }
+
+      span {
+        color: #A1AABF;
+        display: table;
       }
     }
   }

--- a/feature-libs/organization/unit-order/styles/_unit-order.scss
+++ b/feature-libs/organization/unit-order/styles/_unit-order.scss
@@ -49,7 +49,7 @@
       }
 
       span {
-        color: #A1AABF;
+        color: #a1aabf;
         display: table;
       }
     }

--- a/projects/core/src/model/org-unit.model.ts
+++ b/projects/core/src/model/org-unit.model.ts
@@ -32,6 +32,7 @@ export interface B2BUnit {
 
 export interface B2BUser extends User {
   active?: boolean;
+  email?: string;
 }
 
 export interface B2BApprovalProcess {


### PR DESCRIPTION
this is how it's look like with email
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/107864995/194820992-f563d356-b18a-4c35-a885-7bec15c003e6.png">

In addition, I changed the details page to display the email field instead of uid.