### PR TITLE
v5 POC #15566 cxCartItemContext, fixed styling

### DIFF
--- a/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.html
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.html
@@ -40,7 +40,15 @@
         [options]="options"
       >
         <tbody>
-          <ng-template [cxOutlet]="CartOutlets.LIST_ITEM">
+          <ng-template #listItemOutletWrapper>
+            <tr>
+              <td colspan="100" cx-outlet-destination></td>
+            </tr>
+          </ng-template>
+          <ng-template
+            [cxOutlet]="CartOutlets.LIST_ITEM"
+            [cxOutletWrapperTemplate]="listItemOutletWrapper"
+          >
             <tr
               cx-cart-item-list-row
               role="row"

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.module.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.module.ts
@@ -26,7 +26,14 @@ import { ConfiguratorCartEntryBundleInfoComponent } from './configurator-cart-en
 
   providers: [
     provideOutlet({
-      id: CartOutlets.ITEM_BUNDLE_DETAILS,
+      id: CartOutlets.LIST_ITEM,
+      position: OutletPosition.AFTER,
+      component: ConfiguratorCartEntryBundleInfoComponent,
+    }),
+
+    // USING THE SAME COMPONENT FOR BOTH OUTLETS
+    provideOutlet({
+      id: CartOutlets.ITEM,
       position: OutletPosition.AFTER,
       component: ConfiguratorCartEntryBundleInfoComponent,
     }),

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.module.ts
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.module.ts
@@ -33,10 +33,10 @@ import { ConfiguratorIssuesNotificationComponent } from './configurator-issues-n
     provideOutlet({
       id: CartOutlets.LIST_ITEM,
       position: OutletPosition.BEFORE,
-      component: ConfiguratorIssuesNotificationRowComponent,
+      component: ConfiguratorIssuesNotificationComponent,
     }),
 
-    // SPIKE TODO: reuse the same component and outlet in added-to-cart.modal
+    // USING THE SAME COMPONENT FOR BOTH OUTLETS
     provideOutlet({
       id: CartOutlets.ITEM,
       position: OutletPosition.BEFORE,

--- a/projects/storefrontlib/cms-structure/outlet/outlet.directive.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet.directive.ts
@@ -57,6 +57,8 @@ export class OutletDirective<T = any> implements OnDestroy, OnChanges {
    */
   @Input() cxOutletDefer: IntersectionOptions;
 
+  @Input() cxOutletWrapperTemplate: TemplateRef<any>;
+
   @Output() loaded: EventEmitter<boolean> = new EventEmitter<boolean>(true);
 
   subscription = new Subscription();
@@ -167,6 +169,21 @@ export class OutletDirective<T = any> implements OnDestroy, OnChanges {
         undefined,
         this.getComponentInjector(position)
       );
+
+      // SPIKE NEW
+      if (this.cxOutletWrapperTemplate) {
+        const wrapperEmbeddedView = this.vcr.createEmbeddedView(
+          this.cxOutletWrapperTemplate
+        );
+        const destination = wrapperEmbeddedView.rootNodes[0].querySelector(
+          '[cx-outlet-destination]'
+        );
+
+        // WATCH OUT: using native DOM operations is not "the Angular way" of doing things.
+        // Several things might break, when moving/adding other elements inside the same VCR.
+        destination?.appendChild(component.location.nativeElement);
+      }
+
       return component;
     } else if (tmplOrFactory instanceof TemplateRef) {
       const view = this.vcr.createEmbeddedView(


### PR DESCRIPTION
Same as [v3 POC](https://github.com/SAP/spartacus/pull/16272/) plus:
- same outlet components used in added-to-cart and in cart listing view, no need for differentiation
- OutletDirective suport for instantiating components within a custom wrapper template - input `[cxOutletWrapperTemplate]`
- WARNING: this implementation is tricky/hacky. It uses native DOM operation `appendChild` and is not "the Angular way" of doing things. Several things might break, when moving/adding other elements inside the same VCR. For more, see example stackblitz https://stackblitz.com/edit/ng-create-component-within-wrapper-template-v1

related to #15566 