### PR TITLE
[BOPIS] feat: give pickup dialog focus on open

### DIFF
--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.html
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.html
@@ -1,4 +1,8 @@
-<div class="cx-pickup-option-dialog">
+<div
+  class="cx-pickup-option-dialog"
+  [cxFocus]="focusConfig"
+  (esc)="close(CLOSE_WITHOUT_SELECTION)"
+>
   <div class="cx-dialog-content">
     <!-- Modal Header -->
     <div class="modal-header cx-dialog-header">

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.spec.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.spec.ts
@@ -14,6 +14,7 @@ import {
 } from '@spartacus/pickup-in-store/root';
 import {
   IconTestingModule,
+  KeyboardFocusModule,
   LaunchDialogService,
   LAUNCH_CALLER,
   SpinnerModule,
@@ -89,6 +90,7 @@ describe('PickupOptionDialogComponent', () => {
         HttpClientTestingModule,
         I18nTestingModule,
         IconTestingModule,
+        KeyboardFocusModule,
         SpinnerModule,
         StoreModule.forRoot({}),
         EffectsModule.forRoot([]),
@@ -198,6 +200,28 @@ describe('PickupOptionDialogComponent', () => {
     component.close(mockCloseReason);
     expect(launchDialogService.closeDialog).toHaveBeenCalledWith(
       mockCloseReason
+    );
+  });
+
+  it('should close the dialog when user clicks outside', () => {
+    const element = fixture.debugElement.nativeElement;
+    spyOn(component, 'close');
+
+    element.click();
+    expect(component.close).toHaveBeenCalledWith(
+      component.CLOSE_WITHOUT_SELECTION
+    );
+  });
+
+  it('should close the dialog when user presses escape key', () => {
+    const element = (
+      fixture.debugElement.nativeElement as HTMLElement
+    ).querySelector('.cx-pickup-option-dialog');
+    spyOn(component, 'close');
+
+    element?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(component.close).toHaveBeenCalledWith(
+      component.CLOSE_WITHOUT_SELECTION
     );
   });
 });

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  HostListener,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import { PreferredStoreService } from '@spartacus/pickup-in-store/core';
 import {
@@ -13,7 +19,11 @@ import {
   PickupLocationsSearchFacade,
   PickupOptionFacade,
 } from '@spartacus/pickup-in-store/root';
-import { ICON_TYPE, LaunchDialogService } from '@spartacus/storefront';
+import {
+  FocusConfig,
+  ICON_TYPE,
+  LaunchDialogService,
+} from '@spartacus/storefront';
 
 import { Observable, Subscription } from 'rxjs';
 import { filter, take, tap } from 'rxjs/operators';
@@ -37,6 +47,13 @@ export class PickupOptionDialogComponent implements OnInit, OnDestroy {
   cartId: string;
   userId: string;
 
+  readonly focusConfig: FocusConfig = {
+    trap: true,
+    block: true,
+    autofocus: 'input',
+    focusOnEscape: true,
+  };
+
   readonly ICON_TYPE = ICON_TYPE;
   /** The reason given closing the dialog window without selecting a location */
   readonly CLOSE_WITHOUT_SELECTION = 'CLOSE_WITHOUT_SELECTION';
@@ -45,6 +62,7 @@ export class PickupOptionDialogComponent implements OnInit, OnDestroy {
 
   constructor(
     protected activeCartFacade: ActiveCartFacade,
+    protected elementRef: ElementRef,
     protected intendedPickupLocationService: IntendedPickupLocationFacade,
     protected launchDialogService: LaunchDialogService,
     protected pickupLocationsSearchService: PickupLocationsSearchFacade,
@@ -52,6 +70,15 @@ export class PickupOptionDialogComponent implements OnInit, OnDestroy {
     protected preferredStoreService: PreferredStoreService
   ) {
     // Intentional empty constructor
+  }
+
+  @HostListener('click', ['$event'])
+  handleClick(event: UIEvent): void {
+    if (
+      (event.target as any).tagName === this.elementRef.nativeElement.tagName
+    ) {
+      this.close(this.CLOSE_WITHOUT_SELECTION);
+    }
   }
 
   ngOnInit() {

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.module.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.module.ts
@@ -7,7 +7,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { I18nModule } from '@spartacus/core';
-import { IconModule, SpinnerModule } from '@spartacus/storefront';
+import {
+  IconModule,
+  KeyboardFocusModule,
+  SpinnerModule,
+} from '@spartacus/storefront';
 import { StoreListModule } from '../store-list/index';
 import { StoreSearchModule } from '../store-search/index';
 import { PickupOptionDialogComponent } from './pickup-option-dialog.component';
@@ -17,9 +21,10 @@ import { PickupOptionDialogComponent } from './pickup-option-dialog.component';
     CommonModule,
     I18nModule,
     IconModule,
+    KeyboardFocusModule,
+    SpinnerModule,
     StoreListModule,
     StoreSearchModule,
-    SpinnerModule,
   ],
   entryComponents: [PickupOptionDialogComponent],
   declarations: [PickupOptionDialogComponent],

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
@@ -49,7 +49,9 @@ export class PickupOptionsComponent implements OnChanges {
   }
 
   /** Emit to indicate a new store should be selected. */
-  onPickupLocationChange(): void {
+  onPickupLocationChange(): boolean {
     this.pickupLocationChange.emit();
+    // Return false to stop `onPickupOptionChange` being called after this
+    return false;
   }
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/pickup-in-store-utils.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/pickup-in-store-utils.ts
@@ -55,7 +55,7 @@ export const LOCATORS = {
   USE_MY_LOCATION: '#lnkUseMyLocation',
   PICKUP_FROM_HERE_BUTTON_NOTTINGHAM_ICE_CENTER: `[data-pickup-in-store-button="Nottingham Ice Center"]`,
   ADD_TO_CART: 'span[aria-label="Add to cart"]',
-  VIEW_CART: 'a[cxmodalreason="View Cart click"]',
+  VIEW_CART: `a:contains('view cart')`,
   BOPIS_TAG,
   PICKUP_IN_STORE_MODAL: 'cx-pickup-option-dialog',
   HIDE_OUT_OF_STOCK_CHECK_BOX: '#chkHideOutOfStock',

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/pickup-in-store/pickup-checkout-journey.core-e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/pickup-in-store/pickup-checkout-journey.core-e2e-spec.ts
@@ -140,7 +140,7 @@ describe('Pickup Delivery Option - A guest user logs in while checking out with 
         cy.log('order review');
         cy.get(L.CHANGE_STORE_LINK).first().click();
         cy.get(L.PICKUP_IN_STORE_MODAL).should('exist');
-        cy.get(L.USE_MY_LOCATION).click();
+        cy.get(L.USE_MY_LOCATION).click({ force: true });
 
         cy.get(L.ACTIVE_PICK_UP_IN_STORE_BUTTON).last().click();
 

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/pickup-in-store/pickup-checkout-journey.core-e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/pickup-in-store/pickup-checkout-journey.core-e2e-spec.ts
@@ -26,7 +26,7 @@ TODO:- During the order review, the user can change the pickup location.
 TODO:- The user completes checkout and sees the order details. On here they can see their pickup location for the picket item and the delivery for the delivered item. (WIP)
 */
 
-describe('Pickup Delivery Option', () => {
+describe('Pickup Delivery Option - A guest user logs in while checking out with BOPIS', () => {
   viewportContext(['desktop'], () => {
     beforeEach(() => {
       cy.window().then((win) => win.sessionStorage.clear());
@@ -89,8 +89,9 @@ describe('Pickup Delivery Option', () => {
           );
       });
 
-      // Start of:- From the cart, the user can change the location they wish to pick up the product from.
-
+      cy.log(
+        'From the cart, the user can change the location they wish to pick up the product from.'
+      );
       cy.get(L.VIEW_CART).click();
       cy.url().should('include', '/cart');
       cy.get(L.PICKUP_STORE_LOCATION).should('be.visible');
@@ -104,41 +105,39 @@ describe('Pickup Delivery Option', () => {
           'deliveryPointOfService'
         );
 
-        // Start of - The user also add another item only for delivery.(Multiple items in cart)
+        cy.log(
+          'The user also add another item only for delivery. (Multiple items in cart)'
+        );
         cy.get(L.SAP_ICON_HOME_LINK).click();
         cy.get(L.HOME_PAGE_SECOND_PRODUCT).click();
         cy.get(L.ADD_TO_CART).click();
         cy.get(L.VIEW_CART).click();
-        // End of - The user also add another item only for delivery.(Multiple items in cart)
 
-        //Start of:- The user decides to login so the order will show in the user's account.
-
+        cy.log(
+          `The user decides to login so the order will show in the user's account.`
+        );
         register();
 
         cy.wait('@registerUser').then((_interception) => {
           login();
         });
-        // End of:- The user decides to login so the order will show in the user's account.
 
-        // Start of:- The logged in user checks out.
+        cy.log('The logged in user checks out.');
         cy.get(L.MINI_CART_BUTTON).click();
         cy.get(L.PROCEED_TO_CHECKOUT_BUTTON).should('be.visible').click();
 
-        // Start of:- During checkout, the user fill address form.
+        cy.log('During checkout, the user fills address form.');
         fillAddressForm(defaultAddress);
         cy.get(L.CHECKOUT_ADDRESS_FORM_SUBMIT_BUTTON).click();
-        // End of:- During checkout, the user fill address form.
 
-        // Start of:- During checkout, the user selects delivery mode.
+        cy.log('During checkout, the user selects delivery mode.');
         cy.get(L.CHECKOUT_DELIVERY_MODE_CONTINUE_BUTTON).click();
-        // End of:- During checkout, the user selects delivery mode.
 
-        // Start of:- During checkout, the user fill payment form.
+        cy.log('During checkout, the user fill payment form.');
         fillPaymentForm(defaultPaymentDetails);
         cy.get(L.CHECKOUT_PAYMENT_FORM_CONTINUE_BUTTON).click();
-        // End of:- During checkout, the user fill payment form.
 
-        //Start of:- order review
+        cy.log('order review');
         cy.get(L.CHANGE_STORE_LINK).first().click();
         cy.get(L.PICKUP_IN_STORE_MODAL).should('exist');
         cy.get(L.USE_MY_LOCATION).click();
@@ -154,7 +153,6 @@ describe('Pickup Delivery Option', () => {
 
         cy.get(L.REVIEW_ORDER_TERM_CONDITION).click();
         cy.get(L.REVIEW_ORDER_SUBMIT).click();
-        //End of:- order review
       });
     });
   });


### PR DESCRIPTION
When the pickup in store dialog open then give focus to the search box. Additionally allow the user to close the dialog with the escape key or by clicking outside it. This is to improve accessability.