### PR TITLE
fix: add html escape to prevent xss attacks (#16242)

### DIFF
--- a/docs/migration/5_0.md
+++ b/docs/migration/5_0.md
@@ -507,6 +507,15 @@ Due to i18next migration, certain set of keys have been migrated (from `_plural`
 
 - Text type icon symbols are now converted into text, meaning DOM does not render HTML symbols anymore.
 
+### JsonLdScriptFactory
+
+- Removed `DomSanitizer` from constructor.
+- `sanitize` method was removed, replaced by `escapeHTML` for security improvement.
+
+### JsonLdDirective
+- Added `Renderer2` and `ElementRef` to constructor
+- Removed `DomSanitizer` from constructor.
+
 ## Schematics
 
 `Account` and `Profile` CLI names have been changed to `User-Account` and `User-Profile`, respectively, to better reflect their purpose.

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/constructor-deprecations.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/constructor-deprecations.ts
@@ -22,6 +22,8 @@ import { COUPON_CARD_COMPONENT_CONSTRUCTOR_MIGRATION } from './data/coupon-card.
 import { COUPON_DIALOG_COMPONENT_CONSTRUCTOR_MIGRATION } from './data/coupon-dialog.component.migration';
 import { STOCK_NOTIFICATION_DIALOG_COMPONENT_CONSTRUCTOR_MIGRATION } from './data/stock-notification-dialog.component.migration';
 import { STOCK_NOTIFICATION_COMPONENT_CONSTRUCTOR_MIGRATION } from './data/stock-notification.component.migration';
+import { JSON_LD_DIRECTIVE_CONSTRUCTOR_MIGRATION } from './data/json-ld.directive.migration';
+import { JSON_LD_SCRIPT_FACTORY_CONSTRUCTOR_MIGRATION } from './data/json-ld.script.factory.migration';
 
 export const CONSTRUCTOR_DEPRECATIONS_DATA: ConstructorDeprecation[] = [
   ...GENERATED_CONSTRUCTOR_MIGRATIONS,
@@ -39,6 +41,8 @@ export const CONSTRUCTOR_DEPRECATIONS_DATA: ConstructorDeprecation[] = [
   COUPON_DIALOG_COMPONENT_CONSTRUCTOR_MIGRATION,
   STOCK_NOTIFICATION_DIALOG_COMPONENT_CONSTRUCTOR_MIGRATION,
   STOCK_NOTIFICATION_COMPONENT_CONSTRUCTOR_MIGRATION,
+  JSON_LD_SCRIPT_FACTORY_CONSTRUCTOR_MIGRATION,
+  JSON_LD_DIRECTIVE_CONSTRUCTOR_MIGRATION,
 ];
 
 export function migrate(): Rule {

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/json-ld.directive.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/json-ld.directive.migration.ts
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ANGULAR_CORE,
+  ANGULAR_PLATFORM_BROWSER,
+  DOM_SANITIZER,
+  JSON_LD_SCRIPT_FACTORY,
+  RENDERER_2,
+  WINDOW_REF,
+} from '../../../../shared/constants';
+import {
+  SPARTACUS_CORE,
+  SPARTACUS_STOREFRONTLIB,
+} from '../../../../shared/libs-constants';
+import { ConstructorDeprecation } from '../../../../shared/utils/file-utils';
+
+export const JSON_LD_DIRECTIVE_CONSTRUCTOR_MIGRATION: ConstructorDeprecation = {
+  // projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.ts
+  class: JSON_LD_SCRIPT_FACTORY,
+  importPath: SPARTACUS_STOREFRONTLIB,
+  deprecatedParams: [
+    {
+      className: JSON_LD_SCRIPT_FACTORY,
+      importPath: SPARTACUS_STOREFRONTLIB,
+    },
+    {
+      className: DOM_SANITIZER,
+      importPath: ANGULAR_PLATFORM_BROWSER,
+    },
+  ],
+  addParams: [
+    {
+      className: WINDOW_REF,
+      importPath: SPARTACUS_CORE,
+    },
+    {
+      className: RENDERER_2,
+      importPath: ANGULAR_CORE,
+    },
+  ],
+  removeParams: [
+    {
+      className: DOM_SANITIZER,
+      importPath: ANGULAR_PLATFORM_BROWSER,
+    },
+  ],
+};

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/json-ld.script.factory.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/json-ld.script.factory.migration.ts
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ANGULAR_CORE,
+  ANGULAR_PLATFORM_BROWSER,
+  DOM_SANITIZER,
+  JSON_LD_SCRIPT_FACTORY,
+  PLATFORM,
+  PLATFORM_ID_STRING,
+  RENDERER_FACTORY_2,
+  SEO_CONFIG,
+  STRING_TYPE,
+  WINDOW_REF,
+} from '../../../../shared/constants';
+import {
+  SPARTACUS_CORE,
+  SPARTACUS_STOREFRONTLIB,
+} from '../../../../shared/libs-constants';
+import { ConstructorDeprecation } from '../../../../shared/utils/file-utils';
+
+export const JSON_LD_SCRIPT_FACTORY_CONSTRUCTOR_MIGRATION: ConstructorDeprecation =
+  {
+    // projects/storefrontlib/cms-structure/seo/structured-data/json-ld-script.factory.ts
+    class: JSON_LD_SCRIPT_FACTORY,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedParams: [
+      {
+        className: PLATFORM,
+        literalInference: STRING_TYPE,
+        injectionToken: {
+          token: PLATFORM_ID_STRING,
+          importPath: ANGULAR_CORE,
+        },
+      },
+      {
+        className: WINDOW_REF,
+        importPath: SPARTACUS_CORE,
+      },
+      {
+        className: RENDERER_FACTORY_2,
+        importPath: ANGULAR_CORE,
+      },
+      {
+        className: DOM_SANITIZER,
+        importPath: ANGULAR_PLATFORM_BROWSER,
+      },
+      {
+        className: SEO_CONFIG,
+        importPath: SPARTACUS_STOREFRONTLIB,
+      },
+    ],
+    removeParams: [
+      {
+        className: DOM_SANITIZER,
+        importPath: ANGULAR_PLATFORM_BROWSER,
+      },
+    ],
+  };

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/json-ld.script.factory.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/json-ld.script.factory.migration.ts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  JSON_LD_SCRIPT_FACTORY,
+  SANITIZE_METHOD,
+  TODO_SPARTACUS,
+} from '../../../../shared/constants';
+import { SPARTACUS_STOREFRONTLIB } from '../../../../shared/libs-constants';
+import { MethodPropertyDeprecation } from '../../../../shared/utils/file-utils';
+
+// projects/storefrontlib/cms-structure/seo/structured-data/json-ld-script.factory.ts
+export const JSON_LD_SCRIPT_FACTORY_MIGRATION: MethodPropertyDeprecation[] = [
+  {
+    class: JSON_LD_SCRIPT_FACTORY,
+    importPath: SPARTACUS_STOREFRONTLIB,
+    deprecatedNode: SANITIZE_METHOD,
+    comment: `// ${TODO_SPARTACUS} Method '${JSON_LD_SCRIPT_FACTORY}.${SANITIZE_METHOD}' was removed. Use 'escapeHtml' instead.`,
+  },
+];

--- a/projects/schematics/src/shared/constants.ts
+++ b/projects/schematics/src/shared/constants.ts
@@ -568,6 +568,8 @@ export const STOCK_NOTIFICATION_MODULE = 'StockNotificationtModule';
 export const STOCK_NOTIFICATION_DIALOG_COMPONENT =
   'StockNotificationDialogComponent';
 
+export const SANITIZE_METHOD = 'sanitize';
+
 /***** Classes end *****/
 
 /***** Removed public api start *****/

--- a/projects/storefrontlib/cms-structure/seo/structured-data/json-ld-script.factory.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/json-ld-script.factory.spec.ts
@@ -39,17 +39,19 @@ describe('JsonLdScriptFactory', () => {
       expect(scriptElement.innerHTML).toEqual(`[{"foo":"bar-2"}]`);
     });
 
-    describe('sanitized', () => {
+    describe('security', () => {
       beforeEach(() => {
         spyOn(console, 'warn').and.stub();
       });
-      it('should sanitize malicious code', () => {
+      it('should escape html tags within malicious code', () => {
         service.build([{ foo: 'bar-2<script>alert()</script>' }]);
         const scriptElement = winRef.document.getElementById('json-ld');
-        expect(scriptElement.innerHTML).toEqual(`[{"foo":"bar-2"}]`);
+        expect(scriptElement.innerHTML).toEqual(
+          `[{"foo":"bar-2&lt;script&gt;alert()&lt;/script&gt;"}]`
+        );
       });
 
-      it('should sanitize deep nested malicious code', () => {
+      it('should escape html tags within deep nested malicious code', () => {
         service.build([
           {
             foo: { bar: { deep: 'before <script>alert()</script>and after' } },
@@ -57,11 +59,11 @@ describe('JsonLdScriptFactory', () => {
         ]);
         const scriptElement = winRef.document.getElementById('json-ld');
         expect(scriptElement.innerHTML).toEqual(
-          `[{"foo":{"bar":{"deep":"before and after"}}}]`
+          `[{"foo":{"bar":{"deep":"before &lt;script&gt;alert()&lt;/script&gt;and after"}}}]`
         );
       });
 
-      it('should sanitize everywhere', () => {
+      it('should escape html tags everywhere', () => {
         service.build([
           {
             foo: 'clean up <script>alert()</script>please',
@@ -70,7 +72,7 @@ describe('JsonLdScriptFactory', () => {
         ]);
         const scriptElement = winRef.document.getElementById('json-ld');
         expect(scriptElement.innerHTML).toEqual(
-          `[{"foo":"clean up please","bar":"and here as well"}]`
+          `[{"foo":"clean up &lt;script&gt;alert()&lt;/script&gt;please","bar":"and here &lt;script&gt;alert()&lt;/script&gt;as well"}]`
         );
       });
     });

--- a/projects/storefrontlib/cms-structure/seo/structured-data/json-ld-script.factory.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/json-ld-script.factory.ts
@@ -12,9 +12,7 @@ import {
   PLATFORM_ID,
   Renderer2,
   RendererFactory2,
-  SecurityContext,
 } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
 import { WindowRef } from '@spartacus/core';
 import { SeoConfig } from '../config';
 
@@ -22,17 +20,21 @@ import { SeoConfig } from '../config';
   providedIn: 'root',
 })
 export class JsonLdScriptFactory {
+  protected renderer: Renderer2 = this.rendererFactory.createRenderer(
+    null,
+    null
+  );
+
   constructor(
     @Inject(PLATFORM_ID) protected platformId: string,
     protected winRef: WindowRef,
     protected rendererFactory: RendererFactory2,
-    protected sanitizer: DomSanitizer,
     protected config: SeoConfig
   ) {}
 
   build(schema: {}[]): void {
     if (schema && this.isJsonLdRequired()) {
-      this.getJsonLdScriptElement().innerHTML = this.sanitize(schema);
+      this.getJsonLdScriptElement().textContent = this.escapeHtml(schema);
     }
   }
 
@@ -64,30 +66,24 @@ export class JsonLdScriptFactory {
     );
 
     if (!scriptElement) {
-      const renderer: Renderer2 = this.rendererFactory.createRenderer(
-        null,
-        null
-      );
-      const script: HTMLScriptElement = renderer.createElement('script');
+      const script: HTMLScriptElement = this.renderer.createElement('script');
       script.id = id;
       script.type = 'application/ld+json';
-      renderer.appendChild(this.winRef.document.body, script);
+      this.renderer.appendChild(this.winRef.document.body, script);
       scriptElement = script;
     }
     return scriptElement;
   }
 
   /**
-   * Sanitizes the given json-ld schema by leveraging the angular HTML sanitizer.
+   * Secure the given json-ld schema by encoding html characters (aka escaping), eg: <script> becomes &lt;script&gt;
    *
    * The given schema is not trusted, as malicious code could be injected (XSS)
    * into the json-ld script.
    */
-  sanitize(schema: {}): string {
-    return JSON.stringify(schema, (_key, value) =>
-      typeof value === 'string'
-        ? this.sanitizer.sanitize(SecurityContext.HTML, value)
-        : value
-    );
+  escapeHtml(schema: {}): string {
+    const div: HTMLScriptElement = this.renderer.createElement('div');
+    div.textContent = JSON.stringify(schema);
+    return div.innerHTML;
   }
 }

--- a/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.ts
@@ -30,22 +30,19 @@ export class JsonLdDirective {
   }
 
   constructor(
-    private renderer: Renderer2,
+    protected renderer: Renderer2,
     protected jsonLdScriptFactory: JsonLdScriptFactory,
-    private element: ElementRef
+    protected element: ElementRef
   ) {}
 
   /**
-   * attach the json-ld script tag to DOM with the schema data. To avoid xss attacks, HTMl tags within schema data are encoded (aka escaping)
+   * attach the json-ld script tag to DOM with the schema data secured by encoding html tags (aka escaping)
    */
-  protected generateJsonLdScript(schema: string | {}) {
+  protected generateJsonLdScript(schema: string | {}): void {
     if (schema && this.jsonLdScriptFactory.isJsonLdRequired()) {
-      const div: HTMLDivElement = this.renderer.createElement('div');
       const script: HTMLScriptElement = this.renderer.createElement('script');
       script.type = 'application/ld+json';
-      div.textContent = JSON.stringify(schema);
-      script.textContent = div.innerHTML;
-      this.renderer.appendChild(div, script);
+      script.textContent = this.jsonLdScriptFactory.escapeHtml(schema);
       this.renderer.appendChild(this.element.nativeElement, script);
     }
   }


### PR DESCRIPTION
HTML escape is now applied to json-ld content to prevent xss attacks.

PR for 5.0 branch.
same PR as https://github.com/SAP/spartacus/pull/16242