### PR TITLE
chore: add capability to install spartacus from private packages

### DIFF
--- a/scripts/install/config.default.sh
+++ b/scripts/install/config.default.sh
@@ -71,3 +71,9 @@ ADD_EPD_VISUALIZATION=false
 
 # The base URL (origin) of the SAP EPD Fiori launchpad
 EPD_VISUALIZATION_BASE_URL=
+
+#NPM connection info
+#NPM_URL must start by 'https://' and end with '/' char
+NPM_TOKEN=
+NPM_URL= 
+NPM_ALWAYS_AUTH=true


### PR DESCRIPTION
Spartacus can now be installed from sap private npm packages when using install_npm command. Config vars have been added: NPM_TOKEN, NPM_URL,NPM_ALWAYS_AUTH When the install starts, .npmrc file gets created then removed once finished. For security purpose, NPM_TOKEN var gets cleared from config.sh and config.default.sh when install is finished.

BREAKING CHANGE

New config vars have been introduced: NPM_TOKEN, NPM_URL are required to be filled by the user in config.sh file. It is needed only when using install_npm command.