### PR TITLE
CXSPA-1474: update the color for email field

### DIFF
--- a/feature-libs/organization/unit-order/styles/_unit-order.scss
+++ b/feature-libs/organization/unit-order/styles/_unit-order.scss
@@ -49,7 +49,7 @@
       }
 
       span {
-        color: #a1aabf;
+        color: var(--cx-color-light);
         display: table;
       }
     }


### PR DESCRIPTION
the color for email on the `unit-level order history` page was changed after agreement with UX designer