### PR TITLE
fix: integration-libs/epd-visualization e2e test fixes for 5.0.x

### DIFF
--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.service.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.service.ts
@@ -839,14 +839,14 @@ export class VisualViewerService implements OnDestroy {
       const nodeRefsToExclude: NodeRef[] = topLevelHotspotNodeRefs.filter(
         (nodeRef: NodeRef) => !nodeRefsToIncludeSet.has(nodeRef)
       );
-      this.viewport.showHotspots(nodeRefsToExclude, false, null);
+      this.viewport.showHotspots(nodeRefsToExclude, false, 0);
       this.viewport.showHotspots(
         nodeRefsToInclude,
         true,
         this.getCSSColor(this._showAllHotspotsColor)
       );
     } else {
-      this.viewport.showHotspots(topLevelHotspotNodeRefs, false, null);
+      this.viewport.showHotspots(topLevelHotspotNodeRefs, false, 0);
     }
   }
 
@@ -1294,7 +1294,9 @@ export class VisualViewerService implements OnDestroy {
           sap_ui_vk_DrawerToolbar: any
         ) => {
           const core: Core = this.getCore();
-          const uiArea: UIArea = core.getUIArea(this.elementRef.nativeElement);
+          const uiArea: UIArea | null | undefined = core.getUIArea(
+            this.elementRef.nativeElement
+          );
           if (uiArea) {
             const oldViewport = uiArea.getContent()[0] as Viewport;
             this.destroyViewportAssociations(oldViewport);

--- a/integration-libs/epd-visualization/package.json
+++ b/integration-libs/epd-visualization/package.json
@@ -37,7 +37,7 @@
     "@angular/core": "^14.2.3",
     "@angular/forms": "^14.2.3",
     "@angular/router": "^14.2.3",
-    "@sapui5/ts-types-esm": "1.98.0",
+    "@sapui5/ts-types-esm": "1.107.1",
     "@spartacus/cart": "4.1.0-next.0",
     "@spartacus/core": "4.1.0-next.0",
     "@spartacus/schematics": "4.1.0-next.0",

--- a/integration-libs/epd-visualization/root/config/epd-visualization-config.ts
+++ b/integration-libs/epd-visualization/root/config/epd-visualization-config.ts
@@ -53,8 +53,8 @@ export interface Ui5Config {
 export interface VisualizationApiConfig {
   /**
    * This is the base URL that is used to access the EPD Visualization APIs.
-   * Use the origin portion of the URL for your EPD Fiori Launchpad.
-   * i.e. https://mytenantsubdomain.epd.cfapps.eu20.hana.ondemand.com
+   * Use the origin portion of the URL for your EPD Visualization Fiori Launchpad.
+   * i.e. https://mytenant.visualization.eu20.epd.cloud.sap
    */
   baseUrl: string;
 }

--- a/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
+++ b/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
@@ -15,7 +15,7 @@ export function getTestConfig(): EpdVisualizationConfig {
       },
       ui5: {
         bootstrapUrl:
-          'https://sapui5.hana.ondemand.com/1.98.0/resources/sap-ui-core.js',
+          'https://sapui5.hana.ondemand.com/1.107.1/resources/sap-ui-core.js',
       },
     },
   };

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
@@ -22,7 +22,7 @@ import { EpdVisualizationConfig, EpdVisualizationRootModule } from \\"@spartacus
   provideConfig(<EpdVisualizationConfig>{
     epdVisualization: {
       ui5: {
-        bootstrapUrl: \\"https://sapui5.hana.ondemand.com/1.98.0/resources/sap-ui-core.js\\"
+        bootstrapUrl: \\"https://sapui5.hana.ondemand.com/1.107.1/resources/sap-ui-core.js\\"
       },
 
       apis: {
@@ -58,7 +58,7 @@ import { EpdVisualizationConfig, EpdVisualizationRootModule } from \\"@spartacus
   provideConfig(<EpdVisualizationConfig>{
     epdVisualization: {
       ui5: {
-        bootstrapUrl: \\"https://sapui5.hana.ondemand.com/1.98.0/resources/sap-ui-core.js\\"
+        bootstrapUrl: \\"https://sapui5.hana.ondemand.com/1.107.1/resources/sap-ui-core.js\\"
       },
 
       apis: {
@@ -100,7 +100,7 @@ import { EpdVisualizationConfig, EpdVisualizationRootModule, EPD_VISUALIZATION_F
   provideConfig(<EpdVisualizationConfig>{
     epdVisualization: {
       ui5: {
-        bootstrapUrl: \\"https://sapui5.hana.ondemand.com/1.98.0/resources/sap-ui-core.js\\"
+        bootstrapUrl: \\"https://sapui5.hana.ondemand.com/1.107.1/resources/sap-ui-core.js\\"
       },
 
       apis: {

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/schema.json
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/schema.json
@@ -18,8 +18,8 @@
     },
     "baseUrl": {
       "type": "string",
-      "description": "The base URL (origin) of the EPD Fiori Launchpad",
-      "x-prompt": "[EPD Visualization] What is the base URL (origin) of your EPD Fiori Launchpad? e.g. https://mytenant.epd.cfapps.eu20.hana.ondemand.com"
+      "description": "The base URL (origin) of the EPD Visualization Fiori Launchpad",
+      "x-prompt": "[EPD Visualization] What is the base URL (origin) of your EPD Visualization Fiori Launchpad? e.g. https://mytenant.visualization.eu20.epd.cloud.sap"
     }
   },
   "required": []

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@babel/runtime": "^7.18.9",
     "@ngrx/store-devtools": "^14.3.0",
     "@nguniversal/builders": "^14.2.0",
-    "@sapui5/ts-types-esm": "1.98.0",
+    "@sapui5/ts-types-esm": "1.107.1",
     "@schematics/angular": "^14.2.3",
     "@spartacus-eslint/eslint-plugin": "link:./projects/eslint",
     "@types/express": "^4.17.0",

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -265,7 +265,7 @@
     "@angular/core": "^14.2.3",
     "@angular/forms": "^14.2.3",
     "@angular/router": "^14.2.3",
-    "@sapui5/ts-types-esm": "1.98.0",
+    "@sapui5/ts-types-esm": "1.107.1",
     "@spartacus/cart": "4.1.0-next.0",
     "@spartacus/core": "4.1.0-next.0",
     "@spartacus/schematics": "4.1.0-next.0",

--- a/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
@@ -9,7 +9,7 @@ import {
   EPD_VISUALIZATION_FEATURE_NAME,
   SPARTACUS_EPD_VISUALIZATION,
   SPARTACUS_EPD_VISUALIZATION_ASSETS,
-  SPARTACUS_EPD_VISUALIZATION_ROOT
+  SPARTACUS_EPD_VISUALIZATION_ROOT,
 } from '../../libs-constants';
 import { AdditionalFeatureConfiguration } from '../../utils/feature-utils';
 import { LibraryOptions, SchematicConfig } from '../../utils/lib-utils';

--- a/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
@@ -9,7 +9,7 @@ import {
   EPD_VISUALIZATION_FEATURE_NAME,
   SPARTACUS_EPD_VISUALIZATION,
   SPARTACUS_EPD_VISUALIZATION_ASSETS,
-  SPARTACUS_EPD_VISUALIZATION_ROOT,
+  SPARTACUS_EPD_VISUALIZATION_ROOT
 } from '../../libs-constants';
 import { AdditionalFeatureConfiguration } from '../../utils/feature-utils';
 import { LibraryOptions, SchematicConfig } from '../../utils/lib-utils';
@@ -75,7 +75,7 @@ function buildCdsConfig(
       content: `<${EPD_VISUALIZATION_CONFIG}>{
         epdVisualization: {
           ui5: {
-            bootstrapUrl: "https://sapui5.hana.ondemand.com/1.98.0/resources/sap-ui-core.js"
+            bootstrapUrl: "https://sapui5.hana.ondemand.com/1.107.1/resources/sap-ui-core.js"
           },
 
           apis: {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/epd-visualization/visual-picking-tab.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/epd-visualization/visual-picking-tab.ts
@@ -29,7 +29,10 @@ export function configureDefaultProduct() {
 
 export function verifyTabbingOrder() {
   // Ensure the spare parts tab is active
-  cy.get('cx-tab-paragraph-container button').contains('Spare Parts').click();
+  cy.get('cx-tab-paragraph-container button')
+    .contains('Spare Parts')
+    .click()
+    .click();
 
   cy.get('cx-epd-visualization-viewer', { timeout: 50000 }).should(
     'be.visible'
@@ -38,7 +41,10 @@ export function verifyTabbingOrder() {
     timeout: 50000,
   }).should('be.visible');
 
-  cy.get('cx-tab-paragraph-container button').contains('Spare Parts').click();
+  cy.get('cx-tab-paragraph-container button')
+    .contains('Spare Parts')
+    .click()
+    .click();
 
   cy.get('cx-icon.fa-home').parent().parent('button').focus();
 
@@ -150,7 +156,17 @@ export function verifyTabbingOrder() {
     .find('cx-icon')
     .should('have.class', 'cx-icon fas fa-angle-right flip-at-rtl');
 
-  // should end up in the footer area
+  // Focus should move to other tabs
+  cy.pressTab();
+  cy.focused().should('include.text', 'Product Details');
+
+  cy.pressTab();
+  cy.focused().should('include.text', 'Specs');
+
+  cy.pressTab();
+  cy.focused().should('include.text', 'Reviews');
+
+  // Focus should move to the footer area
   cy.pressTab();
   cy.get('cx-footer-navigation:focus-within');
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/vendor/epd-visualization/visualization-lookup/visualization-lookup.e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/vendor/epd-visualization/visualization-lookup/visualization-lookup.e2e-spec.ts
@@ -26,6 +26,7 @@ describe('in Spare Parts Tab', () => {
         cy.wait(`@productPage`);
         cy.get('cx-tab-paragraph-container button')
           .contains('Spare Parts')
+          .click()
           .click();
         cy.wait(`@lookupVisualization`);
         cy.get(
@@ -52,6 +53,7 @@ describe('in Spare Parts Tab', () => {
         cy.wait(`@productPage`);
         cy.get('cx-tab-paragraph-container button')
           .contains('Spare Parts')
+          .click()
           .click();
         cy.wait(`@lookupVisualization`);
         cy.get(
@@ -82,6 +84,7 @@ describe('in Spare Parts Tab', () => {
         cy.wait(`@getProductReferences`);
         cy.get('cx-tab-paragraph-container button')
           .contains('Spare Parts')
+          .click()
           .click();
         cy.get(
           'cx-epd-visualization-visual-picking-tab .no-product-references'

--- a/projects/storefrontapp-e2e-cypress/package.json
+++ b/projects/storefrontapp-e2e-cypress/package.json
@@ -23,7 +23,7 @@
     "cy:run:ci:cds": "cypress run --config-file cypress.ci.json --record --key $CYPRESS_KEY --tag \"2011,b2c,all-cds\" --group CDS --spec \"cypress/integration/vendor/cds/**/*.core-e2e-spec.ts\"",
     "cy:run:ci:cdc": "cypress run --config-file cypress.ci.json --env API_URL=https://backoffice.cp96avkh5f-sapcxteam1-d1-public.model-t.cc.commerce.ondemand.com --record --key $CYPRESS_KEY --tag \"2005,cdc\" --group CDC --spec \"cypress/integration/vendor/cdc/**/*.e2e-spec.ts\"",
     "cy:run:ci:digital-payments": "cypress run --config-file cypress.ci.json --env API_URL=https://backoffice.cp96avkh5f-sapcxteam1-d5-public.model-t.cc.commerce.ondemand.com --record --key $CYPRESS_KEY --tag \"2105,digital-payments\" --group DIGITAL-PAYMENTS --spec \"cypress/integration/vendor/digital-payments/*.e2e-spec.ts\"",
-    "cy:run:ci:epd-visualization": "cypress run --config-file cypress.ci.json --env API_URL=https://api.cp96avkh5f-integrati1-d1-public.model-t.cc.commerce.ondemand.com,BASE_SITE=powertools-epdvisualization-spa --record --key $CYPRESS_KEY --tag \"2105,epd-visualization\" --group EPD_VISUALIZATION --ci-build-id $TRAVIS_BUILD_ID --spec \"cypress/integration/vendor/epd-visualization/**/*.e2e-spec.ts\""
+    "cy:run:ci:epd-visualization": "cypress run --config-file cypress.ci.json --env API_URL=https://api.cp96avkh5f-integrati1-d1-public.model-t.cc.commerce.ondemand.com,BASE_SITE=powertools-epdvisualization-spa --record --key $CYPRESS_KEY --tag \"2105,epd-visualization\" --group EPD_VISUALIZATION --ci-build-id $BUILD_NUMBER --spec \"cypress/integration/vendor/epd-visualization/**/*.e2e-spec.ts\""
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.9.1",

--- a/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
@@ -8,12 +8,12 @@ import { NgModule } from '@angular/core';
 import { CmsConfig, I18nConfig, provideConfig } from '@spartacus/core';
 import {
   epdVisualizationTranslationChunksConfig,
-  epdVisualizationTranslations,
+  epdVisualizationTranslations
 } from '@spartacus/epd-visualization/assets';
 import {
   EpdVisualizationConfig,
   EpdVisualizationRootModule,
-  EPD_VISUALIZATION_FEATURE,
+  EPD_VISUALIZATION_FEATURE
 } from '@spartacus/epd-visualization/root';
 
 const epdVisualizationConfig: EpdVisualizationConfig = {
@@ -25,7 +25,7 @@ const epdVisualizationConfig: EpdVisualizationConfig = {
 
     ui5: {
       bootstrapUrl:
-        'https://sapui5.hana.ondemand.com/1.98.0/resources/sap-ui-core.js',
+        'https://sapui5.hana.ondemand.com/1.107.1/resources/sap-ui-core.js',
     },
   },
 };

--- a/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
@@ -8,12 +8,12 @@ import { NgModule } from '@angular/core';
 import { CmsConfig, I18nConfig, provideConfig } from '@spartacus/core';
 import {
   epdVisualizationTranslationChunksConfig,
-  epdVisualizationTranslations
+  epdVisualizationTranslations,
 } from '@spartacus/epd-visualization/assets';
 import {
   EpdVisualizationConfig,
   EpdVisualizationRootModule,
-  EPD_VISUALIZATION_FEATURE
+  EPD_VISUALIZATION_FEATURE,
 } from '@spartacus/epd-visualization/root';
 
 const epdVisualizationConfig: EpdVisualizationConfig = {

--- a/scripts/install/config.default.sh
+++ b/scripts/install/config.default.sh
@@ -69,7 +69,7 @@ ADD_CDC=false
 # config.epd-visualization.sh contains default values to use in your config.sh when ADD_EPD_VISUALIZATION is true.
 ADD_EPD_VISUALIZATION=false
 
-# The base URL (origin) of the SAP EPD Fiori launchpad
+# The base URL (origin) of the SAP EPD Visualization Fiori launchpad
 EPD_VISUALIZATION_BASE_URL=
 
 #NPM connection info

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,10 +2512,15 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sapui5/ts-types-esm@1.98.0":
-  version "1.98.0"
-  resolved "https://registry.yarnpkg.com/@sapui5/ts-types-esm/-/ts-types-esm-1.98.0.tgz#21e4127164d4ca80f87b9062f78bcf4167945019"
-  integrity sha512-GKxrhBJiAmU7qUKJ0gHykYpoySVk1AYndGyLLqaors3JG3RjyFkwE51SCDOdgMNNd4keqHnAomV9X7jgY4LXHA==
+"@sapui5/ts-types-esm@1.107.1":
+  version "1.107.1"
+  resolved "https://registry.yarnpkg.com/@sapui5/ts-types-esm/-/ts-types-esm-1.107.1.tgz#9e56921b4282949b248b062159d85723aec887d9"
+  integrity sha512-eq58UFBBnzqQCuoBbfYusMtjbxfZfE+jJfJG9n6Sc0rV/su6enrhnZfI5R0wQyKCipvNMRIORktZkTNgYXivKg==
+  dependencies:
+    "@types/jquery" "3.5.13"
+    "@types/offscreencanvas" "2019.6.4"
+    "@types/qunit" "2.5.4"
+    "@types/three" "0.125.3"
 
 "@schematics/angular@14.2.3", "@schematics/angular@^14.2.3":
   version "14.2.3"
@@ -2837,6 +2842,13 @@
     expect "^28.0.0"
     pretty-format "^28.0.0"
 
+"@types/jquery@3.5.13":
+  version "3.5.13"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.5.13.tgz#5482d3ee325d5862f77a91c09369ae0a5b082bf3"
+  integrity sha512-ZxJrup8nz/ZxcU0vantG+TPdboMhB24jad2uSap50zE7Q9rUeYlCF25kFMSmHR33qoeOgqcdHEp3roaookC0Sg==
+  dependencies:
+    "@types/sizzle" "*"
+
 "@types/jsdom@^16.2.4":
   version "16.2.15"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.15.tgz#6c09990ec43b054e49636cba4d11d54367fc90d6"
@@ -2898,6 +2910,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/offscreencanvas@2019.6.4":
+  version "2019.6.4"
+  resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz#64f6d120b53925028299c744fcdd32d2cd525963"
+  integrity sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -2922,6 +2939,11 @@
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/qunit@2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-2.5.4.tgz#0518940acc6013259a8619a1ec34ce0e4ff8d1c4"
+  integrity sha512-VHi2lEd4/zp8OOouf43JXGJJ5ZxHvdLL1dU0Yakp6Iy73SjpuXl7yjwAwmh1qhTv8krDgHteSwaySr++uXX9YQ==
 
 "@types/range-parser@*":
   version "1.2.4"
@@ -2976,6 +2998,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/sizzle@*":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
+  integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
+
 "@types/sockjs@^0.3.33":
   version "0.3.33"
   resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.33.tgz#570d3a0b99ac995360e3136fd6045113b1bd236f"
@@ -2987,6 +3014,11 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
+"@types/three@0.125.3":
+  version "0.125.3"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.125.3.tgz#5d5c29acea66af42a3a32a13a9cc8e88e367d8a3"
+  integrity sha512-tUPMzKooKDvMOhqcNVUPwkt+JNnF8ASgWSsrLgleVd0SjLj4boJhteSsF9f6YDjye0mmUjO+BDMWW83F97ehXA==
 
 "@types/tough-cookie@*":
   version "4.0.2"


### PR DESCRIPTION
Also contains other required updates for 5.0.x:
- Update the UI5 version since 1.98.0 will no longer be available on the CDN after Q1 2023.
- Update text to refer to the EPD Visualization FLP instead of the EPD FLP which is being retired