### PR TITLE
[BOPIS] a11y: add missing aria attributes to dialog

### DIFF
--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.html
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.html
@@ -2,11 +2,14 @@
   class="cx-pickup-option-dialog"
   [cxFocus]="focusConfig"
   (esc)="close(CLOSE_WITHOUT_SELECTION)"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="cx-pickup-option-dialog-title"
 >
   <div class="cx-dialog-content">
     <!-- Modal Header -->
     <div class="modal-header cx-dialog-header">
-      <div class="cx-dialog-title">
+      <div id="cx-pickup-option-dialog-title" class="cx-dialog-title">
         {{ 'pickupOptionDialog.modalHeader' | cxTranslate }}
       </div>
 

--- a/feature-libs/pickup-in-store/components/container/store-search/store-search.component.html
+++ b/feature-libs/pickup-in-store/components/container/store-search/store-search.component.html
@@ -28,11 +28,13 @@
       id="lnkUseMyLocation"
       (click)="useMyLocation()"
       tabindex="0"
+      role="button"
     >
       {{ 'storeSearch.useMyLocation' | cxTranslate }}
     </a>
     |
-    <a class="cx-find-a-store-link" tabindex="0">
+    <!-- TODO implement click for this -->
+    <a class="cx-find-a-store-link" tabindex="0" role="button">
       {{ 'storeSearch.viewAllStores' | cxTranslate }}
     </a>
   </div>


### PR DESCRIPTION
Add the required attributes to indicate that the pickup option dialog is a modal dialog for screen readers.

Add the role of button to use my location and find all stores as that is their function, not navigation.