### PR TITLE
fix: Focused items do not have the highlight outline initially when the modal dialog pops up

### DIFF
--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog-layout.config.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog-layout.config.ts
@@ -10,7 +10,7 @@ import { PickupOptionDialogComponent } from './pickup-option-dialog.component';
 export const defaultPickupOptionsDialogLayoutConfig: LayoutConfig = {
   launch: {
     PICKUP_IN_STORE: {
-      inline: true,
+      inlineRoot: true,
       component: PickupOptionDialogComponent,
       dialogType: DIALOG_TYPE.DIALOG,
     },


### PR DESCRIPTION
fix: Focused items do not have the highlight outline initially when the modal dialog pops up, 

Problem:- Outline is not highlighted if we press the tab button in the input box for searching the store in the modal window which contains the list of stores for pick up.

This was because the trap-focus service stops event propagation of key down which was used in visual-focus directive to add or remove mouse-focus class which hides/ adds outline.

We had two options either to remove the event.stop propagation from trap-focus or listen for keyup which takes place just after key down in the visual-focus directive 

We have changed the listener in the visual-focus directive from key down to key up for this logic considering that it will have minimal effect.