### PR TITLE
fix: removed aria-hidden attribute from active element (CXSPA-1448)

### DIFF
--- a/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.html
+++ b/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.html
@@ -39,7 +39,6 @@
       </div>
     </div>
     <a
-      aria-hidden="true"
       href="{{ getDirections(location) }}"
       target="_blank"
       rel="noopener noreferrer"


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-1448
removed aria-hidden attribute from an active element in the store find list item
