### PR TITLE
fix: long text for exit button for screen readers

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.html
@@ -3,7 +3,7 @@
     class="cx-config-exit-button"
     tabindex="0"
     (click)="exitConfiguration()"
-    [attr.aria-label]="
+    [attr.title]="
       container.routerData.isOwnerCartEntry
         ? ('configurator.button.cancelConfiguration' | cxTranslate)
         : ('configurator.button.exit' | cxTranslate)

--- a/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.html
@@ -4,10 +4,10 @@
     tabindex="0"
     (click)="exitConfiguration()"
     [attr.aria-label]="
-    container.routerData.isOwnerCartEntry
-      ? ('configurator.button.cancelConfiguration' | cxTranslate)
-      : ('configurator.button.exit' | cxTranslate)
-  "
+      container.routerData.isOwnerCartEntry
+        ? ('configurator.button.cancelConfiguration' | cxTranslate)
+        : ('configurator.button.exit' | cxTranslate)
+    "
   >
     <ng-container *ngIf="!container.routerData.isOwnerCartEntry">
       <ng-container *ngIf="isDesktop() | async">

--- a/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.html
@@ -3,6 +3,11 @@
     class="cx-config-exit-button"
     tabindex="0"
     (click)="exitConfiguration()"
+    [attr.aria-label]="
+    container.routerData.isOwnerCartEntry
+      ? ('configurator.button.cancelConfiguration' | cxTranslate)
+      : ('configurator.button.exit' | cxTranslate)
+  "
   >
     <ng-container *ngIf="!container.routerData.isOwnerCartEntry">
       <ng-container *ngIf="isDesktop() | async">

--- a/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.spec.ts
@@ -191,6 +191,22 @@ describe('ConfiguratorExitButton', () => {
       );
     });
 
+    it('should render long text tooltip in mobile mode', () => {
+      spyOn(breakpointService, 'isDown').and.returnValue(of(true));
+      spyOn(breakpointService, 'isUp').and.returnValue(of(false));
+      setRouterTestDataProduct();
+      initialize();
+      CommonConfiguratorTestUtilsService.expectElementContainsA11y(
+        expect,
+        htmlElem,
+        'button',
+        'cx-config-exit-button',
+        0,
+        'title',
+        'configurator.button.exit'
+      );
+    });
+
     it('should render long text in desktop mode', () => {
       spyOn(breakpointService, 'isUp').and.returnValue(of(true));
       spyOn(breakpointService, 'isDown').and.returnValue(of(false));
@@ -204,8 +220,20 @@ describe('ConfiguratorExitButton', () => {
       );
     });
 
+    it('should render long text tooltip in desktop mode', () => {
+      spyOn(breakpointService, 'isUp').and.returnValue(of(true));
+      spyOn(breakpointService, 'isDown').and.returnValue(of(false));
+      setRouterTestDataProduct();
+      initialize();
+      CommonConfiguratorTestUtilsService.expectElementToContainText(
+        expect,
+        htmlElem,
+        '.cx-config-exit-button',
+        'configurator.button.exit'
+      );
+    });
+
     it('should render short text  when navigate from cart', () => {
-      console.log('test');
       spyOn(breakpointService, 'isDown').and.returnValue(of(true));
       spyOn(breakpointService, 'isUp').and.returnValue(of(false));
       setRouterTestDataCartEntry();
@@ -218,6 +246,22 @@ describe('ConfiguratorExitButton', () => {
       );
     });
 
+    it('should render long text tooltip when navigate from cart in mobile mode', () => {
+      spyOn(breakpointService, 'isDown').and.returnValue(of(true));
+      spyOn(breakpointService, 'isUp').and.returnValue(of(false));
+      setRouterTestDataCartEntry();
+      initialize();
+      CommonConfiguratorTestUtilsService.expectElementContainsA11y(
+        expect,
+        htmlElem,
+        'button',
+        'cx-config-exit-button',
+        0,
+        'title',
+        'configurator.button.cancelConfiguration'
+      );
+    });
+
     it('should render long text  when navigate from cart', () => {
       spyOn(breakpointService, 'isDown').and.returnValue(of(false));
       spyOn(breakpointService, 'isUp').and.returnValue(of(true));
@@ -227,6 +271,22 @@ describe('ConfiguratorExitButton', () => {
         expect,
         htmlElem,
         '.cx-config-exit-button',
+        'configurator.button.cancelConfiguration'
+      );
+    });
+
+    it('should render long text tooltip when navigate from cart in desktop mode', () => {
+      spyOn(breakpointService, 'isDown').and.returnValue(of(false));
+      spyOn(breakpointService, 'isUp').and.returnValue(of(true));
+      setRouterTestDataCartEntry();
+      initialize();
+      CommonConfiguratorTestUtilsService.expectElementContainsA11y(
+        expect,
+        htmlElem,
+        'button',
+        'cx-config-exit-button',
+        0,
+        'title',
         'configurator.button.cancelConfiguration'
       );
     });


### PR DESCRIPTION
Provided aria-label for exit button. Thus "Exit Configuration" or "Cancel Configuration" is read by screen readers although the button contains only a short text ("Exit" or "Cancel").