### PR TITLE
OV group headers should be sticky only for mobile widgets

### DIFF
--- a/feature-libs/product-configurator/rulebased/styles/_configurator-overview-form.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-overview-form.scss
@@ -3,10 +3,6 @@
   flex-direction: column;
   justify-content: flex-start;
   max-width: 1140px;
-
-  padding-inline-start: 0px;
-  padding-inline-end: 0px;
-
   padding-block-start: 5px;
   padding-block-end: 5px;
 
@@ -15,127 +11,124 @@
     padding-inline-end: 20px;
   }
 
-  @include forVersion(3, 5) {
-    .cx-group {
-      padding-inline-start: 0px;
-      padding-inline-end: 0px;
-      padding-block-start: 25px;
-      padding-block-end: 25px;
+  .cx-group {
+    padding-block-start: 25px;
+    padding-block-end: 25px;
 
+    margin-inline-start: -20px;
+    margin-inline-end: -25px;
+
+    @include media-breakpoint-up(md) {
+      padding-block-start: 20px;
+      padding-block-end: 20px;
+
+      margin-inline-start: 0px;
+      margin-inline-end: 0px;
+    }
+
+    @include media-breakpoint-down(sm) {
+      padding-block-start: 20px;
+      padding-block-end: 20px;
       margin-inline-start: -20px;
-      margin-inline-end: -25px;
+      margin-inline-end: -20px;
+    }
 
-      @include media-breakpoint-up(md) {
-        padding-block-start: 20px;
-        padding-block-end: 20px;
-        margin-inline-start: 0px;
-        margin-inline-end: 0px;
+    &.topLevel {
+      h2 {
+        font-size: 1.25rem;
+        font-weight: 700;
+        border-bottom: solid 1px var(--cx-color-light);
+        border-top: solid 1px var(--cx-color-light);
+        border-left-style: none;
+        border-right-style: none;
+        background: none;
+        text-transform: none;
       }
+    }
+
+    &.subgroupTopLevel {
+      margin-bottom: -60px;
+    }
+
+    h2 {
+      padding-inline-start: 32px;
+      padding-inline-end: 32px;
+      padding-block-start: 16px;
+      padding-block-end: 16px;
 
       @include media-breakpoint-down(sm) {
-        padding-block-start: 20px;
-        padding-block-end: 20px;
-        margin-inline-start: -20px;
-        margin-inline-end: -20px;
-      }
-
-      &.topLevel {
-        h2 {
-          font-size: 1.25rem;
-          font-weight: 700;
-          border-bottom: solid 1px var(--cx-color-light);
-          border-top: solid 1px var(--cx-color-light);
-          border-left-style: none;
-          border-right-style: none;
-          background: none;
-          text-transform: none;
-        }
-      }
-
-      &.subgroupTopLevel {
-        margin-bottom: -60px;
-      }
-
-      h2 {
-        padding-inline-start: 32px;
-        padding-inline-end: 32px;
+        padding-inline-start: 16px;
+        padding-inline-end: 16px;
         padding-block-start: 16px;
         padding-block-end: 16px;
+      }
 
-        @include media-breakpoint-down(sm) {
-          padding-inline-start: 16px;
-          padding-inline-end: 16px;
-          padding-block-start: 16px;
-          padding-block-end: 16px;
+      border: solid 1px var(--cx-color-light);
+      background-color: var(--cx-color-background);
+      font-size: 1rem;
+      text-transform: uppercase;
+
+      span {
+        @include cx-configurator-truncate-content();
+      }
+    }
+
+    .cx-attribute-value-pair {
+      padding-inline-start: 32px;
+      padding-inline-end: 32px;
+
+      @include media-breakpoint-down(sm) {
+        padding-inline-start: 16px;
+        padding-inline-end: 16px;
+      }
+
+      &.general {
+        @include media-breakpoint-up(md) {
+          &:not(:first-of-type) {
+            .cx-attribute-label {
+              visibility: hidden;
+            }
+          }
         }
 
-        border: solid 1px var(--cx-color-light);
-        background-color: var(--cx-color-background);
-        font-size: 1rem;
-        text-transform: uppercase;
+        @include media-breakpoint-down(sm) {
+          .cx-attribute-label {
+            display: none;
+          }
 
-        span {
-          @include cx-configurator-truncate-content();
+          &.last-value-pair {
+            .cx-attribute-label {
+              display: inline;
+            }
+          }
         }
       }
 
-      .cx-attribute-value-pair {
-        padding-inline-start: 32px;
-        padding-inline-end: 32px;
+      &.bundle {
+        background-color: var(--cx-color-background);
 
-        @include media-breakpoint-down(sm) {
-          padding-inline-start: 16px;
-          padding-inline-end: 16px;
-        }
-
-        &.general {
-          @include media-breakpoint-up(md) {
-            &:not(:first-of-type) {
-              .cx-attribute-label {
-                visibility: hidden;
-              }
-            }
-          }
-
-          @include media-breakpoint-down(sm) {
+        @include media-breakpoint-up(md) {
+          &:not(:first-of-type) {
             .cx-attribute-label {
-              display: none;
-            }
-
-            &.last-value-pair {
-              .cx-attribute-label {
-                display: inline;
-              }
+              visibility: hidden;
             }
           }
         }
+      }
+
+      &.margin {
+        margin-block-start: 15px;
 
         &.bundle {
-          background-color: var(--cx-color-background);
-
-          @include media-breakpoint-up(md) {
-            &:not(:first-of-type) {
-              .cx-attribute-label {
-                visibility: hidden;
-              }
-            }
+          .cx-attribute-label {
+            visibility: visible;
           }
         }
 
-        &.margin {
-          margin-block-start: 15px;
-
-          &.bundle {
+        @include media-breakpoint-up(md) {
+          &.general {
             .cx-attribute-label {
               visibility: visible;
-            }
-          }
-
-          @include media-breakpoint-up(md) {
-            &.general {
-              .cx-attribute-label {
-                visibility: visible;
-              }
             }
           }
         }
@@ -150,28 +143,6 @@
     $subgroupLevel5Top: 216px;
 
     .cx-group {
-      padding-inline-start: 0px;
-      padding-inline-end: 0px;
-      padding-block-start: 25px;
-      padding-block-end: 25px;
-
-      margin-inline-start: -20px;
-      margin-inline-end: -25px;
-
-      @include media-breakpoint-up(md) {
-        padding-block-start: 20px;
-        padding-block-end: 20px;
-        margin-inline-start: 0px;
-        margin-inline-end: 0px;
-      }
-
-      @include media-breakpoint-down(sm) {
-        padding-block-start: 20px;
-        padding-block-end: 20px;
-        margin-inline-start: -20px;
-        margin-inline-end: -20px;
-      }
-
       &.topLevel {
         h2 {
           padding-inline-start: 32px;
@@ -186,19 +157,12 @@
             padding-block-end: 16px;
           }
 
-          font-size: 1.25rem;
-          font-weight: 700;
-          border-bottom: solid 1px var(--cx-color-light);
-          border-top: solid 1px var(--cx-color-light);
-          border-left-style: none;
-          border-right-style: none;
           background-color: var(--cx-color-inverse);
-          text-transform: none;
-          position: sticky;
-          top: 2px;
-          z-index: -1;
-          span {
-            @include cx-configurator-truncate-content();
+
+          @include media-breakpoint-down(sm) {
+            position: sticky;
+            top: 2px;
+            z-index: 5;
           }
         }
       }
@@ -228,12 +192,17 @@
             padding-block-end: 16px;
           }
 
-          border: solid 1px var(--cx-color-light);
-          background-color: var(--cx-color-background);
           font-size: 1rem;
           font-weight: normal;
           text-transform: uppercase;
-          position: sticky;
+          border: solid 1px var(--cx-color-light);
+          background-color: var(--cx-color-background);
+
+          @include forVersion(5.1) {
+            @include media-breakpoint-down(sm) {
+              position: sticky;
+            }
+          }
 
           span {
             @include cx-configurator-truncate-content();
@@ -241,92 +210,32 @@
         }
       }
 
-      &.subgroupLevel2 {
-        h2 {
-          top: $subgroupLevel2Top;
-          z-index: -2;
-        }
-      }
-
-      &.subgroupLevel3 {
-        h2 {
-          top: $subgroupLevel3Top;
-          z-index: -3;
-        }
-      }
-
-      &.subgroupLevel4 {
-        h2 {
-          top: $subgroupLevel4Top;
-          z-index: -4;
-        }
-      }
-
-      &.subgroupLevel5 {
-        h2 {
-          top: $subgroupLevel5Top;
-          z-index: -5;
-        }
-      }
-
-      .cx-attribute-value-pair {
-        padding-inline-start: 32px;
-        padding-inline-end: 32px;
-
-        @include media-breakpoint-down(sm) {
-          padding-inline-start: 16px;
-          padding-inline-end: 16px;
-        }
-
-        &.general {
-          @include media-breakpoint-up(md) {
-            &:not(:first-of-type) {
-              .cx-attribute-label {
-                visibility: hidden;
-              }
-            }
-          }
-
-          @include media-breakpoint-down(sm) {
-            .cx-attribute-label {
-              display: none;
-            }
-
-            &.last-value-pair {
-              .cx-attribute-label {
-                display: inline;
-              }
-            }
+      @include media-breakpoint-down(sm) {
+        &.subgroupLevel2 {
+          h2 {
+            top: $subgroupLevel2Top;
+            z-index: 4;
           }
         }
 
-        &.bundle {
-          background-color: var(--cx-color-background);
-
-          @include media-breakpoint-up(md) {
-            &:not(:first-of-type) {
-              .cx-attribute-label {
-                visibility: hidden;
-              }
-            }
+        &.subgroupLevel3 {
+          h2 {
+            top: $subgroupLevel3Top;
+            z-index: 3;
           }
         }
 
-        &.margin {
-          margin-block-start: 15px;
-
-          &.bundle {
-            .cx-attribute-label {
-              visibility: visible;
-            }
+        &.subgroupLevel4 {
+          h2 {
+            top: $subgroupLevel4Top;
+            z-index: 2;
           }
+        }
 
-          @include media-breakpoint-up(md) {
-            &.general {
-              .cx-attribute-label {
-                visibility: visible;
-              }
-            }
+        &.subgroupLevel5 {
+          h2 {
+            top: $subgroupLevel5Top;
+            z-index: 1;
           }
         }
       }

--- a/feature-libs/product-configurator/rulebased/styles/_configurator-overview-form.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-overview-form.scss
@@ -198,10 +198,8 @@
           border: solid 1px var(--cx-color-light);
           background-color: var(--cx-color-background);
 
-          @include forVersion(5.1) {
-            @include media-breakpoint-down(sm) {
-              position: sticky;
-            }
+          @include media-breakpoint-down(sm) {
+            position: sticky;
           }
 
           span {


### PR DESCRIPTION
To be able to test this PR, you should set `$useLatestStyles` to `true !default` in `_versioning.scss file`.
Before 5.1 version subgroups have not been supported, that's why the styling for it looks weird.