### PR TITLE
Fix/cxspa 1680

### DIFF
--- a/projects/storefrontlib/layout/a11y/keyboard-focus/visible/visible-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/visible/visible-focus.directive.spec.ts
@@ -5,7 +5,7 @@ import {
   ElementRef,
   Input,
 } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BaseFocusService } from '../base/base-focus.service';
 import { VisibleFocusConfig } from '../keyboard-focus.model';
@@ -134,39 +134,39 @@ describe('VisibleFocusDirective', () => {
       );
     });
 
-    it('should not have "mouse-focus" class when keydown is triggered after mousedown', () => {
+    it('should not have "mouse-focus" class when keyup is triggered after mousedown', () => {
       host.triggerEventHandler('mousedown', MockMouseEvent);
       fixture.detectChanges();
       expect((host.nativeElement as HTMLElement).classList).toContain(
         'mouse-focus'
       );
-      host.triggerEventHandler('keydown', MockMouseEvent);
+      host.triggerEventHandler('keyup', MockMouseEvent);
       fixture.detectChanges();
       expect((host.nativeElement as HTMLElement).classList).not.toContain(
         'mouse-focus'
       );
     });
 
-    it('should have "mouse-focus" class when keydown is used for OS functions', () => {
+    it('should have "mouse-focus" class when keyup is used for OS functions', () => {
       host.triggerEventHandler('mousedown', MockMouseEvent);
       fixture.detectChanges();
       expect((host.nativeElement as HTMLElement).classList).toContain(
         'mouse-focus'
       );
-      host.triggerEventHandler('keydown', MockOskeyEvent);
+      host.triggerEventHandler('keyup', MockOskeyEvent);
       fixture.detectChanges();
       expect((host.nativeElement as HTMLElement).classList).toContain(
         'mouse-focus'
       );
     });
 
-    it('should have "mouse-focus" class when keydown is used for filling in a FORM', () => {
+    it('should have "mouse-focus" class when keyup is used for filling in a FORM', () => {
       host.triggerEventHandler('mousedown', MockMouseEvent);
       fixture.detectChanges();
       expect((host.nativeElement as HTMLElement).classList).toContain(
         'mouse-focus'
       );
-      host.triggerEventHandler('keydown', MockFillFormEvent);
+      host.triggerEventHandler('keyup', MockFillFormEvent);
       fixture.detectChanges();
       expect((host.nativeElement as HTMLElement).classList).toContain(
         'mouse-focus'
@@ -179,15 +179,15 @@ describe('VisibleFocusDirective', () => {
       expect((host.nativeElement as HTMLElement).classList).toContain(
         'mouse-focus'
       );
-      host.triggerEventHandler('keydown', MockTabKeyEvent);
+      host.triggerEventHandler('keyup', MockTabKeyEvent);
       fixture.detectChanges();
       expect((host.nativeElement as HTMLElement).classList).not.toContain(
         'mouse-focus'
       );
     });
 
-    it('should have "mouse-focus" class when mousedown is triggered after keydown', () => {
-      host.triggerEventHandler('keydown', MockMouseEvent);
+    it('should have "mouse-focus" class when mousedown is triggered after keyup', () => {
+      host.triggerEventHandler('keyup', MockMouseEvent);
       fixture.detectChanges();
       expect((host.nativeElement as HTMLElement).classList).not.toContain(
         'mouse-focus'

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/visible/visible-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/visible/visible-focus.directive.ts
@@ -38,7 +38,7 @@ export class VisibleFocusDirective extends BaseFocusDirective {
     }
   }
 
-  @HostListener('keydown', ['$event']) handleKeydown(event: KeyboardEvent) {
+  @HostListener('keyup', ['$event']) handleKeyup(event: KeyboardEvent) {
     if (this.shouldFocusVisible) {
       this.mouseFocus = !this.isNavigating(event);
     }


### PR DESCRIPTION
fix: Focused items do not have the highlight outline initially when the modal dialog pops up,

Problem:- Outline is not highlighted if we press tab button in modal window which is rendered inline

This was because the trap-focus service stops event propagation of key down which was used in visual-focus directive to add or remove mouse-focus class which hides/ adds outline.

We had two options either to remove the event.stop propagation from trap-focus or listen for keyup which takes place just after key down in the visual-focus directive

We have changed the listener in the visual-focus directive from key down to key up for this logic considering that it will have minimal effect.


**Example and step to reproduce:-**

In epic/bopis branch, which does not have our fix, the tabbing does not work in modal window after the first input element is focused.
The event we were listening to in visible focus directive is keydown, this in itself is fine but in trap focus service keydown propagation is stopped.
We had two option either to remove code which stop event propagation in trap focus or to change the event listener in visible-focus.directive from keydown to keyup which takes place just before so that me can fix this with minimal effect.
```projects/storefrontlib/layout/a11y/keyboard-focus/visible/visible-focus.directive.ts
 @HostListener('keyup,['$event'])handleKeydown(event: KeyboardEvent){
   @HostListener('keydown',['$event'])handleKeydown(event: KeyboardEvent){
  if(this.shouldFocusVisible){
 this.mouseFocus=!this.isNavigating(event);
    }
