### PR TITLE
CXSPA-1953: Update ASM bind cart replacement behavior

### DIFF
--- a/feature-libs/asm/components/asm-bind-cart/asm-bind-cart.component.ts
+++ b/feature-libs/asm/components/asm-bind-cart/asm-bind-cart.component.ts
@@ -25,14 +25,22 @@ import {
 import { LaunchDialogService, LAUNCH_CALLER } from '@spartacus/storefront';
 import {
   BehaviorSubject,
+  combineLatest,
   defer,
   EMPTY,
   iif,
   Observable,
-  of,
   Subscription,
 } from 'rxjs';
-import { concatMap, filter, finalize, map, take, tap } from 'rxjs/operators';
+import {
+  concatMap,
+  filter,
+  finalize,
+  map,
+  shareReplay,
+  take,
+  tap,
+} from 'rxjs/operators';
 import { BIND_CART_DIALOG_ACTION } from '../asm-bind-cart-dialog/asm-bind-cart-dialog.component';
 
 @Component({
@@ -56,7 +64,10 @@ export class AsmBindCartComponent implements OnInit, OnDestroy {
 
   loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
-  valid$ = this.cartId.statusChanges.pipe(map((status) => status === 'VALID'));
+  valid$ = this.cartId.statusChanges.pipe(
+    map((status) => status === 'VALID'),
+    shareReplay(1)
+  );
 
   activeCartId = '';
 
@@ -95,16 +106,18 @@ export class AsmBindCartComponent implements OnInit, OnDestroy {
   bindCartToCustomer() {
     const anonymousCartId = this.cartId.value;
 
-    const subscription = of(this.loading$.getValue())
+    const subscription = combineLatest([
+      this.loading$.asObservable(),
+      this.valid$,
+    ])
       .pipe(
-        filter((loading) => !loading && Boolean(anonymousCartId)),
-        tap(() => {
-          this.loading$.next(true);
-        }),
+        take(1),
+        filter(([loading, valid]) => !loading && valid),
+        tap(() => this.loading$.next(true)),
         concatMap(() =>
           iif(
             () => Boolean(this.activeCartId),
-            this.openDialog(anonymousCartId as string),
+            this.openDialog(this.activeCartId, anonymousCartId as string),
             this.simpleBindCart(anonymousCartId as string)
           )
         ),
@@ -148,7 +161,7 @@ export class AsmBindCartComponent implements OnInit, OnDestroy {
   /**
    * Opens dialog and passes non-cancel result to select action
    */
-  protected openDialog(anonymousCartId: string) {
+  protected openDialog(activeCartId: string, anonymousCartId: string) {
     return defer(() => {
       this.launchDialogService.openDialogAndSubscribe(
         LAUNCH_CALLER.ASM_BIND_CART,
@@ -161,18 +174,23 @@ export class AsmBindCartComponent implements OnInit, OnDestroy {
     }).pipe(
       filter((dialogResult) => Boolean(dialogResult)),
       concatMap((dialogResult) => {
-        return this.selectBindAction(anonymousCartId, dialogResult);
+        return this.selectBindAction(
+          activeCartId,
+          anonymousCartId,
+          dialogResult
+        );
       })
     );
   }
 
   protected selectBindAction(
+    activeCartId: string,
     anonymousCartId: string,
     action: BIND_CART_DIALOG_ACTION
   ): Observable<unknown> {
     switch (action) {
       case BIND_CART_DIALOG_ACTION.REPLACE:
-        return this.replaceCart(anonymousCartId);
+        return this.replaceCart(activeCartId, anonymousCartId);
 
       case BIND_CART_DIALOG_ACTION.CANCEL:
       default:
@@ -180,19 +198,19 @@ export class AsmBindCartComponent implements OnInit, OnDestroy {
     }
   }
 
-  protected replaceCart(anonymousCartId: string): Observable<unknown> {
-    return of(this.activeCartId).pipe(
-      tap((activeCartId) => {
-        if (activeCartId) {
-          this.savedCartFacade.saveCart({
-            cartId: activeCartId,
-            saveCartName: activeCartId,
-            // TODO(#12660): Remove default value once backend is updated
-            saveCartDescription: '-',
-          });
-        }
-      }),
-      concatMap(() => this.simpleBindCart(anonymousCartId))
+  protected replaceCart(
+    previousActiveCartId: string,
+    anonymousCartId: string
+  ): Observable<unknown> {
+    return this.simpleBindCart(anonymousCartId).pipe(
+      tap(() => {
+        this.savedCartFacade.saveCart({
+          cartId: previousActiveCartId,
+          saveCartName: previousActiveCartId,
+          // TODO(#12660): Remove default value once backend is updated
+          saveCartDescription: '-',
+        });
+      })
     );
   }
 }


### PR DESCRIPTION
The replace action will now save the cart only on successful binding.  Submitting the bind cart form while invalid will no longer attempt to bind the cart.