### PR TITLE
fix: add src in video tag thus can be updated dynamically

### DIFF
--- a/projects/storefrontlib/cms-components/content/video/video.component.html
+++ b/projects/storefrontlib/cms-components/content/video/video.component.html
@@ -15,9 +15,8 @@
     [autoplay]="autoPlay"
     [muted]="mute"
     [attr.aria-label]="'player.label' | cxTranslate"
-  >
-    <source src="{{ source }}" type="{{ data.video?.mime }}" />
-  </video>
+    [src]="source"
+  ></video>
 </div>
 
 <ng-template #loading>


### PR DESCRIPTION
See bug: https://jira.tools.sap/browse/CXSPA-1938
root cause: src attribute value in source tag cannot be updated dynamically [see specs](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element)
The fix consists to remove the source tag embedded within video tag beeing replaced by src attr in video tag.
From reasearch and tests:

- There is no beneftits of using 'source' if only 1 source is specified. The only benefits is when fall back exists (in case of incompatibility with browser) with several source tags present. [see](https://stackoverflow.com/questions/39179834/difference-between-video-src-video-and-video-source-video)

- No benefits in mime value neither, [see](https://stackoverflow.com/questions/34982403/is-mime-type-really-needed-for-playing-video-in-html5)

Fix tested successfully with smart-edit on cx 2211, dev9: https://40.76.109.9:9002
Tested unsupported video ([see](https://tools.woolyss.com/html5-audio-video-tester/)) --> no diff before or after fix