### PR TITLE
fix: Export order confirmation components (#16640)

### DIFF
--- a/feature-libs/order/components/public_api.ts
+++ b/feature-libs/order/components/public_api.ts
@@ -7,6 +7,7 @@
 export * from './amend-order/index';
 export * from './guards/index';
 export * from './order-components.module';
+export * from './order-confirmation/index';
 export * from './order-details/index';
 export * from './order-history/order-history.component';
 export * from './order-history/order-history.module';


### PR DESCRIPTION
This PR exports the order confirmation components (@spartacus/order/components) which were not exposed before.