### PR TITLE
test: PoC to test e2e spec retries on single test failure

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/my-account/close-account.core-e2e-spec-flaky.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/my-account/close-account.core-e2e-spec-flaky.ts
@@ -6,85 +6,107 @@ import { standardUser } from '../../../sample-data/shared-users';
 
 const CLOSE_ACCOUNT_URL = '/my-account/close-account';
 
-describe('My Account - Close Account', () => {
-  viewportContext(['mobile', 'desktop'], () => {
-    before(() =>
-      cy.window().then((win) => {
-        win.sessionStorage.clear();
-      })
-    );
+let _counter = 0;
+let skip = false;
 
-    describe('Anonymous user', () => {
-      it('should redirect to login page', () => {
-        cy.visit(CLOSE_ACCOUNT_URL);
-        cy.location('pathname').should('contain', '/login');
+Cypress.on('fail', (error, test) => {
+  skip = false;
+  console.log('hello');
+  console.log(test);
+  if (_counter < 3) {
+    _counter++;
+    console.log(_counter);
+    // test.run(() => myTest());
+    cy.end();
+    myTest();
+  } else {
+    throw error; // behave as normal
+  }
+});
+
+// Cypress._.times(_runModeRetries, () => {
+const myTest = () =>
+  describe('My Account - Close Account', () => {
+    viewportContext(['mobile', 'desktop'], () => {
+      before(() =>
+        cy.window().then((win) => {
+          win.sessionStorage.clear();
+        })
+      );
+
+      describe('Anonymous user', () => {
+        it('should redirect to login page', () => {
+          cy.visit(CLOSE_ACCOUNT_URL);
+          cy.location('pathname').should('contain', '/login');
+        });
       });
-    });
 
-    describe('Logged in user', () => {
-      before(() => {
-        standardUser.registrationData.email = generateMail(
-          randomString(),
-          true
-        );
-        cy.requireLoggedIn(standardUser);
-        cy.visit('/');
-      });
-
-      beforeEach(() => {
-        cy.restoreLocalStorage();
-      });
-
-      it('should cancel and go back to the homepage', () => {
-        cy.selectUserMenuOption({
-          option: 'Close Account',
+      describe('Logged in user', () => {
+        before(() => {
+          standardUser.registrationData.email = generateMail(
+            randomString(),
+            true
+          );
+          cy.requireLoggedIn(standardUser);
+          cy.visit('/');
         });
 
-        cy.get('cx-close-account a').click({ force: true });
-        cy.location('pathname').should('contain', '/');
-      });
-
-      it('should close account', () => {
-        cy.selectUserMenuOption({
-          option: 'Close Account',
+        beforeEach(() => {
+          cy.restoreLocalStorage();
         });
 
-        cy.intercept(
-          'DELETE',
-          `${Cypress.env('OCC_PREFIX')}/${Cypress.env('BASE_SITE')}/users/*`
-        ).as('deleteQuery');
+        it('should cancel and go back to the homepage', () => {
+          cy.selectUserMenuOption({
+            option: 'Close Account',
+          });
 
-        cy.location('pathname').should('contain', CLOSE_ACCOUNT_URL);
+          cy.get('cx-close-account a').click({ force: true });
+          cy.location('pathname').should('contain', '/');
+        });
 
-        cy.get('cx-close-account button').click({ force: true });
+        it('should close account', () => {
+          cy.selectUserMenuOption({
+            option: 'Close Account',
+          });
 
-        cy.get(
-          'cx-close-account-modal .cx-close-account-modal-container .cx-close-account-modal-footer button:first-of-type'
-        ).click();
+          cy.intercept(
+            'DELETE',
+            `${Cypress.env('OCC_PREFIX')}/${Cypress.env('BASE_SITE')}/users/*`
+          ).as('deleteQuery');
 
-        cy.wait('@deleteQuery');
+          cy.location('pathname').should('contain', CLOSE_ACCOUNT_URL);
 
-        cy.location('pathname').should('contain', '/');
+          cy.get('cx-close-account button').click({ force: true });
 
-        alerts
-          .getSuccessAlert()
-          .should('contain', 'Account closed with success');
-      });
+          cy.get(
+            'cx-close-account-modal .cx-close-account-modal-container .cx-close-account-modal-footer button:first-of-type'
+          ).click();
 
-      it('should not login with a closed account credentials', () => {
-        cy.visit('/login');
-        login(
-          standardUser.registrationData.email,
-          standardUser.registrationData.password
-        );
+          cy.wait('@deleteQuery');
 
-        cy.location('pathname').should('contain', '/login');
-        alerts.getErrorAlert().should('contain', 'User is disabled');
-      });
+          cy.location('pathname').should('contain', '/');
 
-      afterEach(() => {
-        cy.saveLocalStorage();
+          alerts
+            .getSuccessAlert()
+            .should('contain', 'Account closed with success');
+        });
+
+        it('should not login with a closed account credentials', () => {
+          cy.visit('/login');
+          login(
+            standardUser.registrationData.email,
+            standardUser.registrationData.password
+          );
+
+          cy.location('pathname').should('contain', '/login');
+          alerts.getErrorAlert().should('contain', 'User is disabled');
+        });
+
+        afterEach(() => {
+          cy.saveLocalStorage();
+        });
       });
     });
   });
-});
+
+myTest();

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/my-account/close-account.core-e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/my-account/close-account.core-e2e-spec.ts
@@ -7,20 +7,22 @@ import { standardUser } from '../../../sample-data/shared-users';
 const CLOSE_ACCOUNT_URL = '/my-account/close-account';
 
 let failCount = 0;
-const FAIL_LIMIT = 3;
+const FAIL_LIMIT = 2;
 let skip = false;
 
 Cypress.on('fail', (error, test) => {
   console.log('test:', test.title);
-  if (failCount < FAIL_LIMIT && !skip) {
+  if (!skip) {
     failCount++;
     console.log('fail count:', failCount);
-    skip = true;
+    if (failCount < FAIL_LIMIT) {
+      skip = true;
 
-    // On failure, skip all tests and start again
-    test.skip();
-  } else {
-    throw error; // behave as normal
+      // On failure, skip all tests and start again
+      test.skip();
+    } else {
+      throw error; // behave as normal
+    }
   }
 });
 
@@ -44,6 +46,11 @@ const myTest = () =>
         it('should redirect to login page', () => {
           cy.visit(CLOSE_ACCOUNT_URL);
           cy.location('pathname').should('contain', '/login');
+        });
+
+        //TODO REMOVE
+        it('should fail', () => {
+          cy.get('nothing');
         });
       });
 


### PR DESCRIPTION
This PR was to test the possibility of retrying test spec file fails X number of times in order to reduce the number of flaky tests due to random test failures.

This particular method attempted to leverage Cypress functions in order to skip remaining tests on failure, intercept the failure method so that a failure is not reported and retry all tests in the suite.

Unfortunately, it is very difficult to know how Cypress will react when we use their methods in an "unintended" way. We ran into issues and differences when running on open mode vs headless vs ci mode. This method may simply be too difficult to maintain and could break in case of a cypress upgrade.

However, there is a library that seems to do what we want here: https://github.com/bahmutov/cypress-repeat