### PR TITLE
chore: fix console errors for product-configurator tests [CXSPA-2109]

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.component.spec.ts
@@ -86,7 +86,7 @@ describe('ConfiguratorOverviewFilterDialogComponent', () => {
     initialize();
     fixture.debugElement
       .query(By.css('.cx-dialog-header button'))
-      .triggerEventHandler('click');
+      .triggerEventHandler('click', new Event('click'));
     expect(mockLaunchDialogService.closeDialog).toHaveBeenCalledWith(
       'Close Filtering'
     );
@@ -96,7 +96,7 @@ describe('ConfiguratorOverviewFilterDialogComponent', () => {
     initialize();
     fixture.debugElement
       .query(By.css('.cx-modal-container'))
-      .triggerEventHandler('click');
+      .triggerEventHandler('click', new Event('click'));
     expect(mockLaunchDialogService.closeDialog).toHaveBeenCalledWith(
       'Close Filtering'
     );
@@ -106,7 +106,7 @@ describe('ConfiguratorOverviewFilterDialogComponent', () => {
     initialize();
     fixture.debugElement
       .query(By.css('.cx-modal-content'))
-      .triggerEventHandler('click');
+      .triggerEventHandler('click', new Event('click'));
     expect(mockLaunchDialogService.closeDialog).not.toHaveBeenCalled();
   });
 

--- a/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { UntypedFormControl } from '@angular/forms';
+import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { I18nTestingModule } from '@spartacus/core';
 import { CommonConfigurator } from '@spartacus/product-configurator/common';
@@ -42,6 +42,7 @@ function initTestComponent() {
   htmlElem = fixture.nativeElement;
   component = fixture.componentInstance;
   component.config = ovConfig;
+  component.ngOnChanges();
   fixture.detectChanges();
 }
 
@@ -60,7 +61,7 @@ describe('ConfiguratorOverviewFilterComponent', () => {
         initTestData();
         initMocks();
         TestBed.configureTestingModule({
-          imports: [I18nTestingModule],
+          imports: [I18nTestingModule, ReactiveFormsModule],
           declarations: [
             ConfiguratorOverviewFilterComponent,
             MockConfiguratorOverviewFilterBarComponent,
@@ -137,7 +138,7 @@ describe('ConfiguratorOverviewFilterComponent', () => {
       fixture.debugElement
         .queryAll(By.css('.cx-overview-filter-option input'))
         .forEach((element) => {
-          element.triggerEventHandler('change');
+          element.nativeElement.dispatchEvent(new InputEvent('change'));
         });
 
       expect(

--- a/feature-libs/product-configurator/textfield/components/add-to-cart-button/configurator-textfield-add-to-cart-button.component.spec.ts
+++ b/feature-libs/product-configurator/textfield/components/add-to-cart-button/configurator-textfield-add-to-cart-button.component.spec.ts
@@ -5,6 +5,7 @@ import {
   Type,
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   RouterState,
@@ -83,7 +84,7 @@ describe('ConfigTextfieldAddToCartButtonComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
+        imports: [I18nTestingModule, RouterTestingModule],
         declarations: [
           ConfiguratorTextfieldAddToCartButtonComponent,
           MockUrlPipe,

--- a/feature-libs/product-configurator/textfield/components/input-field/configurator-textfield-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/textfield/components/input-field/configurator-textfield-input-field.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
 import { I18nTestingModule } from '@spartacus/core';
 import { CommonConfiguratorTestUtilsService } from '../../../common/testing/common-configurator-test-utils.service';
 import { ConfiguratorTextfieldInputFieldComponent } from './configurator-textfield-input-field.component';
@@ -11,7 +12,7 @@ describe('TextfieldInputFieldComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
+        imports: [I18nTestingModule, ReactiveFormsModule],
         declarations: [ConfiguratorTextfieldInputFieldComponent],
       });
     })


### PR DESCRIPTION
fixes all remaining console errors in product-configurator karma tests, typically errors were:

- NPE due to incomplete DOM events used in specs
- NG0303 caused by missing imports in specs

closes https://jira.tools.sap/browse/CXSPA-2109