### PR TITLE
fix: AMP violation on B2B Registration(CXSPA-1883)

### DIFF
--- a/feature-libs/organization/user-registration/components/form/user-registration-form.component.html
+++ b/feature-libs/organization/user-registration/components/form/user-registration-form.component.html
@@ -6,7 +6,26 @@
       <span class="label-content">{{
         'userRegistrationForm.fields.titleCode.label' | cxTranslate
       }}</span>
+      <!-- TODO:(CXSPA-1695) for next major release update below feature flags -->
       <ng-select
+        *cxFeatureLevel="'5.2'"
+        id="title-code-select"
+        formControlName="titleCode"
+        [searchable]="false"
+        [clearable]="false"
+        [items]="titles$ | async"
+        bindLabel="name"
+        bindValue="code"
+        placeholder="{{
+          'userRegistrationForm.fields.titleCode.placeholder' | cxTranslate
+        }}"
+        [cxNgSelectA11y]="{
+          ariaLabel: 'userRegistrationForm.fields.titleCode.label' | cxTranslate
+        }"
+      >
+      </ng-select>
+      <ng-select
+        *cxFeatureLevel="'!5.2'"
         formControlName="titleCode"
         [searchable]="false"
         [clearable]="false"

--- a/feature-libs/organization/user-registration/components/form/user-registration-form.component.spec.ts
+++ b/feature-libs/organization/user-registration/components/form/user-registration-form.component.spec.ts
@@ -3,7 +3,14 @@ import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { I18nTestingModule, Title, Country, Region } from '@spartacus/core';
+import {
+  I18nTestingModule,
+  Title,
+  Country,
+  Region,
+  FeaturesConfigModule,
+  FeaturesConfig,
+} from '@spartacus/core';
 import { FormErrorsModule } from '@spartacus/storefront';
 import { OrganizationUserRegistration } from '@spartacus/organization/user-registration/root';
 import { NgSelectModule } from '@ng-select/ng-select';
@@ -118,12 +125,19 @@ describe('UserRegistrationFormComponent', () => {
           I18nTestingModule,
           FormErrorsModule,
           RouterTestingModule,
+          FeaturesConfigModule,
         ],
         declarations: [UserRegistrationFormComponent, MockUrlPipe],
         providers: [
           {
             provide: UserRegistrationFormService,
             useClass: MockUserRegistrationFormService,
+          },
+          {
+            provide: FeaturesConfig,
+            useValue: {
+              features: { level: '5.2' },
+            },
           },
         ],
       });

--- a/feature-libs/organization/user-registration/components/form/user-registration-form.module.ts
+++ b/feature-libs/organization/user-registration/components/form/user-registration-form.module.ts
@@ -15,6 +15,7 @@ import {
   I18nModule,
   UrlModule,
   NotAuthGuard,
+  FeaturesConfigModule,
 } from '@spartacus/core';
 import {
   FormErrorsModule,
@@ -35,6 +36,7 @@ import { UserRegistrationFormService } from './user-registration-form.service';
     FormErrorsModule,
     NgSelectModule,
     NgSelectA11yModule,
+    FeaturesConfigModule,
     ConfigModule.withConfig(<CmsConfig>{
       cmsComponents: {
         OrganizationUserRegistrationComponent: {


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-1883

Added id to ng-select tag to pass aria-controls value