### PR TITLE
fix: 'ERROR TypeError: changes.config is undefined' in focus directive

### DIFF
--- a/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.directive.ts
@@ -69,7 +69,7 @@ export class AutoFocusDirective
 
   ngOnChanges(changes: SimpleChanges): void {
     // responsible for refresh focus based on the configured refresh property name
-    if (!!(changes.config.currentValue as AutoFocusConfig)?.refreshFocus) {
+    if (!!(changes.config?.currentValue as AutoFocusConfig)?.refreshFocus) {
       // ensure the autofocus when it's to provided initially
       if (!this.config.autofocus) {
         this.config.autofocus = true;


### PR DESCRIPTION
The ngOnChanges hook of the focus directive falsely assumes that the parameter `changes` always has a property `config`. In case the property is missing, `ERROR TypeError: changes.config is undefined` is logged into the browser console. Other branches in the directive, for example see line 109, correctly use an optional chaining operator to access this property. This PR adds the optional chaining to line 72, as well, so that no error is logged anymore.
For reproducing the issue, please see the description of https://jira.tools.sap/browse/CXSPA-2193

fixes: https://jira.tools.sap/browse/CXSPA-2193
