### PR TITLE
Feature: Tab A11Y directive

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.html
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.html
@@ -1,14 +1,18 @@
 <ng-container *ngIf="routerData$ | async as routerData">
   <ng-container *ngIf="configuration$ | async; else ghostTabBar">
     <ng-container *ngIf="!routerData.displayOnly">
-      <div class="cx-tab-bar" role="tablist">
+      <div
+        class="cx-tab-bar"
+        role="tablist"
+        cxTabList
+        [selectedIndex]="currentIndex | async"
+        (changeTab)="$event === 0 ? configTab.click() : overviewTab.click()"
+      >
         <a
           #configTab
-          [tabindex]="getTabIndexConfigTab()"
+          cxTab
           role="tab"
           [class.active]="!(isOverviewPage$ | async)"
-          [attr.aria-selected]="!(isOverviewPage$ | async)"
-          (keydown)="switchTabOnArrowPress($event, '#configTab')"
           [routerLink]="
             {
               cxRoute: 'configure' + routerData.owner.configuratorType,
@@ -27,11 +31,9 @@
         >
         <a
           #overviewTab
-          [tabindex]="getTabIndexOverviewTab()"
+          cxTab
           role="tab"
           [class.active]="isOverviewPage$ | async"
-          [attr.aria-selected]="isOverviewPage$ | async"
-          (keydown)="switchTabOnArrowPress($event, '#overviewTab')"
           [routerLink]="
             {
               cxRoute: 'configureOverview' + routerData.owner.configuratorType,

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.html
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.html
@@ -5,7 +5,7 @@
         class="cx-tab-bar"
         role="tablist"
         cxTabList
-        [selectedIndex]="currentIndex | async"
+        [selectedIndex]="currentIndex$ | async"
         (changeTab)="$event === 0 ? configTab.click() : overviewTab.click()"
       >
         <a

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.spec.ts
@@ -56,7 +56,7 @@ class MockUrlPipe implements PipeTransform {
   transform(): any {}
 }
 
-describe('ConfigTabBarComponent', () => {
+describe('ConfiguratorTabBarComponent', () => {
   let component: ConfiguratorTabBarComponent;
   let fixture: ComponentFixture<ConfiguratorTabBarComponent>;
   let htmlElem: HTMLElement;
@@ -128,12 +128,20 @@ describe('ConfigTabBarComponent', () => {
     component.isOverviewPage$
       .subscribe((isOv) => expect(isOv).toBe(true))
       .unsubscribe();
+
+    component.currentIndex$
+      .subscribe((index) => expect(index).toBe(1))
+      .unsubscribe();
   });
 
   it('should tell from semantic route that we are on config page', () => {
     mockRouterState.state.semanticRoute = CONFIGURATOR_ROUTE;
     component.isOverviewPage$
       .subscribe((isOv) => expect(isOv).toBe(false))
+      .unsubscribe();
+
+    component.currentIndex$
+      .subscribe((index) => expect(index).toBe(0))
       .unsubscribe();
   });
 
@@ -165,36 +173,6 @@ describe('ConfigTabBarComponent', () => {
           0,
           'aria-label',
           'configurator.a11y.configurationPageLink',
-          'configurator.tabBar.configuration'
-        );
-      });
-
-      it("should contain an element with 'aria-selected' attribute set to true if the configuration page is displayed", () => {
-        mockRouterState.state.semanticRoute = CONFIGURATOR_ROUTE;
-        fixture.detectChanges();
-        CommonConfiguratorTestUtilsService.expectElementContainsA11y(
-          expect,
-          htmlElem,
-          'a',
-          undefined,
-          0,
-          'aria-selected',
-          'true',
-          'configurator.tabBar.configuration'
-        );
-      });
-
-      it("should contain an element with 'aria-selected' attribute set to false if the overview page is displayed", () => {
-        mockRouterState.state.semanticRoute = CONFIG_OVERVIEW_ROUTE;
-        fixture.detectChanges();
-        CommonConfiguratorTestUtilsService.expectElementContainsA11y(
-          expect,
-          htmlElem,
-          'a',
-          undefined,
-          0,
-          'aria-selected',
-          'false',
           'configurator.tabBar.configuration'
         );
       });
@@ -246,36 +224,6 @@ describe('ConfigTabBarComponent', () => {
         );
       });
 
-      it("should contain an element with 'aria-selected' attribute set to false if the configuration page is displayed", () => {
-        mockRouterState.state.semanticRoute = CONFIGURATOR_ROUTE;
-        fixture.detectChanges();
-        CommonConfiguratorTestUtilsService.expectElementContainsA11y(
-          expect,
-          htmlElem,
-          'a',
-          undefined,
-          1,
-          'aria-selected',
-          'false',
-          'configurator.tabBar.overview'
-        );
-      });
-
-      it("should contain an element with 'aria-selected' attribute set to true if the overview page is displayed", () => {
-        mockRouterState.state.semanticRoute = CONFIG_OVERVIEW_ROUTE;
-        fixture.detectChanges();
-        CommonConfiguratorTestUtilsService.expectElementContainsA11y(
-          expect,
-          htmlElem,
-          'a',
-          undefined,
-          1,
-          'aria-selected',
-          'true',
-          'configurator.tabBar.overview'
-        );
-      });
-
       it("should contain an element with 'role' attribute that defines the link as a tab", () => {
         mockRouterState.state.semanticRoute = CONFIGURATOR_ROUTE;
         fixture.detectChanges();
@@ -290,108 +238,6 @@ describe('ConfigTabBarComponent', () => {
           'configurator.tabBar.overview'
         );
       });
-    });
-  });
-
-  describe('getTabIndexOverviewTab', () => {
-    it('should return tabindex 0 if on overview page', () => {
-      mockRouterState.state.semanticRoute = CONFIG_OVERVIEW_ROUTE;
-      expect(component.getTabIndexOverviewTab()).toBe(0);
-    });
-
-    it('should return tabindex -1 if on configuration page', () => {
-      mockRouterState.state.semanticRoute = CONFIGURATOR_ROUTE;
-      expect(component.getTabIndexOverviewTab()).toBe(-1);
-    });
-  });
-
-  describe('getTabIndexConfigTab', () => {
-    it('should return tabindex -1 if on overview page', () => {
-      mockRouterState.state.semanticRoute = CONFIG_OVERVIEW_ROUTE;
-      expect(component.getTabIndexConfigTab()).toBe(-1);
-    });
-
-    it('should return tabindex 0 if on configuration page', () => {
-      mockRouterState.state.semanticRoute = CONFIGURATOR_ROUTE;
-      expect(component.getTabIndexConfigTab()).toBe(0);
-    });
-  });
-
-  describe('switchTabOnArrowPress', () => {
-    it('should focus overview tab if right arrow pressed and if current tab is config tab', () => {
-      fixture.detectChanges();
-      const event = new KeyboardEvent('keydown', {
-        code: 'ArrowRight',
-      });
-      component.switchTabOnArrowPress(event, '#configTab');
-      let focusedElement = document.activeElement;
-      expect(focusedElement?.innerHTML).toBe('configurator.tabBar.overview');
-    });
-
-    it('should focus overview tab if left arrow pressed and if current tab is config tab', () => {
-      fixture.detectChanges();
-      const event = new KeyboardEvent('keydown', {
-        code: 'ArrowLeft',
-      });
-      component.switchTabOnArrowPress(event, '#configTab');
-      let focusedElement = document.activeElement;
-      expect(focusedElement?.innerHTML).toBe('configurator.tabBar.overview');
-    });
-
-    it('should not change focus if up arrow pressed', () => {
-      fixture.detectChanges();
-      const leftEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowLeft',
-      });
-      component.switchTabOnArrowPress(leftEvent, '#configTab');
-      let focusedElement = document.activeElement;
-      expect(focusedElement?.innerHTML).toBe('configurator.tabBar.overview');
-      const downEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowUp',
-      });
-      component.switchTabOnArrowPress(downEvent, '#configTab');
-      document.activeElement;
-      expect(focusedElement?.innerHTML).toBe('configurator.tabBar.overview');
-    });
-
-    it('should not change focus if down arrow pressed', () => {
-      fixture.detectChanges();
-      const leftEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowLeft',
-      });
-      component.switchTabOnArrowPress(leftEvent, '#configTab');
-      let focusedElement = document.activeElement;
-      expect(focusedElement?.innerHTML).toBe('configurator.tabBar.overview');
-      const downEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowDown',
-      });
-      component.switchTabOnArrowPress(downEvent, '#configTab');
-      document.activeElement;
-      expect(focusedElement?.innerHTML).toBe('configurator.tabBar.overview');
-    });
-
-    it('should focus config tab if right arrow pressed and if current tab is overview tab', () => {
-      fixture.detectChanges();
-      const event = new KeyboardEvent('keydown', {
-        code: 'ArrowRight',
-      });
-      component.switchTabOnArrowPress(event, '#overviewTab');
-      let focusedElement = document.activeElement;
-      expect(focusedElement?.innerHTML).toBe(
-        'configurator.tabBar.configuration'
-      );
-    });
-
-    it('should focus config tab if left arrow pressed and if current tab is overview tab', () => {
-      fixture.detectChanges();
-      const event = new KeyboardEvent('keydown', {
-        code: 'ArrowLeft',
-      });
-      component.switchTabOnArrowPress(event, '#overviewTab');
-      let focusedElement = document.activeElement;
-      expect(focusedElement?.innerHTML).toBe(
-        'configurator.tabBar.configuration'
-      );
     });
   });
 });

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.ts
@@ -44,7 +44,7 @@ export class ConfiguratorTabBarComponent {
     )
   );
 
-  currentIndex: Observable<number> = this.isOverviewPage$.pipe(
+  currentIndex$: Observable<number> = this.isOverviewPage$.pipe(
     map((isOverviewPage) => Number(isOverviewPage))
   );
 

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.ts
@@ -4,20 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  ViewChild,
-  ElementRef,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding } from '@angular/core';
 import {
   ConfiguratorRouter,
   ConfiguratorRouterExtractorService,
 } from '@spartacus/product-configurator/common';
 import {} from '@spartacus/storefront';
 import { Observable } from 'rxjs';
-import { map, switchMap, take, tap } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
 import { ConfiguratorCommonsService } from '../../core/facade/configurator-commons.service';
 import { Configurator } from '../../core/model/configurator.model';
 
@@ -28,8 +22,6 @@ import { Configurator } from '../../core/model/configurator.model';
 })
 export class ConfiguratorTabBarComponent {
   @HostBinding('class.ghost') ghostStyle = true;
-  @ViewChild('configTab') configTab: ElementRef<HTMLElement>;
-  @ViewChild('overviewTab') overviewTab: ElementRef<HTMLElement>;
 
   routerData$: Observable<ConfiguratorRouter.Data> =
     this.configRouterExtractorService.extractRouterData();
@@ -52,51 +44,9 @@ export class ConfiguratorTabBarComponent {
     )
   );
 
-  /**
-   * Returns the tabindex for the configuration tab.
-   * The configuration tab is excluded from the tab chain if currently the overview page is displayed.
-   * @returns tabindex of the configuration tab
-   */
-  getTabIndexConfigTab(): number {
-    let tabIndex = 0;
-    this.isOverviewPage$.pipe(take(1)).subscribe((isOvPage) => {
-      if (isOvPage) {
-        tabIndex = -1;
-      }
-    });
-    return tabIndex;
-  }
-
-  /**
-   * Returns the tabindex for the overview tab.
-   * The overview tab is excluded from the tab chain if currently the configuration page is displayed.
-   * @returns tabindex of the overview tab
-   */
-  getTabIndexOverviewTab(): number {
-    let tabIndex = 0;
-    this.isOverviewPage$.pipe(take(1)).subscribe((isOvPage) => {
-      if (!isOvPage) {
-        tabIndex = -1;
-      }
-    });
-    return tabIndex;
-  }
-
-  /**
-   * Switches the focus of the tabs on pressing left or right arrow key.
-   * @param {KeyboardEvent} event - Keyboard event
-   * @param {string} currentTab - Current tab
-   */
-  switchTabOnArrowPress(event: KeyboardEvent, currentTab: string): void {
-    if (event.code === 'ArrowLeft' || event.code === 'ArrowRight') {
-      event.preventDefault();
-      if (currentTab === '#configTab') {
-        this.overviewTab.nativeElement?.focus();
-      } else {
-        this.configTab.nativeElement?.focus();
-      }
-    }
-  }
+  currentIndex: Observable<number> = this.isOverviewPage$.pipe(
+    map((isOverviewPage) => Number(isOverviewPage))
+  );
 
   constructor(
     protected configRouterExtractorService: ConfiguratorRouterExtractorService,

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.module.ts
@@ -15,6 +15,7 @@ import {
   provideDefaultConfig,
   UrlModule,
 } from '@spartacus/core';
+import { TabModule } from 'projects/storefrontlib/layout/a11y/tab';
 import { ConfiguratorTabBarComponent } from './configurator-tab-bar.component';
 
 @NgModule({
@@ -26,6 +27,7 @@ import { ConfiguratorTabBarComponent } from './configurator-tab-bar.component';
     I18nModule,
     UrlModule,
     RouterModule,
+    TabModule,
   ],
   providers: [
     provideDefaultConfig(<CmsConfig>{

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.module.ts
@@ -15,7 +15,7 @@ import {
   provideDefaultConfig,
   UrlModule,
 } from '@spartacus/core';
-import { TabModule } from 'projects/storefrontlib/layout/a11y/tab';
+import { TabModule } from '@spartacus/storefront';
 import { ConfiguratorTabBarComponent } from './configurator-tab-bar.component';
 
 @NgModule({

--- a/feature-libs/storefinder/components/store-finder-components.module.ts
+++ b/feature-libs/storefinder/components/store-finder-components.module.ts
@@ -19,8 +19,8 @@ import {
   IconModule,
   ListNavigationModule,
   SpinnerModule,
+  TabModule,
 } from '@spartacus/storefront';
-import { TabModule } from 'projects/storefrontlib/layout/a11y/tab';
 import { ScheduleComponent } from './schedule-component/schedule.component';
 import { StoreFinderGridComponent } from './store-finder-grid/store-finder-grid.component';
 import { StoreFinderHeaderComponent } from './store-finder-header/store-finder-header.component';

--- a/feature-libs/storefinder/components/store-finder-components.module.ts
+++ b/feature-libs/storefinder/components/store-finder-components.module.ts
@@ -20,6 +20,7 @@ import {
   ListNavigationModule,
   SpinnerModule,
 } from '@spartacus/storefront';
+import { TabModule } from 'projects/storefrontlib/layout/a11y/tab';
 import { ScheduleComponent } from './schedule-component/schedule.component';
 import { StoreFinderGridComponent } from './store-finder-grid/store-finder-grid.component';
 import { StoreFinderHeaderComponent } from './store-finder-header/store-finder-header.component';
@@ -44,6 +45,7 @@ import { StoreFinderComponent } from './store-finder/store-finder.component';
     StoreFinderCoreModule,
     I18nModule,
     IconModule,
+    TabModule,
     // TODO:(CXSPA-1695) #deprecation for next major release remove below feature config
     FeaturesConfigModule,
   ],

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.html
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.html
@@ -64,12 +64,19 @@
 
     <!-- mobile tabs for column set only -->
     <div *ngIf="locations?.stores" class="cx-columns-mobile">
-      <ul class="nav cx-nav" role="tablist">
+      <ul
+        class="nav cx-nav"
+        role="tablist"
+        cxTabList
+        [selectedIndex]="currentDisplayModeIndex"
+        (changeTab)="setDisplayMode(displayModeList[$event])"
+      >
         <li
           class="nav-item cx-nav-item"
           *ngFor="let mode of displayModes | keyvalue"
         >
           <button
+            cxTab
             [id]="'tab-' + mode?.value"
             role="tab"
             [ngClass]="{
@@ -77,9 +84,7 @@
               active: isDisplayModeActive(mode?.value)
             }"
             [attr.aria-controls]="'tab-' + mode?.value + '-panel'"
-            [attr.aria-selected]="isDisplayModeActive(mode?.value)"
             aria-disabled="false"
-            (click)="setDisplayMode(mode?.value)"
           >
             {{ 'storeFinder.' + mode?.value | cxTranslate }}
           </button>

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
@@ -140,8 +140,10 @@ describe('StoreFinderDisplayListComponent', () => {
 
   it('should "setDisplayMode" switch active display mode', () => {
     expect(component.activeDisplayMode).toBe(displayModes.LIST_VIEW);
+    expect(component.currentDisplayModeIndex).toBe(0);
     component.setDisplayMode(displayModes.MAP_VIEW);
     expect(component.activeDisplayMode).toBe(displayModes.MAP_VIEW);
+    expect(component.currentDisplayModeIndex).toBe(1);
   });
 
   it('should "isDisplayModeActive" return valid boolean flag', () => {

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.ts
@@ -30,6 +30,7 @@ export class StoreFinderListComponent {
   storeDetails: PointOfService;
   iconTypes = ICON_TYPE;
   displayModes = LocationDisplayMode;
+  displayModeList = Object.values(LocationDisplayMode);
   activeDisplayMode = LocationDisplayMode.LIST_VIEW;
 
   constructor(
@@ -76,5 +77,11 @@ export class StoreFinderListComponent {
 
   isDisplayModeActive(mode: LocationDisplayMode): boolean {
     return this.activeDisplayMode === mode;
+  }
+
+  get currentDisplayModeIndex(): number {
+    return this.displayModeList.findIndex(
+      (mode) => mode === this.activeDisplayMode
+    );
   }
 }

--- a/projects/storefrontlib/layout/a11y/index.ts
+++ b/projects/storefrontlib/layout/a11y/index.ts
@@ -6,3 +6,4 @@
 
 export * from './keyboard-focus/index';
 export * from './skip-link/index';
+export * from './tab/index';

--- a/projects/storefrontlib/layout/a11y/tab/index.ts
+++ b/projects/storefrontlib/layout/a11y/tab/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './tab-list.directive';
 
 export * from './tab.directive';

--- a/projects/storefrontlib/layout/a11y/tab/index.ts
+++ b/projects/storefrontlib/layout/a11y/tab/index.ts
@@ -1,3 +1,5 @@
 export * from './tab-list.directive';
 
+export * from './tab.directive';
+
 export * from './tab.module';

--- a/projects/storefrontlib/layout/a11y/tab/index.ts
+++ b/projects/storefrontlib/layout/a11y/tab/index.ts
@@ -1,0 +1,3 @@
+export * from './tab-list.directive';
+
+export * from './tab.module';

--- a/projects/storefrontlib/layout/a11y/tab/tab-list.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab-list.directive.spec.ts
@@ -1,0 +1,194 @@
+import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DirectionMode, DirectionService } from '../../direction';
+
+import { TabListDirective } from './tab-list.directive';
+import { TabDirective } from './tab.directive';
+
+describe('TabListDirective', () => {
+  @Component({
+    selector: 'cx-test-component',
+    template: `
+      <div
+        cxTabList
+        [selectedIndex]="selectedIndex"
+        (changeTab)="changeTabSpy.push($event)"
+      >
+        <div cxTab>Foo</div>
+        <div cxTab>Bar</div>
+        <div cxTab>Baz</div>
+      </div>
+    `,
+  })
+  class TestComponent {
+    @ViewChild(TabListDirective, { read: ElementRef })
+    tabListElement: ElementRef<HTMLElement>;
+
+    @ViewChild(TabListDirective)
+    tabListDirective: TabListDirective;
+
+    @Input()
+    selectedIndex: number;
+
+    changeTabSpy: Array<number> = [];
+  }
+
+  class MockDirectionService {
+    getDirection(): DirectionMode {
+      return DirectionMode.LTR;
+    }
+  }
+
+  let fixture: ComponentFixture<TestComponent>;
+  let component: TestComponent;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [TabListDirective, TabDirective, TestComponent],
+        providers: [
+          { provide: DirectionService, useClass: MockDirectionService },
+        ],
+      }).compileComponents();
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+
+    component.selectedIndex = 0;
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('for RTL', () => {
+    beforeEach(() => {
+      const directionService = TestBed.inject(DirectionService);
+      spyOn(directionService, 'getDirection').and.returnValue(
+        DirectionMode.RTL
+      );
+    });
+
+    it('should increment when receiving an arrow-left keydown', (done) => {
+      component.tabListDirective.changeTab.subscribe((value) => {
+        expect(value).toBe(1);
+        done();
+      });
+
+      component.tabListElement.nativeElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'arrowleft' })
+      );
+
+      component.tabListElement.nativeElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'enter' })
+      );
+    });
+
+    it('should decrement when receiving an arrow-left keydown', (done) => {
+      component.tabListDirective.changeTab.subscribe((value) => {
+        expect(value).toBe(2);
+        done();
+      });
+
+      component.tabListElement.nativeElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'arrowright' })
+      );
+
+      component.tabListElement.nativeElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'enter' })
+      );
+    });
+  });
+
+  describe('for LTR', () => {
+    beforeEach(() => {
+      const directionService = TestBed.inject(DirectionService);
+      spyOn(directionService, 'getDirection').and.returnValue(
+        DirectionMode.LTR
+      );
+    });
+
+    it('should decrement when receiving an arrow-left keydown', (done) => {
+      component.tabListDirective.changeTab.subscribe((value) => {
+        expect(value).toBe(2);
+        done();
+      });
+
+      component.tabListElement.nativeElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'arrowleft' })
+      );
+
+      component.tabListElement.nativeElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'enter' })
+      );
+    });
+
+    it('should increment when receiving an arrow-left keydown', (done) => {
+      component.tabListDirective.changeTab.subscribe((value) => {
+        expect(value).toBe(1);
+        done();
+      });
+
+      component.tabListElement.nativeElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'arrowright' })
+      );
+
+      component.tabListElement.nativeElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'enter' })
+      );
+    });
+  });
+
+  it('should set selected index', () => {
+    component.selectedIndex = 1;
+
+    fixture.detectChanges();
+
+    const tabs = fixture.debugElement.queryAll(By.css('[cxTab]'));
+
+    expect(tabs[0].attributes['aria-selected']).toBe('false');
+    expect(tabs[0].attributes['tabindex']).toBe('-1');
+
+    expect(tabs[1].attributes['aria-selected']).toBe('true');
+    expect(tabs[1].attributes['tabindex']).toBe('0');
+
+    expect(tabs[2].attributes['aria-selected']).toBe('false');
+    expect(tabs[2].attributes['tabindex']).toBe('-1');
+  });
+
+  it('should go to the beginning of the list when HOME is pressed', (done) => {
+    component.tabListDirective.changeTab.subscribe((value) => {
+      expect(value).toBe(0);
+      done();
+    });
+
+    component.tabListElement.nativeElement.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'home' })
+    );
+
+    component.tabListElement.nativeElement.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'enter' })
+    );
+  });
+
+  it('should go to the end of the list when END is pressed', (done) => {
+    component.tabListDirective.changeTab.subscribe((value) => {
+      expect(value).toBe(2);
+      done();
+    });
+
+    component.tabListElement.nativeElement.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'end' })
+    );
+
+    component.tabListElement.nativeElement.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'enter' })
+    );
+  });
+});

--- a/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
@@ -25,12 +25,6 @@ export class TabListDirective implements AfterContentInit {
     this.updateTabs(selectedIndex);
   }
 
-  /**
-   * TODO
-   */
-  @Input()
-  automatic = false;
-
   @Output()
   changeTab: EventEmitter<number> = new EventEmitter();
 

--- a/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
@@ -16,7 +16,7 @@ import { TabDirective } from './tab.directive';
   selector: '[cxTabList]',
 })
 export class TabListDirective implements AfterContentInit {
-  @ContentChildren(TabDirective)
+  @ContentChildren(TabDirective, { descendants: true })
   tabs: QueryList<TabDirective> | undefined;
 
   @Input()
@@ -73,14 +73,14 @@ export class TabListDirective implements AfterContentInit {
   @HostListener('keydown.home', ['$event'])
   onHome(event: KeyboardEvent): void {
     event.preventDefault();
-    this.focusTab(0);
+    this.focusTab((this.currentFocusedIndex = 0));
   }
 
   @HostListener('keydown.end', ['$event'])
   onEnd(event: KeyboardEvent): void {
     event.preventDefault();
     if (this.tabs) {
-      this.focusTab(this.tabs.length - 1);
+      this.focusTab((this.currentFocusedIndex = this.tabs.length - 1));
     }
   }
 

--- a/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   AfterContentInit,
   ContentChildren,

--- a/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
@@ -73,14 +73,18 @@ export class TabListDirective implements AfterContentInit {
   @HostListener('keydown.home', ['$event'])
   onHome(event: KeyboardEvent): void {
     event.preventDefault();
-    this.focusTab((this.currentFocusedIndex = 0));
+    this.currentFocusedIndex = 0;
+    this.focusTab(0);
   }
 
   @HostListener('keydown.end', ['$event'])
   onEnd(event: KeyboardEvent): void {
     event.preventDefault();
     if (this.tabs) {
-      this.focusTab((this.currentFocusedIndex = this.tabs.length - 1));
+      const index = this.tabs.length - 1;
+
+      this.currentFocusedIndex = index;
+      this.focusTab(index);
     }
   }
 
@@ -128,11 +132,11 @@ export class TabListDirective implements AfterContentInit {
       tab.tabindex = -1;
     });
 
-    const tab = this.tabs.get(index);
+    const selectedTab = this.tabs.get(index);
 
-    if (tab) {
-      tab.ariaSelected = true;
-      tab.tabindex = 0;
+    if (selectedTab) {
+      selectedTab.ariaSelected = true;
+      selectedTab.tabindex = 0;
     }
   }
 

--- a/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab-list.directive.ts
@@ -1,0 +1,146 @@
+import {
+  AfterContentInit,
+  ContentChildren,
+  Directive,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+  QueryList,
+} from '@angular/core';
+
+import { DirectionMode, DirectionService } from '../../direction';
+import { TabDirective } from './tab.directive';
+
+@Directive({
+  selector: '[cxTabList]',
+})
+export class TabListDirective implements AfterContentInit {
+  @ContentChildren(TabDirective)
+  tabs: QueryList<TabDirective> | undefined;
+
+  @Input()
+  set selectedIndex(selectedIndex: number) {
+    this.currentFocusedIndex = selectedIndex;
+    this.updateTabs(selectedIndex);
+  }
+
+  /**
+   * TODO
+   */
+  @Input()
+  automatic = false;
+
+  @Output()
+  changeTab: EventEmitter<number> = new EventEmitter();
+
+  protected currentFocusedIndex = 0;
+
+  constructor(protected directionService: DirectionService) {}
+
+  ngAfterContentInit(): void {
+    this.updateTabs(this.currentFocusedIndex);
+  }
+
+  @HostListener('keydown.arrowleft')
+  onArrowLeft(): void {
+    let increment = 1;
+
+    if (this.isLTRDirection()) {
+      increment *= -1;
+    }
+
+    const index = this.increment(increment);
+
+    this.currentFocusedIndex = index;
+    this.focusTab(index);
+  }
+
+  @HostListener('keydown.arrowright')
+  onArrowRight(): void {
+    let increment = -1;
+
+    if (this.isLTRDirection()) {
+      increment = 1;
+    }
+
+    const index = this.increment(increment);
+
+    this.currentFocusedIndex = index;
+    this.focusTab(index);
+  }
+
+  @HostListener('keydown.home', ['$event'])
+  onHome(event: KeyboardEvent): void {
+    event.preventDefault();
+    this.focusTab(0);
+  }
+
+  @HostListener('keydown.end', ['$event'])
+  onEnd(event: KeyboardEvent): void {
+    event.preventDefault();
+    if (this.tabs) {
+      this.focusTab(this.tabs.length - 1);
+    }
+  }
+
+  @HostListener('keydown.enter', ['$event'])
+  @HostListener('keydown.space', ['$event'])
+  onActivate(event: KeyboardEvent): void {
+    event.preventDefault();
+    this.changeTab.emit(this.currentFocusedIndex);
+  }
+
+  protected isLTRDirection(): boolean {
+    return this.directionService.getDirection() === DirectionMode.LTR;
+  }
+
+  protected increment(increment: number): number {
+    if (!this.tabs) {
+      return 0;
+    }
+
+    const tabsLength = this.tabs.length ?? 0;
+
+    const selectedIndex = this.currentFocusedIndex + increment;
+
+    if (selectedIndex < 0) {
+      return tabsLength - 1;
+    } else if (selectedIndex >= tabsLength) {
+      return 0;
+    } else {
+      return selectedIndex;
+    }
+  }
+
+  protected updateTabs(selectedIndex: number): void {
+    this.currentFocusedIndex = selectedIndex;
+    this.updateTabState(selectedIndex);
+  }
+
+  protected updateTabState(index: number): void {
+    if (!this.tabs) {
+      return;
+    }
+
+    this.tabs.forEach((tab) => {
+      tab.ariaSelected = false;
+      tab.tabindex = -1;
+    });
+
+    const tab = this.tabs.get(index);
+
+    if (tab) {
+      tab.ariaSelected = true;
+      tab.tabindex = 0;
+    }
+  }
+
+  protected focusTab(index: number): void {
+    const tab = this.tabs?.get(index);
+
+    if (tab) {
+      tab.focus();
+    }
+  }
+}

--- a/projects/storefrontlib/layout/a11y/tab/tab.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab.directive.spec.ts
@@ -1,0 +1,51 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TabDirective } from './tab.directive';
+
+describe('TabDirective', () => {
+  @Component({
+    selector: 'cx-test-component',
+    template: ` <div cxTab></div> `,
+  })
+  class TestComponent {
+    @ViewChild(TabDirective)
+    directive: TabDirective;
+  }
+
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [TabDirective, TestComponent],
+      }).compileComponents();
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should update HTML attributes', () => {
+    component.directive.ariaSelected = true;
+    component.directive.tabindex = -1;
+
+    fixture.detectChanges();
+
+    component.directive.focus();
+
+    const debugElement = fixture.debugElement;
+    const element: HTMLElement = debugElement.nativeElement;
+    const div = element.children.item(0);
+
+    expect(div?.attributes.getNamedItem('aria-selected')?.value).toBe('true');
+    expect(div?.attributes.getNamedItem('tabindex')?.value).toBe('-1');
+  });
+});

--- a/projects/storefrontlib/layout/a11y/tab/tab.directive.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab.directive.ts
@@ -1,0 +1,18 @@
+import { Directive, ElementRef, HostBinding } from '@angular/core';
+
+@Directive({
+  selector: '[cxTab]',
+})
+export class TabDirective {
+  @HostBinding('attr.aria-selected')
+  ariaSelected: boolean;
+
+  @HostBinding('attr.tabindex')
+  tabindex: 0 | -1;
+
+  constructor(protected elementRef: ElementRef<HTMLElement>) {}
+
+  focus(): void {
+    this.elementRef.nativeElement.focus();
+  }
+}

--- a/projects/storefrontlib/layout/a11y/tab/tab.directive.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab.directive.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Directive, ElementRef, HostBinding } from '@angular/core';
 
 @Directive({

--- a/projects/storefrontlib/layout/a11y/tab/tab.module.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab.module.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 

--- a/projects/storefrontlib/layout/a11y/tab/tab.module.ts
+++ b/projects/storefrontlib/layout/a11y/tab/tab.module.ts
@@ -1,0 +1,14 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { TabListDirective } from './tab-list.directive';
+import { TabDirective } from './tab.directive';
+
+const directives = [TabListDirective, TabDirective];
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [...directives],
+  exports: [...directives],
+})
+export class TabModule {}


### PR DESCRIPTION
Reusing tab accessibility code by using directives - a parent directive `[cxTabList]` is placed on the tabs' container and child directives `[cxTab]` are placed on the tabs themselves. They handle `aria-selected` and `tabindex` for the user.

Based on this spec: https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-manual.html

A possible enhancement is to automatically set HTML attribute role to value "tab".