### PR TITLE
chore: console.warn a http timeout

### DIFF
--- a/projects/core/src/http/http-timeout/http-timeout.interceptor.spec.ts
+++ b/projects/core/src/http/http-timeout/http-timeout.interceptor.spec.ts
@@ -66,6 +66,8 @@ describe('HttpTimeoutInterceptor', () => {
     httpClient = TestBed.inject(HttpClient);
     windowRef = TestBed.inject(WindowRef);
     config = TestBed.inject(OccConfig);
+
+    spyOn(console, 'warn');
   });
 
   afterEach(fakeAsync(() => {
@@ -256,6 +258,21 @@ describe('HttpTimeoutInterceptor', () => {
     expect(error instanceof HttpErrorResponse).toBe(true);
     expect(error.error instanceof Error).toBe(true);
     expect(error.error.message).toEqual(
+      `Request to URL '${testUrl}' exceeded expected time of ${SERVER_TIMEOUT}ms and was aborted.`
+    );
+  }));
+
+  it('in case of timeout, it should console.warn', fakeAsync(() => {
+    spyOn(windowRef, 'isBrowser').and.returnValue(false);
+
+    httpClient.get(testUrl).subscribe({ error: () => {} });
+
+    const request = httpMock.expectOne(testUrl);
+    request.event({ type: HttpEventType.Sent });
+
+    tick(VERY_LONG_TIME);
+
+    expect(console.warn).toHaveBeenCalledWith(
       `Request to URL '${testUrl}' exceeded expected time of ${SERVER_TIMEOUT}ms and was aborted.`
     );
   }));

--- a/projects/core/src/http/http-timeout/http-timeout.interceptor.ts
+++ b/projects/core/src/http/http-timeout/http-timeout.interceptor.ts
@@ -108,8 +108,12 @@ export class HttpTimeoutInterceptor implements HttpInterceptor {
     request: HttpRequest<unknown>,
     timeoutValue: number
   ): Error {
-    return new Error(
-      `Request to URL '${request.url}' exceeded expected time of ${timeoutValue}ms and was aborted.`
-    );
+    const message = `Request to URL '${request.url}' exceeded expected time of ${timeoutValue}ms and was aborted.`;
+
+    // If an HTTP call times out, it is considered an unexpected error.
+    // To assist with troubleshooting, the error is logged to the console.
+    console.warn(message);
+
+    return new Error(message);
   }
 }


### PR DESCRIPTION
In 36dcdfcefab0766ab3645ddcf5c5e20f605237e3 we introduced a configurable http timeout mechanism.

But the timeout error object is usually swallowed by Ngrx Effects' logic and not populated to the console.
It's important to assist with troubleshooting the timed out http calls, especially in SSR. 

So in this PR we additionally print the error to the console.

related to closes https://github.com/SAP/spartacus/issues/14559
related to https://jira.tools.sap/browse/CXSPA-529