### PR TITLE
disable test on product-configuration-tabbing for CI 2211.2

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/integration/accessibility/product-configurator-tabbing.core-e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/accessibility/product-configurator-tabbing.core-e2e-spec.ts
@@ -1,9 +1,9 @@
 import { verifyTabbingOrder } from '../../helpers/accessibility/tabbing-order';
 import { tabbingOrderConfig as tabConfig } from '../../helpers/accessibility/tabbing-order.config';
+import { clickAllowAllFromBanner } from '../../helpers/anonymous-consents';
+import * as configuration from '../../helpers/product-configurator';
 import * as configurationOverview from '../../helpers/product-configurator-overview';
 import * as configurationVc from '../../helpers/product-configurator-vc';
-import * as configuration from '../../helpers/product-configurator';
-import { clickAllowAllFromBanner } from '../../helpers/anonymous-consents';
 /**
  * This suite is marked as flaky due to performance (synchronization) issues on
  * https://spartacus-devci767.eastus.cloudapp.azure.com:9002 that we analyze in
@@ -44,7 +44,7 @@ context('Product Configuration', () => {
   });
 
   describe('Product Config Tabbing', () => {
-    it('should allow to navigate with tab key', () => {
+    xit('should allow to navigate with tab key', () => {
       const commerceIsAtLeast2211 = false;
       clickAllowAllFromBanner();
       configurationVc.goToConfigurationPage(electronicsShop, testProduct);


### PR DESCRIPTION
disable a test to have e2e working on patch2 (cx 2211.2) .
single test has been excluded (xit)
It can be fixed later, solution suggested on below jira, ref:
[CXSPA-2357](https://jira.tools.sap/browse/CXSPA-2357)
e2e failure: Product-Configurator on CX 2211.2