### PR TITLE
chore: force-bump transitive dependency 'ua-parser-js' to 1.0.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "webpack-cli": "^4.10.0"
   },
   "resolutions": {
-    "@nguniversal/builders/browser-sync/qs": "6.2.4"
+    "@nguniversal/builders/browser-sync/qs": "6.2.4",
+    "@nguniversal/builders/browser-sync/ua-parser-js": "1.0.33"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10890,10 +10890,10 @@ typescript@~4.1.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
   integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
 
-ua-parser-js@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"
-  integrity sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==
+ua-parser-js@1.0.2, ua-parser-js@1.0.33:
+  version "1.0.33"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.33.tgz#f21f01233e90e7ed0f059ceab46eb190ff17f8f4"
+  integrity sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==
 
 ua-parser-js@^0.7.30:
   version "0.7.33"


### PR DESCRIPTION
related to https://jira.tools.sap/browse/CXSPA-2368