### PR TITLE
fix: update config:update script to not crash on release

### DIFF
--- a/tools/config/index.ts
+++ b/tools/config/index.ts
@@ -17,7 +17,7 @@ import { execSync } from 'child_process';
 import { Command } from 'commander';
 import { readFileSync } from 'fs';
 import glob from 'glob';
-import { NG_PACKAGE_JSON, PACKAGE_JSON } from './const';
+import { NG_PACKAGE_JSON, PACKAGE_JSON, PUBLISHING_VERSION } from './const';
 import { manageDependencies } from './manage-dependencies';
 import { manageTsConfigs } from './tsconfig-paths';
 
@@ -278,7 +278,11 @@ manageDependencies(repository, options);
 manageTsConfigs(repository, options);
 
 // collect and generate dependencies.json file.
+if (PUBLISHING_VERSION) {
+execSync(`yarn generate:deps`);
+} else {
 execSync(`yarn generate:deps --compare=true`);
+}
 
 /**
  * Format all files.


### PR DESCRIPTION
closes: https://jira.tools.sap/browse/CXSPA-2406

It failed because the script runs `yarn generate:deps --compare=true` which compares the file with the previous state and fails if they are different. When it comes to releasing, the file states will be different because the version was updated. So we can add a check to see that if we are releasing, run `yarn generate:deps` instead, which does no comparison, and updates dependencies.json.