### PR TITLE
test: make sure to wait for pricing calls when selecting a value to address flakiness (CXSPA-2421)

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PRODUCT_NO_PRICING } from '../sample-data/b2b-bulk-pricing';
 import * as configuration from './product-configurator';
 
 const addToCartButtonSelector = 'cx-configurator-add-to-cart-button button';

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { PRODUCT_NO_PRICING } from '../sample-data/b2b-bulk-pricing';
 import * as configuration from './product-configurator';
 
 const addToCartButtonSelector = 'cx-configurator-add-to-cart-button button';
@@ -579,6 +580,7 @@ export function registerConfigurationUpdateRoute() {
       'BASE_SITE'
     )}/ccpconfigurator/*`,
   }).as(UPDATE_CONFIG_ALIAS.substring(1)); // strip the '@'
+  registerConfigurationPricingRoute(); // implicitly register config pricing route
 }
 
 /**
@@ -600,14 +602,19 @@ export function registerConfigurationPricingRoute() {
  * @param {string} attributeName - Attribute name
  * @param {uiType} uiType - UI type
  * @param {string} valueName - Value name
+ * @param {boolean} isPricingEnabled - will wait also for pricing request in case pricing is enabled
  */
 export function selectAttributeAndWait(
   attributeName: string,
   uiType: configuration.uiType,
-  valueName: string
+  valueName: string,
+  isPricingEnabled?: boolean
 ): void {
   configuration.selectAttribute(attributeName, uiType, valueName, false);
   cy.wait(UPDATE_CONFIG_ALIAS);
+  if (isPricingEnabled) {
+    cy.wait(CONFIG_PRICING_ALIAS);
+  }
 }
 
 /**
@@ -633,6 +640,7 @@ export function clickOnPreviousBtnAndWait(previousGroup?: string): void {
 export class CommerceRelease {
   isAtLeast2205?: boolean;
   isAtLeast2211?: boolean;
+  isPricingEnabled?: boolean;
 }
 
 export function checkCommerceRelease(
@@ -658,11 +666,15 @@ export function checkCommerceRelease(
     commerceRelease.isAtLeast2211 = responseAsString.includes(
       'immediateConflictResolution'
     );
+    commerceRelease.isPricingEnabled = responseAsString.includes(
+      '"pricingEnabled" : true'
+    );
     cy.log(
       'Is at least 22.05 commerce release: ' + commerceRelease.isAtLeast2205
     );
     cy.log(
       'Is at least 22.11 commerce release: ' + commerceRelease.isAtLeast2211
     );
+    cy.log('Is pricing enabled: ' + commerceRelease.isPricingEnabled);
   });
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/integration/regression/product_configurator/product-configurator-vc-interactive.core-e2e-spec.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/integration/regression/product_configurator/product-configurator-vc-interactive.core-e2e-spec.ts
@@ -116,7 +116,8 @@ context('Product Configuration', () => {
       configurationVc.selectAttributeAndWait(
         COLOUR_HT,
         single_selection_image,
-        WHITE
+        WHITE,
+        commerceRelease.isPricingEnabled
       );
       configurationVc.checkImageSelected(
         single_selection_image,
@@ -126,7 +127,8 @@ context('Product Configuration', () => {
       configurationVc.selectAttributeAndWait(
         COLOUR_HT,
         single_selection_image,
-        TITAN
+        TITAN,
+        commerceRelease.isPricingEnabled
       );
       configurationVc.checkImageSelected(
         single_selection_image,
@@ -143,7 +145,8 @@ context('Product Configuration', () => {
       configurationVc.selectAttributeAndWait(
         CAMERA_SD_CARD,
         checkBoxList,
-        SDHC
+        SDHC,
+        commerceRelease.isPricingEnabled
       );
       configurationVc.clickOnPreviousBtnAndWait(BASICS);
       configurationVc.clickOnNextBtnAndWait(SPECIFICATION);
@@ -182,7 +185,12 @@ context('Product Configuration', () => {
       configurationVc.checkStatusIconNotDisplayed(OPTIONS);
 
       // complete group Display, navigate back, is status changes to Complete
-      configurationVc.selectAttributeAndWait(CAMERA_DISPLAY, radioGroup, P5);
+      configurationVc.selectAttributeAndWait(
+        CAMERA_DISPLAY,
+        radioGroup,
+        P5,
+        commerceRelease.isPricingEnabled
+      );
       configurationVc.clickOnPreviousBtnAndWait(SPECIFICATION);
       configurationVc.checkStatusIconDisplayed(BASICS, ERROR);
       configurationVc.checkStatusIconDisplayed(SPECIFICATION, ERROR);
@@ -195,7 +203,8 @@ context('Product Configuration', () => {
       configurationVc.selectAttributeAndWait(
         CAMERA_FORMAT_PICTURES,
         radioGroup,
-        JPEG
+        JPEG,
+        commerceRelease.isPricingEnabled
       );
       configurationVc.checkStatusIconDisplayed(BASICS, ERROR);
       configurationVc.checkStatusIconDisplayed(SPECIFICATION, COMPLETE);
@@ -366,15 +375,28 @@ context('Product Configuration', () => {
 
     it('should de-select the currently selected value when selecting the retract option', () => {
       //Select another value and verify whether a corresponding value is selected
-      configurationVc.selectAttributeAndWait(CAMERA_MODE, radioGroup, 'S');
+      configurationVc.selectAttributeAndWait(
+        CAMERA_MODE,
+        radioGroup,
+        'S',
+        commerceRelease.isPricingEnabled
+      );
       configuration.checkValueSelected(radioGroup, CAMERA_MODE, 'S');
-      configurationVc.selectAttributeAndWait(CAMERA_MODE, radioGroup, 'P');
+
+      configurationVc.selectAttributeAndWait(
+        CAMERA_MODE,
+        radioGroup,
+        'P',
+        commerceRelease.isPricingEnabled
+      );
       configuration.checkValueSelected(radioGroup, CAMERA_MODE, 'P');
+
       // Select a retract value and verify whether it is selected
       configurationVc.selectAttributeAndWait(
         CAMERA_MODE,
         radioGroup,
-        '###RETRACT_VALUE_CODE###'
+        '###RETRACT_VALUE_CODE###',
+        commerceRelease.isPricingEnabled
       );
       configuration.checkValueSelected(
         radioGroup,
@@ -410,7 +432,8 @@ context('Product Configuration', () => {
       configurationVc.selectAttributeAndWait(
         PROJECTOR_TYPE,
         radioGroup,
-        PROJECTOR_LCD
+        PROJECTOR_LCD,
+        commerceRelease.isPricingEnabled
       );
       configurationVc.clickOnPreviousBtnAndWait(GENERAL);
       configurationVc.clickOnGroupAndWait(3);


### PR DESCRIPTION
In case config pricing is enabled, tests will now wait for the config pricing call to finish after changing a value. This might improve test stability especially if back-end is under load so that responses are slow.