### PR TITLE
fix: Login for out of the box B2C schematics installation

### DIFF
--- a/projects/schematics/src/add-spartacus/schema.json
+++ b/projects/schematics/src/add-spartacus/schema.json
@@ -65,7 +65,6 @@
         "Saved-Cart",
         "Quick-Order",
         "Image-Zoom",
-        "Future-Stock",
         "Product-Variants",
         "SmartEdit",
         "Store-Finder",


### PR DESCRIPTION
Context: Future stock is a b2b feature, and the default 'choices' for schematics are catered for b2c, therefore this needs to be removed from the default installation as it will import the b2boccconfig, which we won't be able to login due to the application using the different 'channel' from users -> orgUsers. 

- fixes installation script when run locally for b2c out of the box
- fixes schematics from customer's application when boostrapping Spartacus out of the box with schematics

closes https://jira.tools.sap/browse/CXSPA-2758