### PR TITLE
chore: Update minimum dependency for express to 4.18.2

### DIFF
--- a/core-libs/setup/package.json
+++ b/core-libs/setup/package.json
@@ -28,7 +28,7 @@
   "optionalDependencies": {
     "@angular/platform-server": "^15.2.0",
     "@nguniversal/express-engine": "^15.2.0",
-    "express": "^4.15.2"
+    "express": "^4.18.2"
   },
   "publishConfig": {
     "access": "public"

--- a/feature-libs/organization/administration/core/administration-core.module.ts
+++ b/feature-libs/organization/administration/core/administration-core.module.ts
@@ -12,13 +12,18 @@ import { CostCenterConnector } from './connectors/cost-center/cost-center.connec
 import { OrgUnitConnector } from './connectors/org-unit/org-unit.connector';
 import { PermissionConnector } from './connectors/permission/permission.connector';
 import { UserGroupConnector } from './connectors/user-group/user-group.connector';
+import { OrganizationsGuardsModule } from './guards/organization-guards.module';
 import { OrganizationBadRequestHandler } from './http-interceptors/bad-request/bad-request.handler';
 import { OrganizationConflictHandler } from './http-interceptors/conflict/conflict.handler';
 import { OrganizationPageMetaModule } from './services/organization-page-meta.module';
 import { OrganizationStoreModule } from './store/organization-store.module';
 
 @NgModule({
-  imports: [OrganizationPageMetaModule, OrganizationStoreModule],
+  imports: [
+    OrganizationPageMetaModule,
+    OrganizationStoreModule,
+    OrganizationsGuardsModule,
+  ],
   providers: [
     {
       provide: HttpErrorHandler,

--- a/feature-libs/organization/administration/core/guards/admin.guard.ts
+++ b/feature-libs/organization/administration/core/guards/admin.guard.ts
@@ -16,9 +16,7 @@ import { UserAccountFacade } from '@spartacus/user/account/root';
 import { Observable } from 'rxjs';
 import { filter, map, pluck } from 'rxjs/operators';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class AdminGuard implements CanActivate {
   constructor(
     protected userAccountFacade: UserAccountFacade,

--- a/feature-libs/organization/administration/core/guards/index.ts
+++ b/feature-libs/organization/administration/core/guards/index.ts
@@ -5,4 +5,5 @@
  */
 
 export * from './admin.guard';
+export * from './organization-guards.module';
 export * from './user.guard';

--- a/feature-libs/organization/administration/core/guards/organization-guards.module.ts
+++ b/feature-libs/organization/administration/core/guards/organization-guards.module.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NgModule } from '@angular/core';
+import { AdminGuard } from './admin.guard';
+import { UserGuard } from './user.guard';
+
+@NgModule({
+  // To ensure effective over-providing from within the child injector of a lazy-loaded module
+  // by other extension libraries or end-user customizations, it's essential to provide guards manually
+  // in the child injector and not in the root injector (providedIn: 'root').
+  //
+  // If guards were provided in the root injector, the only place to over-provide them or their dependencies
+  // would be the root injector (root module), which would break lazy loading for those guards and their dependencies.
+  providers: [AdminGuard, UserGuard],
+})
+export class OrganizationsGuardsModule {}

--- a/feature-libs/organization/administration/core/guards/user.guard.ts
+++ b/feature-libs/organization/administration/core/guards/user.guard.ts
@@ -13,9 +13,7 @@ import {
 } from '@spartacus/core';
 import { B2BUserService } from '../services';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class UserGuard implements CanActivate {
   constructor(
     protected globalMessageService: GlobalMessageService,

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "bootstrap": "^4.6.1",
         "comment-json": "^4.2.3",
         "express": "^4.18.2",
-        "hamburgers": "^1.1.3",
+        "hamburgers": "^1.2.1",
         "i18next": "^21.9.1",
         "i18next-http-backend": "^1.4.1",
         "ngx-infinite-scroll": "^15.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "angular-oauth2-oidc": "^15.0.1",
         "bootstrap": "^4.6.1",
         "comment-json": "^4.2.3",
-        "express": "^4.15.2",
+        "express": "^4.18.2",
         "hamburgers": "^1.1.3",
         "i18next": "^21.9.1",
         "i18next-http-backend": "^1.4.1",
@@ -3141,14 +3141,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
-      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@eslint/js": {
       "version": "8.35.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
@@ -3156,6 +3148,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
+      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@gar/promisify": {
@@ -22517,16 +22517,16 @@
         }
       }
     },
-    "@fortawesome/fontawesome-free": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
-      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA=="
-    },
     "@eslint/js": {
       "version": "8.35.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
       "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
       "dev": true
+    },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
+      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA=="
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "bootstrap": "^4.6.1",
     "comment-json": "^4.2.3",
     "express": "^4.18.2",
-    "hamburgers": "^1.1.3",
+    "hamburgers": "^1.2.1",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",
     "ngx-infinite-scroll": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "angular-oauth2-oidc": "^15.0.1",
     "bootstrap": "^4.6.1",
     "comment-json": "^4.2.3",
-    "express": "^4.15.2",
+    "express": "^4.18.2",
     "hamburgers": "^1.1.3",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -329,7 +329,7 @@
     "angular-oauth2-oidc": "^15.0.1",
     "bootstrap": "^4.6.1",
     "comment-json": "^4.2.3",
-    "express": "^4.15.2",
+    "express": "^4.18.2",
     "hamburgers": "^1.1.3",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -330,7 +330,7 @@
     "bootstrap": "^4.6.1",
     "comment-json": "^4.2.3",
     "express": "^4.18.2",
-    "hamburgers": "^1.1.3",
+    "hamburgers": "^1.2.1",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",
     "ngx-infinite-scroll": "^15.0.0",

--- a/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -69,7 +69,7 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "@spartacus/styles": "~5.0.0",
     "angular-oauth2-oidc": "^15.0.1",
     "bootstrap": "^4.6.1",
-    "express": "^4.15.2",
+    "express": "^4.18.2",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",
     "ngx-infinite-scroll": "^15.0.0",

--- a/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -69,7 +69,7 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "@spartacus/styles": "~5.0.0",
     "angular-oauth2-oidc": "^15.0.1",
     "bootstrap": "^4.6.1",
-    "express": "^4.18.2",
+    "express": "^4.15.2",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",
     "ngx-infinite-scroll": "^15.0.0",

--- a/projects/storefrontlib/cms-structure/services/cms-guards.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-guards.service.spec.ts
@@ -44,6 +44,8 @@ describe('CmsGuardsService', () => {
     }
   }
 
+  class NotGuard {}
+
   const mockActivatedRouteSnapshot: ActivatedRouteSnapshot =
     'ActivatedRouteSnapshot ' as any;
   const mockRouterStateSnapshot: RouterStateSnapshot =
@@ -135,6 +137,69 @@ describe('CmsGuardsService', () => {
         .pipe(take(1))
         .subscribe((res) => (result = res));
       expect(result).toEqual(mockUrlTree);
+    });
+
+    it('should throw error if some guard is not CanActivate', () => {
+      guards.push(PositiveGuard, NotGuard, PositiveGuardObservable);
+
+      expect(() => {
+        service.cmsPageCanActivate(
+          [],
+          mockActivatedRouteSnapshot,
+          mockRouterStateSnapshot
+        );
+      }).toThrowError('Invalid CanActivate guard in cmsMapping');
+    });
+  });
+
+  describe('canActivateGuard', () => {
+    it('should resolve to true if guard resolves to true', () => {
+      let result;
+      service
+        .canActivateGuard(
+          PositiveGuard,
+          mockActivatedRouteSnapshot,
+          mockRouterStateSnapshot
+        )
+        .pipe(take(1))
+        .subscribe((res) => (result = res));
+      expect(result).toEqual(true);
+    });
+
+    it('should resolve to false if guard resolves to false', () => {
+      let result;
+      service
+        .canActivateGuard(
+          NegativeGuard,
+          mockActivatedRouteSnapshot,
+          mockRouterStateSnapshot
+        )
+        .pipe(take(1))
+        .subscribe((res) => (result = res));
+      expect(result).toEqual(false);
+    });
+
+    it('should resolve to UrlTree if guard resolves to UrlTree', () => {
+      let result;
+      service
+        .canActivateGuard(
+          UrlTreeGuard,
+          mockActivatedRouteSnapshot,
+          mockRouterStateSnapshot
+        )
+        .pipe(take(1))
+        .subscribe((res) => (result = res));
+      expect(result).toEqual(mockUrlTree);
+    });
+
+    it('should throw error if guard is not CanActivate', () => {
+      expect(() => {
+        service.canActivateGuard(
+          NotGuard,
+          mockActivatedRouteSnapshot,
+          mockRouterStateSnapshot
+        );
+      }).toThrowError('Invalid CanActivate guard in cmsMapping');
     });
   });
 });

--- a/projects/storefrontlib/cms-structure/services/cms-guards.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-guards.service.ts
@@ -33,18 +33,9 @@ export class CmsGuardsService {
     const guards = this.cmsComponentsService.getGuards(componentTypes);
 
     if (guards.length) {
-      const canActivateObservables = guards.map((guardClass) => {
-        const guard = getLastValueSync(
-          this.unifiedInjector.get<CanActivate>(guardClass)
-        );
-        if (isCanActivate(guard)) {
-          return wrapIntoObservable(guard.canActivate(route, state)).pipe(
-            first()
-          );
-        } else {
-          throw new Error('Invalid CanActivate guard in cmsMapping');
-        }
-      });
+      const canActivateObservables = guards.map((guard) =>
+        this.canActivateGuard(guard, route, state)
+      );
 
       return concat(...canActivateObservables).pipe(
         skipWhile((canActivate: boolean | UrlTree) => canActivate === true),
@@ -53,6 +44,21 @@ export class CmsGuardsService {
       );
     } else {
       return of(true);
+    }
+  }
+
+  canActivateGuard(
+    guardClass: any,
+    route: CmsActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> {
+    const guard = getLastValueSync(
+      this.unifiedInjector.get<CanActivate>(guardClass)
+    );
+    if (isCanActivate(guard)) {
+      return wrapIntoObservable(guard.canActivate(route, state)).pipe(first());
+    } else {
+      throw new Error('Invalid CanActivate guard in cmsMapping');
     }
   }
 }

--- a/projects/storefrontlib/cms-structure/services/cms-routes-impl.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-routes-impl.service.spec.ts
@@ -1,15 +1,22 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
 import { CmsRoute, PageType } from '@spartacus/core';
+import { of } from 'rxjs';
 import { PageLayoutComponent } from '../page/page-layout/page-layout.component';
 import { CmsComponentsService } from './cms-components.service';
+import { CmsGuardsService } from './cms-guards.service';
 import { CmsRoutesImplService } from './cms-routes-impl.service';
 import createSpy = jasmine.createSpy;
 
 describe('CmsRoutesImplService', () => {
   let service: CmsRoutesImplService;
   let cmsMappingService: CmsComponentsService;
-  let mockRouter;
+  let mockRouter: Pick<Router, 'config' | 'navigateByUrl' | 'resetConfig'>;
 
   const mockPageContext = {
     type: PageType.CONTENT_PAGE,
@@ -212,6 +219,118 @@ describe('CmsRoutesImplService', () => {
           '/'
         )
       ).toEqual(true);
+    });
+
+    it('should wrap Cms Guard with a function', () => {
+      const mockUrlTree = new UrlTree();
+
+      const cmsGuardsService = TestBed.inject(CmsGuardsService);
+      spyOn(cmsGuardsService, 'canActivateGuard').and.returnValue(
+        of(mockUrlTree)
+      );
+
+      class TestGuard {}
+      spyOn(cmsMappingService, 'getChildRoutes').and.returnValue({
+        children: [{ path: 'test', canActivate: [TestGuard] }],
+      });
+
+      service.handleCmsRoutesInGuard(
+        mockPageContext,
+        [],
+        '/testRoute2',
+        '/testRoute2'
+      );
+
+      const newRouterConfig = (
+        mockRouter.resetConfig as jasmine.Spy
+      ).calls.mostRecent().args[0];
+      const newChildCmsRoutes = newRouterConfig[0].children;
+      const testGuardFn = newChildCmsRoutes[0].canActivate[0];
+      expect(typeof testGuardFn).toBe('function');
+
+      const mockActivatedRouteSnapshot = {
+        url: [{ path: 'url' }],
+      } as ActivatedRouteSnapshot;
+      const mockRouterStateSnapshot = { url: 'url' } as RouterStateSnapshot;
+
+      let guardResult;
+      testGuardFn(
+        mockActivatedRouteSnapshot,
+        mockRouterStateSnapshot
+      ).subscribe((result: any) => (guardResult = result));
+      expect(guardResult).toBe(mockUrlTree);
+
+      expect(cmsGuardsService.canActivateGuard).toHaveBeenCalledWith(
+        TestGuard,
+        mockActivatedRouteSnapshot,
+        mockRouterStateSnapshot
+      );
+    });
+
+    it('should wrap Cms Guards recursively with a function', () => {
+      const cmsGuardsService = TestBed.inject(CmsGuardsService);
+      spyOn(cmsGuardsService, 'canActivateGuard').and.returnValue(of());
+
+      class TestGuard1 {}
+      class TestGuard2 {}
+      class TestGuard3 {}
+      class TestGuard4 {}
+
+      spyOn(cmsMappingService, 'getChildRoutes').and.returnValue({
+        children: [
+          {
+            path: 'test1',
+            canActivate: [TestGuard1],
+            children: [
+              {
+                path: 'nested1',
+                canActivate: [TestGuard3, TestGuard4],
+              },
+            ],
+          },
+          {
+            path: 'test2',
+            canActivate: [TestGuard2],
+            children: [],
+          },
+        ],
+      });
+
+      service.handleCmsRoutesInGuard(
+        mockPageContext,
+        [],
+        '/testRoute2',
+        '/testRoute2'
+      );
+
+      const newRouterConfig = (
+        mockRouter.resetConfig as jasmine.Spy
+      ).calls.mostRecent().args[0];
+      const newChildCmsRoutes = newRouterConfig[0].children;
+
+      expect(newChildCmsRoutes).toEqual([
+        {
+          path: 'test1',
+          canActivate: [jasmine.any(Function)],
+          children: [
+            {
+              path: 'nested1',
+              canActivate: [jasmine.any(Function), jasmine.any(Function)],
+            },
+          ],
+        },
+        {
+          path: 'test2',
+          canActivate: [jasmine.any(Function)],
+          children: [],
+        },
+      ]);
+      expect(newChildCmsRoutes[0].canActivate).not.toEqual([TestGuard1]);
+      expect(newChildCmsRoutes[1].canActivate).not.toEqual([TestGuard2]);
+      expect(newChildCmsRoutes[0].children[0].canActivate).not.toEqual([
+        TestGuard3,
+        TestGuard4,
+      ]);
     });
   });
 });

--- a/projects/storefrontlib/cms-structure/services/cms-routes-impl.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-routes-impl.service.ts
@@ -4,8 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { Injectable, Type } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  Route,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
 import {
   CmsComponentChildRoutesConfig,
   CmsRoute,
@@ -13,15 +19,18 @@ import {
   PageContext,
   PageType,
 } from '@spartacus/core';
+import { Observable } from 'rxjs';
 import { PageLayoutComponent } from '../page/page-layout/page-layout.component';
 import { CmsComponentsService } from './cms-components.service';
+import { CmsGuardsService } from './cms-guards.service';
 
 // This service should be exposed in public API only after the refactor planned in https://github.com/SAP/spartacus/issues/7070
 @Injectable({ providedIn: 'root' })
 export class CmsRoutesImplService {
   constructor(
     private router: Router,
-    private cmsComponentsService: CmsComponentsService
+    private cmsComponentsService: CmsComponentsService,
+    private cmsGuardsService: CmsGuardsService
   ) {}
 
   private cmsRouteExists(url: string): boolean {
@@ -85,10 +94,14 @@ export class CmsRoutesImplService {
       pageLabel.startsWith('/') &&
       pageLabel.length > 1
     ) {
+      const children = this.wrapCmsGuardsRecursively(
+        childRoutesConfig.children ?? []
+      );
+
       const newRoute: CmsRoute = {
         path: pageLabel.substr(1),
         component: PageLayoutComponent,
-        children: childRoutesConfig.children,
+        children: children,
         data: deepMerge({}, childRoutesConfig?.parent?.data ?? {}, {
           cxCmsRouteContext: {
             type: pageContext.type,
@@ -102,5 +115,53 @@ export class CmsRoutesImplService {
     }
 
     return false;
+  }
+
+  /**
+   * Traverses recursively the given Routes and wraps each `canActivate`
+   * guard of each Route with a special `CanActivateFn` function.
+   *
+   * This special wrapper function allows for resolving
+   * those guards by the Angular Router using the `UnifiedInjector`
+   * instead of only root injector.
+   *
+   * This allows Angular Router to inject the guards (and their dependencies)
+   * even when they are provided only in a child injector of a lazy-loaded module.
+   */
+  private wrapCmsGuardsRecursively(routes: Route[]): Route[] {
+    return routes.map((route) => {
+      if (route.children) {
+        route.children = this.wrapCmsGuardsRecursively(route.children);
+      }
+
+      if (route?.canActivate?.length) {
+        route.canActivate = route.canActivate.map((guard) =>
+          this.wrapCmsGuard(guard)
+        );
+      }
+
+      return route;
+    });
+  }
+
+  /**
+   * Returns a wrapper function `CanActivateFn` (https://angular.io/api/router/CanActivateFn)
+   * that injects the given guard instance and runs its method `.canActivate()`.
+   *
+   * It allows to inject the guard's instance (and it's dependencies)
+   * even if it's 'provided only in a child injector of a lazy-loaded module.
+   */
+  private wrapCmsGuard(
+    guardClass: Type<any>
+  ): (
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ) => Observable<boolean | UrlTree> {
+    return (
+      route: ActivatedRouteSnapshot,
+      state: RouterStateSnapshot
+    ): Observable<boolean | UrlTree> => {
+      return this.cmsGuardsService.canActivateGuard(guardClass, route, state);
+    };
   }
 }

--- a/projects/storefrontstyles/package.json
+++ b/projects/storefrontstyles/package.json
@@ -14,7 +14,7 @@
     "test": "../../node_modules/.bin/jest --config ./jest.schematics.config.js"
   },
   "dependencies": {
-    "hamburgers": "^1.1.3"
+    "hamburgers": "^1.2.1"
   },
   "devDependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
With the npm conversion PR https://github.com/SAP/spartacus/pull/16754, the lock file already contained the latest express version

closes https://jira.tools.sap/browse/CXSPA-2813