### PR TITLE
Update hamburgers package to 1.2.1 as minimum version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "bootstrap": "^4.6.1",
         "comment-json": "^4.2.3",
         "express": "^4.15.2",
-        "hamburgers": "^1.1.3",
+        "hamburgers": "^1.2.1",
         "i18next": "^21.9.1",
         "i18next-http-backend": "^1.4.1",
         "ngx-infinite-scroll": "^15.0.0",
@@ -3141,14 +3141,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
-      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@eslint/js": {
       "version": "8.35.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
@@ -3156,6 +3148,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
+      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@gar/promisify": {
@@ -22517,16 +22517,16 @@
         }
       }
     },
-    "@fortawesome/fontawesome-free": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
-      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA=="
-    },
     "@eslint/js": {
       "version": "8.35.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
       "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
       "dev": true
+    },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
+      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA=="
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "bootstrap": "^4.6.1",
     "comment-json": "^4.2.3",
     "express": "^4.15.2",
-    "hamburgers": "^1.1.3",
+    "hamburgers": "^1.2.1",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",
     "ngx-infinite-scroll": "^15.0.0",

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -330,7 +330,7 @@
     "bootstrap": "^4.6.1",
     "comment-json": "^4.2.3",
     "express": "^4.15.2",
-    "hamburgers": "^1.1.3",
+    "hamburgers": "^1.2.1",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",
     "ngx-infinite-scroll": "^15.0.0",

--- a/projects/storefrontstyles/package.json
+++ b/projects/storefrontstyles/package.json
@@ -14,7 +14,7 @@
     "test": "../../node_modules/.bin/jest --config ./jest.schematics.config.js"
   },
   "dependencies": {
-    "hamburgers": "^1.1.3"
+    "hamburgers": "^1.2.1"
   },
   "devDependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
With the angular 15 upgrade, the lock file contained latest hamburger version, which is 1.2.1 as of writing.

closes https://jira.tools.sap/browse/CXSPA-2814