### PR TITLE
chore: Update minimum dependency for express to 4.18.2

### DIFF
--- a/core-libs/setup/package.json
+++ b/core-libs/setup/package.json
@@ -28,7 +28,7 @@
   "optionalDependencies": {
     "@angular/platform-server": "^15.2.0",
     "@nguniversal/express-engine": "^15.2.0",
-    "express": "^4.15.2"
+    "express": "^4.18.2"
   },
   "publishConfig": {
     "access": "public"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "angular-oauth2-oidc": "^15.0.1",
         "bootstrap": "^4.6.1",
         "comment-json": "^4.2.3",
-        "express": "^4.15.2",
+        "express": "^4.18.2",
         "hamburgers": "^1.2.1",
         "i18next": "^21.9.1",
         "i18next-http-backend": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "angular-oauth2-oidc": "^15.0.1",
     "bootstrap": "^4.6.1",
     "comment-json": "^4.2.3",
-    "express": "^4.15.2",
+    "express": "^4.18.2",
     "hamburgers": "^1.2.1",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -329,7 +329,7 @@
     "angular-oauth2-oidc": "^15.0.1",
     "bootstrap": "^4.6.1",
     "comment-json": "^4.2.3",
-    "express": "^4.15.2",
+    "express": "^4.18.2",
     "hamburgers": "^1.2.1",
     "i18next": "^21.9.1",
     "i18next-http-backend": "^1.4.1",


### PR DESCRIPTION
With the npm conversion PR https://github.com/SAP/spartacus/pull/16754, the lock file already contained the latest express version

related to https://jira.tools.sap/browse/CXSPA-1730

closes https://jira.tools.sap/browse/CXSPA-2813