### PR TITLE
test: adjust class value to get SHOW MORE button from DOM

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/infinite-scroll.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/infinite-scroll.ts
@@ -113,7 +113,7 @@ export function scrollToFooter(
   for (let i = 1; i < iterations; i++) {
     if (isShowMoreButton) {
       cy.scrollTo('bottom');
-      cy.get('div.btn-action')
+      cy.get('div.cx-single-btn-container')
         .contains('SHOW MORE')
         .click({ force: true })
         .wait(defaultQueryAlias)


### PR DESCRIPTION
adjustment needed after blue theme merge.
targeting 'cx-single-btn-container' instead of 'btn-action'
No side effect, fct is only used in infinite-scroll.e2e and infinite-scroll.core-e2e. Tests all passed.
![image](https://user-images.githubusercontent.com/30024415/225974929-bee97dfe-dc3d-485b-aff8-bf14fecf13d5.png)
