### PR TITLE
fix: use theme color for selection outline

### DIFF
--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.html
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.html
@@ -12,6 +12,8 @@
   <cx-epd-visualization-viewer
     [(selectedProductCodes)]="selectedProductCodes"
     [hidden]="hideViewport"
+    [outlineColor]="'--cx-color-primary'"
+    [outlineWidth]="8"
   >
   </cx-epd-visualization-viewer>
 


### PR DESCRIPTION
A red selection outline looks wrong in Santorini.
Use a theme colour.

Increase the outline width to compensate for colours which do not stand out as much.

Closes: https://jira.tools.sap/browse/CXSPA-2907

**======  Before  ======**

![image](https://user-images.githubusercontent.com/52560012/226875819-315a0d95-f3f7-4fd5-ad45-5848ce8f4b22.png)

**======  After  ======**

![image](https://user-images.githubusercontent.com/52560012/226875565-988ed9f9-6875-4ec8-af71-42627350ff9a.png)
