### PR TITLE
chore: make ccv2 e2e tests script compatible with cy12

### DIFF
--- a/run-spartacus-ccv2-e2es.sh
+++ b/run-spartacus-ccv2-e2es.sh
@@ -12,8 +12,7 @@ CYPRESS_SSR_FOLDER="$CYPRESS_ROOT_FOLDER/ssr"
 CYPRESS_VENDOR_FOLDER="$CYPRESS_ROOT_FOLDER/vendor"
 
 
-export E2ES_TO_RUN="$CYPRESS_B2C_FOLDER/checkout/checkout-flow.core-e2e.cy.ts,
-$CYPRESS_B2C_FOLDER/homepage/homepage.core-e2e.cy.ts"
+export E2ES_TO_RUN="$CYPRESS_B2C_FOLDER/checkout/checkout-flow.core-e2e.cy.ts,$CYPRESS_B2C_FOLDER/homepage/homepage.core-e2e.cy.ts"
 
 # install cypress standlone dependencies
 (cd projects/storefrontapp-e2e-cypress && npm install)

--- a/run-spartacus-ccv2-e2es.sh
+++ b/run-spartacus-ccv2-e2es.sh
@@ -4,7 +4,7 @@
 # export ENDPOINT_URL_PUBLIC_SPARTACUS=https://spartacusstore.cg79x9wuu9-eccommerc1-p1-public.model-t.myhybris.cloud
 # export ENDPOINT_URL_PUBLIC_API=https://api.cg79x9wuu9-eccommerc1-p1-public.model-t.myhybris.cloud
 
-CYPRESS_ROOT_FOLDER="cypress/integration"
+CYPRESS_ROOT_FOLDER="cypress/e2e"
 CYPRESS_B2C_FOLDER="$CYPRESS_ROOT_FOLDER/regression"
 CYPRESS_B2B_FOLDER="$CYPRESS_ROOT_FOLDER/b2b/regression"
 CYPRESS_ACCESSIBILITY_FOLDER="$CYPRESS_ROOT_FOLDER/accessibility"
@@ -12,9 +12,8 @@ CYPRESS_SSR_FOLDER="$CYPRESS_ROOT_FOLDER/ssr"
 CYPRESS_VENDOR_FOLDER="$CYPRESS_ROOT_FOLDER/vendor"
 
 
-export E2ES_TO_RUN="$CYPRESS_B2C_FOLDER/checkout/checkout-flow.core-e2e-spec.ts,
-$CYPRESS_B2C_FOLDER/homepage/homepage.core-e2e-spec.ts
-"
+export E2ES_TO_RUN="$CYPRESS_B2C_FOLDER/checkout/checkout-flow.core-e2e.cy.ts,
+$CYPRESS_B2C_FOLDER/homepage/homepage.core-e2e.cy.ts"
 
 # install cypress standlone dependencies
 (cd projects/storefrontapp-e2e-cypress && npm install)


### PR DESCRIPTION
Adjustment of folder paths and filenames due to Cypress12 folder/files organization change. 
Testing:
I ran the script locally on mac os -> success: the 2 *.cy.ts e2e files are process by cypress as expected.