### PR TITLE
fix: initialize 'i18next' only after the config 'i18n' is stable [backport to 5.2.x]

### DIFF
--- a/projects/core/src/i18n/i18next/i18next-providers.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.spec.ts
@@ -1,0 +1,87 @@
+import { APP_INITIALIZER } from '@angular/core';
+import { fakeAsync, flushMicrotasks, TestBed } from '@angular/core/testing';
+import { of, Subject } from 'rxjs';
+import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
+import { I18nConfig } from '../config/i18n-config';
+import { I18nextInitializer } from './i18next-initializer';
+import { i18nextProviders } from './i18next-providers';
+
+class MockConfigInitializerService
+  implements Partial<ConfigInitializerService>
+{
+  getStable() {
+    return of({ i18n: {} });
+  }
+}
+
+class MockI18nextInitializer implements Partial<I18nextInitializer> {
+  initialize() {
+    return Promise.resolve({});
+  }
+}
+
+describe('i18nextProviders', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfigInitializerService,
+          useClass: MockConfigInitializerService,
+        },
+        {
+          provide: I18nextInitializer,
+          useClass: MockI18nextInitializer,
+        },
+        i18nextProviders,
+      ],
+    });
+  });
+  describe('APP_INITIALIZER', () => {
+    it('should initialize `i18next` ONLY after the `i18n` config is stable', fakeAsync(() => {
+      const configInitializerService = TestBed.inject(ConfigInitializerService);
+      const i18nextInitializer = TestBed.inject(I18nextInitializer);
+
+      const mockStableConfig$ = new Subject<I18nConfig>();
+      spyOn(configInitializerService, 'getStable').and.returnValue(
+        mockStableConfig$
+      );
+      spyOn(i18nextInitializer, 'initialize').and.callThrough();
+
+      const appInitializers = TestBed.inject(APP_INITIALIZER);
+      appInitializers[0]() as Promise<any>;
+
+      expect(configInitializerService.getStable).toHaveBeenCalledWith('i18n');
+      expect(i18nextInitializer.initialize).not.toHaveBeenCalled();
+
+      mockStableConfig$.next({ i18n: {} });
+      mockStableConfig$.complete();
+
+      flushMicrotasks();
+      expect(i18nextInitializer.initialize).toHaveBeenCalled();
+    }));
+
+    it('should resolve its promise only after `i18next` is initialized', fakeAsync(() => {
+      const configInitializerService = TestBed.inject(ConfigInitializerService);
+      const i18nextInitializer = TestBed.inject(I18nextInitializer);
+      const appInitializers = TestBed.inject(APP_INITIALIZER);
+
+      let mockResolveI18nextInitialize: Function | undefined;
+      spyOn(i18nextInitializer, 'initialize').and.returnValue(
+        new Promise((resolve) => {
+          mockResolveI18nextInitialize = resolve;
+        })
+      );
+      spyOn(configInitializerService, 'getStable').and.callThrough();
+
+      let appInitializerResolved = false;
+      (appInitializers[0]() as Promise<any>).then(() => {
+        appInitializerResolved = true;
+      });
+
+      expect(appInitializerResolved).toBe(false);
+      mockResolveI18nextInitialize?.();
+      flushMicrotasks();
+      expect(appInitializerResolved).toBe(true);
+    }));
+  });
+});

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -5,14 +5,20 @@
  */
 
 import { APP_INITIALIZER, inject, Provider } from '@angular/core';
+import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
 import { I18nextInitializer } from './i18next-initializer';
 
 export const i18nextProviders: Provider[] = [
   {
     provide: APP_INITIALIZER,
     useFactory: () => {
+      const configInitializerService = inject(ConfigInitializerService);
       const i18nextInitializer = inject(I18nextInitializer);
-      return () => i18nextInitializer.initialize();
+      return () =>
+        configInitializerService
+          .getStable('i18n')
+          .toPromise()
+          .then(() => i18nextInitializer.initialize());
     },
     multi: true,
   },


### PR DESCRIPTION
In PR #16662 we've refactored the logic of the initialization of `i18next`. The refactor shouldn't have introduced breaking changes. However that refactor unintentionally removed the logic responsible for waiting for the `i18n` config to be stable before we initialize `i18next` (see diff: https://github.com/SAP/spartacus/pull/16662/files#diff-b9c2f7d32db998292ce5b32da446437ad64755d84817c3261fdbc89f6438856aL28-L30). This mistake was a behavioral breaking change and caused problems for customized code (see the bug ticket:  https://github.com/SAP/spartacus/issues/17124).

In this PR we bring back the logic of waiting for `i18n` config to be stable before we initialize `i18next` library

fixes #17124
fixes https://jira.tools.sap/browse/CXSPA-2955