### PR TITLE
fix: export `I18NEXT_INSTANCE` in public API [backport to 5.2.x]

### DIFF
--- a/projects/core/src/i18n/i18next/index.ts
+++ b/projects/core/src/i18n/i18next/index.ts
@@ -6,4 +6,5 @@
 
 export * from './i18next-backend/index';
 export * from './i18next-initializer';
+export * from './i18next-instance';
 export * from './i18next-translation.service';


### PR DESCRIPTION
followup of https://github.com/SAP/spartacus/pull/16662

related to https://jira.tools.sap/browse/CXSPA-2061