### PR TITLE
fix: CXSPA-2851 Unexpected error notification shows after customer login

### DIFF
--- a/projects/core/src/user/facade/user-consent.service.spec.ts
+++ b/projects/core/src/user/facade/user-consent.service.spec.ts
@@ -238,8 +238,20 @@ describe('UserConsentService', () => {
         });
       });
       describe('when the user is anonymous', () => {
-        it('should not call getConsents()', () => {
+        it('should not call getConsents() if isUserLoggedIn returns false', () => {
           spyOn(authService, 'isUserLoggedIn').and.returnValue(of(false));
+          spyOn(userIdService, 'getUserId').and.returnValue(
+            of(OCC_USER_ID_ANONYMOUS)
+          );
+          spyOn(service, 'getConsents').and.stub();
+
+          service.getConsent(mockTemplateId).subscribe().unsubscribe();
+
+          expect(service.getConsents).not.toHaveBeenCalled();
+        });
+
+        it('should not call getConsents() if isUserLoggedIn returns true', () => {
+          spyOn(authService, 'isUserLoggedIn').and.returnValue(of(true));
           spyOn(userIdService, 'getUserId').and.returnValue(
             of(OCC_USER_ID_ANONYMOUS)
           );

--- a/projects/core/src/user/facade/user-consent.service.spec.ts
+++ b/projects/core/src/user/facade/user-consent.service.spec.ts
@@ -4,7 +4,10 @@ import { Observable, of } from 'rxjs';
 import { AuthService } from '../../auth/user-auth/facade/auth.service';
 import { UserIdService } from '../../auth/user-auth/facade/user-id.service';
 import { Consent, ConsentTemplate } from '../../model/consent.model';
-import { OCC_USER_ID_CURRENT } from '../../occ/utils/occ-constants';
+import {
+  OCC_USER_ID_ANONYMOUS,
+  OCC_USER_ID_CURRENT,
+} from '../../occ/utils/occ-constants';
 import { PROCESS_FEATURE } from '../../process/store/process-state';
 import * as fromProcessReducers from '../../process/store/reducers';
 import { UserActions } from '../store/actions/index';
@@ -22,10 +25,14 @@ class MockUserIdService implements Partial<UserIdService> {
   takeUserId() {
     return of(OCC_USER_ID_CURRENT);
   }
+  public getUserId(): Observable<string> {
+    return of(OCC_USER_ID_CURRENT);
+  }
 }
 
 describe('UserConsentService', () => {
   let service: UserConsentService;
+  let userIdService: UserIdService;
   let authService: AuthService;
   let store: Store<StateWithUser>;
 
@@ -48,6 +55,7 @@ describe('UserConsentService', () => {
 
     store = TestBed.inject(Store);
     service = TestBed.inject(UserConsentService);
+    userIdService = TestBed.inject(UserIdService);
     authService = TestBed.inject(AuthService);
     spyOn(store, 'dispatch').and.callThrough();
   });
@@ -232,6 +240,9 @@ describe('UserConsentService', () => {
       describe('when the user is anonymous', () => {
         it('should not call getConsents()', () => {
           spyOn(authService, 'isUserLoggedIn').and.returnValue(of(false));
+          spyOn(userIdService, 'getUserId').and.returnValue(
+            of(OCC_USER_ID_ANONYMOUS)
+          );
           spyOn(service, 'getConsents').and.stub();
 
           service.getConsent(mockTemplateId).subscribe().unsubscribe();


### PR DESCRIPTION
This pull request contains a fix for unexpected error notifications popping out after the user logs into his account. 
![Screenshot 2023-03-29 at 13 26 53](https://user-images.githubusercontent.com/28891782/228523797-ac467b21-8dc0-4361-819c-b9a2c1dd30a0.png)

Such an error occurred because of logic in `userConsentService.getConsent()`, only when the CDS feature is enabled due to its additional logic checking consent validity, but the error itself is rather connected with the disconnection between AuthService and UserIdService. The error occurred because method `authService.isUserLoggedIn()` returns true as under the hood it is checking whether the access token is stored in memory. Then logic that uses this method calls `userIdService.takeUserId()` to get the `userId` needed for HTTP Call. Assuming that user is logged in (based on the first condition) we should receive the `current` user. Because the API call is made as an anonymous user but with an access token (which is in place), API responds with a 403 Forbidden error that triggers an error notification.
![image](https://user-images.githubusercontent.com/28891782/228530370-bb208a48-46c1-4df6-b7fe-3fa63fe0bbf9.png)

Unfortunately `userId` and access token are changed separately and there is no connection between changing their state (due to the fact that we're using a third-party library for authentication). That said, `authService.isUserLoggedIn()` may return true even if userId is still `anonymous`.

To fix the issue with an invalid notification, apart from the `isUserLoggedIn()` method, the condition has been extended to check whether `userId === current`.

---
Steps to test the fix:

1. set `cds` to true in `environment.ts`
2. go to the login page
3. login 
4. observe that the error notification doesn't pop out.