### PR TITLE
fix: SSR - enable SSR optimization engine by default

### DIFF
--- a/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
+++ b/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
@@ -9,7 +9,10 @@ import {
   OptimizedSsrEngine,
   SsrCallbackFn,
 } from '../optimized-engine/optimized-ssr-engine';
-import { SsrOptimizationOptions } from '../optimized-engine/ssr-optimization-options';
+import {
+  SsrOptimizationOptions,
+  defaultSsrOptimizationOptions,
+} from '../optimized-engine/ssr-optimization-options';
 import { getServerRequestProviders } from '../providers/ssr-providers';
 
 export type NgExpressEngineInstance = (
@@ -42,7 +45,10 @@ export class NgExpressEngineDecorator {
 
 export function decorateExpressEngine(
   ngExpressEngine: NgExpressEngine,
-  optimizationOptions: SsrOptimizationOptions | null | undefined
+  optimizationOptions:
+    | SsrOptimizationOptions
+    | null
+    | undefined = defaultSsrOptimizationOptions
 ): NgExpressEngine {
   return function (setupOptions: NgSetupOptions) {
     const engineInstance = ngExpressEngine({


### PR DESCRIPTION

This is a fix for unwanted behavior introduced in https://jira.tools.sap/browse/CXSPA-401, where the Spartacus optimization engine is not enabled by default unless the optimization options are explicitly provided.

Closes https://jira.tools.sap/browse/CXSPA-3053