### PR TITLE
fix: use store finder configuration for map

### DIFF
--- a/feature-libs/asm/customer-360/components/sections/asm-customer-map/asm-customer-map.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-map/asm-customer-map.component.html
@@ -49,7 +49,7 @@
     </div>
     <div class="store-map-container">
       <iframe
-        *ngIf="!!(source.config$ | async)?.googleMapsApiKey"
+        *ngIf="storeFinderConfig?.googleMaps?.apiKey"
         [title]="selectedStore.displayName"
         class="store-map"
         loading="lazy"

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-map/asm-customer-map.component.spec.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-map/asm-customer-map.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import {
+  StoreFinderConfig,
   StoreFinderSearchPage,
   StoreFinderService,
 } from '@spartacus/storefinder/core';
@@ -11,7 +12,7 @@ import { Customer360SectionContext } from '../customer-360-section-context.model
 
 import { AsmCustomerMapComponent } from './asm-customer-map.component';
 
-describe('AsmCustomerMapComponent', () => {
+fdescribe('AsmCustomerMapComponent', () => {
   const stores = [
     {
       displayName: 'Boston',
@@ -85,6 +86,12 @@ describe('AsmCustomerMapComponent', () => {
     },
   ];
 
+  const mockStoreFinderConfig = {
+    googleMaps: {
+      radius: 50000,
+      apiKey: 'testkey',
+    },
+  };
   class MockStoreFinderService {
     findStoresAction(): void {}
 
@@ -114,6 +121,7 @@ describe('AsmCustomerMapComponent', () => {
           useExisting: Customer360SectionContextSource,
         },
         { provide: StoreFinderService, useClass: MockStoreFinderService },
+        { provide: StoreFinderConfig, useValue: mockStoreFinderConfig },
       ],
     }).compileComponents();
   });
@@ -122,8 +130,7 @@ describe('AsmCustomerMapComponent', () => {
     const contextSource = TestBed.inject(Customer360SectionContextSource);
 
     contextSource.config$.next({
-      googleMapsApiKey: 'foo',
-      storefinderRadius: 1000,
+      pageSize: 10,
     });
 
     contextSource.data$.next({
@@ -145,14 +152,14 @@ describe('AsmCustomerMapComponent', () => {
       pageSize: 1,
       totalPages: 2,
     });
-    expect(component.selectedStore.displayName).toBe('Boston');
+    expect(component.selectedStore?.displayName).toBe('Boston');
     expect(component.googleMapsUrl).toBeTruthy();
   });
 
   it('should select a store', () => {
     component.selectStore(stores[1]);
 
-    expect(component.selectedStore.displayName).toBe('New York');
+    expect(component.selectedStore?.displayName).toBe('New York');
     expect(component.googleMapsUrl).toBeTruthy();
   });
 

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-map/asm-customer-map.component.spec.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-map/asm-customer-map.component.spec.ts
@@ -12,7 +12,7 @@ import { Customer360SectionContext } from '../customer-360-section-context.model
 
 import { AsmCustomerMapComponent } from './asm-customer-map.component';
 
-fdescribe('AsmCustomerMapComponent', () => {
+describe('AsmCustomerMapComponent', () => {
   const stores = [
     {
       displayName: 'Boston',

--- a/feature-libs/asm/customer-360/root/config/default-customer-360-config.ts
+++ b/feature-libs/asm/customer-360/root/config/default-customer-360-config.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GOOGLE_MAPS_DEVELOPMENT_KEY_CONFIG } from '@spartacus/storefinder/root';
 import { Customer360Type } from '../model';
 import { Customer360Config } from './customer-360-config';
 
@@ -39,7 +38,6 @@ export const defaultCustomer360Config: Customer360Config = {
         components: [
           {
             component: 'AsmCustomer360ProfileComponent',
-            //TODO until backend is ready
             requestData: {
               type: Customer360Type.CUSTOMER_PROFILE,
             },
@@ -63,7 +61,6 @@ export const defaultCustomer360Config: Customer360Config = {
         components: [
           {
             component: 'AsmCustomer360SupportTicketsComponent',
-            //TODO  until backend is ready
             requestData: {
               type: Customer360Type.SUPPORT_TICKET_LIST,
             },
@@ -87,12 +84,6 @@ export const defaultCustomer360Config: Customer360Config = {
               type: Customer360Type.STORE_LOCATION,
             },
             config: {
-              // For security compliance, by default, google maps does not display.
-              // Using special key value 'cx-development' allows google maps to display
-              // without a key, for development or demo purposes.
-              // (refer from app.module)
-              googleMapsApiKey: GOOGLE_MAPS_DEVELOPMENT_KEY_CONFIG,
-              storefinderRadius: 10000000,
               pageSize: 10,
             },
           },

--- a/feature-libs/asm/customer-360/root/model/customer-360-section-config.ts
+++ b/feature-libs/asm/customer-360/root/model/customer-360-section-config.ts
@@ -5,8 +5,5 @@
  */
 
 export abstract class Customer360SectionConfig {
-  googleMapsApiKey?: string;
-  /** In meters. */
-  storefinderRadius?: number;
   pageSize?: number;
 }


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-3188

remove our own configuration for Google map key and radius.  share with storefinder configuration since our map component is using storefinder service.
