### PR TITLE
chore: Codeowners update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,7 +48,7 @@
 # ================================================
 #  ASM
 # ================================================
-/feature-libs/asm/          @SAP/spartacus-codeowners @SAP/spartacus-iceman
+/feature-libs/asm/          @SAP/spartacus-codeowners @SAP/spartacus-holidays
 
 # ================================================
 #  Product Configurator and CPQ integration
@@ -60,8 +60,13 @@
 # ================================================
 /integration-libs/cds/          @SAP/spartacus-codeowners @SAP/spartacus-CDS
 
+# ================================================
+#  (CDC)
+# ================================================
+/integration-libs/cdc/          @SAP/spartacus-codeowners @SAP/spartacus-CDC
 
 # ================================================
-#  BOPIS Feature
+#  BOPIS
 # ================================================
 /feature-libs/pickup-in-store/         @SAP/spartacus-codeowners @SAP/spartacus-colossus
+


### PR DESCRIPTION
- Team holidays owns ASM now
- Adding CDC team