### PR TITLE
Modify routing with CMS cpnt

### DIFF
--- a/integration-libs/opf/components/opf-payment-verification/opf-payment-verification.module.ts
+++ b/integration-libs/opf/components/opf-payment-verification/opf-payment-verification.module.ts
@@ -6,6 +6,7 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { CmsConfig, provideDefaultConfig } from '@spartacus/core';
 import { SpinnerModule } from '@spartacus/storefront';
 import { OpfPaymentVerificationComponent } from './opf-payment-verification.component';
 
@@ -13,5 +14,14 @@ import { OpfPaymentVerificationComponent } from './opf-payment-verification.comp
   declarations: [OpfPaymentVerificationComponent],
   imports: [CommonModule, SpinnerModule],
   exports: [OpfPaymentVerificationComponent],
+  providers: [
+    provideDefaultConfig(<CmsConfig>{
+      cmsComponents: {
+        OpfPaymentVerificationComponent: {
+          component: OpfPaymentVerificationComponent,
+        },
+      },
+    }),
+  ],
 })
 export class OpfPaymentVerificationModule {}

--- a/integration-libs/opf/root/config/default-opf-routing-config.ts
+++ b/integration-libs/opf/root/config/default-opf-routing-config.ts
@@ -10,10 +10,10 @@ export const defaultOpfRoutingConfig: RoutingConfig = {
   routing: {
     routes: {
       paymentVerificationResult: {
-        paths: ['redirect/success'],
+        paths: ['payment-result'],
       },
       paymentVerificationCancel: {
-        paths: ['redirect/failure'],
+        paths: ['payment-cancel'],
       },
     },
   },

--- a/integration-libs/opf/root/opf-root.module.ts
+++ b/integration-libs/opf/root/opf-root.module.ts
@@ -6,20 +6,36 @@
 
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { provideConfigValidator, provideDefaultConfig } from '@spartacus/core';
-import { OpfPaymentVerificationComponent } from '../components/opf-payment-verification';
+import {
+  provideConfigValidator,
+  provideDefaultConfig,
+  provideDefaultConfigFactory,
+} from '@spartacus/core';
+import { CmsPageGuard, PageLayoutComponent } from '@spartacus/storefront';
 import { defaultOpfRoutingConfig } from './config';
 import { defaultOPFCheckoutConfig } from './config/default-opf-checkout-config';
 import { defaultOpfConfig } from './config/default-opf-config';
 import { opfConfidValidator } from './config/opf-config-validator';
+import { OPF_FEATURE } from './feature-name';
 
+export function defaultOpfComponentsConfig() {
+  const config = {
+    featureModules: {
+      [OPF_FEATURE]: {
+        cmsComponents: ['OpfPaymentVerificationComponent'],
+      },
+    },
+  };
+  return config;
+}
 @NgModule({
   imports: [
     RouterModule.forChild([
       {
         // @ts-ignore
         path: null,
-        component: OpfPaymentVerificationComponent,
+        component: PageLayoutComponent,
+        canActivate: [CmsPageGuard],
         data: {
           cxRoute: 'paymentVerificationResult',
         },
@@ -27,7 +43,8 @@ import { opfConfidValidator } from './config/opf-config-validator';
       {
         // @ts-ignore
         path: null,
-        component: OpfPaymentVerificationComponent,
+        component: PageLayoutComponent,
+        canActivate: [CmsPageGuard],
         data: {
           cxRoute: 'paymentVerificationCancel',
         },
@@ -35,6 +52,7 @@ import { opfConfidValidator } from './config/opf-config-validator';
     ]),
   ],
   providers: [
+    provideDefaultConfigFactory(defaultOpfComponentsConfig),
     provideDefaultConfig(defaultOpfConfig),
     provideDefaultConfig(defaultOPFCheckoutConfig),
     // TODO OPF: uncomment once proper type and routing is set up

--- a/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
@@ -5,7 +5,12 @@
  */
 
 import { NgModule, Provider } from '@angular/core';
-import { I18nConfig, provideConfig, RoutingConfig } from '@spartacus/core';
+import {
+  I18nConfig,
+  OccConfig,
+  provideConfig,
+  RoutingConfig,
+} from '@spartacus/core';
 import {
   opfTranslationChunksConfig,
   opfTranslations,
@@ -33,10 +38,10 @@ if (environment.b2b) {
       routing: {
         routes: {
           paymentVerificationResult: {
-            paths: ['redirect/success'],
+            paths: ['payment-result'],
           },
           paymentVerificationCancel: {
-            paths: ['redirect/failure'],
+            paths: ['payment-cancel'],
           },
         },
       },
@@ -46,6 +51,15 @@ if (environment.b2b) {
         baseUrl:
           'https://opf-dev.api.commerce.stage.context.cloud.sap/commerce-cloud-adapter/storefront',
         commerceCloudPublicKey: 'ab4RhYGZ+w5B0SALMPOPlepWk/kmDQjTy2FU5hrQoFg=',
+      },
+    }),
+    provideConfig(<OccConfig>{
+      backend: {
+        occ: {
+          endpoints: {
+            placeOrder: 'users/${userId}/orders/v2?fields=FULL',
+          },
+        },
       },
     }),
     provideConfig(<I18nConfig>{


### PR DESCRIPTION
In order to fox circular dependency
Before: Router was loading an angular Component
Now: Router point to CMS page ('payment-result and payment-cancel') -> this CMS page contains and load the OpfPaymentVerificationComponent
Benefits: customer will be able to customize the UI easily from server side.