### PR TITLE
fix: expose missing services in public API

### DIFF
--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/index.ts
@@ -8,3 +8,4 @@ export * from './product-filter/index';
 export * from './product-list/index';
 export * from './visual-picking-tab.component';
 export * from './visual-picking-tab.module';
+export * from './visual-picking-tab.service';

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/index.ts
@@ -6,3 +6,4 @@
 
 export * from './visual-picking-product-filter.component';
 export * from './visual-picking-product-filter.module';
+export * from './visual-picking-product-filter.service';

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
@@ -8,3 +8,4 @@ export * from './compact-add-to-cart/index';
 export * from './model/index';
 export * from './visual-picking-product-list.component';
 export * from './visual-picking-product-list.module';
+export * from './visual-picking-product-list.service';

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
@@ -6,6 +6,7 @@
 
 export * from './compact-add-to-cart/index';
 export * from './model/index';
+export * from './paged-list/index';
 export * from './visual-picking-product-list.component';
 export * from './visual-picking-product-list.module';
 export * from './visual-picking-product-list.service';

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/index.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/index.ts
@@ -6,3 +6,4 @@
 
 export * from './visual-viewer-animation-slider.component';
 export * from './visual-viewer-animation-slider.module';
+export * from './visual-viewer-animation-slider.service';

--- a/integration-libs/epd-visualization/package.json
+++ b/integration-libs/epd-visualization/package.json
@@ -37,7 +37,7 @@
     "@angular/core": "^15.2.4",
     "@angular/forms": "^15.2.4",
     "@angular/router": "^15.2.4",
-    "@sapui5/ts-types-esm": "1.108.5",
+    "@sapui5/ts-types-esm": "1.108.14",
     "@spartacus/cart": "5.0.0",
     "@spartacus/core": "5.0.0",
     "@spartacus/schematics": "5.0.0",

--- a/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
+++ b/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
@@ -15,7 +15,7 @@ export function getTestConfig(): EpdVisualizationConfig {
       },
       ui5: {
         bootstrapUrl:
-          'https://sapui5.hana.ondemand.com/1.108.5/resources/sap-ui-core.js',
+          'https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js',
       },
     },
   };

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
@@ -22,7 +22,7 @@ import { EpdVisualizationConfig, EpdVisualizationRootModule } from "@spartacus/e
   provideConfig(<EpdVisualizationConfig>{
     epdVisualization: {
       ui5: {
-        bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.5/resources/sap-ui-core.js"
+        bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js"
       },
 
       apis: {
@@ -58,7 +58,7 @@ import { EpdVisualizationConfig, EpdVisualizationRootModule } from "@spartacus/e
   provideConfig(<EpdVisualizationConfig>{
     epdVisualization: {
       ui5: {
-        bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.5/resources/sap-ui-core.js"
+        bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js"
       },
 
       apis: {
@@ -100,7 +100,7 @@ import { EpdVisualizationConfig, EpdVisualizationRootModule, EPD_VISUALIZATION_F
   provideConfig(<EpdVisualizationConfig>{
     epdVisualization: {
       ui5: {
-        bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.5/resources/sap-ui-core.js"
+        bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js"
       },
 
       apis: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@nrwl/eslint-plugin-nx": "^15.9.2",
         "@nrwl/jest": "^15.9.2",
         "@nrwl/workspace": "15.9.2",
-        "@sapui5/ts-types-esm": "1.108.5",
+        "@sapui5/ts-types-esm": "1.108.14",
         "@schematics/angular": "^15.2.4",
         "@types/express": "^4.17.17",
         "@types/fs-extra": "^11.0.1",
@@ -5847,7 +5847,7 @@
       }
     },
     "node_modules/@sapui5/ts-types-esm": {
-      "version": "1.108.5",
+      "version": "1.108.14",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "@nrwl/eslint-plugin-nx": "^15.9.2",
     "@nrwl/jest": "^15.9.2",
     "@nrwl/workspace": "15.9.2",
-    "@sapui5/ts-types-esm": "1.108.5",
+    "@sapui5/ts-types-esm": "1.108.14",
     "@schematics/angular": "^15.2.4",
     "@types/express": "^4.17.17",
     "@types/fs-extra": "^11.0.1",

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -307,7 +307,7 @@
     "@angular/core": "^15.2.4",
     "@angular/forms": "^15.2.4",
     "@angular/router": "^15.2.4",
-    "@sapui5/ts-types-esm": "1.108.5",
+    "@sapui5/ts-types-esm": "1.108.14",
     "@spartacus/cart": "5.0.0",
     "@spartacus/core": "5.0.0",
     "@spartacus/schematics": "5.0.0",

--- a/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
@@ -75,7 +75,7 @@ function buildCdsConfig(
       content: `<${EPD_VISUALIZATION_CONFIG}>{
         epdVisualization: {
           ui5: {
-            bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.5/resources/sap-ui-core.js"
+            bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js"
           },
 
           apis: {

--- a/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
@@ -25,7 +25,7 @@ const epdVisualizationConfig: EpdVisualizationConfig = {
 
     ui5: {
       bootstrapUrl:
-        'https://sapui5.hana.ondemand.com/1.108.5/resources/sap-ui-core.js',
+        'https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js',
     },
   },
 };


### PR DESCRIPTION
Expose the following in `@spartacus/epd-visualization/components`:

- `VisualPickingTabService`
- `VisualPickingProductFilterService`
- `VisualPickingProductListService`
- `VisualViewerAnimationSliderService`
- `PagedListComponent`

JIRA: https://jira.tools.sap/browse/CXSPA-3342