### PR TITLE
fix: expose missing services in public API

### DIFF
--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/index.ts
@@ -8,3 +8,4 @@ export * from './product-filter/index';
 export * from './product-list/index';
 export * from './visual-picking-tab.component';
 export * from './visual-picking-tab.module';
+export * from './visual-picking-tab.service';

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/index.ts
@@ -6,3 +6,4 @@
 
 export * from './visual-picking-product-filter.component';
 export * from './visual-picking-product-filter.module';
+export * from './visual-picking-product-filter.service';

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
@@ -8,3 +8,4 @@ export * from './compact-add-to-cart/index';
 export * from './model/index';
 export * from './visual-picking-product-list.component';
 export * from './visual-picking-product-list.module';
+export * from './visual-picking-product-list.service';

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
@@ -6,6 +6,7 @@
 
 export * from './compact-add-to-cart/index';
 export * from './model/index';
+export * from './paged-list/index';
 export * from './visual-picking-product-list.component';
 export * from './visual-picking-product-list.module';
 export * from './visual-picking-product-list.service';

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/index.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/index.ts
@@ -6,3 +6,4 @@
 
 export * from './visual-viewer-animation-slider.component';
 export * from './visual-viewer-animation-slider.module';
+export * from './visual-viewer-animation-slider.service';


### PR DESCRIPTION
Expose the following in `@spartacus/epd-visualization/components`:

- `VisualPickingTabService`
- `VisualPickingProductFilterService`
- `VisualPickingProductListService`
- `VisualViewerAnimationSliderService`
- `PagedListComponent`

JIRA: https://jira.tools.sap/browse/CXSPA-3342