### PR TITLE
CXSPA-3075: Cleanup deprecated `throwError()`

### DIFF
--- a/feature-libs/asm/components/asm-bind-cart/asm-bind-cart.component.spec.ts
+++ b/feature-libs/asm/components/asm-bind-cart/asm-bind-cart.component.spec.ts
@@ -230,7 +230,9 @@ describe('AsmBindCartComponent', () => {
       it('should alert through global messsages when the bind cart fails', () => {
         const expectedErrorMessage = 'mock-error-message';
         (asmBindCartFacade.bindCart as jasmine.Spy).and.returnValue(
-          throwError({ details: [{ message: expectedErrorMessage }] })
+          throwError(() => ({
+            details: [{ message: expectedErrorMessage }],
+          }))
         );
 
         component.bindCartToCustomer();

--- a/feature-libs/asm/occ/adapters/occ-asm.adapter.ts
+++ b/feature-libs/asm/occ/adapters/occ-asm.adapter.ts
@@ -28,7 +28,7 @@ import {
   User,
   normalizeHttpError,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -72,7 +72,9 @@ export class OccAsmAdapter implements AsmAdapter {
     );
 
     return this.http.get<CustomerListsPage>(url, { headers, params }).pipe(
-      catchError((error) => throwError(() => normalizeHttpError(error))),
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      }),
       this.converterService.pipeable(CUSTOMER_LISTS_NORMALIZER)
     );
   }
@@ -120,7 +122,9 @@ export class OccAsmAdapter implements AsmAdapter {
     );
 
     return this.http.get<CustomerSearchPage>(url, { headers, params }).pipe(
-      catchError((error) => throwError(() => normalizeHttpError(error))),
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      }),
       this.converterService.pipeable(CUSTOMER_SEARCH_PAGE_NORMALIZER)
     );
   }
@@ -145,9 +149,11 @@ export class OccAsmAdapter implements AsmAdapter {
       }
     );
 
-    return this.http
-      .post<void>(url, {}, { headers, params })
-      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
+    return this.http.post<void>(url, {}, { headers, params }).pipe(
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   createCustomer(user: CustomerRegistrationForm): Observable<User> {

--- a/feature-libs/asm/occ/adapters/occ-asm.adapter.ts
+++ b/feature-libs/asm/occ/adapters/occ-asm.adapter.ts
@@ -23,10 +23,10 @@ import {
   BaseSiteService,
   ConverterService,
   InterceptorUtil,
-  normalizeHttpError,
   OccEndpointsService,
-  User,
   USE_CUSTOMER_SUPPORT_AGENT_TOKEN,
+  User,
+  normalizeHttpError,
 } from '@spartacus/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -72,7 +72,7 @@ export class OccAsmAdapter implements AsmAdapter {
     );
 
     return this.http.get<CustomerListsPage>(url, { headers, params }).pipe(
-      catchError((error) => throwError(normalizeHttpError(error))),
+      catchError((error) => throwError(() => normalizeHttpError(error))),
       this.converterService.pipeable(CUSTOMER_LISTS_NORMALIZER)
     );
   }
@@ -120,7 +120,7 @@ export class OccAsmAdapter implements AsmAdapter {
     );
 
     return this.http.get<CustomerSearchPage>(url, { headers, params }).pipe(
-      catchError((error) => throwError(normalizeHttpError(error))),
+      catchError((error) => throwError(() => normalizeHttpError(error))),
       this.converterService.pipeable(CUSTOMER_SEARCH_PAGE_NORMALIZER)
     );
   }
@@ -147,7 +147,7 @@ export class OccAsmAdapter implements AsmAdapter {
 
     return this.http
       .post<void>(url, {}, { headers, params })
-      .pipe(catchError((error) => throwError(normalizeHttpError(error))));
+      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
   }
 
   createCustomer(user: CustomerRegistrationForm): Observable<User> {
@@ -165,8 +165,10 @@ export class OccAsmAdapter implements AsmAdapter {
         prefix: false,
       }
     );
-    return this.http
-      .post<User>(url, user, { headers, params })
-      .pipe(catchError((error) => throwError(normalizeHttpError(error))));
+    return this.http.post<User>(url, user, { headers, params }).pipe(
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 }

--- a/feature-libs/cart/base/core/store/effects/cart-voucher.effect.spec.ts
+++ b/feature-libs/cart/base/core/store/effects/cart-voucher.effect.spec.ts
@@ -82,7 +82,9 @@ describe('Cart Voucher effect', () => {
 
     it('should fail', () => {
       const error = new HttpErrorResponse({ error: 'error' });
-      cartVoucherConnector.add = createSpy().and.returnValue(throwError(error));
+      cartVoucherConnector.add = createSpy().and.returnValue(
+        throwError(() => error)
+      );
       const action = new CartActions.CartAddVoucher({
         userId,
         cartId,

--- a/feature-libs/cart/base/core/store/effects/cart.effect.spec.ts
+++ b/feature-libs/cart/base/core/store/effects/cart.effect.spec.ts
@@ -165,13 +165,13 @@ describe('Cart effect', () => {
         extraData: { active: true },
       });
       loadMock.and.returnValue(
-        throwError({
+        throwError(() => ({
           error: {
             errors: [
               { reason: 'notFound', subjectType: 'cart', subject: '123456' },
             ],
           },
-        })
+        }))
       );
       const removeCartCompletion = new CartActions.RemoveCart({ cartId });
       actions$ = hot('-a', { a: action });
@@ -199,7 +199,7 @@ describe('Cart effect', () => {
         },
       });
       const action = new CartActions.LoadCart(payload);
-      loadMock.and.returnValue(throwError(httpError));
+      loadMock.and.returnValue(throwError(() => httpError));
       const removeCartCompletion = new CartActions.LoadCartFail({
         ...payload,
         error: normalizeHttpError(httpError),

--- a/feature-libs/cart/base/occ/adapters/occ-cart-validation.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-validation.adapter.ts
@@ -33,7 +33,7 @@ export class OccCartValidationAdapter implements CartValidationAdapter {
     });
 
     return this.http.post<any>(url, null).pipe(
-      catchError((error) => throwError(normalizeHttpError(error))),
+      catchError((error) => throwError(() => normalizeHttpError(error))),
       this.converter.pipeable(CART_VALIDATION_NORMALIZER)
     );
   }

--- a/feature-libs/cart/base/occ/adapters/occ-cart-validation.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-validation.adapter.ts
@@ -7,16 +7,16 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
-  CartValidationAdapter,
   CART_VALIDATION_NORMALIZER,
+  CartValidationAdapter,
 } from '@spartacus/cart/base/core';
 import { CartModificationList } from '@spartacus/cart/base/root';
 import {
   ConverterService,
-  normalizeHttpError,
   OccEndpointsService,
+  normalizeHttpError,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -33,7 +33,9 @@ export class OccCartValidationAdapter implements CartValidationAdapter {
     });
 
     return this.http.post<any>(url, null).pipe(
-      catchError((error) => throwError(() => normalizeHttpError(error))),
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      }),
       this.converter.pipeable(CART_VALIDATION_NORMALIZER)
     );
   }

--- a/feature-libs/cart/base/occ/adapters/occ-cart-voucher.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-voucher.adapter.ts
@@ -54,7 +54,7 @@ export class OccCartVoucherAdapter implements CartVoucherAdapter {
     const headers = this.getHeaders(userId);
 
     return this.http.post(url, toAdd, { headers, params }).pipe(
-      catchError((error: any) => throwError(error)),
+      catchError((error: any) => throwError(() => error)),
       this.converter.pipeable(CART_VOUCHER_NORMALIZER)
     );
   }
@@ -69,6 +69,6 @@ export class OccCartVoucherAdapter implements CartVoucherAdapter {
 
     return this.http
       .delete(url, { headers })
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 }

--- a/feature-libs/cart/base/occ/adapters/occ-cart-voucher.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-voucher.adapter.ts
@@ -11,9 +11,10 @@ import { CART_VOUCHER_NORMALIZER } from '@spartacus/cart/base/root';
 import {
   ConverterService,
   InterceptorUtil,
-  OccEndpointsService,
   OCC_USER_ID_ANONYMOUS,
+  OccEndpointsService,
   USE_CLIENT_TOKEN,
+  normalizeHttpError,
 } from '@spartacus/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -54,7 +55,7 @@ export class OccCartVoucherAdapter implements CartVoucherAdapter {
     const headers = this.getHeaders(userId);
 
     return this.http.post(url, toAdd, { headers, params }).pipe(
-      catchError((error: any) => throwError(() => error)),
+      catchError((error: any) => throwError(() => normalizeHttpError(error))),
       this.converter.pipeable(CART_VOUCHER_NORMALIZER)
     );
   }
@@ -69,6 +70,8 @@ export class OccCartVoucherAdapter implements CartVoucherAdapter {
 
     return this.http
       .delete(url, { headers })
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 }

--- a/feature-libs/cart/base/occ/adapters/occ-cart-voucher.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-voucher.adapter.ts
@@ -16,7 +16,7 @@ import {
   USE_CLIENT_TOKEN,
   normalizeHttpError,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -55,7 +55,9 @@ export class OccCartVoucherAdapter implements CartVoucherAdapter {
     const headers = this.getHeaders(userId);
 
     return this.http.post(url, toAdd, { headers, params }).pipe(
-      catchError((error: any) => throwError(() => normalizeHttpError(error))),
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      }),
       this.converter.pipeable(CART_VOUCHER_NORMALIZER)
     );
   }
@@ -68,10 +70,10 @@ export class OccCartVoucherAdapter implements CartVoucherAdapter {
 
     const headers = this.getHeaders(userId);
 
-    return this.http
-      .delete(url, { headers })
-      .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
-      );
+    return this.http.delete(url, { headers }).pipe(
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 }

--- a/feature-libs/cart/quick-order/components/page-context/quick-order-order-entries.context.spec.ts
+++ b/feature-libs/cart/quick-order/components/page-context/quick-order-order-entries.context.spec.ts
@@ -202,11 +202,11 @@ describe('QuickOrderOrderEntriesContext', () => {
     it('should catch unknown identifier error', () => {
       canAdd$.next(true);
       productConnector.get = createSpy().and.returnValue(
-        throwError({
+        throwError(() => ({
           error: {
             errors: [{ type: 'UnknownIdentifierError' }],
           },
-        })
+        }))
       );
 
       const unableToAddProductsData: ProductData[] = [
@@ -238,7 +238,9 @@ describe('QuickOrderOrderEntriesContext', () => {
 
     it('should catch unknown errors', () => {
       canAdd$.next(true);
-      productConnector.get = createSpy().and.returnValue(throwError({}));
+      productConnector.get = createSpy().and.returnValue(
+        throwError(() => ({}))
+      );
 
       const unableToAddProductsData: ProductData[] = [
         { productCode: unhandledItemErrorId, quantity: 1 },

--- a/feature-libs/checkout/b2b/occ/adapters/occ-checkout-cost-center.adapter.spec.ts
+++ b/feature-libs/checkout/b2b/occ/adapters/occ-checkout-cost-center.adapter.spec.ts
@@ -103,7 +103,9 @@ describe(`OccCheckoutCostCenterAdapter`, () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'put').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'put').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -127,7 +129,7 @@ describe(`OccCheckoutCostCenterAdapter`, () => {
             if (calledTimes === 3) {
               return of(cartData);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 

--- a/feature-libs/checkout/b2b/occ/adapters/occ-checkout-cost-center.adapter.ts
+++ b/feature-libs/checkout/b2b/occ/adapters/occ-checkout-cost-center.adapter.ts
@@ -15,7 +15,7 @@ import {
   normalizeHttpError,
   OccEndpointsService,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -34,7 +34,9 @@ export class OccCheckoutCostCenterAdapter implements CheckoutCostCenterAdapter {
     return this.http
       .put(this.getSetCartCostCenterEndpoint(userId, cartId, costCenterId), {})
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({ shouldRetry: isJaloError }),
         this.converter.pipeable(CART_NORMALIZER)
       );

--- a/feature-libs/checkout/b2b/occ/adapters/occ-checkout-cost-center.adapter.ts
+++ b/feature-libs/checkout/b2b/occ/adapters/occ-checkout-cost-center.adapter.ts
@@ -34,7 +34,7 @@ export class OccCheckoutCostCenterAdapter implements CheckoutCostCenterAdapter {
     return this.http
       .put(this.getSetCartCostCenterEndpoint(userId, cartId, costCenterId), {})
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({ shouldRetry: isJaloError }),
         this.converter.pipeable(CART_NORMALIZER)
       );

--- a/feature-libs/checkout/b2b/occ/adapters/occ-checkout-payment-type.adapter.spec.ts
+++ b/feature-libs/checkout/b2b/occ/adapters/occ-checkout-payment-type.adapter.spec.ts
@@ -130,7 +130,9 @@ describe(`OccCheckoutPaymentTypeAdapter`, () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'get').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'get').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -154,7 +156,7 @@ describe(`OccCheckoutPaymentTypeAdapter`, () => {
             if (calledTimes === 3) {
               return of(paymentTypesList);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -233,7 +235,9 @@ describe(`OccCheckoutPaymentTypeAdapter`, () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'put').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'put').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -257,7 +261,7 @@ describe(`OccCheckoutPaymentTypeAdapter`, () => {
             if (calledTimes === 3) {
               return of(cartData);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 

--- a/feature-libs/checkout/b2b/occ/adapters/occ-checkout-payment-type.adapter.ts
+++ b/feature-libs/checkout/b2b/occ/adapters/occ-checkout-payment-type.adapter.ts
@@ -6,21 +6,21 @@
 
 import { HttpClient, HttpContext } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Cart, CART_NORMALIZER, PaymentType } from '@spartacus/cart/base/root';
+import { CART_NORMALIZER, Cart, PaymentType } from '@spartacus/cart/base/root';
 import {
-  CheckoutPaymentTypeAdapter,
   CHECKOUT_PAYMENT_TYPE_NORMALIZER,
+  CheckoutPaymentTypeAdapter,
 } from '@spartacus/checkout/b2b/core';
 import {
-  backOff,
   ConverterService,
-  isJaloError,
-  normalizeHttpError,
+  OCC_HTTP_TOKEN,
   Occ,
   OccEndpointsService,
-  OCC_HTTP_TOKEN,
+  backOff,
+  isJaloError,
+  normalizeHttpError,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 @Injectable()
@@ -41,7 +41,9 @@ export class OccCheckoutPaymentTypeAdapter
     return this.http
       .get<Occ.PaymentTypeList>(this.getPaymentTypesEndpoint(), { context })
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({ shouldRetry: isJaloError }),
         map((paymentTypeList) => paymentTypeList.paymentTypes ?? []),
         this.converter.pipeableMany(CHECKOUT_PAYMENT_TYPE_NORMALIZER)
@@ -69,7 +71,9 @@ export class OccCheckoutPaymentTypeAdapter
         {}
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({ shouldRetry: isJaloError }),
         this.converter.pipeable(CART_NORMALIZER)
       );

--- a/feature-libs/checkout/b2b/occ/adapters/occ-checkout-payment-type.adapter.ts
+++ b/feature-libs/checkout/b2b/occ/adapters/occ-checkout-payment-type.adapter.ts
@@ -41,7 +41,7 @@ export class OccCheckoutPaymentTypeAdapter
     return this.http
       .get<Occ.PaymentTypeList>(this.getPaymentTypesEndpoint(), { context })
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({ shouldRetry: isJaloError }),
         map((paymentTypeList) => paymentTypeList.paymentTypes ?? []),
         this.converter.pipeableMany(CHECKOUT_PAYMENT_TYPE_NORMALIZER)
@@ -69,7 +69,7 @@ export class OccCheckoutPaymentTypeAdapter
         {}
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({ shouldRetry: isJaloError }),
         this.converter.pipeable(CART_NORMALIZER)
       );

--- a/feature-libs/checkout/base/components/services/express-checkout.service.spec.ts
+++ b/feature-libs/checkout/base/components/services/express-checkout.service.spec.ts
@@ -213,7 +213,7 @@ describe('ExpressCheckoutService', () => {
 
       it('should return false if set delivery address error', (done) => {
         checkoutDeliveryAddressFacade.setDeliveryAddress =
-          createSpy().and.returnValue(throwError('err'));
+          createSpy().and.returnValue(throwError(() => 'err'));
 
         service
           .trySetDefaultCheckoutDetails()
@@ -269,7 +269,7 @@ describe('ExpressCheckoutService', () => {
 
       it('should return false if set payment method error', (done) => {
         checkoutPaymentService.setPaymentDetails = createSpy().and.returnValue(
-          throwError('err')
+          throwError(() => 'err')
         );
 
         service
@@ -310,7 +310,7 @@ describe('ExpressCheckoutService', () => {
 
       it('should return false if set delivery mode error', (done) => {
         checkoutDeliveryModesFacade.setDeliveryMode =
-          createSpy().and.returnValue(throwError('err'));
+          createSpy().and.returnValue(throwError(() => 'err'));
 
         service
           .trySetDefaultCheckoutDetails()

--- a/feature-libs/checkout/base/core/facade/checkout-delivery-modes.service.spec.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-delivery-modes.service.spec.ts
@@ -234,7 +234,7 @@ describe(`CheckoutDeliveryModesService`, () => {
 
     it(`should dispatch CheckoutDeliveryModeClearedErrorEvent event on error`, () => {
       connector.clearCheckoutDeliveryMode = createSpy().and.returnValue(
-        throwError('err')
+        throwError(() => 'err')
       );
 
       service.clearCheckoutDeliveryMode();

--- a/feature-libs/checkout/base/core/facade/checkout-delivery-modes.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-delivery-modes.service.ts
@@ -27,8 +27,8 @@ import {
   QueryState,
   UserIdService,
 } from '@spartacus/core';
-import { combineLatest, Observable, throwError } from 'rxjs';
-import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { Observable, combineLatest } from 'rxjs';
+import { filter, map, switchMap, take, tap } from 'rxjs/operators';
 import { CheckoutDeliveryModesConnector } from '../connectors/checkout-delivery-modes/checkout-delivery-modes.connector';
 
 @Injectable()
@@ -95,35 +95,35 @@ export class CheckoutDeliveryModesService
             this.checkoutDeliveryModesConnector
               .clearCheckoutDeliveryMode(userId, cartId)
               .pipe(
-                tap(() => {
-                  this.eventService.dispatch(
-                    {
-                      userId,
-                      cartId,
-                      /**
-                       * As we know the cart is not anonymous (precondition checked),
-                       * we can safely use the cartId, which is actually the cart.code.
-                       */
-                      cartCode: cartId,
-                    },
-                    CheckoutDeliveryModeClearedEvent
-                  );
-                }),
-                catchError((error) => {
-                  this.eventService.dispatch(
-                    {
-                      userId,
-                      cartId,
-                      /**
-                       * As we know the cart is not anonymous (precondition checked),
-                       * we can safely use the cartId, which is actually the cart.code.
-                       */
-                      cartCode: cartId,
-                    },
-                    CheckoutDeliveryModeClearedErrorEvent
-                  );
-
-                  return throwError(() => error);
+                tap({
+                  next: () => {
+                    this.eventService.dispatch(
+                      {
+                        userId,
+                        cartId,
+                        /**
+                         * As we know the cart is not anonymous (precondition checked),
+                         * we can safely use the cartId, which is actually the cart.code.
+                         */
+                        cartCode: cartId,
+                      },
+                      CheckoutDeliveryModeClearedEvent
+                    );
+                  },
+                  error: () => {
+                    this.eventService.dispatch(
+                      {
+                        userId,
+                        cartId,
+                        /**
+                         * As we know the cart is not anonymous (precondition checked),
+                         * we can safely use the cartId, which is actually the cart.code.
+                         */
+                        cartCode: cartId,
+                      },
+                      CheckoutDeliveryModeClearedErrorEvent
+                    );
+                  },
                 })
               )
           )

--- a/feature-libs/checkout/base/core/facade/checkout-delivery-modes.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-delivery-modes.service.ts
@@ -123,7 +123,7 @@ export class CheckoutDeliveryModesService
                     CheckoutDeliveryModeClearedErrorEvent
                   );
 
-                  return throwError(error);
+                  return throwError(() => error);
                 })
               )
           )

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-address.adapter.spec.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-address.adapter.spec.ts
@@ -127,7 +127,9 @@ describe(`OccCheckoutDeliveryAddressAdapter`, () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'post').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'post').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -151,7 +153,7 @@ describe(`OccCheckoutDeliveryAddressAdapter`, () => {
             if (calledTimes === 3) {
               return of(mockAddress);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -205,7 +207,9 @@ describe(`OccCheckoutDeliveryAddressAdapter`, () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'put').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'put').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -229,7 +233,7 @@ describe(`OccCheckoutDeliveryAddressAdapter`, () => {
             if (calledTimes === 3) {
               return of(cartData);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -283,7 +287,9 @@ describe(`OccCheckoutDeliveryAddressAdapter`, () => {
 
   describe(`back-off`, () => {
     it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-      spyOn(httpClient, 'delete').and.returnValue(throwError(mockJaloError));
+      spyOn(httpClient, 'delete').and.returnValue(
+        throwError(() => mockJaloError)
+      );
 
       let result: HttpErrorModel | undefined;
       const subscription = service
@@ -307,7 +313,7 @@ describe(`OccCheckoutDeliveryAddressAdapter`, () => {
           if (calledTimes === 3) {
             return of(checkoutData);
           }
-          return throwError(mockJaloError);
+          return throwError(() => mockJaloError);
         })
       );
 

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-address.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-address.adapter.ts
@@ -8,17 +8,17 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { CheckoutDeliveryAddressAdapter } from '@spartacus/checkout/base/core';
 import {
-  Address,
   ADDRESS_NORMALIZER,
   ADDRESS_SERIALIZER,
-  backOff,
+  Address,
   ConverterService,
-  isJaloError,
-  normalizeHttpError,
   Occ,
   OccEndpointsService,
+  backOff,
+  isJaloError,
+  normalizeHttpError,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -47,7 +47,9 @@ export class OccCheckoutDeliveryAddressAdapter
         }
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         }),
@@ -78,7 +80,9 @@ export class OccCheckoutDeliveryAddressAdapter
         {}
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -103,7 +107,9 @@ export class OccCheckoutDeliveryAddressAdapter
     return this.http
       .delete<unknown>(this.getRemoveDeliveryAddressEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         })

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-address.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-address.adapter.ts
@@ -47,7 +47,7 @@ export class OccCheckoutDeliveryAddressAdapter
         }
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         }),
@@ -78,7 +78,7 @@ export class OccCheckoutDeliveryAddressAdapter
         {}
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -103,7 +103,7 @@ export class OccCheckoutDeliveryAddressAdapter
     return this.http
       .delete<unknown>(this.getRemoveDeliveryAddressEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         })

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-modes.adapter.spec.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-modes.adapter.spec.ts
@@ -121,7 +121,9 @@ describe(`OccCheckoutDeliveryModesAdapter`, () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'get').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'get').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -144,7 +146,7 @@ describe(`OccCheckoutDeliveryModesAdapter`, () => {
             if (calledTimes === 3) {
               return of(mockDeliveryModes);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -200,7 +202,9 @@ describe(`OccCheckoutDeliveryModesAdapter`, () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'put').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'put').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -224,7 +228,7 @@ describe(`OccCheckoutDeliveryModesAdapter`, () => {
             if (calledTimes === 3) {
               return of(cartData);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -277,7 +281,9 @@ describe(`OccCheckoutDeliveryModesAdapter`, () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'delete').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'delete').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -301,7 +307,7 @@ describe(`OccCheckoutDeliveryModesAdapter`, () => {
             if (calledTimes === 3) {
               return of(checkoutData);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-modes.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-modes.adapter.ts
@@ -19,7 +19,7 @@ import {
   isJaloError,
   normalizeHttpError,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 @Injectable()
@@ -40,7 +40,9 @@ export class OccCheckoutDeliveryModesAdapter
     return this.http
       .put(this.getSetDeliveryModeEndpoint(userId, cartId, deliveryModeId), {})
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -68,7 +70,9 @@ export class OccCheckoutDeliveryModesAdapter
     return this.http
       .get<Occ.DeliveryModeList>(this.getDeliveryModesEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         }),
@@ -90,7 +94,9 @@ export class OccCheckoutDeliveryModesAdapter
     return this.http
       .delete<unknown>(this.getClearDeliveryModeEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         })

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-modes.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-modes.adapter.ts
@@ -40,7 +40,7 @@ export class OccCheckoutDeliveryModesAdapter
     return this.http
       .put(this.getSetDeliveryModeEndpoint(userId, cartId, deliveryModeId), {})
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -68,7 +68,7 @@ export class OccCheckoutDeliveryModesAdapter
     return this.http
       .get<Occ.DeliveryModeList>(this.getDeliveryModesEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         }),
@@ -90,7 +90,7 @@ export class OccCheckoutDeliveryModesAdapter
     return this.http
       .delete<unknown>(this.getClearDeliveryModeEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         })

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.spec.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.spec.ts
@@ -249,7 +249,9 @@ describe('OccCheckoutPaymentAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'put').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'put').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -273,7 +275,7 @@ describe('OccCheckoutPaymentAdapter', () => {
             if (calledTimes === 3) {
               return of(cartData);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -350,7 +352,9 @@ describe('OccCheckoutPaymentAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'get').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'get').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -374,7 +378,7 @@ describe('OccCheckoutPaymentAdapter', () => {
             if (calledTimes === 3) {
               return of(paymentProviderInfo);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
         spyOn(httpClient, 'post').and.returnValues(
@@ -432,7 +436,9 @@ describe('OccCheckoutPaymentAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'get').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'get').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service['getProviderSubInfo'](userId, cartId)
@@ -455,7 +461,7 @@ describe('OccCheckoutPaymentAdapter', () => {
             if (calledTimes === 3) {
               return of(cartData);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -515,7 +521,9 @@ describe('OccCheckoutPaymentAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'post').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'post').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service['createSubWithProvider'](mockUrl, params)
@@ -538,7 +546,7 @@ describe('OccCheckoutPaymentAdapter', () => {
             if (calledTimes === 3) {
               return of(mockPaymentProvider);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -600,7 +608,9 @@ describe('OccCheckoutPaymentAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'post').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'post').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service['createSubWithProvider'](mockUrl, params)
@@ -623,7 +633,7 @@ describe('OccCheckoutPaymentAdapter', () => {
             if (calledTimes === 3) {
               return of(mockPaymentProvider);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -683,7 +693,9 @@ describe('OccCheckoutPaymentAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'post').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'post').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service['createDetailsWithParameters'](
@@ -710,7 +722,7 @@ describe('OccCheckoutPaymentAdapter', () => {
             if (calledTimes === 3) {
               return of(mockPaymentDetails);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -776,7 +788,9 @@ describe('OccCheckoutPaymentAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'post').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'post').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service['createDetailsWithParameters'](
@@ -803,7 +817,7 @@ describe('OccCheckoutPaymentAdapter', () => {
             if (calledTimes === 3) {
               return of(mockPaymentDetails);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 
@@ -882,7 +896,9 @@ describe('OccCheckoutPaymentAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'get').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'get').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -906,7 +922,7 @@ describe('OccCheckoutPaymentAdapter', () => {
             if (calledTimes === 3) {
               return of(cardTypesList);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
@@ -13,16 +13,16 @@ import {
   PAYMENT_DETAILS_SERIALIZER,
 } from '@spartacus/checkout/base/core';
 import {
-  backOff,
   ConverterService,
   HttpParamsURIEncoder,
-  isJaloError,
-  normalizeHttpError,
   Occ,
   OccEndpointsService,
   PAYMENT_DETAILS_NORMALIZER,
+  backOff,
+  isJaloError,
+  normalizeHttpError,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 
 @Injectable()
@@ -76,9 +76,9 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
               cartId,
               fromPaymentProvider
             ).pipe(
-              catchError((error) =>
-                throwError(() => normalizeHttpError(error))
-              ),
+              catchError((error) => {
+                throw normalizeHttpError(error);
+              }),
               backOff({
                 shouldRetry: isJaloError,
               }),
@@ -101,7 +101,9 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
         {}
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -123,7 +125,9 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
     return this.http
       .get<Occ.CardTypeList>(this.getPaymentCardTypesEndpoint())
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         }),
@@ -143,7 +147,9 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
     return this.http
       .get(this.getPaymentProviderSubInfoEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -181,7 +187,9 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
         responseType: 'text',
       })
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -209,7 +217,9 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
         { headers }
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         })

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
@@ -76,7 +76,9 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
               cartId,
               fromPaymentProvider
             ).pipe(
-              catchError((error) => throwError(normalizeHttpError(error))),
+              catchError((error) =>
+                throwError(() => normalizeHttpError(error))
+              ),
               backOff({
                 shouldRetry: isJaloError,
               }),
@@ -99,7 +101,7 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
         {}
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -121,7 +123,7 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
     return this.http
       .get<Occ.CardTypeList>(this.getPaymentCardTypesEndpoint())
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         }),
@@ -141,7 +143,7 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
     return this.http
       .get(this.getPaymentProviderSubInfoEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -179,7 +181,7 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
         responseType: 'text',
       })
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         })
@@ -207,7 +209,7 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
         { headers }
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         })

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout.adapter.spec.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout.adapter.spec.ts
@@ -108,7 +108,9 @@ describe('OccCheckoutAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'get').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'get').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -132,7 +134,7 @@ describe('OccCheckoutAdapter', () => {
             if (calledTimes === 3) {
               return of(checkoutData);
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout.adapter.ts
@@ -7,18 +7,18 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
-  CheckoutAdapter,
   CHECKOUT_NORMALIZER,
+  CheckoutAdapter,
 } from '@spartacus/checkout/base/core';
 import { CheckoutState } from '@spartacus/checkout/base/root';
 import {
-  backOff,
   ConverterService,
+  OccEndpointsService,
+  backOff,
   isJaloError,
   normalizeHttpError,
-  OccEndpointsService,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -36,7 +36,9 @@ export class OccCheckoutAdapter implements CheckoutAdapter {
     return this.http
       .get<CheckoutState>(this.getGetCheckoutDetailsEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         }),

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout.adapter.ts
@@ -36,7 +36,7 @@ export class OccCheckoutAdapter implements CheckoutAdapter {
     return this.http
       .get<CheckoutState>(this.getGetCheckoutDetailsEndpoint(userId, cartId))
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         }),

--- a/feature-libs/checkout/base/root/http-interceptors/checkout-cart.interceptor.spec.ts
+++ b/feature-libs/checkout/base/root/http-interceptors/checkout-cart.interceptor.spec.ts
@@ -128,7 +128,7 @@ describe('CheckoutCartInterceptor', () => {
   function createRequest(): TestRequest {
     http
       .get('/test')
-      .pipe(catchError((error: any) => throwError(error)))
+      .pipe(catchError((error: any) => throwError(() => error)))
       .subscribe({
         next: () => {},
         error: () => {},

--- a/feature-libs/checkout/base/root/http-interceptors/checkout-cart.interceptor.ts
+++ b/feature-libs/checkout/base/root/http-interceptors/checkout-cart.interceptor.ts
@@ -14,8 +14,8 @@ import {
 import { Injectable } from '@angular/core';
 import { MultiCartFacade } from '@spartacus/cart/base/root';
 import { RouterState, RoutingService } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
-import { catchError, switchMap, take } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { switchMap, take, tap } from 'rxjs/operators';
 
 /**
  * Interceptor that handles "Cart not found" errors while a user is in a checkout step.
@@ -38,21 +38,22 @@ export class CheckoutCartInterceptor implements HttpInterceptor {
       take(1),
       switchMap((state: RouterState) => {
         return next.handle(request).pipe(
-          catchError((response) => {
-            if (
-              response instanceof HttpErrorResponse &&
-              this.isUserInCheckoutRoute(state.state?.semanticRoute)
-            ) {
-              if (this.isCartNotFoundError(response)) {
-                this.routingService.go({ cxRoute: 'cart' });
+          tap({
+            error: (response) => {
+              if (
+                response instanceof HttpErrorResponse &&
+                this.isUserInCheckoutRoute(state.state?.semanticRoute)
+              ) {
+                if (this.isCartNotFoundError(response)) {
+                  this.routingService.go({ cxRoute: 'cart' });
 
-                const cartCode = this.getCartIdFromError(response);
-                if (cartCode) {
-                  this.multiCartFacade.reloadCart(cartCode);
+                  const cartCode = this.getCartIdFromError(response);
+                  if (cartCode) {
+                    this.multiCartFacade.reloadCart(cartCode);
+                  }
                 }
               }
-            }
-            return throwError(() => response);
+            },
           })
         );
       })

--- a/feature-libs/checkout/base/root/http-interceptors/checkout-cart.interceptor.ts
+++ b/feature-libs/checkout/base/root/http-interceptors/checkout-cart.interceptor.ts
@@ -52,7 +52,7 @@ export class CheckoutCartInterceptor implements HttpInterceptor {
                 }
               }
             }
-            return throwError(response);
+            return throwError(() => response);
           })
         );
       })

--- a/feature-libs/customer-ticketing/occ/adapters/occ-customer-ticketing.adapter.ts
+++ b/feature-libs/customer-ticketing/occ/adapters/occ-customer-ticketing.adapter.ts
@@ -8,11 +8,10 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
   ConverterService,
-  normalizeHttpError,
   OccEndpointsService,
+  normalizeHttpError,
 } from '@spartacus/core';
 import {
-  CustomerTicketingAdapter,
   CUSTOMER_TICKETING_ASSOCIATED_OBJECTS_NORMALIZER,
   CUSTOMER_TICKETING_CATEGORY_NORMALIZER,
   CUSTOMER_TICKETING_CREATE_NORMALIZER,
@@ -20,6 +19,7 @@ import {
   CUSTOMER_TICKETING_EVENT_NORMALIZER,
   CUSTOMER_TICKETING_FILE_NORMALIZER,
   CUSTOMER_TICKETING_LIST_NORMALIZER,
+  CustomerTicketingAdapter,
 } from '@spartacus/customer-ticketing/core';
 import {
   AssociatedObject,
@@ -31,7 +31,7 @@ import {
   TicketList,
   TicketStarter,
 } from '@spartacus/customer-ticketing/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
 
 @Injectable()
@@ -49,7 +49,9 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         this.getTicketAssociatedObjectsEndpoint(customerId)
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         map(
           (associatedObjectList) =>
             associatedObjectList.ticketAssociatedObjects ?? []
@@ -72,7 +74,9 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
     return this.http
       .get<CategoriesList>(this.getTicketCategoriesEndpoint())
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         map((categoryList) => categoryList.ticketCategories ?? []),
         this.converter.pipeableMany(CUSTOMER_TICKETING_CATEGORY_NORMALIZER)
       );
@@ -87,7 +91,7 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
       .get<TicketDetails>(this.getTicketEndpoint(customerId, ticketId))
       .pipe(
         catchError((errorResponse) => {
-          return throwError(() => normalizeHttpError(errorResponse));
+          throw normalizeHttpError(errorResponse);
         }),
         tap((ticket) => ticket.ticketEvents?.reverse()),
         this.converter.pipeable(CUSTOMER_TICKETING_DETAILS_NORMALIZER)
@@ -112,7 +116,9 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         headers: new HttpHeaders().set('Content-Type', 'application/json'),
       })
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(CUSTOMER_TICKETING_CREATE_NORMALIZER)
       );
   }
@@ -136,7 +142,9 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         this.getTicketsEndpoint(customerId, pageSize, currentPage, sort)
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(CUSTOMER_TICKETING_LIST_NORMALIZER)
       );
   }
@@ -173,7 +181,9 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         }
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(CUSTOMER_TICKETING_EVENT_NORMALIZER)
       );
   }
@@ -205,7 +215,9 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         formData
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(CUSTOMER_TICKETING_FILE_NORMALIZER)
       );
   }
@@ -244,7 +256,9 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         httpOptions
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(CUSTOMER_TICKETING_FILE_NORMALIZER)
       );
   }

--- a/feature-libs/customer-ticketing/occ/adapters/occ-customer-ticketing.adapter.ts
+++ b/feature-libs/customer-ticketing/occ/adapters/occ-customer-ticketing.adapter.ts
@@ -49,7 +49,7 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         this.getTicketAssociatedObjectsEndpoint(customerId)
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         map(
           (associatedObjectList) =>
             associatedObjectList.ticketAssociatedObjects ?? []
@@ -72,7 +72,7 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
     return this.http
       .get<CategoriesList>(this.getTicketCategoriesEndpoint())
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         map((categoryList) => categoryList.ticketCategories ?? []),
         this.converter.pipeableMany(CUSTOMER_TICKETING_CATEGORY_NORMALIZER)
       );
@@ -87,7 +87,7 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
       .get<TicketDetails>(this.getTicketEndpoint(customerId, ticketId))
       .pipe(
         catchError((errorResponse) => {
-          return throwError(normalizeHttpError(errorResponse));
+          return throwError(() => normalizeHttpError(errorResponse));
         }),
         tap((ticket) => ticket.ticketEvents?.reverse()),
         this.converter.pipeable(CUSTOMER_TICKETING_DETAILS_NORMALIZER)
@@ -112,7 +112,7 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         headers: new HttpHeaders().set('Content-Type', 'application/json'),
       })
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(CUSTOMER_TICKETING_CREATE_NORMALIZER)
       );
   }
@@ -136,7 +136,7 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         this.getTicketsEndpoint(customerId, pageSize, currentPage, sort)
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(CUSTOMER_TICKETING_LIST_NORMALIZER)
       );
   }
@@ -173,7 +173,7 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         }
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(CUSTOMER_TICKETING_EVENT_NORMALIZER)
       );
   }
@@ -205,7 +205,7 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         formData
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(CUSTOMER_TICKETING_FILE_NORMALIZER)
       );
   }
@@ -244,7 +244,7 @@ export class OccCustomerTicketingAdapter implements CustomerTicketingAdapter {
         httpOptions
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(CUSTOMER_TICKETING_FILE_NORMALIZER)
       );
   }

--- a/feature-libs/order/core/facade/order-history.service.spec.ts
+++ b/feature-libs/order/core/facade/order-history.service.spec.ts
@@ -174,7 +174,7 @@ describe('OrderHistoryService', () => {
 
   it('should NOT load order list data when user is anonymous', () => {
     spyOn(userIdService, 'takeUserId').and.callFake(() => {
-      return throwError('Error');
+      return throwError(() => 'Error');
     });
 
     userOrderService.loadOrderList(10, 1, 'byDate');

--- a/feature-libs/order/core/facade/order-return-request.service.spec.ts
+++ b/feature-libs/order/core/facade/order-return-request.service.spec.ts
@@ -149,7 +149,7 @@ describe('OrderReturnRequestService', () => {
 
   it('should NOT load order return requests list when user is anonymous', () => {
     spyOn(userIdService, 'takeUserId').and.callFake(() => {
-      return throwError('Error');
+      return throwError(() => 'Error');
     });
 
     orderReturnRequestService.loadOrderReturnRequestList(10, 1, 'byDate');

--- a/feature-libs/order/core/facade/replenishment-order-history.service.spec.ts
+++ b/feature-libs/order/core/facade/replenishment-order-history.service.spec.ts
@@ -90,7 +90,7 @@ describe('UserReplenishmentOrderService', () => {
 
     it('should NOT be able to load replenishment order details when user is anonymous', () => {
       spyOn(userIdService, 'takeUserId').and.callFake(() => {
-        return throwError('Error');
+        return throwError(() => 'Error');
       });
 
       userReplenishmentOrderService.loadReplenishmentOrderDetails(
@@ -191,7 +191,7 @@ describe('UserReplenishmentOrderService', () => {
 
     it('should NOT be able to load replenishment order details when user is anonymous', () => {
       spyOn(userIdService, 'takeUserId').and.callFake(() => {
-        return throwError('Error');
+        return throwError(() => 'Error');
       });
 
       userReplenishmentOrderService.cancelReplenishmentOrder(

--- a/feature-libs/order/core/store/effects/consignment-tracking.effect.spec.ts
+++ b/feature-libs/order/core/store/effects/consignment-tracking.effect.spec.ts
@@ -71,7 +71,7 @@ describe('Consignment Tracking effect', () => {
 
     it('should handle failures for load consignment tracking', () => {
       spyOn(orderHistoryConnector, 'getConsignmentTracking').and.returnValue(
-        throwError('Error')
+        throwError(() => 'Error')
       );
 
       const action = new OrderActions.LoadConsignmentTracking(

--- a/feature-libs/order/core/store/effects/order-details.effect.spec.ts
+++ b/feature-libs/order/core/store/effects/order-details.effect.spec.ts
@@ -89,7 +89,9 @@ describe('Order Details effect', () => {
     });
 
     it('should handle failures for load order details', () => {
-      spyOn(orderHistoryConnector, 'get').and.returnValue(throwError('Error'));
+      spyOn(orderHistoryConnector, 'get').and.returnValue(
+        throwError(() => 'Error')
+      );
 
       const action = new OrderActions.LoadOrderDetails(mockOrderDetailsParams);
 
@@ -118,7 +120,7 @@ describe('Order Details effect', () => {
 
     it('should handle failures for cancel an order', () => {
       spyOn(orderHistoryConnector, 'cancel').and.returnValue(
-        throwError('Error')
+        throwError(() => 'Error')
       );
 
       const action = new OrderActions.CancelOrder(mockCancelOrderParams);

--- a/feature-libs/order/core/store/effects/order-return-request.effect.spec.ts
+++ b/feature-libs/order/core/store/effects/order-return-request.effect.spec.ts
@@ -82,7 +82,7 @@ describe('Order Return Request effect', () => {
 
     it('should handle failures for create order return request', () => {
       spyOn(orderHistoryConnector, 'return').and.returnValue(
-        throwError('Error')
+        throwError(() => 'Error')
       );
 
       const action = new OrderActions.CreateOrderReturnRequest({
@@ -127,7 +127,7 @@ describe('Order Return Request effect', () => {
 
     it('should handle failures for load return request list', () => {
       spyOn(orderHistoryConnector, 'getReturnRequestList').and.returnValue(
-        throwError('Error')
+        throwError(() => 'Error')
       );
       const action = new OrderActions.LoadOrderReturnRequestList({
         userId: 'test@sap.com',
@@ -171,7 +171,7 @@ describe('Order Return Request effect', () => {
 
     it('should handle failures for load an order return request', () => {
       spyOn(orderHistoryConnector, 'getReturnRequestDetail').and.returnValue(
-        throwError('Error')
+        throwError(() => 'Error')
       );
 
       const action = new OrderActions.LoadOrderReturnRequest({
@@ -212,7 +212,7 @@ describe('Order Return Request effect', () => {
 
     it('should handle failures for cancel return request', () => {
       spyOn(orderHistoryConnector, 'cancelReturnRequest').and.returnValue(
-        throwError('Error')
+        throwError(() => 'Error')
       );
 
       const action = new OrderActions.CancelOrderReturnRequest(

--- a/feature-libs/order/core/store/effects/orders.effect.spec.ts
+++ b/feature-libs/order/core/store/effects/orders.effect.spec.ts
@@ -75,7 +75,7 @@ describe('Orders effect', () => {
 
       it('should handle failures for load user Orders', () => {
         spyOn(orderHistoryConnector, 'getHistory').and.returnValue(
-          throwError(mockError)
+          throwError(() => mockError)
         );
 
         const action = new OrderActions.LoadUserOrders({
@@ -121,7 +121,7 @@ describe('Orders effect', () => {
         spyOn(
           replenishmentOrderHistoryConnector,
           'loadReplenishmentDetailsHistory'
-        ).and.returnValue(throwError(mockError));
+        ).and.returnValue(throwError(() => mockError));
 
         const action = new OrderActions.LoadUserOrders({
           userId: 'test@sap.com',

--- a/feature-libs/order/core/store/effects/replenishment-order-details.effect.spec.ts
+++ b/feature-libs/order/core/store/effects/replenishment-order-details.effect.spec.ts
@@ -95,7 +95,7 @@ describe('ReplenishmentOrderDetailsEffect', () => {
     });
 
     it('should return an error when it fails to load a replenishment order details', () => {
-      spyOn(connector, 'load').and.returnValue(throwError(mockError));
+      spyOn(connector, 'load').and.returnValue(throwError(() => mockError));
 
       const action = new OrderActions.LoadReplenishmentOrderDetails({
         userId: mockUserId,
@@ -138,7 +138,7 @@ describe('ReplenishmentOrderDetailsEffect', () => {
 
     it('should return an error when it fails to cancel a replenishment order', () => {
       spyOn(connector, 'cancelReplenishmentOrder').and.returnValue(
-        throwError(mockError)
+        throwError(() => mockError)
       );
 
       const action = new OrderActions.CancelReplenishmentOrder({

--- a/feature-libs/order/core/store/effects/replenishment-orders.effect.spec.ts
+++ b/feature-libs/order/core/store/effects/replenishment-orders.effect.spec.ts
@@ -67,7 +67,7 @@ describe('Replenishment Orders effect', () => {
 
     it('should handle failures for load user Replenishment Orders', () => {
       spyOn(replenishmentOrderHistoryConnector, 'loadHistory').and.returnValue(
-        throwError('Error')
+        throwError(() => 'Error')
       );
 
       const action = new OrderActions.LoadUserReplenishmentOrders({

--- a/feature-libs/order/occ/adapters/occ-order-history.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-order-history.adapter.ts
@@ -9,24 +9,25 @@ import { Injectable } from '@angular/core';
 import {
   ConverterService,
   InterceptorUtil,
-  Occ,
-  OccEndpointsService,
   OCC_USER_ID_ANONYMOUS,
   OCC_USER_ID_CURRENT,
+  Occ,
+  OccEndpointsService,
   USE_CLIENT_TOKEN,
+  normalizeHttpError,
 } from '@spartacus/core';
 import { OrderHistoryAdapter } from '@spartacus/order/core';
 import {
+  CONSIGNMENT_TRACKING_NORMALIZER,
   CancellationRequestEntryInputList,
   ConsignmentTracking,
-  CONSIGNMENT_TRACKING_NORMALIZER,
-  Order,
-  OrderHistoryList,
   ORDER_HISTORY_NORMALIZER,
   ORDER_NORMALIZER,
   ORDER_RETURNS_NORMALIZER,
   ORDER_RETURN_REQUEST_INPUT_SERIALIZER,
   ORDER_RETURN_REQUEST_NORMALIZER,
+  Order,
+  OrderHistoryList,
   ReturnRequest,
   ReturnRequestEntryInputList,
   ReturnRequestList,
@@ -114,7 +115,9 @@ export class OccOrderHistoryAdapter implements OrderHistoryAdapter {
 
     return this.http
       .post(url, cancelRequestInput, { headers })
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 
   public createReturnRequest(
@@ -134,7 +137,7 @@ export class OccOrderHistoryAdapter implements OrderHistoryAdapter {
     );
 
     return this.http.post(url, returnRequestInput, { headers }).pipe(
-      catchError((error: any) => throwError(() => error)),
+      catchError((error: any) => throwError(() => normalizeHttpError(error))),
       this.converter.pipeable(ORDER_RETURN_REQUEST_NORMALIZER)
     );
   }
@@ -193,6 +196,8 @@ export class OccOrderHistoryAdapter implements OrderHistoryAdapter {
 
     return this.http
       .patch(url, returnRequestModification, { headers })
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 }

--- a/feature-libs/order/occ/adapters/occ-order-history.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-order-history.adapter.ts
@@ -33,7 +33,7 @@ import {
   ReturnRequestList,
   ReturnRequestModification,
 } from '@spartacus/order/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 const CONTENT_TYPE_JSON_HEADER = { 'Content-Type': 'application/json' };
@@ -113,11 +113,11 @@ export class OccOrderHistoryAdapter implements OrderHistoryAdapter {
       ...CONTENT_TYPE_JSON_HEADER,
     });
 
-    return this.http
-      .post(url, cancelRequestInput, { headers })
-      .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
-      );
+    return this.http.post(url, cancelRequestInput, { headers }).pipe(
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   public createReturnRequest(
@@ -137,7 +137,9 @@ export class OccOrderHistoryAdapter implements OrderHistoryAdapter {
     );
 
     return this.http.post(url, returnRequestInput, { headers }).pipe(
-      catchError((error: any) => throwError(() => normalizeHttpError(error))),
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      }),
       this.converter.pipeable(ORDER_RETURN_REQUEST_NORMALIZER)
     );
   }
@@ -194,10 +196,10 @@ export class OccOrderHistoryAdapter implements OrderHistoryAdapter {
       ...CONTENT_TYPE_JSON_HEADER,
     });
 
-    return this.http
-      .patch(url, returnRequestModification, { headers })
-      .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
-      );
+    return this.http.patch(url, returnRequestModification, { headers }).pipe(
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 }

--- a/feature-libs/order/occ/adapters/occ-order-history.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-order-history.adapter.ts
@@ -114,7 +114,7 @@ export class OccOrderHistoryAdapter implements OrderHistoryAdapter {
 
     return this.http
       .post(url, cancelRequestInput, { headers })
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 
   public createReturnRequest(
@@ -134,7 +134,7 @@ export class OccOrderHistoryAdapter implements OrderHistoryAdapter {
     );
 
     return this.http.post(url, returnRequestInput, { headers }).pipe(
-      catchError((error: any) => throwError(error)),
+      catchError((error: any) => throwError(() => error)),
       this.converter.pipeable(ORDER_RETURN_REQUEST_NORMALIZER)
     );
   }
@@ -193,6 +193,6 @@ export class OccOrderHistoryAdapter implements OrderHistoryAdapter {
 
     return this.http
       .patch(url, returnRequestModification, { headers })
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 }

--- a/feature-libs/order/occ/adapters/occ-order.adapter.spec.ts
+++ b/feature-libs/order/occ/adapters/occ-order.adapter.spec.ts
@@ -122,7 +122,9 @@ describe('OccOrderAdapter', () => {
 
     describe(`back-off`, () => {
       it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-        spyOn(httpClient, 'post').and.returnValue(throwError(mockJaloError));
+        spyOn(httpClient, 'post').and.returnValue(
+          throwError(() => mockJaloError)
+        );
 
         let result: HttpErrorModel | undefined;
         const subscription = service
@@ -146,7 +148,7 @@ describe('OccOrderAdapter', () => {
             if (calledTimes === 3) {
               return of({});
             }
-            return throwError(mockJaloError);
+            return throwError(() => mockJaloError);
           })
         );
 

--- a/feature-libs/order/occ/adapters/occ-order.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-order.adapter.ts
@@ -7,19 +7,19 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
-  backOff,
   ConverterService,
   InterceptorUtil,
-  isJaloError,
-  normalizeHttpError,
+  OCC_USER_ID_ANONYMOUS,
   Occ,
   OccEndpointsService,
-  OCC_USER_ID_ANONYMOUS,
   USE_CLIENT_TOKEN,
+  backOff,
+  isJaloError,
+  normalizeHttpError,
 } from '@spartacus/core';
 import { OrderAdapter } from '@spartacus/order/core';
-import { Order, ORDER_NORMALIZER } from '@spartacus/order/root';
-import { Observable, throwError } from 'rxjs';
+import { ORDER_NORMALIZER, Order } from '@spartacus/order/root';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -50,7 +50,9 @@ export class OccOrderAdapter implements OrderAdapter {
         { headers }
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({
           shouldRetry: isJaloError,
         }),

--- a/feature-libs/order/occ/adapters/occ-order.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-order.adapter.ts
@@ -50,7 +50,7 @@ export class OccOrderAdapter implements OrderAdapter {
         { headers }
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
         }),

--- a/feature-libs/order/occ/adapters/occ-reorder-order.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-reorder-order.adapter.ts
@@ -9,12 +9,12 @@ import { Injectable } from '@angular/core';
 import { CartModificationList } from '@spartacus/cart/base/root';
 import {
   ConverterService,
-  normalizeHttpError,
   OccEndpointsService,
+  normalizeHttpError,
 } from '@spartacus/core';
 import { ReorderOrderAdapter } from '@spartacus/order/core';
 import { REORDER_ORDER_NORMALIZER } from '@spartacus/order/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -31,7 +31,9 @@ export class OccReorderOrderAdapter implements ReorderOrderAdapter {
     return this.http
       .post(this.getReorderOrderEndpoint(orderId, userId), {}, { headers })
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(REORDER_ORDER_NORMALIZER)
       );
   }

--- a/feature-libs/order/occ/adapters/occ-reorder-order.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-reorder-order.adapter.ts
@@ -31,7 +31,7 @@ export class OccReorderOrderAdapter implements ReorderOrderAdapter {
     return this.http
       .post(this.getReorderOrderEndpoint(orderId, userId), {}, { headers })
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(REORDER_ORDER_NORMALIZER)
       );
   }

--- a/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.spec.ts
+++ b/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.spec.ts
@@ -127,7 +127,9 @@ describe(`OccScheduledReplenishmentOrderAdapter`, () => {
 
   describe(`back-off`, () => {
     it(`should unsuccessfully backOff on Jalo error`, fakeAsync(() => {
-      spyOn(httpClient, 'post').and.returnValue(throwError(mockJaloError));
+      spyOn(httpClient, 'post').and.returnValue(
+        throwError(() => mockJaloError)
+      );
 
       let result: HttpErrorModel | undefined;
       const subscription = occAdapter
@@ -156,7 +158,7 @@ describe(`OccScheduledReplenishmentOrderAdapter`, () => {
           if (calledTimes === 3) {
             return of(mockReplenishmentOrder);
           }
-          return throwError(mockJaloError);
+          return throwError(() => mockJaloError);
         })
       );
 

--- a/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.ts
@@ -7,20 +7,20 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
-  backOff,
   ConverterService,
+  OccEndpointsService,
+  backOff,
   isJaloError,
   normalizeHttpError,
-  OccEndpointsService,
 } from '@spartacus/core';
 import { ScheduledReplenishmentOrderAdapter } from '@spartacus/order/core';
 import {
-  ReplenishmentOrder,
   REPLENISHMENT_ORDER_FORM_SERIALIZER,
   REPLENISHMENT_ORDER_NORMALIZER,
+  ReplenishmentOrder,
   ScheduleReplenishmentForm,
 } from '@spartacus/order/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -57,7 +57,9 @@ export class OccScheduledReplenishmentOrderAdapter
         { headers }
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         backOff({ shouldRetry: isJaloError }),
         this.converter.pipeable(REPLENISHMENT_ORDER_NORMALIZER)
       );

--- a/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.ts
@@ -57,7 +57,7 @@ export class OccScheduledReplenishmentOrderAdapter
         { headers }
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         backOff({ shouldRetry: isJaloError }),
         this.converter.pipeable(REPLENISHMENT_ORDER_NORMALIZER)
       );

--- a/feature-libs/organization/account-summary/occ/adapters/occ-account-summary.adapter.ts
+++ b/feature-libs/organization/account-summary/occ/adapters/occ-account-summary.adapter.ts
@@ -8,20 +8,20 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
   ConverterService,
-  normalizeHttpError,
   OccEndpointsService,
+  normalizeHttpError,
 } from '@spartacus/core';
 import {
-  AccountSummaryAdapter,
   ACCOUNT_SUMMARY_DOCUMENT_NORMALIZER,
   ACCOUNT_SUMMARY_NORMALIZER,
+  AccountSummaryAdapter,
 } from '@spartacus/organization/account-summary/core';
 import {
   AccountSummaryDetails,
   AccountSummaryList,
   DocumentQueryParams,
 } from '@spartacus/organization/account-summary/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -41,9 +41,9 @@ export class OccAccountSummaryAdapter implements AccountSummaryAdapter {
         this.buildAccountSummaryUrl(userId, orgUnitId)
       )
       .pipe(
-        catchError((error: HttpErrorResponse) =>
-          throwError(() => normalizeHttpError(error))
-        ),
+        catchError((error: HttpErrorResponse) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(ACCOUNT_SUMMARY_NORMALIZER)
       );
   }
@@ -58,9 +58,9 @@ export class OccAccountSummaryAdapter implements AccountSummaryAdapter {
         this.buildDocumentListUrl(userId, orgUnitId, params)
       )
       .pipe(
-        catchError((error: HttpErrorResponse) =>
-          throwError(() => normalizeHttpError(error))
-        ),
+        catchError((error: HttpErrorResponse) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(ACCOUNT_SUMMARY_DOCUMENT_NORMALIZER)
       );
   }
@@ -86,9 +86,9 @@ export class OccAccountSummaryAdapter implements AccountSummaryAdapter {
         options
       )
       .pipe(
-        catchError((error: HttpErrorResponse) =>
-          throwError(() => normalizeHttpError(error))
-        )
+        catchError((error: HttpErrorResponse) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 

--- a/feature-libs/organization/account-summary/occ/adapters/occ-account-summary.adapter.ts
+++ b/feature-libs/organization/account-summary/occ/adapters/occ-account-summary.adapter.ts
@@ -42,7 +42,7 @@ export class OccAccountSummaryAdapter implements AccountSummaryAdapter {
       )
       .pipe(
         catchError((error: HttpErrorResponse) =>
-          throwError(normalizeHttpError(error))
+          throwError(() => normalizeHttpError(error))
         ),
         this.converter.pipeable(ACCOUNT_SUMMARY_NORMALIZER)
       );
@@ -59,7 +59,7 @@ export class OccAccountSummaryAdapter implements AccountSummaryAdapter {
       )
       .pipe(
         catchError((error: HttpErrorResponse) =>
-          throwError(normalizeHttpError(error))
+          throwError(() => normalizeHttpError(error))
         ),
         this.converter.pipeable(ACCOUNT_SUMMARY_DOCUMENT_NORMALIZER)
       );
@@ -87,7 +87,7 @@ export class OccAccountSummaryAdapter implements AccountSummaryAdapter {
       )
       .pipe(
         catchError((error: HttpErrorResponse) =>
-          throwError(normalizeHttpError(error))
+          throwError(() => normalizeHttpError(error))
         )
       );
   }

--- a/feature-libs/organization/account-summary/root/http-interceptors/blob-error.interceptor.ts
+++ b/feature-libs/organization/account-summary/root/http-interceptors/blob-error.interceptor.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { FileReaderService } from '@spartacus/storefront';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
 @Injectable({
@@ -38,18 +38,15 @@ export class BlobErrorInterceptor implements HttpInterceptor {
             .pipe(
               switchMap((errorString: any) => {
                 const error = JSON.parse(errorString);
-                return throwError(
-                  () =>
-                    new HttpErrorResponse({
-                      ...errResponse,
-                      error,
-                      url: errResponse.url ?? undefined,
-                    })
-                );
+                throw new HttpErrorResponse({
+                  ...errResponse,
+                  error,
+                  url: errResponse.url ?? undefined,
+                });
               })
             );
         } else {
-          return throwError(() => errResponse);
+          throw errResponse;
         }
       })
     );

--- a/feature-libs/organization/account-summary/root/http-interceptors/blob-error.interceptor.ts
+++ b/feature-libs/organization/account-summary/root/http-interceptors/blob-error.interceptor.ts
@@ -39,16 +39,17 @@ export class BlobErrorInterceptor implements HttpInterceptor {
               switchMap((errorString: any) => {
                 const error = JSON.parse(errorString);
                 return throwError(
-                  new HttpErrorResponse({
-                    ...errResponse,
-                    error,
-                    url: errResponse.url ?? undefined,
-                  })
+                  () =>
+                    new HttpErrorResponse({
+                      ...errResponse,
+                      error,
+                      url: errResponse.url ?? undefined,
+                    })
                 );
               })
             );
         } else {
-          return throwError(errResponse);
+          return throwError(() => errResponse);
         }
       })
     );

--- a/feature-libs/organization/administration/core/store/effects/b2b-user.effect.spec.ts
+++ b/feature-libs/organization/administration/core/store/effects/b2b-user.effect.spec.ts
@@ -194,7 +194,7 @@ describe('B2B User Effects', () => {
 
     it('should return LoadB2BUserFail action if user not loaded', () => {
       b2bUserConnector.get = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.LoadB2BUser({ userId, orgCustomerId });
       const completion = new B2BUserActions.LoadB2BUserFail({
@@ -226,7 +226,7 @@ describe('B2B User Effects', () => {
 
     it('should return LoadB2BUsersFail action if B2B Users not loaded', () => {
       b2bUserConnector.getList = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.LoadB2BUsers({ userId, params });
       const completion = new B2BUserActions.LoadB2BUsersFail({ error, params });
@@ -264,7 +264,7 @@ describe('B2B User Effects', () => {
 
     it('should return LoadB2BUserUserGroupsFail action if B2BUser UserGroup not loaded', () => {
       b2bUserConnector.getUserGroups = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.LoadB2BUserUserGroups({
         userId,
@@ -309,7 +309,7 @@ describe('B2B User Effects', () => {
 
     it('should return CreateB2BUserFail action if user not created', () => {
       b2bUserConnector.create = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.CreateB2BUser({ userId, orgCustomer });
       const completion1 = new B2BUserActions.CreateB2BUserFail({
@@ -348,7 +348,7 @@ describe('B2B User Effects', () => {
 
     it('should return UpdateB2BUserFail action if user not updated', () => {
       b2bUserConnector.update = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.UpdateB2BUser({
         userId,
@@ -419,7 +419,7 @@ describe('B2B User Effects', () => {
 
     it('should return LoadB2BUserApproversFail action if approvers not loaded', () => {
       b2bUserConnector.getApprovers = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.LoadB2BUserApprovers({
         userId,
@@ -471,7 +471,7 @@ describe('B2B User Effects', () => {
 
     it('should return LoadB2BUserApproversFail action if Permissions not loaded', () => {
       b2bUserConnector.getPermissions = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.LoadB2BUserPermissions({
         userId,
@@ -519,7 +519,7 @@ describe('B2B User Effects', () => {
 
     it('should return AssignB2BUserApproverFail action if approver not assigned', () => {
       b2bUserConnector.assignApprover = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.AssignB2BUserApprover({
         userId,
@@ -568,7 +568,7 @@ describe('B2B User Effects', () => {
 
     it('should return UnassignB2BUserApproverFail action if approver not unassigned', () => {
       b2bUserConnector.unassignApprover = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.UnassignB2BUserApprover({
         userId,
@@ -618,7 +618,7 @@ describe('B2B User Effects', () => {
 
     it('should return AssignB2BUserPermissionFail action if permission not assigned', () => {
       b2bUserConnector.assignPermission = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.AssignB2BUserPermission({
         userId,
@@ -668,7 +668,7 @@ describe('B2B User Effects', () => {
 
     it('should return UnassignB2BUserPermissionFail action if permission not unassigned', () => {
       b2bUserConnector.unassignPermission = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.UnassignB2BUserPermission({
         userId,
@@ -718,7 +718,7 @@ describe('B2B User Effects', () => {
 
     it('should return AssignB2BUserUserGroupFail action if UserGroup was not assigned', () => {
       b2bUserConnector.assignUserGroup = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.AssignB2BUserUserGroup({
         userId,
@@ -768,7 +768,7 @@ describe('B2B User Effects', () => {
 
     it('should return UnassignB2BUserUserGroupFail action if UserGroup was not unassigned', () => {
       b2bUserConnector.unassignUserGroup = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new B2BUserActions.UnassignB2BUserUserGroup({
         userId,

--- a/feature-libs/organization/administration/core/store/effects/budget.effect.spec.ts
+++ b/feature-libs/organization/administration/core/store/effects/budget.effect.spec.ts
@@ -106,7 +106,7 @@ describe('Budget Effects', () => {
 
     it('should return LoadBudgetFail action if budget not updated', () => {
       budgetConnector.get = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new BudgetActions.LoadBudget({ userId, budgetCode });
       const completion = new BudgetActions.LoadBudgetFail({
@@ -140,7 +140,7 @@ describe('Budget Effects', () => {
 
     it('should return LoadBudgetsFail action if budgets not loaded', () => {
       budgetConnector.getList = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new BudgetActions.LoadBudgets({ userId, params });
       const completion = new BudgetActions.LoadBudgetsFail({ error, params });
@@ -166,7 +166,7 @@ describe('Budget Effects', () => {
 
     it('should return CreateBudgetFail action if budget not created', () => {
       budgetConnector.create = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new BudgetActions.CreateBudget({ userId, budget });
       const completion1 = new BudgetActions.CreateBudgetFail({
@@ -204,7 +204,7 @@ describe('Budget Effects', () => {
 
     it('should return UpdateBudgetFail action if budget not created', () => {
       budgetConnector.update = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new BudgetActions.UpdateBudget({
         userId,

--- a/feature-libs/organization/administration/core/store/effects/cost-center.effect.spec.ts
+++ b/feature-libs/organization/administration/core/store/effects/cost-center.effect.spec.ts
@@ -133,7 +133,7 @@ describe('CostCenter Effects', () => {
 
     it('should return LoadCostCenterFail action if costCenter not updated', () => {
       costCenterConnector.get = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new CostCenterActions.LoadCostCenter({
         userId,
@@ -175,7 +175,7 @@ describe('CostCenter Effects', () => {
 
     it('should return LoadCostCentersFail action if costCenters not loaded', () => {
       costCenterConnector.getList = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new CostCenterActions.LoadCostCenters({ userId, params });
       const completion = new CostCenterActions.LoadCostCentersFail({
@@ -212,7 +212,7 @@ describe('CostCenter Effects', () => {
 
     it('should return CreateCostCenterFail action if costCenter not created', () => {
       costCenterConnector.create = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new CostCenterActions.CreateCostCenter({
         userId,
@@ -258,7 +258,7 @@ describe('CostCenter Effects', () => {
 
     it('should return UpdateCostCenterFail action if costCenter not created', () => {
       costCenterConnector.update = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new CostCenterActions.UpdateCostCenter({
         userId,
@@ -310,7 +310,7 @@ describe('CostCenter Effects', () => {
 
     it('should return LoadAssignedBudgetsFail action if budgets not loaded', () => {
       costCenterConnector.getBudgets = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new CostCenterActions.LoadAssignedBudgets({
         userId,
@@ -359,7 +359,7 @@ describe('CostCenter Effects', () => {
 
     it('should return UpdateCostCenterFail action if budget not assigned', () => {
       costCenterConnector.assignBudget = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new CostCenterActions.AssignBudget({
         userId,
@@ -407,7 +407,7 @@ describe('CostCenter Effects', () => {
 
     it('should return UnassignBudgetFail action if budget not unassigned', () => {
       costCenterConnector.unassignBudget = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new CostCenterActions.UnassignBudget({
         userId,

--- a/feature-libs/organization/administration/core/store/effects/org-unit.effect.spec.ts
+++ b/feature-libs/organization/administration/core/store/effects/org-unit.effect.spec.ts
@@ -137,7 +137,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return LoadOrgUnitFail action if orgUnit not updated', () => {
       orgUnitConnector.get = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.LoadOrgUnit({ userId, orgUnitId });
       const completion = new OrgUnitActions.LoadOrgUnitFail({
@@ -167,7 +167,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return LoadOrgUnitNodesFail action if orgUnits not loaded', () => {
       orgUnitConnector.getList = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.LoadOrgUnitNodes({ userId });
       const completion = new OrgUnitActions.LoadOrgUnitNodesFail({ error });
@@ -193,7 +193,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return LoadOrgUnitNodesFail action if orgUnits not loaded', () => {
       orgUnitConnector.create = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.CreateUnit({ userId, unit: orgUnit });
       const completion1 = new OrgUnitActions.CreateUnitFail({
@@ -231,7 +231,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return UpdateOrgUnitNodesFail action if orgUnits not loaded', () => {
       orgUnitConnector.update = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.UpdateUnit({
         userId,
@@ -284,7 +284,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return CreateAddressFail action if address is not loaded', () => {
       orgUnitConnector.createAddress = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.CreateAddress({
         userId,
@@ -334,7 +334,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return UpdateAddressFail action if address is not loaded', () => {
       orgUnitConnector.updateAddress = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.UpdateAddress({
         userId,
@@ -382,7 +382,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return DeleteAddressFail action if address is not loaded', () => {
       orgUnitConnector.deleteAddress = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.DeleteAddress({
         userId,
@@ -431,7 +431,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return AssignRoleFail action if address is not loaded', () => {
       orgUnitConnector.assignRole = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.AssignRole({
         userId,
@@ -479,7 +479,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return UnassignRoleFail action if address is not loaded', () => {
       orgUnitConnector.unassignRole = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.UnassignRole({
         userId,
@@ -530,7 +530,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return AssignApproverFail action if address is not loaded', () => {
       orgUnitConnector.assignApprover = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.AssignApprover({
         userId,
@@ -584,7 +584,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return UnassignApproverFail action if address is not loaded', () => {
       orgUnitConnector.unassignApprover = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.UnassignApprover({
         userId,
@@ -629,7 +629,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return LoadApprovalProcessesFail action if address is not loaded', () => {
       orgUnitConnector.getApprovalProcesses = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.LoadApprovalProcesses({
         userId,
@@ -683,7 +683,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return LoadUsersFail action if address is not loaded', () => {
       orgUnitConnector.getUsers = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.LoadAssignedUsers({
         userId,
@@ -725,7 +725,7 @@ describe('OrgUnit Effects', () => {
 
     it('should return LoadTreeFail action if address is not loaded', () => {
       orgUnitConnector.getTree = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrgUnitActions.LoadTree({
         userId,

--- a/feature-libs/organization/administration/core/store/effects/permission.effect.spec.ts
+++ b/feature-libs/organization/administration/core/store/effects/permission.effect.spec.ts
@@ -6,8 +6,8 @@ import { StoreModule } from '@ngrx/store';
 import {
   normalizeHttpError,
   OccConfig,
-  SearchConfig,
   OrderApprovalPermissionType,
+  SearchConfig,
 } from '@spartacus/core';
 import {
   OrganizationActions,
@@ -121,7 +121,7 @@ describe('Permission Effects', () => {
 
     it('should return LoadPermissionFail action if permission not updated', () => {
       permissionConnector.get = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new PermissionActions.LoadPermission({
         userId,
@@ -163,7 +163,7 @@ describe('Permission Effects', () => {
 
     it('should return LoadPermissionsFail action if permissions not loaded', () => {
       permissionConnector.getList = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new PermissionActions.LoadPermissions({ userId, params });
       const completion = new PermissionActions.LoadPermissionsFail({
@@ -200,7 +200,7 @@ describe('Permission Effects', () => {
 
     it('should return CreatePermissionFail action if permission not created', () => {
       permissionConnector.create = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new PermissionActions.CreatePermission({
         userId,
@@ -246,7 +246,7 @@ describe('Permission Effects', () => {
 
     it('should return UpdatePermissionFail action if permission not created', () => {
       permissionConnector.update = createSpy('update').and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new PermissionActions.UpdatePermission({
         userId,
@@ -285,7 +285,7 @@ describe('Permission Effects', () => {
 
     it('should return LoadPermissionTypesFail action if permission types are not updated', () => {
       permissionConnector.getTypes = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new PermissionActions.LoadPermissionTypes();
       const completion = new PermissionActions.LoadPermissionTypesFail({

--- a/feature-libs/organization/administration/core/store/effects/user-group.effect.spec.ts
+++ b/feature-libs/organization/administration/core/store/effects/user-group.effect.spec.ts
@@ -146,7 +146,7 @@ describe('UserGroup Effects', () => {
 
     it('should return LoadUserGroupFail action if userGroup not updated', () => {
       userGroupConnector.get = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new UserGroupActions.LoadUserGroup({
         userId,
@@ -186,7 +186,7 @@ describe('UserGroup Effects', () => {
 
     it('should return LoadUserGroupsFail action if userGroups not loaded', () => {
       userGroupConnector.getList = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new UserGroupActions.LoadUserGroups({
         userId,
@@ -223,7 +223,7 @@ describe('UserGroup Effects', () => {
 
     it('should return CreateUserGroupFail action if userGroup not created', () => {
       userGroupConnector.create = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new UserGroupActions.CreateUserGroup({
         userId,
@@ -264,7 +264,7 @@ describe('UserGroup Effects', () => {
 
     it('should return UpdateUserGroupFail action if userGroup not created', () => {
       userGroupConnector.update = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new UserGroupActions.UpdateUserGroup({
         userId,
@@ -310,7 +310,7 @@ describe('UserGroup Effects', () => {
 
     it('should return DeleteUserGroupFail action if userGroup not created', () => {
       userGroupConnector.delete = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new UserGroupActions.DeleteUserGroup({
         userId,
@@ -362,7 +362,7 @@ describe('UserGroup Effects', () => {
 
     it('should return LoadPermissionFail action if permissions not loaded', () => {
       userGroupConnector.getAvailableOrderApprovalPermissions =
-        createSpy().and.returnValue(throwError(httpErrorResponse));
+        createSpy().and.returnValue(throwError(() => httpErrorResponse));
       const action = new UserGroupActions.LoadPermissions({
         userId,
         userGroupId,
@@ -408,7 +408,7 @@ describe('UserGroup Effects', () => {
 
     it('should return CreateUserGroupOrderApprovalPermissionFail action if permission not assigned', () => {
       userGroupConnector.assignOrderApprovalPermission =
-        createSpy().and.returnValue(throwError(httpErrorResponse));
+        createSpy().and.returnValue(throwError(() => httpErrorResponse));
       const action = new UserGroupActions.AssignPermission({
         userId,
         userGroupId,
@@ -452,7 +452,7 @@ describe('UserGroup Effects', () => {
 
     it('should return DeleteUserGroupOrderApprovalPermissionFail action if permission not unassigned', () => {
       userGroupConnector.unassignOrderApprovalPermission =
-        createSpy().and.returnValue(throwError(httpErrorResponse));
+        createSpy().and.returnValue(throwError(() => httpErrorResponse));
       const action = new UserGroupActions.UnassignPermission({
         userId,
         userGroupId,
@@ -504,7 +504,7 @@ describe('UserGroup Effects', () => {
 
     it('should return LoadUserGroupAvailableOrgCustomersFail action if users not loaded', () => {
       userGroupConnector.getAvailableOrgCustomers = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new UserGroupActions.LoadAvailableOrgCustomers({
         userId,
@@ -553,7 +553,7 @@ describe('UserGroup Effects', () => {
 
     it('should return CreateUserGroupOrderApprovalPermissionFail action if user not assigned', () => {
       userGroupConnector.assignMember = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new UserGroupActions.AssignMember({
         userId,
@@ -602,7 +602,7 @@ describe('UserGroup Effects', () => {
 
     it('should return DeleteUserGroupMemberSuccessFail action if users not unassigned', () => {
       userGroupConnector.unassignMember = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new UserGroupActions.UnassignMember({
         userId,
@@ -649,7 +649,7 @@ describe('UserGroup Effects', () => {
 
     it('should return DeleteUserGroupMemberSuccessFail action if users not unassigned', () => {
       userGroupConnector.unassignAllMembers = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new UserGroupActions.UnassignAllMembers({
         userId,

--- a/feature-libs/organization/order-approval/core/store/effects/order-approval.effect.spec.ts
+++ b/feature-libs/organization/order-approval/core/store/effects/order-approval.effect.spec.ts
@@ -4,10 +4,10 @@ import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { StoreModule } from '@ngrx/store';
 import { normalizeHttpError, OccConfig, SearchConfig } from '@spartacus/core';
-import { OrderApprovalConnector } from '../../connectors/order-approval.connector';
 import { cold, hot } from 'jasmine-marbles';
 import { TestColdObservable } from 'jasmine-marbles/src/test-observables';
 import { Observable, of, throwError } from 'rxjs';
+import { OrderApprovalConnector } from '../../connectors/order-approval.connector';
 import {
   OrderApproval,
   OrderApprovalDecision,
@@ -115,7 +115,7 @@ describe('OrderApproval Effects', () => {
 
     it('should return LoadOrderApprovalFail action if orderApproval not updated', () => {
       orderApprovalConnector.get = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrderApprovalActions.LoadOrderApproval({
         userId,
@@ -163,7 +163,7 @@ describe('OrderApproval Effects', () => {
 
     it('should return LoadOrderApprovalsFail action if orderApprovals not loaded', () => {
       orderApprovalConnector.getList = createSpy().and.returnValue(
-        throwError(httpErrorResponse)
+        throwError(() => httpErrorResponse)
       );
       const action = new OrderApprovalActions.LoadOrderApprovals({
         userId,
@@ -213,7 +213,7 @@ describe('OrderApproval Effects', () => {
     it('should return MakeDecisionFail action if decision not created', () => {
       orderApprovalConnector.makeDecision = createSpy(
         'makeDecision'
-      ).and.returnValue(throwError(httpErrorResponse));
+      ).and.returnValue(throwError(() => httpErrorResponse));
       const action = new OrderApprovalActions.MakeDecision({
         userId,
         orderApprovalCode,

--- a/feature-libs/organization/unit-order/core/services/unit-order.service.spec.ts
+++ b/feature-libs/organization/unit-order/core/services/unit-order.service.spec.ts
@@ -120,7 +120,7 @@ describe('UnitOrderService', () => {
 
   it('should NOT load order list data when user is anonymous', () => {
     spyOn(userIdService, 'takeUserId').and.callFake(() => {
-      return throwError('Error');
+      return throwError(() => 'Error');
     });
 
     unitOrderService.loadOrderList(10, 1, 'byDate');

--- a/feature-libs/organization/unit-order/core/store/effects/unit-order.effect.spec.ts
+++ b/feature-libs/organization/unit-order/core/store/effects/unit-order.effect.spec.ts
@@ -71,7 +71,7 @@ describe('Orders effect', () => {
 
       it('should handle failures for load user Orders', () => {
         spyOn(orderHistoryConnector, 'getUnitOrderHistory').and.returnValue(
-          throwError(mockError)
+          throwError(() => mockError)
         );
 
         const action = new UnitOrderActions.LoadUnitOrders({
@@ -127,7 +127,7 @@ describe('Orders effect', () => {
 
       it('should handle failures for load order details', () => {
         spyOn(orderHistoryConnector, 'getUnitOrderDetail').and.returnValue(
-          throwError('Error')
+          throwError(() => 'Error')
         );
 
         const action = new UnitOrderActions.LoadOrderDetails(

--- a/feature-libs/organization/user-registration/occ/adapters/occ-user-registration.adapter.ts
+++ b/feature-libs/organization/user-registration/occ/adapters/occ-user-registration.adapter.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import {
   ConverterService,
   InterceptorUtil,
@@ -46,7 +46,7 @@ export class OccUserRegistrationAdapter implements UserRegistrationAdapter {
 
     return this.http
       .post<OrganizationUserRegistration>(url, userData, { headers })
-      .pipe(catchError((error) => throwError(normalizeHttpError(error))));
+      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
   }
 
   protected getOrganizationUserRegistrationEndpoint(): string {

--- a/feature-libs/organization/user-registration/occ/adapters/occ-user-registration.adapter.ts
+++ b/feature-libs/organization/user-registration/occ/adapters/occ-user-registration.adapter.ts
@@ -9,16 +9,16 @@ import { Injectable } from '@angular/core';
 import {
   ConverterService,
   InterceptorUtil,
-  normalizeHttpError,
   OccEndpointsService,
   USE_CLIENT_TOKEN,
+  normalizeHttpError,
 } from '@spartacus/core';
 import {
   ORGANIZATION_USER_REGISTRATION_SERIALIZER,
   UserRegistrationAdapter,
 } from '@spartacus/organization/user-registration/core';
 import { OrganizationUserRegistration } from '@spartacus/organization/user-registration/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable({
@@ -46,7 +46,11 @@ export class OccUserRegistrationAdapter implements UserRegistrationAdapter {
 
     return this.http
       .post<OrganizationUserRegistration>(url, userData, { headers })
-      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
+      .pipe(
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        })
+      );
   }
 
   protected getOrganizationUserRegistrationEndpoint(): string {

--- a/feature-libs/pickup-in-store/core/store/effects/default-point-of-service-name.effect.spec.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/default-point-of-service-name.effect.spec.ts
@@ -21,7 +21,7 @@ let ForceErrorInMockUserProfileFacadeGo = false;
 export class MockUserProfileFacade implements Partial<UserProfileFacade> {
   update(_details: User): Observable<unknown> {
     return ForceErrorInMockUserProfileFacadeGo
-      ? throwError('An RX JS ERROR')
+      ? throwError(() => 'An RX JS ERROR')
       : of({});
   }
   get(): Observable<User | undefined> {

--- a/feature-libs/pickup-in-store/core/store/effects/stock.effect.spec.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/stock.effect.spec.ts
@@ -68,7 +68,9 @@ describe('StockEffect', () => {
       statusText: 'Not Found',
       error: 'Error',
     });
-    spyOn(stockConnector, 'loadStockLevels').and.returnValue(throwError(error));
+    spyOn(stockConnector, 'loadStockLevels').and.returnValue(
+      throwError(() => error)
+    );
     const action = new StockLevel({ productCode: 'P0001', location: '' });
     const actionFail = new StockLevelFail(normalizeHttpError(error));
 

--- a/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.spec.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.spec.ts
@@ -88,7 +88,7 @@ describe(`OccPickupLocationAdapter`, () => {
       expect(mockReq.request.responseType).toEqual('json');
     });
     it('should call normalized http error for getStoreDetails', fakeAsync(() => {
-      spyOn(httpClient, 'get').and.returnValue(throwError(mockJaloError));
+      spyOn(httpClient, 'get').and.returnValue(throwError(() => mockJaloError));
       let result: HttpErrorModel | undefined;
       const subscription = occAdapter
         .getStoreDetails(storeName)

--- a/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
@@ -12,7 +12,7 @@ import {
   PointOfService,
 } from '@spartacus/core';
 import { PickupLocationAdapter } from '@spartacus/pickup-in-store/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -33,7 +33,9 @@ export class OccPickupLocationAdapter implements PickupLocationAdapter {
         })
       )
       .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 }

--- a/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
@@ -32,6 +32,8 @@ export class OccPickupLocationAdapter implements PickupLocationAdapter {
           queryParams: { fields: 'FULL' },
         })
       )
-      .pipe(catchError((error: any) => throwError(normalizeHttpError(error))));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 }

--- a/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.spec.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.spec.ts
@@ -85,7 +85,7 @@ describe(`OccStockAdapter`, () => {
       expect(mockReq.request.responseType).toEqual('json');
     });
     it('should call normalized http error for loadStockLevels', fakeAsync(() => {
-      spyOn(httpClient, 'get').and.returnValue(throwError(mockJaloError));
+      spyOn(httpClient, 'get').and.returnValue(throwError(() => mockJaloError));
       let result: HttpErrorModel | undefined;
       const subscription = occAdapter
         .loadStockLevels(productCode, locationParam)
@@ -115,7 +115,7 @@ describe(`OccStockAdapter`, () => {
       expect(mockReq.request.responseType).toEqual('json');
     });
     it('should call normalized http error for loadStockLevelAtStore', fakeAsync(() => {
-      spyOn(httpClient, 'get').and.returnValue(throwError(mockJaloError));
+      spyOn(httpClient, 'get').and.returnValue(throwError(() => mockJaloError));
       let result: HttpErrorModel | undefined;
       const subscription = occAdapter
         .loadStockLevelAtStore(productCode, storeName)

--- a/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
@@ -14,7 +14,7 @@ import {
 } from '@spartacus/core';
 import { StockAdapter } from '@spartacus/pickup-in-store/core';
 import { LocationSearchParams } from '@spartacus/pickup-in-store/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /**
@@ -41,7 +41,9 @@ export class OccStockAdapter implements StockAdapter {
         })
       )
       .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 
@@ -56,7 +58,9 @@ export class OccStockAdapter implements StockAdapter {
         })
       )
       .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 }

--- a/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
@@ -40,7 +40,9 @@ export class OccStockAdapter implements StockAdapter {
           queryParams: { ...location, fields: 'FULL' },
         })
       )
-      .pipe(catchError((error: any) => throwError(normalizeHttpError(error))));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 
   loadStockLevelAtStore(
@@ -53,6 +55,8 @@ export class OccStockAdapter implements StockAdapter {
           urlParams: { productCode, storeName },
         })
       )
-      .pipe(catchError((error: any) => throwError(normalizeHttpError(error))));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 }

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-basic.effect.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-basic.effect.spec.ts
@@ -13,11 +13,11 @@ import {
 import { cold, hot } from 'jasmine-marbles';
 import { Observable, of, throwError } from 'rxjs';
 import {
+  ATTRIBUTE_1_CHECKBOX,
   CONFIG_ID,
-  GROUP_ID_CONFLICT_HEADER,
   GROUP_ID_CONFLICT_1,
   GROUP_ID_CONFLICT_2,
-  ATTRIBUTE_1_CHECKBOX,
+  GROUP_ID_CONFLICT_HEADER,
 } from '../../../testing/configurator-test-data';
 import { ConfiguratorTestUtils } from '../../../testing/configurator-test-utils';
 import { RulebasedConfiguratorConnector } from '../../connectors/rulebased-configurator.connector';
@@ -305,7 +305,7 @@ describe('ConfiguratorEffect', () => {
     });
 
     it('should emit a fail action in case something goes wrong', () => {
-      createMock.and.returnValue(throwError(errorResponse));
+      createMock.and.returnValue(throwError(() => errorResponse));
 
       const action = new ConfiguratorActions.CreateConfiguration({
         owner: productConfiguration.owner,
@@ -344,7 +344,7 @@ describe('ConfiguratorEffect', () => {
     });
 
     it('should emit a fail action in case connector raises an error', () => {
-      readMock.and.returnValue(throwError(errorResponse));
+      readMock.and.returnValue(throwError(() => errorResponse));
       const action = new ConfiguratorActions.ReadConfiguration({
         configuration: productConfiguration,
         groupId: '',
@@ -398,7 +398,7 @@ describe('ConfiguratorEffect', () => {
     });
 
     it('should emit a fail action in case something goes wrong', () => {
-      overviewMock.and.returnValue(throwError(errorResponse));
+      overviewMock.and.returnValue(throwError(() => errorResponse));
       const overviewAction = new ConfiguratorActions.GetConfigurationOverview(
         productConfiguration
       );
@@ -438,7 +438,7 @@ describe('ConfiguratorEffect', () => {
     });
 
     it('should emit a fail action in case something goes wrong', () => {
-      updateOverviewMock.and.returnValue(throwError(errorResponse));
+      updateOverviewMock.and.returnValue(throwError(() => errorResponse));
       const overviewAction =
         new ConfiguratorActions.UpdateConfigurationOverview(
           productConfiguration
@@ -480,7 +480,7 @@ describe('ConfiguratorEffect', () => {
     });
 
     it('should emit a fail action in case something goes wrong', () => {
-      updateConfigurationMock.and.returnValue(throwError(errorResponse));
+      updateConfigurationMock.and.returnValue(throwError(() => errorResponse));
       const payloadInput = productConfiguration;
       const action = new ConfiguratorActions.UpdateConfiguration(payloadInput);
 
@@ -510,7 +510,7 @@ describe('ConfiguratorEffect', () => {
     });
 
     it('should emit a fail action in case something goes wrong', () => {
-      readPriceSummaryMock.and.returnValue(throwError(errorResponse));
+      readPriceSummaryMock.and.returnValue(throwError(() => errorResponse));
       const payloadInput = productConfiguration;
       const updatePriceSummaryAction =
         new ConfiguratorActions.UpdatePriceSummary(payloadInput);
@@ -798,7 +798,7 @@ describe('ConfiguratorEffect', () => {
     });
 
     it('should emit ReadConfigurationFail in case read call is not successful', () => {
-      readMock.and.returnValue(throwError(errorResponse));
+      readMock.and.returnValue(throwError(() => errorResponse));
       const payloadInput: Configurator.Configuration = {
         ...ConfiguratorTestUtils.createConfiguration(configId, owner),
         productCode: productCode,

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-cart.effect.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-cart.effect.spec.ts
@@ -440,7 +440,7 @@ describe('ConfiguratorCartEffect', () => {
     });
 
     it('should emit a fail action if something goes wrong', () => {
-      readFromCartEntryObs = throwError(errorResponse);
+      readFromCartEntryObs = throwError(() => errorResponse);
 
       const completion = new ConfiguratorActions.ReadCartEntryConfigurationFail(
         {
@@ -484,7 +484,7 @@ describe('ConfiguratorCartEffect', () => {
 
     it('should emit a fail action if something goes wrong', () => {
       readConfigurationForOrderEntryMock.and.returnValue(
-        throwError(errorResponse)
+        throwError(() => errorResponse)
       );
       const readFromOrderEntry: CommonConfigurator.ReadConfigurationFromOrderEntryParameters =
         {
@@ -573,7 +573,7 @@ describe('ConfiguratorCartEffect', () => {
     });
 
     it('should emit CartAddEntryFail in case add to cart call is not successful', () => {
-      addToCartMock.and.returnValue(throwError(errorResponse));
+      addToCartMock.and.returnValue(throwError(() => errorResponse));
       const payloadInput: Configurator.AddToCartParameters = {
         userId: userId,
         cartId: cartId,
@@ -620,7 +620,7 @@ describe('ConfiguratorCartEffect', () => {
     });
 
     it('should emit AddToCartFail in case update cart entry call is not successful', () => {
-      updateCartEntryMock.and.returnValue(throwError(errorResponse));
+      updateCartEntryMock.and.returnValue(throwError(() => errorResponse));
 
       const action = new ConfiguratorActions.UpdateCartEntry(
         payloadInputUpdateConfiguration

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-variant.effect.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-variant.effect.spec.ts
@@ -156,7 +156,7 @@ describe('ConfiguratorVariantEffect', () => {
   });
 
   it('should emit a fail action in case something goes wrong', () => {
-    searchVariantsMock.and.returnValue(throwError(errorResponse));
+    searchVariantsMock.and.returnValue(throwError(() => errorResponse));
 
     const action = new ConfiguratorActions.SearchVariants(productConfiguration);
 

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-rest.interceptor.spec.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-rest.interceptor.spec.ts
@@ -92,7 +92,7 @@ describe('CpqConfiguratorRestInterceptor', () => {
         capturedRequestsStack.push(request);
         const cpqResponse = cpqResponseStack.pop();
         return cpqResponse instanceof HttpErrorResponse
-          ? throwError(cpqResponse)
+          ? throwError(() => cpqResponse)
           : of(cpqResponse);
       }
     );

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-rest.interceptor.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-rest.interceptor.ts
@@ -80,7 +80,7 @@ export class CpqConfiguratorRestInterceptor implements HttpInterceptor {
         );
       }
     }
-    return throwError(errorResponse); //propagate error
+    return throwError(() => errorResponse); //propagate error
   }
 
   protected extractCpqSessionId(response: HttpEvent<any>) {

--- a/feature-libs/product-configurator/textfield/core/state/effects/configurator-textfield.effect.spec.ts
+++ b/feature-libs/product-configurator/textfield/core/state/effects/configurator-textfield.effect.spec.ts
@@ -123,7 +123,7 @@ describe('ConfiguratorTextfieldEffect', () => {
   });
 
   it('should emit a fail action in case something goes wrong', () => {
-    createMock.and.returnValue(throwError(errorResponse));
+    createMock.and.returnValue(throwError(() => errorResponse));
     const payloadInput = {
       productCode: productCode,
       owner: ConfiguratorModelUtils.createInitialOwner(),
@@ -164,7 +164,7 @@ describe('ConfiguratorTextfieldEffect', () => {
   });
 
   it('should emit a fail action in case read from cart leads to an error', () => {
-    readFromCartEntryMock.and.returnValue(throwError(errorResponse));
+    readFromCartEntryMock.and.returnValue(throwError(() => errorResponse));
     const payloadInput: CommonConfigurator.ReadConfigurationFromCartEntryParameters =
       {
         owner: ConfiguratorModelUtils.createInitialOwner(),
@@ -207,7 +207,7 @@ describe('ConfiguratorTextfieldEffect', () => {
   });
 
   it('should emit a fail action in case read from order entry leads to an error', () => {
-    readFromOrderEntryMock.and.returnValue(throwError(errorResponse));
+    readFromOrderEntryMock.and.returnValue(throwError(() => errorResponse));
     const payloadInput: CommonConfigurator.ReadConfigurationFromOrderEntryParameters =
       {
         owner: ConfiguratorModelUtils.createInitialOwner(),
@@ -266,7 +266,7 @@ describe('ConfiguratorTextfieldEffect', () => {
     });
 
     it('should emit AddToCartFail in case add to cart call is not successful', () => {
-      addToCartMock.and.returnValue(throwError(errorResponse));
+      addToCartMock.and.returnValue(throwError(() => errorResponse));
       const payloadInput = {
         userId: userId,
         cartId: cartId,
@@ -317,7 +317,7 @@ describe('ConfiguratorTextfieldEffect', () => {
     });
 
     it('should emit CartUpdateEntryFail in case update cart entry is not successful', () => {
-      updateCartEntryMock.and.returnValue(throwError(errorResponse));
+      updateCartEntryMock.and.returnValue(throwError(() => errorResponse));
       const payloadInput: ConfiguratorTextfield.UpdateCartEntryParameters = {
         userId: userId,
         cartId: cartId,

--- a/feature-libs/product/future-stock/occ/adapters/occ-future-stock.adapter.ts
+++ b/feature-libs/product/future-stock/occ/adapters/occ-future-stock.adapter.ts
@@ -8,15 +8,15 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import {
-  OccEndpointsService,
   ConverterService,
   normalizeHttpError,
+  OccEndpointsService,
 } from '@spartacus/core';
 
 import {
   FutureStockAdapter,
-  FUTURE_STOCK_NORMALIZER,
   FUTURE_STOCK_LIST_NORMALIZER,
+  FUTURE_STOCK_NORMALIZER,
   ProductFutureStock,
   ProductFutureStockList,
 } from '@spartacus/product/future-stock/core';
@@ -38,7 +38,7 @@ export class OccFutureStockAdapter implements FutureStockAdapter {
     return this.http
       .get<ProductFutureStock>(this.getFutureStockEndpoint(userId, productCode))
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(FUTURE_STOCK_NORMALIZER)
       );
   }
@@ -52,7 +52,7 @@ export class OccFutureStockAdapter implements FutureStockAdapter {
         this.getFutureStocksEndpoint(userId, productCodes)
       )
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(FUTURE_STOCK_LIST_NORMALIZER)
       );
   }

--- a/feature-libs/product/future-stock/occ/adapters/occ-future-stock.adapter.ts
+++ b/feature-libs/product/future-stock/occ/adapters/occ-future-stock.adapter.ts
@@ -14,13 +14,13 @@ import {
 } from '@spartacus/core';
 
 import {
-  FutureStockAdapter,
   FUTURE_STOCK_LIST_NORMALIZER,
   FUTURE_STOCK_NORMALIZER,
+  FutureStockAdapter,
   ProductFutureStock,
   ProductFutureStockList,
 } from '@spartacus/product/future-stock/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -38,7 +38,9 @@ export class OccFutureStockAdapter implements FutureStockAdapter {
     return this.http
       .get<ProductFutureStock>(this.getFutureStockEndpoint(userId, productCode))
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(FUTURE_STOCK_NORMALIZER)
       );
   }
@@ -52,7 +54,9 @@ export class OccFutureStockAdapter implements FutureStockAdapter {
         this.getFutureStocksEndpoint(userId, productCodes)
       )
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(FUTURE_STOCK_LIST_NORMALIZER)
       );
   }

--- a/feature-libs/user/account/occ/adapters/occ-user-account.adapter.ts
+++ b/feature-libs/user/account/occ/adapters/occ-user-account.adapter.ts
@@ -13,8 +13,8 @@ import {
   OccEndpointsService,
 } from '@spartacus/core';
 import {
-  USER_ACCOUNT_NORMALIZER,
   UserAccountAdapter,
+  USER_ACCOUNT_NORMALIZER,
 } from '@spartacus/user/account/core';
 import { User } from '@spartacus/user/account/root';
 import { Observable, throwError } from 'rxjs';
@@ -31,7 +31,7 @@ export class OccUserAccountAdapter implements UserAccountAdapter {
   load(userId: string): Observable<User> {
     const url = this.occEndpoints.buildUrl('user', { urlParams: { userId } });
     return this.http.get<Occ.User>(url).pipe(
-      catchError((error) => throwError(normalizeHttpError(error))),
+      catchError((error) => throwError(() => normalizeHttpError(error))),
       this.converter.pipeable(USER_ACCOUNT_NORMALIZER)
     );
   }

--- a/feature-libs/user/account/occ/adapters/occ-user-account.adapter.ts
+++ b/feature-libs/user/account/occ/adapters/occ-user-account.adapter.ts
@@ -13,11 +13,11 @@ import {
   OccEndpointsService,
 } from '@spartacus/core';
 import {
-  UserAccountAdapter,
   USER_ACCOUNT_NORMALIZER,
+  UserAccountAdapter,
 } from '@spartacus/user/account/core';
 import { User } from '@spartacus/user/account/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -31,7 +31,9 @@ export class OccUserAccountAdapter implements UserAccountAdapter {
   load(userId: string): Observable<User> {
     const url = this.occEndpoints.buildUrl('user', { urlParams: { userId } });
     return this.http.get<Occ.User>(url).pipe(
-      catchError((error) => throwError(() => normalizeHttpError(error))),
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      }),
       this.converter.pipeable(USER_ACCOUNT_NORMALIZER)
     );
   }

--- a/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.spec.ts
+++ b/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.spec.ts
@@ -125,7 +125,7 @@ describe('CloseAccountModalComponent', () => {
   it('should dismiss modal when account failed to close', () => {
     spyOn(component, 'onError').and.callThrough();
     // spyOn(launchDialogService, 'closeDialog').and.callThrough();
-    (userFacade.close as any).and.returnValue(throwError(undefined));
+    (userFacade.close as any).and.returnValue(throwError(() => undefined));
 
     component.ngOnInit();
     component.closeAccount();

--- a/feature-libs/user/profile/components/reset-password/reset-password-component.service.spec.ts
+++ b/feature-libs/user/profile/components/reset-password/reset-password-component.service.spec.ts
@@ -174,7 +174,7 @@ describe('ResetPasswordComponentService', () => {
           const error = new HttpErrorModel();
           error.details = [{ message: 'error message' }];
           spyOn(userPasswordService, 'reset').and.returnValue(
-            throwError(error)
+            throwError(() => error)
           );
           service.resetPassword(resetToken);
           expect(globalMessageService.add).toHaveBeenCalledWith(
@@ -184,13 +184,17 @@ describe('ResetPasswordComponentService', () => {
         });
 
         it('should not show error message', () => {
-          spyOn(userPasswordService, 'reset').and.returnValue(throwError(null));
+          spyOn(userPasswordService, 'reset').and.returnValue(
+            throwError(() => null)
+          );
           service.resetPassword(resetToken);
           expect(globalMessageService.add).not.toHaveBeenCalled();
         });
 
         it('should not show error message', () => {
-          spyOn(userPasswordService, 'reset').and.returnValue(throwError({}));
+          spyOn(userPasswordService, 'reset').and.returnValue(
+            throwError(() => ({}))
+          );
           service.resetPassword(resetToken);
           expect(globalMessageService.add).not.toHaveBeenCalled();
         });
@@ -198,7 +202,9 @@ describe('ResetPasswordComponentService', () => {
     });
 
     it('should not reset invalid form', () => {
-      spyOn(userPasswordService, 'reset').and.returnValue(throwError({}));
+      spyOn(userPasswordService, 'reset').and.returnValue(
+        throwError(() => ({}))
+      );
       passwordConfirm.setValue('Diff123!');
       service.resetPassword(resetToken);
       expect(userPasswordService.reset).not.toHaveBeenCalled();

--- a/feature-libs/user/profile/occ/adapters/occ-user-profile.adapter.ts
+++ b/feature-libs/user/profile/occ/adapters/occ-user-profile.adapter.ts
@@ -47,7 +47,7 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     user = this.converter.convert(user, USER_PROFILE_SERIALIZER);
     return this.http
       .patch(url, user)
-      .pipe(catchError((error) => throwError(normalizeHttpError(error))));
+      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
   }
 
   register(user: UserSignUp): Observable<User> {
@@ -59,7 +59,7 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     user = this.converter.convert(user, USER_SIGN_UP_SERIALIZER);
 
     return this.http.post<User>(url, user, { headers }).pipe(
-      catchError((error) => throwError(normalizeHttpError(error))),
+      catchError((error) => throwError(() => normalizeHttpError(error))),
       this.converter.pipeable(USER_PROFILE_NORMALIZER)
     );
   }
@@ -76,7 +76,7 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
       .set('password', password);
 
     return this.http.post<User>(url, httpParams, { headers }).pipe(
-      catchError((error) => throwError(normalizeHttpError(error))),
+      catchError((error) => throwError(() => normalizeHttpError(error))),
       this.converter.pipeable(USER_PROFILE_NORMALIZER)
     );
   }
@@ -93,7 +93,7 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     headers = InterceptorUtil.createHeader(USE_CLIENT_TOKEN, true, headers);
     return this.http
       .post(url, httpParams, { headers })
-      .pipe(catchError((error) => throwError(normalizeHttpError(error))));
+      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
   }
 
   resetPassword(token: string, newPassword: string): Observable<unknown> {
@@ -105,7 +105,7 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
 
     return this.http
       .post(url, { token, newPassword }, { headers })
-      .pipe(catchError((error) => throwError(normalizeHttpError(error))));
+      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
   }
 
   updateEmail(
@@ -124,7 +124,7 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     });
     return this.http
       .put(url, httpParams, { headers })
-      .pipe(catchError((error) => throwError(normalizeHttpError(error))));
+      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
   }
 
   updatePassword(
@@ -143,7 +143,7 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     });
     return this.http
       .put(url, httpParams, { headers })
-      .pipe(catchError((error) => throwError(normalizeHttpError(error))));
+      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
   }
 
   close(userId: string): Observable<unknown> {
@@ -153,13 +153,13 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     const url = this.occEndpoints.buildUrl(endpoint, { urlParams: { userId } });
     return this.http
       .delete<User>(url)
-      .pipe(catchError((error) => throwError(normalizeHttpError(error))));
+      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
   }
 
   loadTitles(): Observable<Title[]> {
     const url = this.occEndpoints.buildUrl('titles');
     return this.http.get<Occ.TitleList>(url).pipe(
-      catchError((error) => throwError(normalizeHttpError(error))),
+      catchError((error) => throwError(() => normalizeHttpError(error))),
       map((titleList) => titleList.titles ?? []),
       this.converter.pipeableMany(TITLE_NORMALIZER)
     );

--- a/feature-libs/user/profile/occ/adapters/occ-user-profile.adapter.ts
+++ b/feature-libs/user/profile/occ/adapters/occ-user-profile.adapter.ts
@@ -9,21 +9,21 @@ import { Injectable } from '@angular/core';
 import {
   ConverterService,
   InterceptorUtil,
-  normalizeHttpError,
   Occ,
   OccEndpointsService,
   USE_CLIENT_TOKEN,
+  normalizeHttpError,
 } from '@spartacus/core';
 import { User } from '@spartacus/user/account/root';
 import {
   TITLE_NORMALIZER,
-  UserProfileAdapter,
   USER_PROFILE_NORMALIZER,
   USER_PROFILE_SERIALIZER,
   USER_SIGN_UP_SERIALIZER,
+  UserProfileAdapter,
 } from '@spartacus/user/profile/core';
 import { Title, UserSignUp } from '@spartacus/user/profile/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 const CONTENT_TYPE_JSON_HEADER = { 'Content-Type': 'application/json' };
@@ -45,9 +45,11 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
       : 'user';
     const url = this.occEndpoints.buildUrl(endpoint, { urlParams: { userId } });
     user = this.converter.convert(user, USER_PROFILE_SERIALIZER);
-    return this.http
-      .patch(url, user)
-      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
+    return this.http.patch(url, user).pipe(
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   register(user: UserSignUp): Observable<User> {
@@ -59,7 +61,9 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     user = this.converter.convert(user, USER_SIGN_UP_SERIALIZER);
 
     return this.http.post<User>(url, user, { headers }).pipe(
-      catchError((error) => throwError(() => normalizeHttpError(error))),
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      }),
       this.converter.pipeable(USER_PROFILE_NORMALIZER)
     );
   }
@@ -76,7 +80,9 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
       .set('password', password);
 
     return this.http.post<User>(url, httpParams, { headers }).pipe(
-      catchError((error) => throwError(() => normalizeHttpError(error))),
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      }),
       this.converter.pipeable(USER_PROFILE_NORMALIZER)
     );
   }
@@ -91,9 +97,11 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
       ...CONTENT_TYPE_URLENCODED_HEADER,
     });
     headers = InterceptorUtil.createHeader(USE_CLIENT_TOKEN, true, headers);
-    return this.http
-      .post(url, httpParams, { headers })
-      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
+    return this.http.post(url, httpParams, { headers }).pipe(
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   resetPassword(token: string, newPassword: string): Observable<unknown> {
@@ -103,9 +111,11 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     });
     headers = InterceptorUtil.createHeader(USE_CLIENT_TOKEN, true, headers);
 
-    return this.http
-      .post(url, { token, newPassword }, { headers })
-      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
+    return this.http.post(url, { token, newPassword }, { headers }).pipe(
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   updateEmail(
@@ -122,9 +132,11 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     const headers = new HttpHeaders({
       ...CONTENT_TYPE_URLENCODED_HEADER,
     });
-    return this.http
-      .put(url, httpParams, { headers })
-      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
+    return this.http.put(url, httpParams, { headers }).pipe(
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   updatePassword(
@@ -141,9 +153,11 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
     const headers = new HttpHeaders({
       ...CONTENT_TYPE_URLENCODED_HEADER,
     });
-    return this.http
-      .put(url, httpParams, { headers })
-      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
+    return this.http.put(url, httpParams, { headers }).pipe(
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   close(userId: string): Observable<unknown> {
@@ -151,15 +165,19 @@ export class OccUserProfileAdapter implements UserProfileAdapter {
       ? 'userCloseAccount'
       : 'user';
     const url = this.occEndpoints.buildUrl(endpoint, { urlParams: { userId } });
-    return this.http
-      .delete<User>(url)
-      .pipe(catchError((error) => throwError(() => normalizeHttpError(error))));
+    return this.http.delete<User>(url).pipe(
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   loadTitles(): Observable<Title[]> {
     const url = this.occEndpoints.buildUrl('titles');
     return this.http.get<Occ.TitleList>(url).pipe(
-      catchError((error) => throwError(() => normalizeHttpError(error))),
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      }),
       map((titleList) => titleList.titles ?? []),
       this.converter.pipeableMany(TITLE_NORMALIZER)
     );

--- a/integration-libs/cdc/core/auth/services/user-authentication/cdc-user-authentication-token.service.ts
+++ b/integration-libs/cdc/core/auth/services/user-authentication/cdc-user-authentication-token.service.ts
@@ -46,6 +46,6 @@ export class CdcUserAuthenticationTokenService {
 
     return this.http
       .post<Partial<AuthToken> & { expires_in?: number }>(url, params)
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 }

--- a/integration-libs/cdc/core/auth/services/user-authentication/cdc-user-authentication-token.service.ts
+++ b/integration-libs/cdc/core/auth/services/user-authentication/cdc-user-authentication-token.service.ts
@@ -11,7 +11,7 @@ import {
   AuthToken,
   normalizeHttpError,
 } from '@spartacus/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 @Injectable()
@@ -51,7 +51,9 @@ export class CdcUserAuthenticationTokenService {
     return this.http
       .post<Partial<AuthToken> & { expires_in?: number }>(url, params)
       .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 }

--- a/integration-libs/cdc/core/auth/services/user-authentication/cdc-user-authentication-token.service.ts
+++ b/integration-libs/cdc/core/auth/services/user-authentication/cdc-user-authentication-token.service.ts
@@ -6,7 +6,11 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { AuthConfigService, AuthToken } from '@spartacus/core';
+import {
+  AuthConfigService,
+  AuthToken,
+  normalizeHttpError,
+} from '@spartacus/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -46,6 +50,8 @@ export class CdcUserAuthenticationTokenService {
 
     return this.http
       .post<Partial<AuthToken> & { expires_in?: number }>(url, params)
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 }

--- a/integration-libs/cdc/core/store/effects/cdc-user-addresses.effect.spec.ts
+++ b/integration-libs/cdc/core/store/effects/cdc-user-addresses.effect.spec.ts
@@ -130,7 +130,7 @@ describe('CDC User Addresses effect', () => {
       };
 
       spyOn(cdcJSService, 'updateAddressWithoutScreenSet').and.returnValue(
-        throwError(error)
+        throwError(() => error)
       );
 
       const expected = cold('-#', null, error);
@@ -178,7 +178,7 @@ describe('CDC User Addresses effect', () => {
       const expected = cold('-#', null, error);
 
       spyOn(cdcJSService, 'updateAddressWithoutScreenSet').and.returnValue(
-        throwError(error)
+        throwError(() => error)
       );
 
       expect(cdcUserAddressesEffect.cdcUpdateUserAddress$).toBeObservable(
@@ -224,7 +224,7 @@ describe('CDC User Addresses effect', () => {
       const expected = cold('-#', null, error);
 
       spyOn(cdcJSService, 'updateAddressWithoutScreenSet').and.returnValue(
-        throwError(error)
+        throwError(() => error)
       );
 
       expect(cdcUserAddressesEffect.cdcUpdateUserAddress$).toBeObservable(
@@ -274,7 +274,7 @@ describe('CDC User Addresses effect', () => {
       const expected = cold('-#', null, error);
 
       spyOn(cdcJSService, 'updateAddressWithoutScreenSet').and.returnValue(
-        throwError(error)
+        throwError(() => error)
       );
 
       expect(cdcUserAddressesEffect.cdcDeleteUserAddress$).toBeObservable(

--- a/integration-libs/cdc/root/service/cdc-js.service.ts
+++ b/integration-libs/cdc/root/service/cdc-js.service.ts
@@ -193,7 +193,7 @@ export class CdcJsService implements OnDestroy {
     user: UserSignUp
   ): Observable<{ status: string }> {
     if (!user.uid || !user.password) {
-      return throwError(null);
+      return throwError(() => null);
     } else {
       return this.invokeAPI('accounts.initRegistration', {}).pipe(
         switchMap((response) => this.onInitRegistrationHandler(user, response))
@@ -212,7 +212,7 @@ export class CdcJsService implements OnDestroy {
     response: any
   ): Observable<{ status: string }> {
     if (!response?.regToken || !user?.uid || !user?.password) {
-      return throwError(null);
+      return throwError(() => null);
     } else {
       const regSource: string = this.winRef.nativeWindow?.location?.href || '';
       return this.invokeAPI('accounts.register', {
@@ -351,7 +351,7 @@ export class CdcJsService implements OnDestroy {
    */
   resetPasswordWithoutScreenSet(email: string): Observable<{ status: string }> {
     if (!email || email?.length === 0) {
-      return throwError('No email provided');
+      return throwError(() => 'No email provided');
     } else {
       return this.invokeAPI('accounts.resetPassword', {
         loginID: email,
@@ -398,7 +398,7 @@ export class CdcJsService implements OnDestroy {
       !user?.lastName ||
       user?.lastName?.length === 0
     ) {
-      return throwError('User details not provided');
+      return throwError(() => 'User details not provided');
     } else {
       const profileObj = {
         profile: {
@@ -435,7 +435,7 @@ export class CdcJsService implements OnDestroy {
       !newPassword ||
       newPassword?.length === 0
     ) {
-      return throwError('No passwords provided');
+      return throwError(() => 'No passwords provided');
     } else {
       return this.invokeAPI(setAccountInfoAPI, {
         password: oldPassword,
@@ -487,14 +487,14 @@ export class CdcJsService implements OnDestroy {
       !newEmail ||
       newEmail?.length === 0
     ) {
-      return throwError('Email or password not provided');
+      return throwError(() => 'Email or password not provided');
     } else {
       //Verify the password by attempting to login
       return this.getLoggedInUserEmail().pipe(
         switchMap((user) => {
           const email = user?.uid;
           if (!email || email?.length === 0) {
-            return throwError('Email or password not provided');
+            return throwError(() => 'Email or password not provided');
           }
           // Verify the password by attempting to login
           // - CDC doesn't require to verify password before changing an email, but the default Spartacus requires it.
@@ -555,7 +555,7 @@ export class CdcJsService implements OnDestroy {
     country?: string
   ): Observable<{ status: string }> {
     if (!formattedAddress || formattedAddress?.length === 0) {
-      return throwError('No address provided');
+      return throwError(() => 'No address provided');
     } else {
       const profileObj = {
         address: formattedAddress,

--- a/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.spec.ts
+++ b/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.spec.ts
@@ -108,7 +108,7 @@ describe('CdcLoginComponentService', () => {
     it('should handle a failed request through CDC SDK', () => {
       cdcJsService.didLoad = createSpy().and.returnValue(of(true));
       (cdcJsService.loginUserWithoutScreenSet as jasmine.Spy).and.returnValue(
-        throwError('test error: such email does not exist!')
+        throwError(() => 'test error: such email does not exist!')
       );
       cdcLoginService.login();
       expect(cdcLoginService['busy$'].value).toBe(false);

--- a/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.spec.ts
+++ b/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.spec.ts
@@ -109,7 +109,9 @@ describe('CDCForgotPasswordComponentService', () => {
         cdcJsService.didLoad = createSpy().and.returnValue(of(true));
         (
           cdcJsService.resetPasswordWithoutScreenSet as jasmine.Spy
-        ).and.returnValue(throwError('test error: such email does not exist!'));
+        ).and.returnValue(
+          throwError(() => 'test error: such email does not exist!')
+        );
         service.requestEmail();
         expect(routingService.go).not.toHaveBeenCalled();
         expect(service['busy$'].value).toBe(false);

--- a/integration-libs/cdc/user-profile/register/cdc-register-component.service.ts
+++ b/integration-libs/cdc/user-profile/register/cdc-register-component.service.ts
@@ -68,7 +68,7 @@ export class CDCRegisterComponentService extends RegisterComponentService {
    */
   register(user: UserSignUp): Observable<User> {
     if (!user.firstName || !user.lastName || !user.uid || !user.password) {
-      return throwError(`The provided user is not valid: ${user}`);
+      return throwError(() => `The provided user is not valid: ${user}`);
     }
 
     return this.cdcJSService.didLoad().pipe(

--- a/integration-libs/cdc/user-profile/update-profile/cdc-update-profile-component.service.spec.ts
+++ b/integration-libs/cdc/user-profile/update-profile/cdc-update-profile-component.service.spec.ts
@@ -114,7 +114,10 @@ describe('UpdateProfileComponentService', () => {
       spyOn(globalMessageService, 'add');
       service.form.patchValue(mockUser);
       cdcJsService.updateProfileWithoutScreenSet = createSpy().and.returnValue(
-        throwError({ status: 'ERROR', errorMessage: 'Error has occurred' })
+        throwError(() => ({
+          status: 'ERROR',
+          errorMessage: 'Error has occurred',
+        }))
       );
 
       service.updateProfile();

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
@@ -8,8 +8,8 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConverterService, normalizeHttpError } from '@spartacus/core';
 import {
-  NodesResponse,
   NODES_RESPONSE_NORMALIZER,
+  NodesResponse,
   SceneAdapter,
 } from '@spartacus/epd-visualization/core';
 import {
@@ -17,7 +17,7 @@ import {
   EpdVisualizationInnerConfig,
   VisualizationApiConfig,
 } from '@spartacus/epd-visualization/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /**
@@ -92,7 +92,9 @@ export class StorageV1Adapter implements SceneAdapter {
     return this.http
       .get(this.getUrl(sceneId, nodeIds, $expand, $filter, contentType))
       .pipe(
-        catchError((error) => throwError(() => normalizeHttpError(error))),
+        catchError((error) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(NODES_RESPONSE_NORMALIZER)
       );
   }

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
@@ -92,7 +92,7 @@ export class StorageV1Adapter implements SceneAdapter {
     return this.http
       .get(this.getUrl(sceneId, nodeIds, $expand, $filter, contentType))
       .pipe(
-        catchError((error) => throwError(normalizeHttpError(error))),
+        catchError((error) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(NODES_RESPONSE_NORMALIZER)
       );
   }

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
@@ -8,8 +8,8 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConverterService, normalizeHttpError } from '@spartacus/core';
 import {
-  LookupVisualizationsResponse,
   LOOKUP_VISUALIZATIONS_RESPONSE_NORMALIZER,
+  LookupVisualizationsResponse,
   VisualizationAdapter,
 } from '@spartacus/epd-visualization/core';
 import {
@@ -18,7 +18,7 @@ import {
   UsageId,
   VisualizationApiConfig,
 } from '@spartacus/epd-visualization/root';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /**
@@ -73,7 +73,9 @@ export class VisualizationV1Adapter implements VisualizationAdapter {
     folderUsageId: UsageId
   ): Observable<LookupVisualizationsResponse> {
     return this.http.get(this.getUrl(visualizationUsageId, folderUsageId)).pipe(
-      catchError((error) => throwError(() => normalizeHttpError(error))),
+      catchError((error) => {
+        throw normalizeHttpError(error);
+      }),
       this.converter.pipeable(LOOKUP_VISUALIZATIONS_RESPONSE_NORMALIZER)
     );
   }

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
@@ -73,7 +73,7 @@ export class VisualizationV1Adapter implements VisualizationAdapter {
     folderUsageId: UsageId
   ): Observable<LookupVisualizationsResponse> {
     return this.http.get(this.getUrl(visualizationUsageId, folderUsageId)).pipe(
-      catchError((error) => throwError(normalizeHttpError(error))),
+      catchError((error) => throwError(() => normalizeHttpError(error))),
       this.converter.pipeable(LOOKUP_VISUALIZATIONS_RESPONSE_NORMALIZER)
     );
   }

--- a/projects/core/src/auth/client-auth/http-interceptors/client-token.interceptor.ts
+++ b/projects/core/src/auth/client-auth/http-interceptors/client-token.interceptor.ts
@@ -73,7 +73,7 @@ export class ClientTokenInterceptor implements HttpInterceptor {
                 next
               );
             }
-            return throwError(errResponse);
+            return throwError(() => errResponse);
           })
         );
       })

--- a/projects/core/src/auth/client-auth/http-interceptors/client-token.interceptor.ts
+++ b/projects/core/src/auth/client-auth/http-interceptors/client-token.interceptor.ts
@@ -12,7 +12,7 @@ import {
   HttpRequest,
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { catchError, switchMap, take } from 'rxjs/operators';
 import { OccEndpointsService } from '../../../occ/services/occ-endpoints.service';
 import {
@@ -73,7 +73,7 @@ export class ClientTokenInterceptor implements HttpInterceptor {
                 next
               );
             }
-            return throwError(() => errResponse);
+            throw errResponse;
           })
         );
       })

--- a/projects/core/src/auth/user-auth/http-interceptors/auth.interceptor.ts
+++ b/projects/core/src/auth/user-auth/http-interceptors/auth.interceptor.ts
@@ -80,7 +80,7 @@ export class AuthInterceptor implements HttpInterceptor {
                 }
                 break;
             }
-            return throwError(errResponse);
+            return throwError(() => errResponse);
           })
         )
       )

--- a/projects/core/src/auth/user-auth/http-interceptors/auth.interceptor.ts
+++ b/projects/core/src/auth/user-auth/http-interceptors/auth.interceptor.ts
@@ -12,7 +12,7 @@ import {
   HttpRequest,
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { EMPTY, Observable, of, throwError } from 'rxjs';
+import { EMPTY, Observable, of } from 'rxjs';
 import { catchError, map, switchMap, take } from 'rxjs/operators';
 import { AuthConfigService } from '../services/auth-config.service';
 import { AuthHttpHeaderService } from '../services/auth-http-header.service';
@@ -80,7 +80,7 @@ export class AuthInterceptor implements HttpInterceptor {
                 }
                 break;
             }
-            return throwError(() => errResponse);
+            throw errResponse;
           })
         )
       )

--- a/projects/core/src/cms/connectors/page/cms-page.connector.ts
+++ b/projects/core/src/cms/connectors/page/cms-page.connector.ts
@@ -6,7 +6,7 @@
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { PageContext } from '../../../routing/models/page-context.model';
 import { CmsStructureModel } from '../../model/page.model';
@@ -41,7 +41,7 @@ export class CmsPageConnector {
                 ) {
                   return of({});
                 } else {
-                  return throwError(() => error);
+                  throw error;
                 }
               })
             );

--- a/projects/core/src/cms/connectors/page/cms-page.connector.ts
+++ b/projects/core/src/cms/connectors/page/cms-page.connector.ts
@@ -41,7 +41,7 @@ export class CmsPageConnector {
                 ) {
                   return of({});
                 } else {
-                  return throwError(error);
+                  return throwError(() => error);
                 }
               })
             );

--- a/projects/core/src/cms/store/effects/page.effect.spec.ts
+++ b/projects/core/src/cms/store/effects/page.effect.spec.ts
@@ -1,7 +1,9 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action, StoreModule } from '@ngrx/store';
+import { normalizeHttpError } from '@spartacus/core';
 import { cold, hot } from 'jasmine-marbles';
 import { Observable, of, throwError } from 'rxjs';
 import { AuthActions } from '../../../auth/user-auth/store/actions/index';
@@ -14,8 +16,6 @@ import { CmsStructureModel, Page } from '../../model/page.model';
 import { CmsActions } from '../actions/index';
 import { CMS_FEATURE } from '../cms-state';
 import * as fromEffects from './page.effect';
-import { HttpErrorResponse } from '@angular/common/http';
-import { normalizeHttpError } from '@spartacus/core';
 
 function mockDateNow(): number {
   return 1000000000000;
@@ -137,7 +137,9 @@ describe('Page Effects', () => {
 
       it('should dispatch LoadPageDataFail action', () => {
         const error = new HttpErrorResponse({ error: 'error' });
-        spyOn<any>(cmsPageConnector, 'get').and.returnValue(throwError(error));
+        spyOn<any>(cmsPageConnector, 'get').and.returnValue(
+          throwError(() => error)
+        );
         const action = new CmsActions.LoadCmsPageData(pageContext);
 
         const completion = new CmsActions.LoadCmsPageDataFail(

--- a/projects/core/src/global-message/http-interceptors/http-error.interceptor.spec.ts
+++ b/projects/core/src/global-message/http-interceptors/http-error.interceptor.spec.ts
@@ -105,7 +105,7 @@ describe('HttpErrorInterceptor', () => {
       it('should call handleError for ' + handlerClass.name, function () {
         http
           .get('/123')
-          .pipe(catchError((error: any) => throwError(error)))
+          .pipe(catchError((error: any) => throwError(() => error)))
           .subscribe({
             error: (error) => (this.error = error),
           });
@@ -147,7 +147,7 @@ describe('HttpErrorInterceptor', () => {
 
         http
           .get('/validation-error')
-          .pipe(catchError((error: any) => throwError(error)))
+          .pipe(catchError((error: any) => throwError(() => error)))
           .subscribe({
             error: (error) => ({
               if(this) {
@@ -172,7 +172,7 @@ describe('HttpErrorInterceptor', () => {
         spyOn(console, 'warn');
         http
           .get('/unknown')
-          .pipe(catchError((error: any) => throwError(error)))
+          .pipe(catchError((error: any) => throwError(() => error)))
           .subscribe({
             error: (error) => ({
               if(this) {

--- a/projects/core/src/global-message/http-interceptors/http-error.interceptor.ts
+++ b/projects/core/src/global-message/http-interceptors/http-error.interceptor.ts
@@ -12,8 +12,8 @@ import {
   HttpRequest,
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
-import { catchError, shareReplay } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { shareReplay, tap } from 'rxjs/operators';
 import { UnifiedInjector } from '../../lazy-loading/unified-injector';
 import { resolveApplicable } from '../../util/applicable';
 import { getLastValueSync } from '../../util/rxjs/get-last-value-sync';
@@ -32,11 +32,12 @@ export class HttpErrorInterceptor implements HttpInterceptor {
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(
-      catchError((response: any) => {
-        if (response instanceof HttpErrorResponse) {
-          this.handleErrorResponse(request, response);
-        }
-        return throwError(() => response);
+      tap({
+        error: (response: any) => {
+          if (response instanceof HttpErrorResponse) {
+            this.handleErrorResponse(request, response);
+          }
+        },
       })
     );
   }

--- a/projects/core/src/global-message/http-interceptors/http-error.interceptor.ts
+++ b/projects/core/src/global-message/http-interceptors/http-error.interceptor.ts
@@ -36,7 +36,7 @@ export class HttpErrorInterceptor implements HttpInterceptor {
         if (response instanceof HttpErrorResponse) {
           this.handleErrorResponse(request, response);
         }
-        return throwError(response);
+        return throwError(() => response);
       })
     );
   }

--- a/projects/core/src/lazy-loading/facade-factory/facade-factory.service.ts
+++ b/projects/core/src/lazy-loading/facade-factory/facade-factory.service.ts
@@ -47,7 +47,7 @@ export class FacadeFactoryService {
   ): Observable<T> {
     if (!this.featureModules.isConfigured(feature)) {
       return throwError(
-        new Error(`Feature ${feature} is not configured properly`)
+        () => new Error(`Feature ${feature} is not configured properly`)
       );
     }
 

--- a/projects/core/src/lazy-loading/feature-modules.service.ts
+++ b/projects/core/src/lazy-loading/feature-modules.service.ts
@@ -46,7 +46,8 @@ export class FeatureModulesService {
       if (!this.features.has(featureName)) {
         if (!this.isConfigured(featureName)) {
           return throwError(
-            new Error('No module defined for Feature Module ' + featureName)
+            () =>
+              new Error('No module defined for Feature Module ' + featureName)
           );
         }
 

--- a/projects/core/src/lazy-loading/lazy-modules.service.ts
+++ b/projects/core/src/lazy-loading/lazy-modules.service.ts
@@ -13,17 +13,15 @@ import {
   OnDestroy,
 } from '@angular/core';
 import {
-  combineLatest,
   ConnectableObservable,
-  from,
   Observable,
+  Subscription,
+  combineLatest,
+  from,
   of,
   queueScheduler,
-  Subscription,
-  throwError,
 } from 'rxjs';
 import {
-  catchError,
   concatMap,
   map,
   observeOn,
@@ -159,12 +157,13 @@ export class LazyModulesService implements OnDestroy {
       this.runModuleInitializerFunctions(moduleInits);
     if (asyncInitPromises.length) {
       return from(Promise.all(asyncInitPromises)).pipe(
-        catchError((error) => {
-          console.error(
-            'MODULE_INITIALIZER promise was rejected while lazy loading a module.',
-            error
-          );
-          return throwError(() => error);
+        tap({
+          error: (error) => {
+            console.error(
+              'MODULE_INITIALIZER promise was rejected while lazy loading a module.',
+              error
+            );
+          },
         }),
         switchMap(() => of(moduleRef))
       );

--- a/projects/core/src/lazy-loading/lazy-modules.service.ts
+++ b/projects/core/src/lazy-loading/lazy-modules.service.ts
@@ -164,7 +164,7 @@ export class LazyModulesService implements OnDestroy {
             'MODULE_INITIALIZER promise was rejected while lazy loading a module.',
             error
           );
-          return throwError(error);
+          return throwError(() => error);
         }),
         switchMap(() => of(moduleRef))
       );

--- a/projects/core/src/occ/adapters/user/occ-anonymous-consent-templates.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-anonymous-consent-templates.adapter.ts
@@ -6,7 +6,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { AnonymousConsentTemplatesAdapter } from '../../../anonymous-consents/connectors/anonymous-consent-templates.adapter';
 import { ANONYMOUS_CONSENT_NORMALIZER } from '../../../anonymous-consents/connectors/converters';
@@ -34,7 +34,9 @@ export class OccAnonymousConsentTemplatesAdapter
   loadAnonymousConsentTemplates(): Observable<ConsentTemplate[]> {
     const url = this.occEndpoints.buildUrl('anonymousConsentTemplates');
     return this.http.get<Occ.ConsentTemplateList>(url).pipe(
-      catchError((error: any) => throwError(() => normalizeHttpError(error))),
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      }),
       map((consentList) => consentList.consentTemplates ?? []),
       this.converter.pipeableMany(CONSENT_TEMPLATE_NORMALIZER)
     );
@@ -46,7 +48,9 @@ export class OccAnonymousConsentTemplatesAdapter
     return this.http
       .head<Occ.ConsentTemplateList>(url, { observe: 'response' })
       .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error))),
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        }),
         map(
           (response) => response.headers.get(ANONYMOUS_CONSENTS_HEADER) ?? ''
         ),

--- a/projects/core/src/occ/adapters/user/occ-anonymous-consent-templates.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-anonymous-consent-templates.adapter.ts
@@ -11,12 +11,13 @@ import { catchError, map } from 'rxjs/operators';
 import { AnonymousConsentTemplatesAdapter } from '../../../anonymous-consents/connectors/anonymous-consent-templates.adapter';
 import { ANONYMOUS_CONSENT_NORMALIZER } from '../../../anonymous-consents/connectors/converters';
 import {
-  AnonymousConsent,
   ANONYMOUS_CONSENTS_HEADER,
+  AnonymousConsent,
   ConsentTemplate,
 } from '../../../model/consent.model';
 import { CONSENT_TEMPLATE_NORMALIZER } from '../../../user/connectors/consent/converters';
 import { ConverterService } from '../../../util/converter.service';
+import { normalizeHttpError } from '../../../util/normalize-http-error';
 import { Occ } from '../../occ-models/occ.models';
 import { OccEndpointsService } from '../../services/occ-endpoints.service';
 
@@ -33,7 +34,7 @@ export class OccAnonymousConsentTemplatesAdapter
   loadAnonymousConsentTemplates(): Observable<ConsentTemplate[]> {
     const url = this.occEndpoints.buildUrl('anonymousConsentTemplates');
     return this.http.get<Occ.ConsentTemplateList>(url).pipe(
-      catchError((error) => throwError(() => error)),
+      catchError((error: any) => throwError(() => normalizeHttpError(error))),
       map((consentList) => consentList.consentTemplates ?? []),
       this.converter.pipeableMany(CONSENT_TEMPLATE_NORMALIZER)
     );
@@ -45,7 +46,7 @@ export class OccAnonymousConsentTemplatesAdapter
     return this.http
       .head<Occ.ConsentTemplateList>(url, { observe: 'response' })
       .pipe(
-        catchError((error) => throwError(() => error)),
+        catchError((error: any) => throwError(() => normalizeHttpError(error))),
         map(
           (response) => response.headers.get(ANONYMOUS_CONSENTS_HEADER) ?? ''
         ),

--- a/projects/core/src/occ/adapters/user/occ-anonymous-consent-templates.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-anonymous-consent-templates.adapter.ts
@@ -33,7 +33,7 @@ export class OccAnonymousConsentTemplatesAdapter
   loadAnonymousConsentTemplates(): Observable<ConsentTemplate[]> {
     const url = this.occEndpoints.buildUrl('anonymousConsentTemplates');
     return this.http.get<Occ.ConsentTemplateList>(url).pipe(
-      catchError((error) => throwError(error)),
+      catchError((error) => throwError(() => error)),
       map((consentList) => consentList.consentTemplates ?? []),
       this.converter.pipeableMany(CONSENT_TEMPLATE_NORMALIZER)
     );
@@ -45,7 +45,7 @@ export class OccAnonymousConsentTemplatesAdapter
     return this.http
       .head<Occ.ConsentTemplateList>(url, { observe: 'response' })
       .pipe(
-        catchError((error) => throwError(error)),
+        catchError((error) => throwError(() => error)),
         map(
           (response) => response.headers.get(ANONYMOUS_CONSENTS_HEADER) ?? ''
         ),

--- a/projects/core/src/occ/adapters/user/occ-user-address.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-address.adapter.ts
@@ -6,7 +6,7 @@
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { Address, AddressValidation } from '../../../model/address.model';
 import {
@@ -44,7 +44,9 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
     });
 
     return this.http.get<Occ.AddressList>(url, { headers }).pipe(
-      catchError((error: any) => throwError(() => normalizeHttpError(error))),
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      }),
       map((addressList) => addressList.addresses ?? []),
       this.converter.pipeableMany(ADDRESS_NORMALIZER)
     );
@@ -59,11 +61,11 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
     });
     address = this.converter.convert(address, ADDRESS_SERIALIZER);
 
-    return this.http
-      .post(url, address, { headers })
-      .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
-      );
+    return this.http.post(url, address, { headers }).pipe(
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   update(userId: string, addressId: string, address: Address): Observable<{}> {
@@ -75,11 +77,11 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
     });
     address = this.converter.convert(address, ADDRESS_SERIALIZER);
 
-    return this.http
-      .patch(url, address, { headers })
-      .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
-      );
+    return this.http.patch(url, address, { headers }).pipe(
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   verify(userId: string, address: Address): Observable<AddressValidation> {
@@ -95,7 +97,9 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
     address = this.converter.convert(address, ADDRESS_SERIALIZER);
 
     return this.http.post<AddressValidation>(url, address, { headers }).pipe(
-      catchError((error: any) => throwError(() => normalizeHttpError(error))),
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      }),
       this.converter.pipeable(ADDRESS_VALIDATION_NORMALIZER)
     );
   }
@@ -108,10 +112,10 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
       ...CONTENT_TYPE_JSON_HEADER,
     });
 
-    return this.http
-      .delete(url, { headers })
-      .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
-      );
+    return this.http.delete(url, { headers }).pipe(
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-address.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-address.adapter.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../user/connectors/address/converters';
 import { UserAddressAdapter } from '../../../user/connectors/address/user-address.adapter';
 import { ConverterService } from '../../../util/converter.service';
+import { normalizeHttpError } from '../../../util/normalize-http-error';
 import { Occ } from '../../occ-models/occ.models';
 import { OccEndpointsService } from '../../services/occ-endpoints.service';
 import {
@@ -43,7 +44,7 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
     });
 
     return this.http.get<Occ.AddressList>(url, { headers }).pipe(
-      catchError((error: any) => throwError(() => error)),
+      catchError((error: any) => throwError(() => normalizeHttpError(error))),
       map((addressList) => addressList.addresses ?? []),
       this.converter.pipeableMany(ADDRESS_NORMALIZER)
     );
@@ -60,7 +61,9 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
 
     return this.http
       .post(url, address, { headers })
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 
   update(userId: string, addressId: string, address: Address): Observable<{}> {
@@ -74,7 +77,9 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
 
     return this.http
       .patch(url, address, { headers })
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 
   verify(userId: string, address: Address): Observable<AddressValidation> {
@@ -90,7 +95,7 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
     address = this.converter.convert(address, ADDRESS_SERIALIZER);
 
     return this.http.post<AddressValidation>(url, address, { headers }).pipe(
-      catchError((error: any) => throwError(() => error)),
+      catchError((error: any) => throwError(() => normalizeHttpError(error))),
       this.converter.pipeable(ADDRESS_VALIDATION_NORMALIZER)
     );
   }
@@ -105,6 +110,8 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
 
     return this.http
       .delete(url, { headers })
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-address.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-address.adapter.ts
@@ -43,7 +43,7 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
     });
 
     return this.http.get<Occ.AddressList>(url, { headers }).pipe(
-      catchError((error: any) => throwError(error)),
+      catchError((error: any) => throwError(() => error)),
       map((addressList) => addressList.addresses ?? []),
       this.converter.pipeableMany(ADDRESS_NORMALIZER)
     );
@@ -60,7 +60,7 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
 
     return this.http
       .post(url, address, { headers })
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 
   update(userId: string, addressId: string, address: Address): Observable<{}> {
@@ -74,7 +74,7 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
 
     return this.http
       .patch(url, address, { headers })
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 
   verify(userId: string, address: Address): Observable<AddressValidation> {
@@ -90,7 +90,7 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
     address = this.converter.convert(address, ADDRESS_SERIALIZER);
 
     return this.http.post<AddressValidation>(url, address, { headers }).pipe(
-      catchError((error: any) => throwError(error)),
+      catchError((error: any) => throwError(() => error)),
       this.converter.pipeable(ADDRESS_VALIDATION_NORMALIZER)
     );
   }
@@ -105,6 +105,6 @@ export class OccUserAddressAdapter implements UserAddressAdapter {
 
     return this.http
       .delete(url, { headers })
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-consent.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-consent.adapter.ts
@@ -29,7 +29,7 @@ export class OccUserConsentAdapter implements UserConsentAdapter {
     });
     const headers = new HttpHeaders({ 'Cache-Control': 'no-cache' });
     return this.http.get<Occ.ConsentTemplateList>(url, { headers }).pipe(
-      catchError((error: any) => throwError(error)),
+      catchError((error: any) => throwError(() => error)),
       map((consentList) => consentList.consentTemplates ?? []),
       this.converter.pipeableMany(CONSENT_TEMPLATE_NORMALIZER)
     );
@@ -53,7 +53,7 @@ export class OccUserConsentAdapter implements UserConsentAdapter {
     return this.http
       .post<Occ.ConsentTemplate>(url, httpParams, { headers })
       .pipe(
-        catchError((error) => throwError(error)),
+        catchError((error) => throwError(() => error)),
         this.converter.pipeable(CONSENT_TEMPLATE_NORMALIZER)
       );
   }

--- a/projects/core/src/occ/adapters/user/occ-user-consent.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-consent.adapter.ts
@@ -12,6 +12,7 @@ import { ConsentTemplate } from '../../../model/consent.model';
 import { CONSENT_TEMPLATE_NORMALIZER } from '../../../user/connectors/consent/converters';
 import { UserConsentAdapter } from '../../../user/connectors/consent/user-consent.adapter';
 import { ConverterService } from '../../../util/converter.service';
+import { normalizeHttpError } from '../../../util/normalize-http-error';
 import { Occ } from '../../occ-models/occ.models';
 import { OccEndpointsService } from '../../services/occ-endpoints.service';
 
@@ -29,7 +30,7 @@ export class OccUserConsentAdapter implements UserConsentAdapter {
     });
     const headers = new HttpHeaders({ 'Cache-Control': 'no-cache' });
     return this.http.get<Occ.ConsentTemplateList>(url, { headers }).pipe(
-      catchError((error: any) => throwError(() => error)),
+      catchError((error: any) => throwError(() => normalizeHttpError(error))),
       map((consentList) => consentList.consentTemplates ?? []),
       this.converter.pipeableMany(CONSENT_TEMPLATE_NORMALIZER)
     );
@@ -53,7 +54,7 @@ export class OccUserConsentAdapter implements UserConsentAdapter {
     return this.http
       .post<Occ.ConsentTemplate>(url, httpParams, { headers })
       .pipe(
-        catchError((error) => throwError(() => error)),
+        catchError((error: any) => throwError(() => normalizeHttpError(error))),
         this.converter.pipeable(CONSENT_TEMPLATE_NORMALIZER)
       );
   }

--- a/projects/core/src/occ/adapters/user/occ-user-consent.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-consent.adapter.ts
@@ -6,7 +6,7 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { ConsentTemplate } from '../../../model/consent.model';
 import { CONSENT_TEMPLATE_NORMALIZER } from '../../../user/connectors/consent/converters';
@@ -30,7 +30,9 @@ export class OccUserConsentAdapter implements UserConsentAdapter {
     });
     const headers = new HttpHeaders({ 'Cache-Control': 'no-cache' });
     return this.http.get<Occ.ConsentTemplateList>(url, { headers }).pipe(
-      catchError((error: any) => throwError(() => normalizeHttpError(error))),
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      }),
       map((consentList) => consentList.consentTemplates ?? []),
       this.converter.pipeableMany(CONSENT_TEMPLATE_NORMALIZER)
     );
@@ -54,7 +56,9 @@ export class OccUserConsentAdapter implements UserConsentAdapter {
     return this.http
       .post<Occ.ConsentTemplate>(url, httpParams, { headers })
       .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error))),
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        }),
         this.converter.pipeable(CONSENT_TEMPLATE_NORMALIZER)
       );
   }

--- a/projects/core/src/occ/adapters/user/occ-user-interests.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-interests.adapter.ts
@@ -6,7 +6,7 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, forkJoin, throwError } from 'rxjs';
+import { Observable, forkJoin } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import {
   NotificationType,
@@ -67,7 +67,9 @@ export class OccUserInterestsAdapter implements UserInterestsAdapter {
       )
       .pipe(
         this.converter.pipeable(PRODUCT_INTERESTS_NORMALIZER),
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 
@@ -91,9 +93,9 @@ export class OccUserInterestsAdapter implements UserInterestsAdapter {
             }
           )
           .pipe(
-            catchError((error: any) =>
-              throwError(() => normalizeHttpError(error))
-            )
+            catchError((error: any) => {
+              throw normalizeHttpError(error);
+            })
           )
       );
     });
@@ -120,7 +122,9 @@ export class OccUserInterestsAdapter implements UserInterestsAdapter {
         }
       )
       .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-interests.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-interests.adapter.ts
@@ -66,7 +66,7 @@ export class OccUserInterestsAdapter implements UserInterestsAdapter {
       )
       .pipe(
         this.converter.pipeable(PRODUCT_INTERESTS_NORMALIZER),
-        catchError((error: any) => throwError(error))
+        catchError((error: any) => throwError(() => error))
       );
   }
 
@@ -89,7 +89,7 @@ export class OccUserInterestsAdapter implements UserInterestsAdapter {
               params: params,
             }
           )
-          .pipe(catchError((error: any) => throwError(error)))
+          .pipe(catchError((error: any) => throwError(() => error)))
       );
     });
     return forkJoin(r);
@@ -114,6 +114,6 @@ export class OccUserInterestsAdapter implements UserInterestsAdapter {
           params,
         }
       )
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-interests.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-interests.adapter.ts
@@ -6,7 +6,7 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { forkJoin, Observable, throwError } from 'rxjs';
+import { Observable, forkJoin, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import {
   NotificationType,
@@ -16,6 +16,7 @@ import {
 import { PRODUCT_INTERESTS_NORMALIZER } from '../../../user/connectors/interests/converters';
 import { UserInterestsAdapter } from '../../../user/connectors/interests/user-interests.adapter';
 import { ConverterService } from '../../../util/converter.service';
+import { normalizeHttpError } from '../../../util/normalize-http-error';
 import { OccConfig } from '../../config/occ-config';
 import { OccEndpointsService } from '../../services/occ-endpoints.service';
 
@@ -66,7 +67,7 @@ export class OccUserInterestsAdapter implements UserInterestsAdapter {
       )
       .pipe(
         this.converter.pipeable(PRODUCT_INTERESTS_NORMALIZER),
-        catchError((error: any) => throwError(() => error))
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
       );
   }
 
@@ -89,7 +90,11 @@ export class OccUserInterestsAdapter implements UserInterestsAdapter {
               params: params,
             }
           )
-          .pipe(catchError((error: any) => throwError(() => error)))
+          .pipe(
+            catchError((error: any) =>
+              throwError(() => normalizeHttpError(error))
+            )
+          )
       );
     });
     return forkJoin(r);
@@ -114,6 +119,8 @@ export class OccUserInterestsAdapter implements UserInterestsAdapter {
           params,
         }
       )
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-notification-preference.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-notification-preference.adapter.ts
@@ -6,7 +6,7 @@
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import {
   NotificationPreference,
@@ -48,7 +48,9 @@ export class OccUserNotificationPreferenceAdapter
       .pipe(
         map((list) => list.preferences ?? []),
         this.converter.pipeableMany(NOTIFICATION_PREFERENCE_NORMALIZER),
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 
@@ -69,7 +71,9 @@ export class OccUserNotificationPreferenceAdapter
         { headers }
       )
       .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-notification-preference.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-notification-preference.adapter.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../user/connectors/notification-preference';
 import { UserNotificationPreferenceAdapter } from '../../../user/connectors/notification-preference/user-notification-preference.adapter';
 import { ConverterService } from '../../../util/converter.service';
+import { normalizeHttpError } from '../../../util/normalize-http-error';
 import { OccEndpointsService } from '../../services/occ-endpoints.service';
 
 const headers = new HttpHeaders({
@@ -47,7 +48,7 @@ export class OccUserNotificationPreferenceAdapter
       .pipe(
         map((list) => list.preferences ?? []),
         this.converter.pipeableMany(NOTIFICATION_PREFERENCE_NORMALIZER),
-        catchError((error: any) => throwError(() => error))
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
       );
   }
 
@@ -67,6 +68,8 @@ export class OccUserNotificationPreferenceAdapter
         { preferences: preferences },
         { headers }
       )
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-notification-preference.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-notification-preference.adapter.ts
@@ -47,7 +47,7 @@ export class OccUserNotificationPreferenceAdapter
       .pipe(
         map((list) => list.preferences ?? []),
         this.converter.pipeableMany(NOTIFICATION_PREFERENCE_NORMALIZER),
-        catchError((error: any) => throwError(error))
+        catchError((error: any) => throwError(() => error))
       );
   }
 
@@ -67,6 +67,6 @@ export class OccUserNotificationPreferenceAdapter
         { preferences: preferences },
         { headers }
       )
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-payment.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-payment.adapter.ts
@@ -35,7 +35,7 @@ export class OccUserPaymentAdapter implements UserPaymentAdapter {
     });
 
     return this.http.get<Occ.PaymentDetailsList>(url, { headers }).pipe(
-      catchError((error: any) => throwError(error)),
+      catchError((error: any) => throwError(() => error)),
       map((methodList) => methodList.payments ?? []),
       this.converter.pipeableMany(PAYMENT_DETAILS_NORMALIZER)
     );
@@ -51,7 +51,7 @@ export class OccUserPaymentAdapter implements UserPaymentAdapter {
 
     return this.http
       .delete(url, { headers })
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 
   setDefault(userId: string, paymentMethodID: string): Observable<{}> {
@@ -70,6 +70,6 @@ export class OccUserPaymentAdapter implements UserPaymentAdapter {
         { billingAddress: { titleCode: 'mr' }, defaultPayment: true },
         { headers }
       )
-      .pipe(catchError((error: any) => throwError(error)));
+      .pipe(catchError((error: any) => throwError(() => error)));
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-payment.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-payment.adapter.ts
@@ -12,6 +12,7 @@ import { PAYMENT_DETAILS_NORMALIZER } from '../../../checkout/connectors/payment
 import { PaymentDetails } from '../../../model/payment.model';
 import { UserPaymentAdapter } from '../../../user/connectors/payment/user-payment.adapter';
 import { ConverterService } from '../../../util/converter.service';
+import { normalizeHttpError } from '../../../util/normalize-http-error';
 import { Occ } from '../../occ-models/occ.models';
 import { OccEndpointsService } from '../../services/occ-endpoints.service';
 
@@ -35,7 +36,7 @@ export class OccUserPaymentAdapter implements UserPaymentAdapter {
     });
 
     return this.http.get<Occ.PaymentDetailsList>(url, { headers }).pipe(
-      catchError((error: any) => throwError(() => error)),
+      catchError((error: any) => throwError(() => normalizeHttpError(error))),
       map((methodList) => methodList.payments ?? []),
       this.converter.pipeableMany(PAYMENT_DETAILS_NORMALIZER)
     );
@@ -51,7 +52,9 @@ export class OccUserPaymentAdapter implements UserPaymentAdapter {
 
     return this.http
       .delete(url, { headers })
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 
   setDefault(userId: string, paymentMethodID: string): Observable<{}> {
@@ -70,6 +73,8 @@ export class OccUserPaymentAdapter implements UserPaymentAdapter {
         { billingAddress: { titleCode: 'mr' }, defaultPayment: true },
         { headers }
       )
-      .pipe(catchError((error: any) => throwError(() => error)));
+      .pipe(
+        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+      );
   }
 }

--- a/projects/core/src/occ/adapters/user/occ-user-payment.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-payment.adapter.ts
@@ -6,7 +6,7 @@
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { PAYMENT_DETAILS_NORMALIZER } from '../../../checkout/connectors/payment/converters';
 import { PaymentDetails } from '../../../model/payment.model';
@@ -36,7 +36,9 @@ export class OccUserPaymentAdapter implements UserPaymentAdapter {
     });
 
     return this.http.get<Occ.PaymentDetailsList>(url, { headers }).pipe(
-      catchError((error: any) => throwError(() => normalizeHttpError(error))),
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      }),
       map((methodList) => methodList.payments ?? []),
       this.converter.pipeableMany(PAYMENT_DETAILS_NORMALIZER)
     );
@@ -50,11 +52,11 @@ export class OccUserPaymentAdapter implements UserPaymentAdapter {
       ...CONTENT_TYPE_JSON_HEADER,
     });
 
-    return this.http
-      .delete(url, { headers })
-      .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
-      );
+    return this.http.delete(url, { headers }).pipe(
+      catchError((error: any) => {
+        throw normalizeHttpError(error);
+      })
+    );
   }
 
   setDefault(userId: string, paymentMethodID: string): Observable<{}> {
@@ -74,7 +76,9 @@ export class OccUserPaymentAdapter implements UserPaymentAdapter {
         { headers }
       )
       .pipe(
-        catchError((error: any) => throwError(() => normalizeHttpError(error)))
+        catchError((error: any) => {
+          throw normalizeHttpError(error);
+        })
       );
   }
 }

--- a/projects/core/src/user/store/effects/notification-preference.effect.spec.ts
+++ b/projects/core/src/user/store/effects/notification-preference.effect.spec.ts
@@ -3,11 +3,11 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { cold, hot } from 'jasmine-marbles';
 import { Observable, of, throwError } from 'rxjs';
-import { UserNotificationPreferenceConnector } from '../../connectors/notification-preference/user-notification-preference.connector';
+import { NotificationPreference } from '../../../model/notification-preference.model';
 import { UserNotificationPreferenceAdapter } from '../../connectors/notification-preference/user-notification-preference.adapter';
+import { UserNotificationPreferenceConnector } from '../../connectors/notification-preference/user-notification-preference.connector';
 import { UserActions } from '../actions/index';
 import * as fromEffect from './notification-preference.effect';
-import { NotificationPreference } from '../../../model/notification-preference.model';
 
 const userId = 'testUser';
 const mockNotificationPreference: NotificationPreference[] = [
@@ -63,7 +63,7 @@ describe('Notification Preference Effect', () => {
 
     it('should return LoadNotificationPreferencesFail action', () => {
       spyOn(userNotificationPreferenceConnector, 'loadAll').and.returnValue(
-        throwError(error)
+        throwError(() => error)
       );
 
       const action = new UserActions.LoadNotificationPreferences(userId);
@@ -104,7 +104,7 @@ describe('Notification Preference Effect', () => {
 
     it('should return NotificationPreferencesFail action', () => {
       spyOn(userNotificationPreferenceConnector, 'update').and.returnValue(
-        throwError(error)
+        throwError(() => error)
       );
 
       const action = new UserActions.UpdateNotificationPreferences({

--- a/projects/core/src/user/store/effects/product-interests.effect.spec.ts
+++ b/projects/core/src/user/store/effects/product-interests.effect.spec.ts
@@ -1,17 +1,17 @@
-import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { provideMockActions } from '@ngrx/effects/testing';
-import * as fromInterestsEffect from './product-interests.effect';
-import { UserActions } from '../actions/index';
+import { TestBed } from '@angular/core/testing';
 import { Actions } from '@ngrx/effects';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { cold, hot } from 'jasmine-marbles';
 import { of, throwError } from 'rxjs';
 import {
   NotificationType,
   ProductInterestSearchResult,
 } from '../../../model/product-interest.model';
-import { cold, hot } from 'jasmine-marbles';
-import { UserInterestsConnector } from '../../connectors/interests/user-interests.connector';
 import { UserInterestsAdapter } from '../../connectors/interests/user-interests.adapter';
+import { UserInterestsConnector } from '../../connectors/interests/user-interests.connector';
+import { UserActions } from '../actions/index';
+import * as fromInterestsEffect from './product-interests.effect';
 
 const loadParams = {
   userId: 'qingyu@sap.com',
@@ -63,7 +63,7 @@ describe('Product Interests Effect', () => {
     });
     it('should be able to handle failures for load product interests', () => {
       spyOn(userInterestConnector, 'getInterests').and.returnValue(
-        throwError('Error')
+        throwError(() => 'Error')
       );
       const action = new UserActions.LoadProductInterests(loadParams);
       const completion = new UserActions.LoadProductInterestsFail(undefined);
@@ -141,7 +141,7 @@ describe('Product Interests Effect', () => {
 
     it('should be able to handle failures for remove product interest', () => {
       spyOn(userInterestConnector, 'removeInterest').and.returnValue(
-        throwError('Error')
+        throwError(() => 'Error')
       );
       const action = new UserActions.RemoveProductInterest(delParams);
       const completion = new UserActions.RemoveProductInterestFail(undefined);

--- a/projects/core/src/user/store/effects/user-consents.effect.spec.ts
+++ b/projects/core/src/user/store/effects/user-consents.effect.spec.ts
@@ -102,7 +102,7 @@ describe('User Consents effect', () => {
         msg: 'Mock error',
       };
       spyOn(userConsentAdapter, 'giveConsent').and.returnValue(
-        throwError(mockError)
+        throwError(() => mockError)
       );
 
       const action = new UserActions.TransferAnonymousConsent({
@@ -129,7 +129,7 @@ describe('User Consents effect', () => {
         msg: 'Mock error',
       };
       spyOn(userConsentAdapter, 'giveConsent').and.returnValue(
-        throwError(mockError)
+        throwError(() => mockError)
       );
 
       const action = new UserActions.GiveUserConsent({

--- a/projects/core/src/util/rxjs/back-off.spec.ts
+++ b/projects/core/src/util/rxjs/back-off.spec.ts
@@ -20,7 +20,7 @@ describe(`backOff`, () => {
           if (calledTimes === 3) {
             return of(recoveredValue);
           }
-          return throwError(error);
+          return throwError(() => error);
         });
         const test$ = source$.pipe(backOff());
 
@@ -37,7 +37,7 @@ describe(`backOff`, () => {
       it(`should NOT be able to recover`, fakeAsync(() => {
         const initialError = 'error';
 
-        const source$ = throwError(initialError);
+        const source$ = throwError(() => initialError);
         const test$ = source$.pipe(backOff());
 
         let result: string | undefined;
@@ -72,7 +72,7 @@ describe(`backOff`, () => {
     describe(`errFn`, () => {
       describe(`evaluates to false`, () => {
         it(`should not retry and just re-throw the error`, (done) => {
-          const source$ = throwError('error');
+          const source$ = throwError(() => 'error');
           const test$ = source$.pipe(backOff({ shouldRetry: () => false }));
 
           test$.subscribe({
@@ -89,7 +89,7 @@ describe(`backOff`, () => {
           it(`should re-throw the initial error`, fakeAsync(() => {
             const initialError = 'error';
 
-            const source$ = throwError(initialError);
+            const source$ = throwError(() => initialError);
             const test$ = source$.pipe(backOff({ shouldRetry: doBackOff }));
 
             let result: string | undefined;
@@ -110,7 +110,7 @@ describe(`backOff`, () => {
             const initialError = 'error';
             const recoveredValue = 'xxx';
 
-            const error$ = throwError(initialError);
+            const error$ = throwError(() => initialError);
             // at first, we throw an error by returning the false
             const recovery$ = new BehaviorSubject<boolean>(false);
             const source$ = recovery$.pipe(
@@ -153,7 +153,9 @@ describe(`backOff`, () => {
           };
 
           const error$ = new BehaviorSubject<HttpErrorModel>(initialError);
-          const source$ = error$.pipe(switchMap((error) => throwError(error)));
+          const source$ = error$.pipe(
+            switchMap((error) => throwError(() => error))
+          );
 
           let errorResult: HttpErrorModel | undefined;
           let result: HttpErrorModel | undefined;
@@ -187,7 +189,7 @@ describe(`backOff`, () => {
       it(`should use the provided maxTries option`, fakeAsync(() => {
         const initialError = 'error';
 
-        const source$ = throwError(initialError);
+        const source$ = throwError(() => initialError);
         const test$ = source$.pipe(
           backOff({ shouldRetry: doBackOff, maxTries: 2 })
         );
@@ -207,7 +209,7 @@ describe(`backOff`, () => {
       it(`should use the provided delay option`, fakeAsync(() => {
         const initialError = 'error';
 
-        const source$ = throwError(initialError);
+        const source$ = throwError(() => initialError);
         const test$ = source$.pipe(
           backOff({ shouldRetry: doBackOff, delay: 100 })
         );
@@ -227,7 +229,7 @@ describe(`backOff`, () => {
       it(`should use both the provided maxTries and delay options`, fakeAsync(() => {
         const initialError = 'error';
 
-        const source$ = throwError(initialError);
+        const source$ = throwError(() => initialError);
         const test$ = source$.pipe(
           backOff({ shouldRetry: doBackOff, maxTries: 2, delay: 100 })
         );

--- a/projects/core/src/util/rxjs/back-off.ts
+++ b/projects/core/src/util/rxjs/back-off.ts
@@ -4,15 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  Observable,
-  of,
-  OperatorFunction,
-  range,
-  throwError,
-  timer,
-  zip,
-} from 'rxjs';
+import { Observable, of, OperatorFunction, range, timer, zip } from 'rxjs';
 import { map, mergeMap, retryWhen } from 'rxjs/operators';
 import { HttpErrorModel } from '../../model/misc.model';
 
@@ -62,7 +54,7 @@ export function backOff<T>(options?: BackOffOptions): OperatorFunction<T, T> {
             // if we've re-tried more than the maxTries, OR
             // if the source error is not the one we want to exponentially retry
             if (currentRetry > maxTries || !shouldRetry(attemptError)) {
-              return throwError(() => attemptError);
+              throw attemptError;
             }
 
             return of(currentRetry);

--- a/projects/core/src/util/rxjs/back-off.ts
+++ b/projects/core/src/util/rxjs/back-off.ts
@@ -62,7 +62,7 @@ export function backOff<T>(options?: BackOffOptions): OperatorFunction<T, T> {
             // if we've re-tried more than the maxTries, OR
             // if the source error is not the one we want to exponentially retry
             if (currentRetry > maxTries || !shouldRetry(attemptError)) {
-              return throwError(attemptError);
+              return throwError(() => attemptError);
             }
 
             return of(currentRetry);


### PR DESCRIPTION
The primary signature of `throwError` now accepts an error factory function as its argument.  
In addition to this change, other operators using a callback or projection function have been refactored such that you can simpler and clearer `throw`-keyword to notify the error output of the observable, instead of using `throwError` with an error factory.