### PR TITLE
feat: retry OPF placeOrder and paymentVerify calls when 500 statusCode

### DIFF
--- a/integration-libs/opf/occ/adapters/occ-opf-order.adapter.ts
+++ b/integration-libs/opf/occ/adapters/occ-opf-order.adapter.ts
@@ -21,6 +21,7 @@ import { OpfOrderAdapter } from '@spartacus/opf/core';
 import { Order, ORDER_NORMALIZER } from '@spartacus/order/root';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
+import { isHttp500Error } from '../utils/opf-occ-http-error-handlers';
 
 @Injectable()
 export class OccOpfOrderAdapter implements OpfOrderAdapter {
@@ -53,6 +54,10 @@ export class OccOpfOrderAdapter implements OpfOrderAdapter {
         catchError((error) => throwError(normalizeHttpError(error))),
         backOff({
           shouldRetry: isJaloError,
+        }),
+        backOff({
+          shouldRetry: isHttp500Error,
+          maxTries: 2,
         }),
         this.converter.pipeable(ORDER_NORMALIZER)
       );

--- a/integration-libs/opf/occ/adapters/occ-opf.adapter.ts
+++ b/integration-libs/opf/occ/adapters/occ-opf.adapter.ts
@@ -31,6 +31,7 @@ import {
 } from '@spartacus/opf/root';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
+import { isHttp500Error } from '../utils/opf-occ-http-error-handlers';
 
 @Injectable()
 export class OccOpfAdapter implements OpfAdapter {
@@ -120,6 +121,10 @@ export class OccOpfAdapter implements OpfAdapter {
         catchError((error) => throwError(error)),
         backOff({
           shouldRetry: isJaloError,
+        }),
+        backOff({
+          shouldRetry: isHttp500Error,
+          maxTries: 2,
         }),
         this.converter.pipeable(OPF_PAYMENT_VERIFICATION_NORMALIZER)
       );

--- a/integration-libs/opf/occ/utils/opf-occ-http-error-handlers.ts
+++ b/integration-libs/opf/occ/utils/opf-occ-http-error-handlers.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { HttpErrorModel } from '@spartacus/core';
 
 export function isHttp500Error(err: HttpErrorModel): boolean {

--- a/integration-libs/opf/occ/utils/opf-occ-http-error-handlers.ts
+++ b/integration-libs/opf/occ/utils/opf-occ-http-error-handlers.ts
@@ -7,5 +7,5 @@
 import { HttpErrorModel } from '@spartacus/core';
 
 export function isHttp500Error(err: HttpErrorModel): boolean {
-  return err?.status && err.status >= 500 ? true : false;
+  return !!err?.status && err.status >= 500;
 }

--- a/integration-libs/opf/occ/utils/opf-occ-http-error-handlers.ts
+++ b/integration-libs/opf/occ/utils/opf-occ-http-error-handlers.ts
@@ -1,0 +1,5 @@
+import { HttpErrorModel } from '@spartacus/core';
+
+export function isHttp500Error(err: HttpErrorModel): boolean {
+  return err?.status && err.status >= 500 ? true : false;
+}


### PR DESCRIPTION
Cover CXSPA-3168 and CXSPA-3167
2 attempts on OPF Adapter Verify request when response is http statusCode 5xx
2 attempts on OCC PlaveOrderV2 request when response is http statusCode 5xx
<img width="1386" alt="image" src="https://github.com/SAP/spartacus/assets/30024415/8a464ffe-c661-47d5-832b-3c1b48255917">
