### PR TITLE
Refactor opf-checkout-billing-address component

### DIFF
--- a/integration-libs/opf/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.html
+++ b/integration-libs/opf/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.html
@@ -3,7 +3,7 @@
     *ngIf="{
       billingAddress: billingAddress$ | async,
       isSameAsDelivery: isSameAsDelivery$ | async
-    } as observables"
+    } as addressData"
   >
     <div class="form-group">
       <div class="form-check">
@@ -11,7 +11,7 @@
           <input
             type="checkbox"
             class="form-check-input"
-            [checked]="observables.isSameAsDelivery"
+            [checked]="addressData.isSameAsDelivery"
             (change)="toggleSameAsDeliveryAddress()"
             [attr.aria-label]="
               'paymentForm.billingAddressSameAsShipping' | cxTranslate
@@ -24,14 +24,14 @@
       </div>
     </div>
 
-    <ng-container *ngIf="!isEditBillingAddress && observables.billingAddress">
+    <ng-container *ngIf="!isEditBillingAddress && addressData.billingAddress">
       <div class="cx-custom-address-info">
         <cx-card
-          [content]="observables.billingAddress | cxGetAddressCardContent"
+          [content]="addressData.billingAddress | cxGetAddressCardContent"
         ></cx-card>
 
         <button
-          *ngIf="!observables.isSameAsDelivery"
+          *ngIf="!addressData.isSameAsDelivery"
           (click)="editCustomBillingAddress()"
         >
           <cx-icon [type]="iconTypes.PENCIL"></cx-icon>
@@ -41,7 +41,7 @@
 
     <ng-container *ngIf="isEditBillingAddress">
       <cx-address-form
-        [addressData]="observables.billingAddress || {}"
+        [addressData]="addressData.billingAddress || {}"
         class="cx-form"
         [showTitleCode]="true"
         [showCancelBtn]="true"

--- a/integration-libs/opf/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.html
+++ b/integration-libs/opf/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.html
@@ -1,67 +1,61 @@
 <ng-container *ngIf="!(isLoadingAddress$ | async); else loading">
-  <div class="form-group">
-    <div class="form-check">
-      <label>
-        <input
-          type="checkbox"
-          class="form-check-input"
-          [checked]="isSameAsDelivery"
-          (change)="toggleSameAsDeliveryAddress()"
-          [attr.aria-label]="
-            'paymentForm.billingAddressSameAsShipping' | cxTranslate
-          "
-        />
-        <span class="form-check-label">{{
-          'paymentForm.sameAsDeliveryAddress' | cxTranslate
-        }}</span>
-      </label>
-    </div>
-  </div>
-
   <ng-container
-    *ngIf="
-      !isEditBillingAddress &&
-      isSameAsDelivery &&
-      (deliveryAddress$ | async) as deliveryAddress
-    "
+    *ngIf="{
+      billingAddress: billingAddress$ | async,
+      isSameAsDelivery: isSameAsDelivery$ | async
+    } as observables"
   >
-    <cx-card [content]="deliveryAddress | cxGetAddressCardContent"></cx-card>
-  </ng-container>
-
-  <ng-container
-    *ngIf="
-      !isEditBillingAddress &&
-      !isSameAsDelivery &&
-      (billingAddress$ | async) as userCustomBillingAddress
-    "
-  >
-    <div class="cx-custom-address-info">
-      <cx-card
-        [content]="userCustomBillingAddress | cxGetAddressCardContent"
-      ></cx-card>
-
-      <button (click)="editCustomBillingAddress()">
-        <cx-icon [type]="iconTypes.PENCIL"></cx-icon>
-      </button>
+    <div class="form-group">
+      <div class="form-check">
+        <label>
+          <input
+            type="checkbox"
+            class="form-check-input"
+            [checked]="observables.isSameAsDelivery"
+            (change)="toggleSameAsDeliveryAddress()"
+            [attr.aria-label]="
+              'paymentForm.billingAddressSameAsShipping' | cxTranslate
+            "
+          />
+          <span class="form-check-label">{{
+            'paymentForm.sameAsDeliveryAddress' | cxTranslate
+          }}</span>
+        </label>
+      </div>
     </div>
+
+    <ng-container *ngIf="!isEditBillingAddress && observables.billingAddress">
+      <div class="cx-custom-address-info">
+        <cx-card
+          [content]="observables.billingAddress | cxGetAddressCardContent"
+        ></cx-card>
+
+        <button
+          *ngIf="!observables.isSameAsDelivery"
+          (click)="editCustomBillingAddress()"
+        >
+          <cx-icon [type]="iconTypes.PENCIL"></cx-icon>
+        </button>
+      </div>
+    </ng-container>
+
+    <ng-container *ngIf="isEditBillingAddress">
+      <cx-address-form
+        [addressData]="observables.billingAddress || {}"
+        class="cx-form"
+        [showTitleCode]="true"
+        [showCancelBtn]="true"
+        actionBtnLabel="{{ 'common.save' | cxTranslate }}"
+        cancelBtnLabel="{{ 'common.cancel' | cxTranslate }}"
+        (submitAddress)="onSubmitAddress($event)"
+        (backToAddress)="cancelAndHideForm()"
+        [setAsDefaultField]="false"
+        [countries]="countries$"
+      ></cx-address-form>
+    </ng-container>
   </ng-container>
 </ng-container>
 
 <ng-template #loading>
   <cx-spinner></cx-spinner>
 </ng-template>
-
-<ng-container *ngIf="isEditBillingAddress">
-  <cx-address-form
-    [addressData]="(billingAddress$ | async) || {}"
-    class="cx-form"
-    [showTitleCode]="true"
-    [showCancelBtn]="true"
-    actionBtnLabel="{{ 'common.save' | cxTranslate }}"
-    cancelBtnLabel="{{ 'common.cancel' | cxTranslate }}"
-    (submitAddress)="onSubmitAddress($event)"
-    (backToAddress)="cancelAndHideForm()"
-    [setAsDefaultField]="false"
-    [countries]="countries$"
-  ></cx-address-form>
-</ng-container>

--- a/integration-libs/opf/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.module.ts
+++ b/integration-libs/opf/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.module.ts
@@ -19,7 +19,6 @@ import {
 } from '@spartacus/storefront';
 import { GetAddressCardContent } from './get-address-card-content.pipe';
 import { OpfCheckoutBillingAddressFormComponent } from './opf-checkout-billing-address-form.component';
-import { OpfCheckoutBillingAddressFormService } from './opf-checkout-billing-address-form.service';
 
 @NgModule({
   declarations: [OpfCheckoutBillingAddressFormComponent, GetAddressCardContent],
@@ -36,6 +35,5 @@ import { OpfCheckoutBillingAddressFormService } from './opf-checkout-billing-add
     AddressFormModule,
     SpinnerModule,
   ],
-  providers: [OpfCheckoutBillingAddressFormService],
 })
 export class OpfCheckoutBillingAddressFormModule {}


### PR DESCRIPTION
- Fixed bug with old address in subject by moving service to component providers from module. Now Service destroyed with the component and state of service properties are fresh related to component
- Removed delivery address from component and service, because basically component should not be interested in what it is displaying, delivery address or billing, thanks to this a little bit simplified logic inside of template and component.
- isSameAsDelivery flag moved to the service