### PR TITLE
CXSPA-3535: Fix regression in command service error handling

### DIFF
--- a/integration-libs/cdc/user-profile/register/cdc-register-component.service.ts
+++ b/integration-libs/cdc/user-profile/register/cdc-register-component.service.ts
@@ -22,15 +22,18 @@ import {
   UserRegisterFacade,
   UserSignUp,
 } from '@spartacus/user/profile/root';
-import { merge, Observable, throwError } from 'rxjs';
+import { Observable, merge, throwError } from 'rxjs';
 import { filter, map, switchMap, tap } from 'rxjs/operators';
 
 @Injectable()
 export class CDCRegisterComponentService extends RegisterComponentService {
   protected registerCommand: Command<{ user: UserSignUp }, User> =
-    this.command.create(({ user }) =>
-      // Registering user through CDC Gigya SDK
-      this.cdcJSService.registerUserWithoutScreenSet(user)
+    this.command.create(
+      ({ user }) =>
+        // Registering user through CDC Gigya SDK
+        this.cdcJSService.registerUserWithoutScreenSet(
+          user
+        ) as unknown as Observable<User>
     );
 
   protected loadUserTokenFailed$: Observable<boolean> = this.eventService

--- a/projects/core/src/util/command-query/command.service.spec.ts
+++ b/projects/core/src/util/command-query/command.service.spec.ts
@@ -1,19 +1,31 @@
 import { TestBed } from '@angular/core/testing';
 
-import { EMPTY, Observable, PartialObserver, Subject, of } from 'rxjs';
+import {
+  EMPTY,
+  NEVER,
+  Observable,
+  PartialObserver,
+  Subject,
+  of,
+  throwError,
+} from 'rxjs';
 import { Command, CommandService, CommandStrategy } from './command.service';
 
-/** Utility function to create a full observer filled with spies and optional overrides */
+/** Utility function to create a full observer filled with spies */
 function createObserverSpy<T>(
-  name: string,
-  observerOverrides?: PartialObserver<T>
+  name: string
 ): jasmine.SpyObj<PartialObserver<T>> {
-  return jasmine.createSpyObj(name, {
+  const mockObserver = jasmine.createSpyObj(name, {
     next: () => {},
     error: () => {},
     complete: () => {},
-    ...observerOverrides,
   });
+  // use default method
+  mockObserver.next.and.callThrough();
+  mockObserver.error.and.callThrough();
+  mockObserver.complete.and.callThrough();
+
+  return mockObserver;
 }
 
 describe('CommandService', () => {
@@ -34,45 +46,71 @@ describe('CommandService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('create should return command', () => {
-    const command = service.create(() => EMPTY);
-    expect(command.execute).toBeDefined();
+  describe('create()', () => {
+    it('should return command', () => {
+      const command = service.create(() => EMPTY);
+      expect(command.execute).toBeDefined();
+    });
   });
 
-  describe('command', () => {
-    let command: Command<string, string>;
-    let commandExecutedTimes: number;
+  describe('command()', () => {
+    let mockRuntimeError: Error;
+    let faultyCommandFactoryControl: { shouldThrowError: boolean };
+    let faultyCommandFactory: jasmine.Spy<
+      (cmd: Observable<string>) => Observable<string>
+    >;
+    let commandFactory: jasmine.Spy<
+      (cmd: Observable<string>) => Observable<string>
+    >;
 
     beforeEach(() => {
-      commandExecutedTimes = 0;
-      command = service.create((input) => {
-        commandExecutedTimes++;
-        return of(input + commandExecutedTimes);
-      });
+      commandFactory = jasmine.createSpy('commandFactory', (cmd) => cmd);
+      commandFactory.and.callThrough();
+
+      faultyCommandFactoryControl = { shouldThrowError: true };
+      mockRuntimeError = new Error('mock runtime error');
+      mockRuntimeError.stack = undefined; // stack trace not relevant on a static error value
+      faultyCommandFactory = jasmine.createSpy(
+        'faultyCommandFactory',
+        (cmd) => {
+          if (faultyCommandFactoryControl.shouldThrowError) {
+            throw mockRuntimeError;
+          } else {
+            return cmd;
+          }
+        }
+      );
+      faultyCommandFactory.and.callThrough();
     });
 
     it('should execute command without subscription', () => {
-      expect(commandExecutedTimes).toBe(0);
-      command.execute('test');
-      expect(commandExecutedTimes).toBe(1);
+      let command = service.create(commandFactory);
+
+      expect(commandFactory).toHaveBeenCalledTimes(0);
+      command.execute(of('test'));
+      expect(commandFactory).toHaveBeenCalledTimes(1);
     });
 
-    it('should execute command and return result', (done) => {
-      command.execute('test').subscribe((result) => {
-        expect(result).toEqual('test1');
-        done();
+    it('should execute command and return result', () => {
+      let command = service.create(commandFactory);
+      const expected = 'test';
+      const input = of(expected);
+
+      command.execute(input).subscribe((result) => {
+        expect(result).toEqual(expected);
       });
     });
 
-    describe('CommandStrategy.Queue', () => {
+    describe('with CommandStrategy.Queue', () => {
       let queueCommand: Command<Observable<string>, string>;
+      const strategy = CommandStrategy.Queue;
       let observer1: jasmine.SpyObj<PartialObserver<string>>;
       let observer2: jasmine.SpyObj<PartialObserver<string>>;
 
       beforeEach(() => {
         // use argument as command request
-        queueCommand = service.create((obs) => obs, {
-          strategy: CommandStrategy.Queue,
+        queueCommand = service.create(commandFactory, {
+          strategy: strategy,
         });
 
         spyOn(request1, 'subscribe').and.callThrough();
@@ -80,6 +118,32 @@ describe('CommandService', () => {
 
         observer1 = createObserverSpy('observer1');
         observer2 = createObserverSpy('observer2');
+      });
+
+      it('should catch commandFactory errors and pass them to the notifier', () => {
+        queueCommand = service.create(faultyCommandFactory, {
+          strategy: strategy,
+        });
+
+        queueCommand.execute(of('')).subscribe(observer1);
+
+        expect(observer1.error).toHaveBeenCalledWith(mockRuntimeError);
+      });
+
+      it('should continue processing other commands after a commandFactory error', () => {
+        const observer1 = createObserverSpy('observer1');
+        const observer2 = createObserverSpy('observer2');
+        queueCommand = service.create(faultyCommandFactory, {
+          strategy: strategy,
+        });
+        const expected = '';
+        faultyCommandFactoryControl.shouldThrowError = true;
+
+        queueCommand.execute(NEVER).subscribe(observer1);
+        faultyCommandFactoryControl.shouldThrowError = false;
+        queueCommand.execute(of(expected)).subscribe(observer2);
+
+        expect(observer2.next).toHaveBeenCalledWith(expected);
       });
 
       it('should queue subsequent requests when the preceding request is in-progress', () => {
@@ -90,8 +154,8 @@ describe('CommandService', () => {
         expect(request2.subscribe).not.toHaveBeenCalled();
       });
 
-      it('should queue requests as the default method', () => {
-        queueCommand = service.create((obs) => obs);
+      it('should queue requests as the default strategy', () => {
+        queueCommand = service.create(commandFactory);
         queueCommand.execute(request1);
         queueCommand.execute(request2);
 
@@ -128,33 +192,61 @@ describe('CommandService', () => {
       });
     });
 
-    describe('CommandStrategy.Parallel', () => {
-      let paralleCommand: Command<Observable<string>, string>;
+    describe('with CommandStrategy.Parallel', () => {
+      let parallelCommand: Command<Observable<string>, string>;
+      const strategy = CommandStrategy.Parallel;
 
       beforeEach(() => {
         // use argument as command request
-        paralleCommand = service.create((obs) => obs, {
-          strategy: CommandStrategy.Parallel,
+        parallelCommand = service.create(commandFactory, {
+          strategy: strategy,
         });
         spyOn(request1, 'subscribe').and.callThrough();
         spyOn(request2, 'subscribe').and.callThrough();
       });
 
+      it('should catch commandFactory errors and pass them to the notifier', () => {
+        const observer = createObserverSpy('observer');
+        parallelCommand = service.create(faultyCommandFactory, {
+          strategy: strategy,
+        });
+
+        parallelCommand.execute(NEVER).subscribe(observer);
+
+        expect(observer.error).toHaveBeenCalledWith(mockRuntimeError);
+      });
+
+      it('should continue processing other commands after a commandFactory error', () => {
+        const observer1 = createObserverSpy('observer1');
+        const observer2 = createObserverSpy('observer2');
+        parallelCommand = service.create(faultyCommandFactory, {
+          strategy: strategy,
+        });
+        const expected = '';
+        faultyCommandFactoryControl.shouldThrowError = true;
+
+        parallelCommand.execute(NEVER).subscribe(observer1);
+        faultyCommandFactoryControl.shouldThrowError = false;
+        parallelCommand.execute(of(expected)).subscribe(observer2);
+
+        expect(observer2.next).toHaveBeenCalledWith(expected);
+      });
+
       it('should initiate requests in parallel', () => {
-        paralleCommand.execute(request1);
-        paralleCommand.execute(request2);
+        parallelCommand.execute(request1);
+        parallelCommand.execute(request2);
 
         expect(request1.subscribe).toHaveBeenCalled();
         expect(request2.subscribe).toHaveBeenCalled();
       });
 
-      it('should not allow errors in one request to interfere with other requests', () => {
+      it('should not allow an error in one request to interfere with other in-progress requests', () => {
         let expected = 'result2';
         let expectedError = 'error1';
         const observer1 = createObserverSpy('observer1');
         const observer2 = createObserverSpy('observer2');
-        paralleCommand.execute(request1).subscribe(observer1);
-        paralleCommand.execute(request2).subscribe(observer2);
+        parallelCommand.execute(request1).subscribe(observer1);
+        parallelCommand.execute(request2).subscribe(observer2);
 
         request1.error(expectedError);
         request2.next(expected);
@@ -167,13 +259,14 @@ describe('CommandService', () => {
       });
     });
 
-    describe('CommandStrategy.CancelPrevious', () => {
+    describe('with CommandStrategy.CancelPrevious', () => {
       let cancelPrevCommand: Command<Observable<string>, string>;
+      const strategy = CommandStrategy.CancelPrevious;
 
       beforeEach(() => {
         // use argument as command request
-        cancelPrevCommand = service.create((obs) => obs, {
-          strategy: CommandStrategy.CancelPrevious,
+        cancelPrevCommand = service.create(commandFactory, {
+          strategy: strategy,
         });
         spyOn(request1, 'unsubscribe').and.callThrough();
       });
@@ -189,26 +282,125 @@ describe('CommandService', () => {
         expect(observer1.error).not.toHaveBeenCalled();
         expect(observer1.complete).toHaveBeenCalled();
       });
+
+      it('should catch commandFactory errors and pass them to the notifier', () => {
+        const observer = createObserverSpy('observer');
+        cancelPrevCommand = service.create(faultyCommandFactory, {
+          strategy: strategy,
+        });
+
+        cancelPrevCommand.execute(NEVER).subscribe(observer);
+
+        expect(observer.error).toHaveBeenCalledWith(mockRuntimeError);
+      });
+
+      it('should continue processing other commands after a commandFactory error', () => {
+        const observer1 = createObserverSpy('observer1');
+        const observer2 = createObserverSpy('observer2');
+        cancelPrevCommand = service.create(faultyCommandFactory, {
+          strategy: strategy,
+        });
+        const expected = '';
+        faultyCommandFactoryControl.shouldThrowError = true;
+
+        cancelPrevCommand.execute(NEVER).subscribe(observer1);
+        faultyCommandFactoryControl.shouldThrowError = false;
+        cancelPrevCommand.execute(of(expected)).subscribe(observer2);
+
+        expect(observer2.next).toHaveBeenCalledWith(expected);
+      });
     });
 
-    describe('CommandStrategy.ErrorPrevious', () => {
+    describe('with CommandStrategy.ErrorPrevious', () => {
       let errorPrevCommand: Command<Observable<string>, string>;
+      const strategy = CommandStrategy.ErrorPrevious;
 
       beforeEach(() => {
         // use argument as command request
         errorPrevCommand = service.create((obs) => obs, {
-          strategy: CommandStrategy.ErrorPrevious,
+          strategy: strategy,
         });
       });
 
-      it('should error in-progress requests', () => {
+      it('should mirror the command request notifications to the subscriber', () => {
+        const observer = createObserverSpy('observer1');
+        const expected = 'expected value';
+
+        errorPrevCommand.execute(request1).subscribe(observer);
+        request1.next(expected);
+        request1.complete();
+
+        expect(observer.next).toHaveBeenCalledWith(expected);
+        expect(observer.error).not.toHaveBeenCalled();
+        expect(observer.complete).toHaveBeenCalled();
+      });
+
+      it('should error in-progress requests when new request comes in', () => {
+        let actual: Error | undefined;
+        const observer1 = createObserverSpy('observer1');
+        (observer1.error as jasmine.Spy).and.callFake(
+          (result) => (actual = result)
+        );
+        const observer2 = createObserverSpy('observer2');
+
+        errorPrevCommand.execute(request1).subscribe(observer1);
+        errorPrevCommand.execute(request2).subscribe(observer2);
+
+        request1.next('r1');
+        request1.complete();
+
+        expect(observer1.error).toHaveBeenCalledWith(jasmine.any(Error));
+        expect(actual?.message).toEqual('Canceled by next command');
+      });
+
+      it('should not error completed requests', () => {
         const observer1 = createObserverSpy('observer1');
         const observer2 = createObserverSpy('observer2');
+
         errorPrevCommand.execute(request1).subscribe(observer1);
+        request1.complete();
 
         errorPrevCommand.execute(request2).subscribe(observer2);
 
-        expect(observer1.error).toHaveBeenCalledWith(jasmine.any(Error));
+        expect(observer1.error).not.toHaveBeenCalled();
+      });
+
+      it("should mirror the commandFactory observable's error notifications to the subscriber", () => {
+        const observer = createObserverSpy('observer');
+        const mockRequestError = new Error('request error');
+
+        errorPrevCommand
+          .execute(throwError(mockRequestError))
+          .subscribe(observer);
+
+        expect(observer.error).toHaveBeenCalledWith(mockRequestError);
+      });
+
+      it('should catch errors thrown by commandFactory and pass them to the subscriber', () => {
+        const observer = createObserverSpy('observer');
+        errorPrevCommand = service.create(faultyCommandFactory, {
+          strategy: strategy,
+        });
+
+        errorPrevCommand.execute(NEVER).subscribe(observer);
+
+        expect(observer.error).toHaveBeenCalledWith(mockRuntimeError);
+      });
+
+      it('should continue processing other commands after a commandFactory error', () => {
+        const observer1 = createObserverSpy('observer1');
+        const observer2 = createObserverSpy('observer2');
+        errorPrevCommand = service.create(faultyCommandFactory, {
+          strategy: strategy,
+        });
+        const expected = '';
+        faultyCommandFactoryControl.shouldThrowError = true;
+
+        errorPrevCommand.execute(NEVER).subscribe(observer1);
+        faultyCommandFactoryControl.shouldThrowError = false;
+        errorPrevCommand.execute(of(expected)).subscribe(observer2);
+
+        expect(observer2.next).toHaveBeenCalledWith(expected);
       });
     });
   });

--- a/projects/core/src/util/command-query/command.service.spec.ts
+++ b/projects/core/src/util/command-query/command.service.spec.ts
@@ -222,7 +222,7 @@ describe('CommandService', () => {
         parallelCommand = service.create(faultyCommandFactory, {
           strategy: strategy,
         });
-        const expected = '';
+        const expected = 'expected value';
         faultyCommandFactoryControl.shouldThrowError = true;
 
         parallelCommand.execute(NEVER).subscribe(observer1);
@@ -241,7 +241,7 @@ describe('CommandService', () => {
       });
 
       it('should not allow an error in one request to interfere with other in-progress requests', () => {
-        let expected = 'result2';
+        let expectedValue = 'result2';
         let expectedError = 'error1';
         const observer1 = createObserverSpy('observer1');
         const observer2 = createObserverSpy('observer2');
@@ -249,12 +249,12 @@ describe('CommandService', () => {
         parallelCommand.execute(request2).subscribe(observer2);
 
         request1.error(expectedError);
-        request2.next(expected);
+        request2.next(expectedValue);
         request2.complete();
 
         expect(observer1.next).not.toHaveBeenCalled();
         expect(observer1.error).toHaveBeenCalledWith(expectedError);
-        expect(observer2.next).toHaveBeenCalledWith(expected);
+        expect(observer2.next).toHaveBeenCalledWith(expectedValue);
         expect(observer2.complete).toHaveBeenCalled();
       });
     });

--- a/projects/core/src/util/command-query/command.service.ts
+++ b/projects/core/src/util/command-query/command.service.ts
@@ -11,14 +11,13 @@ import {
   ReplaySubject,
   Subject,
   Subscription,
+  defer,
   zip,
 } from 'rxjs';
 import {
   catchError,
   concatMap,
-  finalize,
   mergeMap,
-  retry,
   switchMap,
   tap,
 } from 'rxjs/operators';
@@ -47,36 +46,62 @@ export class CommandService implements OnDestroy {
   }
 
   create<PARAMS = undefined, RESULT = unknown>(
-    commandFactory: (command: PARAMS) => Observable<any>,
+    commandFactory: (command: PARAMS) => Observable<RESULT>,
     options?: { strategy?: CommandStrategy }
   ): Command<PARAMS, RESULT> {
     const commands$ = new Subject<PARAMS>();
     const results$ = new Subject<ReplaySubject<RESULT>>();
 
-    let process$: Observable<any>;
+    let process$: Observable<unknown>;
 
     switch (options?.strategy) {
       case CommandStrategy.CancelPrevious:
       case CommandStrategy.ErrorPrevious:
         process$ = zip(commands$, results$).pipe(
-          switchMap(([cmd, notifier$]) =>
-            commandFactory(cmd).pipe(
-              tap(notifier$),
-              finalize(() =>
-                options.strategy === CommandStrategy.CancelPrevious
-                  ? notifier$.complete()
-                  : notifier$.error(new Error('Canceled by next command'))
-              )
-            )
-          ),
-          retry()
+          switchMap(
+            ([cmd, notifier$]) =>
+              new Observable((subscriber) => {
+                // connect notifier to command factory return observable
+                const commandSubscription = defer(() =>
+                  commandFactory(cmd)
+                ).subscribe({
+                  next: (n) => {
+                    notifier$.next(n);
+                  },
+                  error: (e) => {
+                    notifier$.error(e);
+                    subscriber.complete();
+                  },
+                  complete: () => {
+                    notifier$.complete();
+                    subscriber.complete();
+                  },
+                });
+
+                // add unsubscribe logic
+                subscriber.add(() => {
+                  commandSubscription.unsubscribe();
+
+                  if (!notifier$.closed && !notifier$.hasError) {
+                    // command has ended yet, so close notifier$ according to strategy
+                    if (options.strategy === CommandStrategy.CancelPrevious) {
+                      notifier$.complete();
+                    } else {
+                      notifier$.error(new Error('Canceled by next command'));
+                    }
+                  }
+                });
+
+                return commandSubscription;
+              })
+          )
         );
         break;
 
       case CommandStrategy.Parallel:
         process$ = zip(commands$, results$).pipe(
           mergeMap(([cmd, notifier$]) =>
-            commandFactory(cmd).pipe(
+            defer(() => commandFactory(cmd)).pipe(
               tap(notifier$),
               catchError(() => EMPTY)
             )
@@ -88,7 +113,7 @@ export class CommandService implements OnDestroy {
       default:
         process$ = zip(commands$, results$).pipe(
           concatMap(([cmd, notifier$]) =>
-            commandFactory(cmd).pipe(
+            defer(() => commandFactory(cmd)).pipe(
               tap(notifier$),
               catchError(() => EMPTY)
             )


### PR DESCRIPTION
Catch errors thrown by the commandFactory function and pass them to the subscriber.