### PR TITLE
Set z-index property to a higher number for navigation header

### DIFF
--- a/projects/storefrontstyles/scss/components/layout/header/_header.scss
+++ b/projects/storefrontstyles/scss/components/layout/header/_header.scss
@@ -38,7 +38,7 @@ $space: 0.5rem;
     .navigation {
       position: absolute;
       width: 100%;
-      z-index: 3;
+      z-index: 20;
 
       @include media-breakpoint-down(md) {
         height: 100vh;


### PR DESCRIPTION
Configurator readOnly view (order history / checkout process): Catalog and overview not properly aligned in mobile view