### PR TITLE
Fix failing cypress test: quantity stepper next to add-to-cart button

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-cart.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-cart.e2e-flaky.cy.ts
@@ -115,15 +115,18 @@ context('Product Configuration', () => {
       configuration.increaseQuantity();
       configuration.decreaseQuantity();
       configuration.enterQuantityValue(10);
+      configuration.checkQuantityStepper(10);
       configurationVc.clickAddToCartBtn();
-      configurationOverviewVc.checkQuantity(10);
+      configurationOverviewVc.checkQuantityNotDisplayed();
       configurationVc.goToCart(electronicsShop);
       configurationCart.checkQuantityStepper(0, 10);
       configurationCart.increaseQuantity(0);
       configurationCart.increaseQuantity(0);
       configurationCart.decreaseQuantity(0);
+      configurationCart.checkQuantityStepper(0, 11);
       configurationCart.clickOnEditConfigurationLink(0);
-      configuration.checkQuantity(11);
+      configuration.checkQuantityStepperNotDisplayed();
+      configuration.checkQuantityNotDisplayed();
     });
   });
 

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview-vc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview-vc.ts
@@ -259,7 +259,7 @@ export function checkViewPortScrolledToGroup(groupIdx: number) {
 }
 
 /**
- * Verifies whether a quantity value that has been entered into the quantity stepper is not displayed next to the add-to-cart button.
+ * Verifies that quantity is not displayed.
  */
 export function checkQuantityNotDisplayed() {
   cy.get(addToCartQuantitySelector).should('not.exist');

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview-vc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview-vc.ts
@@ -259,12 +259,8 @@ export function checkViewPortScrolledToGroup(groupIdx: number) {
 }
 
 /**
- * Verifies whether a quantity value that has been entered into the quantity stepper is equal to the expected value.
- *
- * @param expectedValue
+ * Verifies whether a quantity value that has been entered into the quantity stepper is not displayed next to the add-to-cart button.
  */
-export function checkQuantity(expectedValue: number) {
-  cy.get(addToCartQuantitySelector).then((elem) => {
-    expect(elem.text().trim()).to.equal(expectedValue.toString());
-  });
+export function checkQuantityNotDisplayed() {
+  cy.get(addToCartQuantitySelector).should('not.exist');
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
@@ -591,6 +591,20 @@ export function clickExitConfigurationBtn(): void {
 }
 
 /**
+ * Verifies whether the quantity stepper is not displayed next to the add-to-cart button.
+ */
+export function checkQuantityStepperNotDisplayed() {
+  cy.get(quantityStepperSelector).should('not.exist');
+}
+
+/**
+ * Verifies whether a quantity value that has been entered into the quantity stepper is not displayed next to the add-to-cart button.
+ */
+export function checkQuantityNotDisplayed() {
+  cy.get(quantitySelector).should('not.exist');
+}
+
+/**
  * Verifies whether a quantity value that is entered into the quantity stepper is equal to the expected value.
  *
  * @param {number} expectedValue - expected quantity value

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
@@ -598,7 +598,7 @@ export function checkQuantityStepperNotDisplayed() {
 }
 
 /**
- * Verifies whether a quantity value that has been entered into the quantity stepper is not displayed next to the add-to-cart button.
+ * Verifies that quantity is not displayed.
  */
 export function checkQuantityNotDisplayed() {
   cy.get(quantitySelector).should('not.exist');


### PR DESCRIPTION
Fix failing cypress test: quantity stepper next to add-to-cart button