### PR TITLE
fix: Set z-index property to a higher number for navigation header

### DIFF
--- a/projects/storefrontstyles/scss/components/layout/header/_header.scss
+++ b/projects/storefrontstyles/scss/components/layout/header/_header.scss
@@ -38,7 +38,7 @@ $space: 0.5rem;
     .navigation {
       position: absolute;
       width: 100%;
-      z-index: 3;
+      z-index: 20;
 
       @include media-breakpoint-down(md) {
         height: 100vh;


### PR DESCRIPTION
Set z-index property to a higher number for the navigation header to hide completely all elements behind the header when it is expanded