### PR TITLE
fix: Login page displayed for few seconds when payment canceled/failed

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -145,6 +145,11 @@ describe('OptimizedSsrEngine', () => {
           "maxRenderTime": 300000,
           "reuseCurrentRendering": true,
           "debug": false,
+          "blockSsr": [
+            "checkout",
+            "my-account",
+            "asm"
+          ],
           "renderingStrategyResolver": "() => ssr_optimization_options_1.RenderingStrategy.ALWAYS_SSR"
         }",
         ]

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -5,16 +5,12 @@
  */
 
 /* webpackIgnore: true */
-import { Request, Response } from 'express';
+import {Request, Response} from 'express';
 import * as fs from 'fs';
-import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
-import { getRequestUrl } from '../express-utils/express-request-url';
-import { RenderingCache } from './rendering-cache';
-import {
-  defaultSsrOptimizationOptions,
-  RenderingStrategy,
-  SsrOptimizationOptions,
-} from './ssr-optimization-options';
+import {NgExpressEngineInstance} from '../engine-decorator/ng-express-engine-decorator';
+import {getRequestUrl} from '../express-utils/express-request-url';
+import {RenderingCache} from './rendering-cache';
+import {defaultSsrOptimizationOptions, RenderingStrategy, SsrOptimizationOptions,} from './ssr-optimization-options';
 
 /**
  * Returns the full url for the given SSR Request.
@@ -63,10 +59,10 @@ export class OptimizedSsrEngine {
   ) {
     this.ssrOptions = ssrOptions
       ? {
-          ...defaultSsrOptimizationOptions,
-          // overrides the default options
-          ...ssrOptions,
-        }
+        ...defaultSsrOptimizationOptions,
+        // overrides the default options
+        ...ssrOptions,
+      }
       : undefined;
     this.logOptions();
   }
@@ -111,9 +107,19 @@ export class OptimizedSsrEngine {
   }
 
   protected getRenderingStrategy(request: Request): RenderingStrategy {
+    if (this.shouldBlockRendering(request)) {
+      return RenderingStrategy.ALWAYS_CSR;
+    }
+
     return this.ssrOptions?.renderingStrategyResolver
       ? this.ssrOptions.renderingStrategyResolver(request)
       : RenderingStrategy.DEFAULT;
+  }
+
+  protected shouldBlockRendering(request: Request): boolean {
+    return !!this.ssrOptions?.blockSsr?.length ?
+      this.ssrOptions.blockSsr.some((route: string) => request.url.includes(route))
+      : false;
   }
 
   /**
@@ -321,11 +327,11 @@ export class OptimizedSsrEngine {
    * Instead, it waits for the current rendering to complete and then reuse the result for all waiting requests.
    */
   private handleRender({
-    filePath,
-    options,
-    renderCallback,
-    request,
-  }: {
+                         filePath,
+                         options,
+                         renderCallback,
+                         request,
+                       }: {
     filePath: string;
     options: any;
     renderCallback: SsrCallbackFn;
@@ -380,11 +386,11 @@ export class OptimizedSsrEngine {
    * its result.
    */
   private startRender({
-    filePath,
-    options,
-    renderCallback,
-    request,
-  }: {
+                        filePath,
+                        options,
+                        renderCallback,
+                        request,
+                      }: {
     filePath: string;
     options: any;
     renderCallback: SsrCallbackFn;

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -118,7 +118,7 @@ export class OptimizedSsrEngine {
 
   protected shouldBlockRendering(request: Request): boolean {
     return !!this.ssrOptions?.blockSsr?.length ?
-      this.ssrOptions.blockSsr.some((route: string) => request.url.includes(route))
+      this.ssrOptions.blockSsr.some((route: string) => request.url?.includes(route))
       : false;
   }
 

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -5,12 +5,16 @@
  */
 
 /* webpackIgnore: true */
-import {Request, Response} from 'express';
+import { Request, Response } from 'express';
 import * as fs from 'fs';
-import {NgExpressEngineInstance} from '../engine-decorator/ng-express-engine-decorator';
-import {getRequestUrl} from '../express-utils/express-request-url';
-import {RenderingCache} from './rendering-cache';
-import {defaultSsrOptimizationOptions, RenderingStrategy, SsrOptimizationOptions,} from './ssr-optimization-options';
+import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
+import { getRequestUrl } from '../express-utils/express-request-url';
+import { RenderingCache } from './rendering-cache';
+import {
+  defaultSsrOptimizationOptions,
+  RenderingStrategy,
+  SsrOptimizationOptions,
+} from './ssr-optimization-options';
 
 /**
  * Returns the full url for the given SSR Request.
@@ -59,10 +63,10 @@ export class OptimizedSsrEngine {
   ) {
     this.ssrOptions = ssrOptions
       ? {
-        ...defaultSsrOptimizationOptions,
-        // overrides the default options
-        ...ssrOptions,
-      }
+          ...defaultSsrOptimizationOptions,
+          // overrides the default options
+          ...ssrOptions,
+        }
       : undefined;
     this.logOptions();
   }
@@ -117,8 +121,10 @@ export class OptimizedSsrEngine {
   }
 
   protected shouldBlockRendering(request: Request): boolean {
-    return !!this.ssrOptions?.blockSsr?.length ?
-      this.ssrOptions.blockSsr.some((route: string) => request.url?.includes(route))
+    return !!this.ssrOptions?.blockSsr?.length
+      ? this.ssrOptions.blockSsr.some((route: string) =>
+          request.url?.includes(route)
+        )
       : false;
   }
 
@@ -327,11 +333,11 @@ export class OptimizedSsrEngine {
    * Instead, it waits for the current rendering to complete and then reuse the result for all waiting requests.
    */
   private handleRender({
-                         filePath,
-                         options,
-                         renderCallback,
-                         request,
-                       }: {
+    filePath,
+    options,
+    renderCallback,
+    request,
+  }: {
     filePath: string;
     options: any;
     renderCallback: SsrCallbackFn;
@@ -386,11 +392,11 @@ export class OptimizedSsrEngine {
    * its result.
    */
   private startRender({
-                        filePath,
-                        options,
-                        renderCallback,
-                        request,
-                      }: {
+    filePath,
+    options,
+    renderCallback,
+    request,
+  }: {
     filePath: string;
     options: any;
     renderCallback: SsrCallbackFn;

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Request} from 'express';
+import { Request } from 'express';
 
 export interface SsrOptimizationOptions {
   /**
@@ -129,5 +129,5 @@ export const defaultSsrOptimizationOptions: SsrOptimizationOptions = {
   maxRenderTime: 300_000,
   reuseCurrentRendering: true,
   debug: false,
-  blockSsr: ['checkout', 'my-account', 'asm']
+  blockSsr: ['checkout', 'my-account', 'asm'],
 };

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Request } from 'express';
+import {Request} from 'express';
 
 export interface SsrOptimizationOptions {
   /**
@@ -58,6 +58,11 @@ export interface SsrOptimizationOptions {
    * @param req
    */
   renderingStrategyResolver?: (req: Request) => RenderingStrategy;
+
+  /**
+   * Block ssr from rendering for specific routes and queries
+   */
+  blockSsr?: Array<string>;
 
   /**
    * Time in milliseconds to wait for rendering when SSR_ALWAYS render strategy is set for the request.
@@ -124,4 +129,5 @@ export const defaultSsrOptimizationOptions: SsrOptimizationOptions = {
   maxRenderTime: 300_000,
   reuseCurrentRendering: true,
   debug: false,
+  blockSsr: ['checkout', 'my-account', 'asm']
 };


### PR DESCRIPTION
The other solution to handle this would be to just provide the default option for `renderingStrategyResolver`, which I think should work better than adding new options to the existing interface.

BREAKING CHANGE:

SsrOptimizationOptions has a new option.

Closes: https://jira.tools.sap/browse/CXSPA-3492