### PR TITLE
fix: image not displayed in Confirmation page

### DIFF
--- a/integration-libs/opf/base/occ/config/default-occ-opf-order-config.ts
+++ b/integration-libs/opf/base/occ/config/default-occ-opf-order-config.ts
@@ -10,7 +10,7 @@ export const defaultOccOpfOrderConfig: OccConfig = {
   backend: {
     occ: {
       endpoints: {
-        placeOpfOrder: 'users/${userId}/orders/v2',
+        placeOpfOrder: 'users/${userId}/orders/v2?fields=FULL',
       },
     },
   },

--- a/integration-libs/opf/base/occ/opf-base-occ.module.ts
+++ b/integration-libs/opf/base/occ/opf-base-occ.module.ts
@@ -8,6 +8,8 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { provideDefaultConfig } from '@spartacus/core';
 import { OpfOrderAdapter, OpfPaymentAdapter } from '@spartacus/opf/base/core';
+import { OccOrderNormalizer } from '@spartacus/order/occ';
+import { ORDER_NORMALIZER } from '@spartacus/order/root';
 import { OccOpfOrderAdapter } from './adapters';
 import { OccOpfPaymentAdapter } from './adapters/occ-opf.adapter';
 import { defaultOccOpfConfig } from './config/default-occ-opf-config';
@@ -25,6 +27,11 @@ import { defaultOccOpfOrderConfig } from './config/default-occ-opf-order-config'
     {
       provide: OpfOrderAdapter,
       useClass: OccOpfOrderAdapter,
+    },
+    {
+      provide: ORDER_NORMALIZER,
+      useExisting: OccOrderNormalizer,
+      multi: true,
     },
   ],
 })


### PR DESCRIPTION
2 changes:
- OrderNormalizer was not triggered as the no service was mapped with ORDER_NORMALIZER token, so added the mapping.
- add 'field=FULL' query parameter when placing the order so response contains full order details that includes images urls.