### PR TITLE
fix: sonar findings (CXSPA-3575)

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
@@ -45,8 +45,8 @@ export class ConfiguratorAttributeNumericInputFieldService {
     numberTotalPlaces: number,
     numberDecimalPlaces: number
   ): boolean {
-    const escape = '\\';
-    const search: RegExp = new RegExp(escape + groupingSeparator, 'g');
+    const regexEscape = '\\';
+    const search: RegExp = new RegExp(regexEscape + groupingSeparator, 'g');
     const woGrouping = input.replace(search, '');
     const splitParts = woGrouping.split(decimalSeparator);
 

--- a/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.ts
@@ -67,8 +67,8 @@ export class ConfiguratorOverviewFormComponent {
   ): boolean {
     if (groups) {
       let hasAttributes =
-        groups.find((group) =>
-          (group.attributes ? group.attributes.length : 0) > 0
+        groups.find(
+          (group) => (group.attributes ? group.attributes.length : 0) > 0
         ) !== undefined;
       if (!hasAttributes) {
         hasAttributes =

--- a/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.ts
@@ -68,7 +68,7 @@ export class ConfiguratorOverviewFormComponent {
     if (groups) {
       let hasAttributes =
         groups.find((group) =>
-          group.attributes ? group.attributes.length : 0 > 0
+          (group.attributes ? group.attributes.length : 0) > 0
         ) !== undefined;
       if (!hasAttributes) {
         hasAttributes =


### PR DESCRIPTION
* rename local var escape -> regexEscape to not override escape function
* ternary op has lower precendence than  'bigger than' op, hence grouping is required. Still outcome is same.