### PR TITLE
feature: show validation message for empty required field if input is removed [CXSPA-3630]

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
@@ -1,30 +1,59 @@
 <div id="{{ createAttributeIdForConfigurator(attribute) }}" class="form-group">
-  <input
-    [formControl]="attributeInputForm"
-    class="form-control"
-    [class.ng-invalid]="
-      isRequired &&
-      attribute.incomplete &&
-      (!attributeInputForm.value || attributeInputForm.value.length === 0)
-    "
-    maxlength="{{ attribute.maxlength }}"
-    [attr.aria-label]="
-      attribute.userInput === undefined || attribute.userInput.length === 0
-        ? ('configurator.a11y.valueOfAttributeBlank'
-          | cxTranslate
-            : {
-                attribute: attribute.label
-              })
-        : ('configurator.a11y.valueOfAttributeFull'
-          | cxTranslate
-            : {
-                value: attribute.userInput,
-                attribute: attribute.label
-              })
-    "
-    [attr.aria-describedby]="createAttributeUiKey('label', attribute.name)"
-    [cxFocus]="{
-      key: createAttributeIdForConfigurator(attribute)
-    }"
-  />
+  <ng-container *cxFeatureLevel="'!6.2'">
+    <input
+      [formControl]="attributeInputForm"
+      [required]="isRequired"
+      class="form-control"
+      attr.required="{{ attribute.required }}"
+      maxlength="{{ attribute.maxlength }}"
+      [attr.aria-label]="
+        attribute.userInput === undefined || attribute.userInput.length === 0
+          ? ('configurator.a11y.valueOfAttributeBlank'
+            | cxTranslate
+              : {
+                  attribute: attribute.label
+                })
+          : ('configurator.a11y.valueOfAttributeFull'
+            | cxTranslate
+              : {
+                  value: attribute.userInput,
+                  attribute: attribute.label
+                })
+      "
+      [attr.aria-describedby]="createAttributeUiKey('label', attribute.name)"
+      [cxFocus]="{
+        key: createAttributeIdForConfigurator(attribute)
+      }"
+    />
+  </ng-container>
+  <ng-container *cxFeatureLevel="'6.2'">
+    <input
+      [formControl]="attributeInputForm"
+      class="form-control"
+      [class.ng-invalid]="
+        isRequired &&
+        attribute.incomplete &&
+        (!attributeInputForm.value || attributeInputForm.value.length === 0)
+      "
+      maxlength="{{ attribute.maxlength }}"
+      [attr.aria-label]="
+        attribute.userInput === undefined || attribute.userInput.length === 0
+          ? ('configurator.a11y.valueOfAttributeBlank'
+            | cxTranslate
+              : {
+                  attribute: attribute.label
+                })
+          : ('configurator.a11y.valueOfAttributeFull'
+            | cxTranslate
+              : {
+                  value: attribute.userInput,
+                  attribute: attribute.label
+                })
+      "
+      [attr.aria-describedby]="createAttributeUiKey('label', attribute.name)"
+      [cxFocus]="{
+        key: createAttributeIdForConfigurator(attribute)
+      }"
+    />
+  </ng-container>
 </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
@@ -30,9 +30,7 @@
     <input
       [formControl]="attributeInputForm"
       class="form-control"
-      [class.ng-invalid]="
-        isRequired && isUserInputEmpty
-      "
+      [class.ng-invalid]="isRequired && isUserInputEmpty"
       maxlength="{{ attribute.maxlength }}"
       [attr.aria-label]="
         isUserInputEmpty

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
@@ -7,7 +7,7 @@
       attr.required="{{ attribute.required }}"
       maxlength="{{ attribute.maxlength }}"
       [attr.aria-label]="
-        attribute.userInput === undefined || attribute.userInput.length === 0
+        isUserInputEmpty
           ? ('configurator.a11y.valueOfAttributeBlank'
             | cxTranslate
               : {
@@ -31,13 +31,11 @@
       [formControl]="attributeInputForm"
       class="form-control"
       [class.ng-invalid]="
-        isRequired &&
-        attribute.incomplete &&
-        (!attributeInputForm.value || attributeInputForm.value.length === 0)
+        isRequired && isUserInputEmpty
       "
       maxlength="{{ attribute.maxlength }}"
       [attr.aria-label]="
-        attribute.userInput === undefined || attribute.userInput.length === 0
+        isUserInputEmpty
           ? ('configurator.a11y.valueOfAttributeBlank'
             | cxTranslate
               : {

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
@@ -2,7 +2,11 @@
   <input
     [formControl]="attributeInputForm"
     class="form-control"
-    [class.ng-invalid]="isRequired && (!attributeInputForm.value || attributeInputForm.value.length === 0)"
+    [class.ng-invalid]="
+      isRequired &&
+      attribute.incomplete &&
+      (!attributeInputForm.value || attributeInputForm.value.length === 0)
+    "
     maxlength="{{ attribute.maxlength }}"
     [attr.aria-label]="
       attribute.userInput === undefined || attribute.userInput.length === 0

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.html
@@ -1,9 +1,8 @@
 <div id="{{ createAttributeIdForConfigurator(attribute) }}" class="form-group">
   <input
     [formControl]="attributeInputForm"
-    [required]="isRequired"
     class="form-control"
-    attr.required="{{ attribute.required }}"
+    [class.ng-invalid]="isRequired && (!attributeInputForm.value || attributeInputForm.value.length === 0)"
     maxlength="{{ attribute.maxlength }}"
     [attr.aria-label]="
       attribute.userInput === undefined || attribute.userInput.length === 0

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
@@ -118,6 +118,10 @@ describe('ConfigAttributeInputFieldComponent', () => {
     expect(styleClasses).toContain('ng-invalid');
   });
 
+  it('should not consider empty required input field as invalid, despite that it will be marked as error on the UI, so that engine is still called', () => {
+    expect(component.attributeInputForm.valid).toBe(true);
+  });
+
   it('should set form as touched on init', () => {
     expect(component.attributeInputForm.touched).toEqual(true);
   });

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { I18nTestingModule } from '@spartacus/core';
+import { FeaturesConfig, FeaturesConfigModule, I18nTestingModule } from '@spartacus/core';
 import { CommonConfigurator } from '@spartacus/product-configurator/common';
 import { CommonConfiguratorTestUtilsService } from '../../../../../common/testing/common-configurator-test-utils.service';
 import { Configurator } from '../../../../core/model/configurator.model';
@@ -46,7 +46,7 @@ describe('ConfigAttributeInputFieldComponent', () => {
           ConfiguratorAttributeInputFieldComponent,
           MockFocusDirective,
         ],
-        imports: [ReactiveFormsModule, I18nTestingModule],
+        imports: [ReactiveFormsModule, I18nTestingModule, FeaturesConfigModule],
         providers: [
           {
             provide: ConfiguratorUISettingsConfig,
@@ -59,6 +59,12 @@ describe('ConfigAttributeInputFieldComponent', () => {
           {
             provide: ConfiguratorCommonsService,
             useClass: MockConfiguratorCommonsService,
+          },
+          {
+            provide: FeaturesConfig,
+            useValue: {
+              features: { level: '*' },
+            },
           },
         ],
       })

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
@@ -8,7 +8,11 @@ import {
 } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { FeaturesConfig, FeaturesConfigModule, I18nTestingModule } from '@spartacus/core';
+import {
+  FeaturesConfig,
+  FeaturesConfigModule,
+  I18nTestingModule,
+} from '@spartacus/core';
 import { CommonConfigurator } from '@spartacus/product-configurator/common';
 import { CommonConfiguratorTestUtilsService } from '../../../../../common/testing/common-configurator-test-utils.service';
 import { Configurator } from '../../../../core/model/configurator.model';

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
@@ -303,7 +303,7 @@ describe('ConfigAttributeInputFieldComponent', () => {
       expect(component.isUserInputEmpty).toBe(true);
     });
 
-    it('should return true if the ure is no user input', () => {
+    it('should return true if there is no user input', () => {
       component.attribute.userInput = undefined;
       expect(component.isUserInputEmpty).toBe(true);
     });

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
@@ -291,4 +291,21 @@ describe('ConfigAttributeInputFieldComponent', () => {
       expect(component.isRequired).toBe(false);
     });
   });
+
+  describe('isUserInputEmpty', () => {
+    it('should return false if a value is present', () => {
+      component.attribute.userInput = 'abc';
+      expect(component.isUserInputEmpty).toBe(false);
+    });
+
+    it('should return true if the user input only contains blanks', () => {
+      component.attribute.userInput = '  ';
+      expect(component.isUserInputEmpty).toBe(true);
+    });
+
+    it('should return true if the ure is no user input', () => {
+      component.attribute.userInput = undefined;
+      expect(component.isUserInputEmpty).toBe(true);
+    });
+  });
 });

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
@@ -100,7 +100,7 @@ export class ConfiguratorAttributeInputFieldComponent
 
   /**
    * Verifies if the user input has a non-blank value.
-   * @returns isEmpty?
+   * @returns {boolean} - 'True' if the user input is undefined, empty or contains only blanks, otherwise 'false'.
    */
   get isUserInputEmpty(): boolean {
     return (

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
@@ -99,6 +99,16 @@ export class ConfiguratorAttributeInputFieldComponent
   }
 
   /**
+   * Checks if the user input has a non blank value.
+   * @returns isEmpty?
+   */
+  get isUserInputEmpty(): boolean {
+    return (
+      !this.attribute.userInput || this.attribute.userInput.trim().length === 0
+    );
+  }
+
+  /**
    * Checks if the component needs to be marked as required.
    * This is never the case if it is used as sub component for an attribute type which allows an additional value
    * @returns Required?

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
@@ -99,7 +99,7 @@ export class ConfiguratorAttributeInputFieldComponent
   }
 
   /**
-   * Checks if the user input has a non blank value.
+   * Verifies if the user input has a non-blank value.
    * @returns isEmpty?
    */
   get isUserInputEmpty(): boolean {

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.module.ts
@@ -7,7 +7,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { I18nModule, provideDefaultConfig } from '@spartacus/core';
+import { FeaturesConfigModule, I18nModule, provideDefaultConfig } from '@spartacus/core';
 import { KeyboardFocusModule } from '@spartacus/storefront';
 import { ConfiguratorAttributeCompositionConfig } from '../../composition/configurator-attribute-composition.config';
 import { ConfiguratorAttributeInputFieldComponent } from './configurator-attribute-input-field.component';
@@ -19,6 +19,7 @@ import { ConfiguratorAttributeInputFieldComponent } from './configurator-attribu
     ReactiveFormsModule,
     CommonModule,
     I18nModule,
+    FeaturesConfigModule,
   ],
   providers: [
     provideDefaultConfig(<ConfiguratorAttributeCompositionConfig>{

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.module.ts
@@ -7,7 +7,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { FeaturesConfigModule, I18nModule, provideDefaultConfig } from '@spartacus/core';
+import {
+  FeaturesConfigModule,
+  I18nModule,
+  provideDefaultConfig,
+} from '@spartacus/core';
 import { KeyboardFocusModule } from '@spartacus/storefront';
 import { ConfiguratorAttributeCompositionConfig } from '../../composition/configurator-attribute-composition.config';
 import { ConfiguratorAttributeInputFieldComponent } from './configurator-attribute-input-field.component';

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
@@ -2,29 +2,53 @@
   this.getHelpTextForInterval()
 }}</label>
 <div id="{{ createAttributeIdForConfigurator(attribute) }}" class="form-group">
-  <input
-    [formControl]="attributeInputForm"
-    [class.ng-invalid]="
-      isRequired &&
-      (!attributeInputForm.value || attributeInputForm.value.length === 0)
-    "
-    class="form-control"
-    [attr.aria-describedby]="
-      mustDisplayValidationMessage()
-        ? createAttributeUiKey('label', attribute.name) +
-          ' ' +
-          createAttributeUiKey('attribute-msg', attribute.name)
-        : createAttributeUiKey('label', attribute.name)
-    "
-    attr.role="{{ attribute.dataType }}"
-    attr.required="{{ attribute.required }}"
-    (change)="onChange()"
-    maxlength="{{ attribute.maxlength }}"
-    [attr.aria-label]="getAriaLabelComplete()"
-    [cxFocus]="{
-      key: createAttributeIdForConfigurator(attribute)
-    }"
-  />
+  <ng-container *cxFeatureLevel="'!6.2'">
+    <input
+      [formControl]="attributeInputForm"
+      [required]="isRequired"
+      class="form-control"
+      [attr.aria-describedby]="
+        mustDisplayValidationMessage()
+          ? createAttributeUiKey('label', attribute.name) +
+            ' ' +
+            createAttributeUiKey('attribute-msg', attribute.name)
+          : createAttributeUiKey('label', attribute.name)
+      "
+      attr.role="{{ attribute.dataType }}"
+      attr.required="{{ attribute.required }}"
+      (change)="onChange()"
+      maxlength="{{ attribute.maxlength }}"
+      [attr.aria-label]="getAriaLabelComplete()"
+      [cxFocus]="{
+        key: createAttributeIdForConfigurator(attribute)
+      }"
+    />
+  </ng-container>
+  <ng-container *cxFeatureLevel="'6.2'">
+    <input
+      [formControl]="attributeInputForm"
+      [class.ng-invalid]="
+        isRequired &&
+        (!attributeInputForm.value || attributeInputForm.value.length === 0)
+      "
+      class="form-control"
+      [attr.aria-describedby]="
+        mustDisplayValidationMessage()
+          ? createAttributeUiKey('label', attribute.name) +
+            ' ' +
+            createAttributeUiKey('attribute-msg', attribute.name)
+          : createAttributeUiKey('label', attribute.name)
+      "
+      attr.role="{{ attribute.dataType }}"
+      attr.required="{{ attribute.required }}"
+      (change)="onChange()"
+      maxlength="{{ attribute.maxlength }}"
+      [attr.aria-label]="getAriaLabelComplete()"
+      [cxFocus]="{
+        key: createAttributeIdForConfigurator(attribute)
+      }"
+    />
+  </ng-container>
 </div>
 <div
   class="cx-validation-msg"

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
@@ -4,7 +4,7 @@
 <div id="{{ createAttributeIdForConfigurator(attribute) }}" class="form-group">
   <input
     [formControl]="attributeInputForm"
-    [required]="isRequired"
+    [class.ng-invalid]="isRequired && (!attributeInputForm.value || attributeInputForm.value.length === 0)"
     class="form-control"
     [attr.aria-describedby]="
       mustDisplayValidationMessage()

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
@@ -4,7 +4,10 @@
 <div id="{{ createAttributeIdForConfigurator(attribute) }}" class="form-group">
   <input
     [formControl]="attributeInputForm"
-    [class.ng-invalid]="isRequired && (!attributeInputForm.value || attributeInputForm.value.length === 0)"
+    [class.ng-invalid]="
+      isRequired &&
+      (!attributeInputForm.value || attributeInputForm.value.length === 0)
+    "
     class="form-control"
     [attr.aria-describedby]="
       mustDisplayValidationMessage()

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
@@ -27,10 +27,7 @@
   <ng-container *cxFeatureLevel="'6.2'">
     <input
       [formControl]="attributeInputForm"
-      [class.ng-invalid]="
-        isRequired &&
-        (!attributeInputForm.value || attributeInputForm.value.length === 0)
-      "
+      [class.ng-invalid]="isRequired && isUserInputEmpty"
       class="form-control"
       [attr.aria-describedby]="
         mustDisplayValidationMessage()

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
@@ -274,7 +274,8 @@ export class ConfiguratorAttributeNumericInputFieldService {
     negativeAllowed: boolean
   ): ValidatorFn {
     return (control: AbstractControl): { [key: string]: any } | null => {
-      const input: string = control.value;
+      let input: string = control.value;
+      input = input.trim();
       if (input) {
         return this.getValidationErrorsNumericFormat(
           input,
@@ -348,7 +349,7 @@ export class ConfiguratorAttributeNumericInputFieldService {
     currentValue?: string
   ): ValidatorFn {
     return (control: AbstractControl): { [key: string]: any } | null => {
-      const input: string = control.value;
+      const input: string = control.value.trim();
       if (
         input &&
         input !== currentValue && //this is to ensure that selected interval consisting of only one value will not lead to a validation error

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
@@ -274,8 +274,7 @@ export class ConfiguratorAttributeNumericInputFieldService {
     negativeAllowed: boolean
   ): ValidatorFn {
     return (control: AbstractControl): { [key: string]: any } | null => {
-      let input: string = control.value;
-      input = input.trim();
+      let input = control.value?.trim();
       if (input) {
         return this.getValidationErrorsNumericFormat(
           input,

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
@@ -349,7 +349,7 @@ export class ConfiguratorAttributeNumericInputFieldService {
     currentValue?: string
   ): ValidatorFn {
     return (control: AbstractControl): { [key: string]: any } | null => {
-      const input: string = control.value.trim();
+      const input = control.value?.trim();
       if (
         input &&
         input !== currentValue && //this is to ensure that selected interval consisting of only one value will not lead to a validation error

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
@@ -274,7 +274,7 @@ export class ConfiguratorAttributeNumericInputFieldService {
     negativeAllowed: boolean
   ): ValidatorFn {
     return (control: AbstractControl): { [key: string]: any } | null => {
-      let input = control.value?.trim();
+      const input = control.value?.trim();
       if (input) {
         return this.getValidationErrorsNumericFormat(
           input,

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.spec.ts
@@ -14,6 +14,7 @@ import {
 import { ReactiveFormsModule } from '@angular/forms';
 import {
   FeatureConfigService,
+  FeaturesConfigModule,
   I18nTestingModule,
   LanguageService,
 } from '@spartacus/core';
@@ -139,7 +140,7 @@ describe('ConfigAttributeNumericInputFieldComponent', () => {
           MockFocusDirective,
           MockCxIconComponent,
         ],
-        imports: [ReactiveFormsModule, I18nTestingModule],
+        imports: [ReactiveFormsModule, I18nTestingModule, FeaturesConfigModule],
         providers: [
           { provide: LanguageService, useValue: mockLanguageService },
           {
@@ -457,6 +458,7 @@ describe('ConfigAttributeNumericInputFieldComponent', () => {
       component.attribute.userInput = '123';
       fixture.detectChanges();
       component.ngOnInit();
+      htmlElem = fixture.debugElement.nativeElement;
       tick(DEBOUNCE_TIME);
       CommonConfiguratorTestUtilsService.expectElementContainsA11y(
         expect,

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.spec.ts
@@ -20,17 +20,17 @@ import {
 import { CommonConfigurator } from '@spartacus/product-configurator/common';
 import { of } from 'rxjs';
 import { CommonConfiguratorTestUtilsService } from '../../../../../common/testing/common-configurator-test-utils.service';
+import { ConfiguratorCommonsService } from '../../../../core/facade/configurator-commons.service';
 import { Configurator } from '../../../../core/model/configurator.model';
+import { ConfiguratorTestUtils } from '../../../../testing/configurator-test-utils';
 import { ConfiguratorUISettingsConfig } from '../../../config/configurator-ui-settings.config';
 import { defaultConfiguratorUISettingsConfig } from '../../../config/default-configurator-ui-settings.config';
+import { ConfiguratorAttributeCompositionContext } from '../../composition/configurator-attribute-composition.model';
 import { ConfiguratorAttributeNumericInputFieldComponent } from './configurator-attribute-numeric-input-field.component';
 import {
   ConfiguratorAttributeNumericInputFieldService,
   ConfiguratorAttributeNumericInterval,
 } from './configurator-attribute-numeric-input-field.component.service';
-import { ConfiguratorTestUtils } from '../../../../testing/configurator-test-utils';
-import { ConfiguratorAttributeCompositionContext } from '../../composition/configurator-attribute-composition.model';
-import { ConfiguratorCommonsService } from '../../../../core/facade/configurator-commons.service';
 
 @Directive({
   selector: '[cxFocus]',
@@ -223,6 +223,12 @@ describe('ConfigAttributeNumericInputFieldComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should not consider empty required input field as invalid, despite that it will be marked as error on the UI, so that engine is still called', () => {
+    component.attribute.required = true;
+    fixture.detectChanges();
+    expect(component.attributeInputForm.valid).toBe(true);
   });
 
   describe('ngOnInit', () => {

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.module.ts
@@ -7,7 +7,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { I18nModule, provideDefaultConfig } from '@spartacus/core';
+import {
+  FeaturesConfigModule,
+  I18nModule,
+  provideDefaultConfig,
+} from '@spartacus/core';
 import { IconModule, KeyboardFocusModule } from '@spartacus/storefront';
 import { ConfiguratorAttributeCompositionConfig } from '../../composition/configurator-attribute-composition.config';
 import { ConfiguratorAttributeNumericInputFieldComponent } from './configurator-attribute-numeric-input-field.component';
@@ -20,6 +24,7 @@ import { ConfiguratorAttributeNumericInputFieldComponent } from './configurator-
     CommonModule,
     I18nModule,
     IconModule,
+    FeaturesConfigModule,
   ],
   providers: [
     provideDefaultConfig(<ConfiguratorAttributeCompositionConfig>{


### PR DESCRIPTION
Before we let the validation of empty required input fields was managed by the input control itself by just setting the required property to true. This had 2 draw backs.
* if an existing input was removed this was considered as validation error an not sent to the engine. After updating another attribute, the engine returned the previous value, hence the user input was lost.
* The corresponding 'missing required field' message is generated in the attribute footer, not by the validation, hence it was missing if an existing input was removed, as the attribute was still considered 'complete'.
With this PR only the 'ng-invalid' style class, which causes the red box, is set for empty required input fields, hence eliminating the two drawback mentioned before.