### PR TITLE
feat: move private part of MultiCartEffects (setting active cart id on LoadCartSuccess) to a public extendable service [6.1.x]

### DIFF
--- a/feature-libs/cart/base/core/public_api.ts
+++ b/feature-libs/cart/base/core/public_api.ts
@@ -12,6 +12,7 @@ export * from './facade/index';
 export * from './guards/index';
 export * from './services/index';
 export * from './store/actions/index';
+export * from './store/effects/multi-cart-effect.service';
 export * from './store/multi-cart-state';
 export * from './store/selectors/index';
 export * from './utils/utils';

--- a/feature-libs/cart/base/core/store/effects/index.ts
+++ b/feature-libs/cart/base/core/store/effects/index.ts
@@ -19,4 +19,5 @@ export const effects: any[] = [
 export * from './cart-entry.effect';
 export * from './cart-voucher.effect';
 export * from './cart.effect';
+export * from './multi-cart-effect.service';
 export * from './multi-cart.effect';

--- a/feature-libs/cart/base/core/store/effects/multi-cart-effect.service.spec.ts
+++ b/feature-libs/cart/base/core/store/effects/multi-cart-effect.service.spec.ts
@@ -1,0 +1,79 @@
+import { TestBed } from '@angular/core/testing';
+import { Cart, CartType } from '@spartacus/cart/base/root';
+import { CartActions } from '../actions';
+import { MultiCartEffectsService } from './multi-cart-effect.service';
+
+const testCart: Cart = {
+  code: 'xxx',
+  guid: 'testGuid',
+  totalItems: 0,
+  totalPrice: {
+    currencyIso: 'USD',
+    value: 0,
+  },
+  totalPriceWithTax: {
+    currencyIso: 'USD',
+    value: 0,
+  },
+};
+
+describe('MultiCartEffectsService', () => {
+  let service: MultiCartEffectsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MultiCartEffectsService],
+    });
+
+    service = TestBed.inject(MultiCartEffectsService);
+  });
+
+  describe('getActiveCartTypeOnLoadSuccess', () => {
+    it('should return active cart id being value from LoadCartSuccess', () => {
+      const action = new CartActions.LoadCartSuccess({
+        userId: 'userId',
+        cartId: 'cartId',
+        cart: testCart,
+        extraData: { active: true },
+      });
+
+      const setActiveCartIdAction = new CartActions.SetCartTypeIndex({
+        cartType: CartType.ACTIVE,
+        cartId: 'cartId',
+      });
+
+      expect(service.getActiveCartTypeOnLoadSuccess(action)).toEqual(
+        setActiveCartIdAction
+      );
+    });
+
+    it('should return empty active cart id if the cart from LoadCartSuccess is active and saved', () => {
+      const action = new CartActions.LoadCartSuccess({
+        userId: 'userId',
+        cartId: 'cartId',
+        cart: { code: 'test', saveTime: new Date() },
+        extraData: { active: true },
+      });
+
+      const setActiveCartIdAction = new CartActions.SetCartTypeIndex({
+        cartType: CartType.ACTIVE,
+        cartId: '',
+      });
+
+      expect(service.getActiveCartTypeOnLoadSuccess(action)).toEqual(
+        setActiveCartIdAction
+      );
+    });
+
+    it('should return undefined if cart from LoadCartSuccess is not active', () => {
+      const action = new CartActions.LoadCartSuccess({
+        userId: 'userId',
+        cartId: 'cartId',
+        cart: testCart,
+        extraData: { active: false },
+      });
+
+      expect(service.getActiveCartTypeOnLoadSuccess(action)).toBeUndefined();
+    });
+  });
+});

--- a/feature-libs/cart/base/core/store/effects/multi-cart-effect.service.ts
+++ b/feature-libs/cart/base/core/store/effects/multi-cart-effect.service.ts
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable } from '@angular/core';
+import { CartType } from '@spartacus/cart/base/root';
+import { CartActions } from '../actions/index';
+
+@Injectable()
+export class MultiCartEffectsService {
+  /**
+   * Verifies if cart is the active cart or saved cart and returns the appropriate cart type
+   * @param action
+   * @returns cart type
+   */
+  getActiveCartTypeOnLoadSuccess(
+    action: CartActions.LoadCartSuccess
+  ): CartActions.SetCartTypeIndex | undefined {
+    if (action?.payload?.extraData?.active) {
+      // saved cart is not active cart
+      if (action.payload?.cart.saveTime) {
+        return new CartActions.SetCartTypeIndex({
+          cartType: CartType.ACTIVE,
+          cartId: '',
+        });
+      }
+      return new CartActions.SetCartTypeIndex({
+        cartType: CartType.ACTIVE,
+        cartId: action.meta.entityId as string,
+      });
+    }
+  }
+}

--- a/feature-libs/cart/base/core/store/multi-cart-store.module.ts
+++ b/feature-libs/cart/base/core/store/multi-cart-store.module.ts
@@ -10,6 +10,7 @@ import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { StateModule } from '@spartacus/core';
 import { effects } from './effects/index';
+import { MultiCartEffectsService } from './effects/multi-cart-effect.service';
 import { MULTI_CART_FEATURE } from './multi-cart-state';
 import {
   multiCartMetaReducers,
@@ -26,6 +27,6 @@ import {
     }),
     EffectsModule.forFeature(effects),
   ],
-  providers: [multiCartReducerProvider],
+  providers: [multiCartReducerProvider, MultiCartEffectsService],
 })
 export class MultiCartStoreModule {}


### PR DESCRIPTION
(forward-port of PR https://github.com/SAP/spartacus/pull/17511 to 6.1.x)

Moved logic from `MultiCartEffects` (which is in private API) to a public extendable service `MultiCartEffectsService`, so to allow FSA for extending it.

The moved logic is responsible for setting active cart id on LoadCartSuccess action.

closes https://jira.tools.sap/browse/CXSPA-3551