### PR TITLE
chore: Fix for failing CDS unit tests

### DIFF
--- a/integration-libs/cds/src/profiletag/services/profiletag-event.service.spec.ts
+++ b/integration-libs/cds/src/profiletag/services/profiletag-event.service.spec.ts
@@ -68,225 +68,232 @@ describe('ProfileTagEventTracker', () => {
       getActive: () => getActiveBehavior,
     };
   }
-  beforeEach(() => {
-    setVariables();
-    TestBed.configureTestingModule({
-      providers: [
-        { provide: CdsConfig, useValue: mockCDSConfig },
-        { provide: WindowRef, useValue: mockedWindowRef },
-        { provide: BaseSiteService, useValue: baseSiteService },
-        { provide: PLATFORM_ID, useValue: 'browser' },
-      ],
+
+  describe('no local storage called', () => {
+    beforeEach(() => {
+      setVariables();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: CdsConfig, useValue: mockCDSConfig },
+          { provide: WindowRef, useValue: mockedWindowRef },
+          { provide: BaseSiteService, useValue: baseSiteService },
+          { provide: PLATFORM_ID, useValue: 'browser' },
+        ],
+      });
+      profileTagEventTracker = TestBed.inject(ProfileTagEventService);
+      nativeWindow = TestBed.inject(WindowRef)
+        .nativeWindow as ProfileTagWindowObject;
     });
-    profileTagEventTracker = TestBed.inject(ProfileTagEventService);
-    nativeWindow = TestBed.inject(WindowRef)
-      .nativeWindow as ProfileTagWindowObject;
-  });
 
-  it('should be created', () => {
-    expect(profileTagEventTracker).toBeTruthy();
-  });
-
-  it('Should first wait for the basesite to be active before adding config parameters to the q array', () => {
-    expect(appendChildSpy).not.toHaveBeenCalled();
-    expect(nativeWindow.Y_TRACKING.eventLayer.push).not.toHaveBeenCalled();
-    expect(nativeWindow.Y_TRACKING.q).not.toBeDefined();
-  });
-
-  it(`Should add config parameters to the q array after the base site is active`, () => {
-    const profileTagLoaded$ = profileTagEventTracker.addTracker();
-    const subscription = profileTagLoaded$.subscribe();
-    const baseSite = 'electronics-test';
-    getActiveBehavior.next(baseSite);
-    subscription.unsubscribe();
-
-    expect(nativeWindow.Y_TRACKING.q[0][0]).toEqual({
-      ...mockCDSConfig.cds.profileTag,
-      tenant: mockCDSConfig.cds.tenant,
-      siteId: baseSite,
-      spa: true,
+    it('should be created', () => {
+      expect(profileTagEventTracker).toBeTruthy();
     });
-    expect(appendChildSpy).toHaveBeenCalled();
-    expect(nativeWindow.Y_TRACKING.eventLayer.push).not.toHaveBeenCalled();
-  });
 
-  it(`Should not add config parameters to the q array if PT is already loaded`, () => {
-    const profileTagLoaded$ = profileTagEventTracker.addTracker();
-    let subscription = profileTagLoaded$.subscribe();
-    const baseSite = 'electronics-test';
-    getActiveBehavior.next(baseSite);
-    subscription.unsubscribe();
-
-    expect(nativeWindow.Y_TRACKING.q[0][0]).toEqual({
-      ...mockCDSConfig.cds.profileTag,
-      tenant: mockCDSConfig.cds.tenant,
-      siteId: baseSite,
-      spa: true,
+    it('Should first wait for the basesite to be active before adding config parameters to the q array', () => {
+      expect(appendChildSpy).not.toHaveBeenCalled();
+      expect(nativeWindow.Y_TRACKING.eventLayer.push).not.toHaveBeenCalled();
+      expect(nativeWindow.Y_TRACKING.q).not.toBeDefined();
     });
-    expect(nativeWindow.Y_TRACKING.eventLayer.push).not.toHaveBeenCalled();
 
-    // reset the mock correctly so that the existing script is detected
-    spyOn(mockedWindowRef.document, 'querySelector').and.returnValue(
-      {} as Element
-    );
-    // retrigger profile-tag
-    subscription = profileTagLoaded$.subscribe();
-    subscription.unsubscribe();
-    expect(appendChildSpy).toHaveBeenCalledTimes(1);
-    expect(nativeWindow.Y_TRACKING.q[0].length).toEqual(1);
-  });
+    it(`Should add config parameters to the q array after the base site is active`, () => {
+      const profileTagLoaded$ = profileTagEventTracker.addTracker();
+      const subscription = profileTagLoaded$.subscribe();
+      const baseSite = 'electronics-test';
+      getActiveBehavior.next(baseSite);
+      subscription.unsubscribe();
 
-  it(`Should not call the push method if the event receiver callback hasn't been called`, () => {
-    const profileTagLoaded$ = profileTagEventTracker.addTracker();
-    const subscription = profileTagLoaded$.subscribe();
-    getActiveBehavior.next('electronics-test');
-    getConsentBehavior.next({ consent: 'test' });
-    subscription.unsubscribe();
+      expect(nativeWindow.Y_TRACKING.q[0][0]).toEqual({
+        ...mockCDSConfig.cds.profileTag,
+        tenant: mockCDSConfig.cds.tenant,
+        siteId: baseSite,
+        spa: true,
+      });
+      expect(appendChildSpy).toHaveBeenCalled();
+      expect(nativeWindow.Y_TRACKING.eventLayer.push).not.toHaveBeenCalled();
+    });
 
-    expect(nativeWindow.Y_TRACKING.eventLayer.push).not.toHaveBeenCalled();
-  });
+    it(`Should not add config parameters to the q array if PT is already loaded`, () => {
+      const profileTagLoaded$ = profileTagEventTracker.addTracker();
+      let subscription = profileTagLoaded$.subscribe();
+      const baseSite = 'electronics-test';
+      getActiveBehavior.next(baseSite);
+      subscription.unsubscribe();
 
-  it(`Should call the pageLoaded method if the site is active even when the event receiver callback
+      expect(nativeWindow.Y_TRACKING.q[0][0]).toEqual({
+        ...mockCDSConfig.cds.profileTag,
+        tenant: mockCDSConfig.cds.tenant,
+        siteId: baseSite,
+        spa: true,
+      });
+      expect(nativeWindow.Y_TRACKING.eventLayer.push).not.toHaveBeenCalled();
+
+      // reset the mock correctly so that the existing script is detected
+      spyOn(mockedWindowRef.document, 'querySelector').and.returnValue(
+        {} as Element
+      );
+      // retrigger profile-tag
+      subscription = profileTagLoaded$.subscribe();
+      subscription.unsubscribe();
+      expect(appendChildSpy).toHaveBeenCalledTimes(1);
+      expect(nativeWindow.Y_TRACKING.q[0].length).toEqual(1);
+    });
+
+    it(`Should not call the push method if the event receiver callback hasn't been called`, () => {
+      const profileTagLoaded$ = profileTagEventTracker.addTracker();
+      const subscription = profileTagLoaded$.subscribe();
+      getActiveBehavior.next('electronics-test');
+      getConsentBehavior.next({ consent: 'test' });
+      subscription.unsubscribe();
+
+      expect(nativeWindow.Y_TRACKING.eventLayer.push).not.toHaveBeenCalled();
+    });
+
+    it(`Should call the pageLoaded method if the site is active even when the event receiver callback
    has not been called with loaded`, () => {
-    let loaded = 0;
-    const subscription = profileTagEventTracker
-      .addTracker()
-      .pipe(tap(() => loaded++))
-      .subscribe();
-    getActiveBehavior.next('electronics-test');
-    subscription.unsubscribe();
+      let loaded = 0;
+      const subscription = profileTagEventTracker
+        .addTracker()
+        .pipe(tap(() => loaded++))
+        .subscribe();
+      getActiveBehavior.next('electronics-test');
+      subscription.unsubscribe();
 
-    expect(loaded).toEqual(1);
+      expect(loaded).toEqual(1);
+    });
+
+    it(`Should call the debugChanged method when profileTagDebug value changes`, () => {
+      let timesCalled = 0;
+      const subscription = profileTagEventTracker
+        .getProfileTagEvents()
+        .pipe(tap(() => timesCalled++))
+        .subscribe();
+
+      const debugEvent = <DebugEvent>(
+        new CustomEvent(InternalProfileTagEventNames.DEBUG_FLAG_CHANGED, {
+          detail: { debug: true },
+        })
+      );
+      eventListener[InternalProfileTagEventNames.DEBUG_FLAG_CHANGED](
+        debugEvent
+      );
+      subscription.unsubscribe();
+
+      expect(timesCalled).toEqual(1);
+    });
+
+    it(`Should call the consentReferenceChanged method when consentReference value changes`, () => {
+      let timesCalled = 0;
+      const subscription = profileTagEventTracker
+        .getProfileTagEvents()
+        .pipe(tap(() => timesCalled++))
+        .subscribe();
+
+      let consentReferenceChangedEvent = <ConsentReferenceEvent>(
+        new CustomEvent(InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED, {
+          detail: { consentReference: 'some_id' },
+        })
+      );
+      eventListener[InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED](
+        consentReferenceChangedEvent
+      );
+
+      consentReferenceChangedEvent = <ConsentReferenceEvent>(
+        new CustomEvent(InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED, {
+          detail: { consentReference: 'another_id' },
+        })
+      );
+      eventListener[InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED](
+        consentReferenceChangedEvent
+      );
+      subscription.unsubscribe();
+
+      expect(timesCalled).toEqual(2);
+    });
+
+    it('Should give the lastest consent reference to late subscribers', () => {
+      let cr1 = null;
+      let cr2 = null;
+      let cr3 = null;
+      const subscription1CR = profileTagEventTracker
+        .getConsentReference()
+        .subscribe((cr) => (cr1 = cr));
+      const consentReferenceChangedEvent = <ConsentReferenceEvent>(
+        new CustomEvent(InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED, {
+          detail: { consentReference: 'some_id' },
+        })
+      );
+      eventListener[InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED](
+        consentReferenceChangedEvent
+      );
+      const subscription2CR = profileTagEventTracker
+        .getConsentReference()
+        .subscribe((cr) => (cr2 = cr));
+      const subscription3CR = profileTagEventTracker
+        .getConsentReference()
+        .subscribe((cr) => (cr3 = cr));
+      subscription1CR.unsubscribe();
+      subscription2CR.unsubscribe();
+      subscription3CR.unsubscribe();
+      expect(cr1).toEqual(cr2);
+      expect(cr3).toEqual(cr2);
+      expect(cr1).toEqual('some_id');
+    });
   });
 
-  it(`Should call the debugChanged method when profileTagDebug value changes`, () => {
-    let timesCalled = 0;
-    const subscription = profileTagEventTracker
-      .getProfileTagEvents()
-      .pipe(tap(() => timesCalled++))
-      .subscribe();
+  describe('getting consent-reference from local storage', () => {
+    beforeEach(() => {
+      setVariables();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: CdsConfig, useValue: mockCDSConfig },
+          { provide: WindowRef, useValue: mockedWindowRef },
+          { provide: BaseSiteService, useValue: baseSiteService },
+          { provide: PLATFORM_ID, useValue: '' },
+        ],
+      });
+      nativeWindow = TestBed.inject(WindowRef)
+        .nativeWindow as ProfileTagWindowObject;
+    });
 
-    const debugEvent = <DebugEvent>(
-      new CustomEvent(InternalProfileTagEventNames.DEBUG_FLAG_CHANGED, {
-        detail: { debug: true },
-      })
-    );
-    eventListener[InternalProfileTagEventNames.DEBUG_FLAG_CHANGED](debugEvent);
-    subscription.unsubscribe();
+    it('Should load consent-reference from local storage on page refresh', () => {
+      spyOn(window.localStorage, 'getItem').and.returnValue(
+        '{"cr":{"electronics-test-consentReference":{"consentReference": "abc"}}}'
+      );
+      profileTagEventTracker = TestBed.inject(ProfileTagEventService);
 
-    expect(timesCalled).toEqual(1);
-  });
+      expect(window.localStorage.getItem).toHaveBeenCalledTimes(1);
+      expect(profileTagEventTracker.latestConsentReference.value).toEqual(
+        'abc'
+      );
+    });
 
-  it(`Should call the consentReferenceChanged method when consentReference value changes`, () => {
-    let timesCalled = 0;
-    const subscription = profileTagEventTracker
-      .getProfileTagEvents()
-      .pipe(tap(() => timesCalled++))
-      .subscribe();
+    it('Should not load consent-reference from local storage on page refresh if consent is not granted', () => {
+      spyOn(window.localStorage, 'getItem').and.returnValue(undefined);
+      profileTagEventTracker = TestBed.inject(ProfileTagEventService);
 
-    let consentReferenceChangedEvent = <ConsentReferenceEvent>(
-      new CustomEvent(InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED, {
-        detail: { consentReference: 'some_id' },
-      })
-    );
-    eventListener[InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED](
-      consentReferenceChangedEvent
-    );
+      expect(window.localStorage.getItem).toHaveBeenCalledTimes(1);
+      expect(
+        profileTagEventTracker.latestConsentReference.value
+      ).not.toBeDefined();
+    });
 
-    consentReferenceChangedEvent = <ConsentReferenceEvent>(
-      new CustomEvent(InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED, {
-        detail: { consentReference: 'another_id' },
-      })
-    );
-    eventListener[InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED](
-      consentReferenceChangedEvent
-    );
-    subscription.unsubscribe();
+    it('Should not load consent-reference from local storage on page refresh if consent is not granted for this base-site', () => {
+      spyOn(window.localStorage, 'getItem').and.returnValue(
+        '{"cr":{"electronics-x-consentReference":{"consentReference": "abc"}}}'
+      );
+      profileTagEventTracker = TestBed.inject(ProfileTagEventService);
 
-    expect(timesCalled).toEqual(2);
-  });
+      expect(window.localStorage.getItem).toHaveBeenCalledTimes(1);
+      expect(
+        profileTagEventTracker.latestConsentReference.value
+      ).not.toBeDefined();
+    });
 
-  it('Should give the lastest consent reference to late subscribers', () => {
-    let cr1 = null;
-    let cr2 = null;
-    let cr3 = null;
-    const subscription1CR = profileTagEventTracker
-      .getConsentReference()
-      .subscribe((cr) => (cr1 = cr));
-    const consentReferenceChangedEvent = <ConsentReferenceEvent>(
-      new CustomEvent(InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED, {
-        detail: { consentReference: 'some_id' },
-      })
-    );
-    eventListener[InternalProfileTagEventNames.CONSENT_REFERENCE_LOADED](
-      consentReferenceChangedEvent
-    );
-    const subscription2CR = profileTagEventTracker
-      .getConsentReference()
-      .subscribe((cr) => (cr2 = cr));
-    const subscription3CR = profileTagEventTracker
-      .getConsentReference()
-      .subscribe((cr) => (cr3 = cr));
-    subscription1CR.unsubscribe();
-    subscription2CR.unsubscribe();
-    subscription3CR.unsubscribe();
-    expect(cr1).toEqual(cr2);
-    expect(cr3).toEqual(cr2);
-    expect(cr1).toEqual('some_id');
-  });
+    it('Should not load consent-reference from local storage, if running in SSR mode', () => {
+      mockedWindowRef.isBrowser = () => false;
+      profileTagEventTracker = TestBed.inject(ProfileTagEventService);
 
-  it('Should load consent-reference from local storage on page refresh', () => {
-    spyOn(window.localStorage, 'getItem').and.returnValue(
-      '{"cr":{"electronics-test-consentReference":{"consentReference": "abc"}}}'
-    );
-    profileTagEventTracker = new ProfileTagEventService(
-      mockedWindowRef,
-      mockCDSConfig,
-      baseSiteService,
-      ''
-    );
-    expect(window.localStorage.getItem).toHaveBeenCalledTimes(1);
-    expect(profileTagEventTracker.latestConsentReference.value).toEqual('abc');
-  });
-
-  it('Should not load consent-reference from local storage on page refresh if consent is not granted', () => {
-    spyOn(window.localStorage, 'getItem').and.returnValue(undefined);
-    profileTagEventTracker = new ProfileTagEventService(
-      mockedWindowRef,
-      mockCDSConfig,
-      baseSiteService,
-      ''
-    );
-    expect(window.localStorage.getItem).toHaveBeenCalledTimes(1);
-    expect(
-      profileTagEventTracker.latestConsentReference.value
-    ).not.toBeDefined();
-  });
-
-  it('Should not load consent-reference from local storage on page refresh if consent is not granted for this base-site', () => {
-    spyOn(window.localStorage, 'getItem').and.returnValue(
-      '{"cr":{"electronics-x-consentReference":{"consentReference": "abc"}}}'
-    );
-    profileTagEventTracker = new ProfileTagEventService(
-      mockedWindowRef,
-      mockCDSConfig,
-      baseSiteService,
-      ''
-    );
-    expect(window.localStorage.getItem).toHaveBeenCalledTimes(1);
-    expect(
-      profileTagEventTracker.latestConsentReference.value
-    ).not.toBeDefined();
-  });
-
-  it('Should not load consent-reference from local storage, if running in SSR mode', () => {
-    mockedWindowRef.isBrowser = () => false;
-    profileTagEventTracker = new ProfileTagEventService(
-      mockedWindowRef,
-      mockCDSConfig,
-      baseSiteService,
-      ''
-    );
-    expect(profileTagEventTracker.latestConsentReference).toBeUndefined();
+      expect(profileTagEventTracker.latestConsentReference).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
This PR contains a fix for CDS unit tests.
Since in `ProfileTagEventService` class an `inject` function has been used to provide `LoggerService`, this class should be tested as injectable (by using TestBed helper). Because in some test cases new instance of `ProfileTagEventService` was created with the 'new' operator, Angular was throwing an error that `inject` has been used in the wrong place.