### PR TITLE
fix: 'this' is undefined in ProductEffects.productLoadEffect

### DIFF
--- a/projects/core/src/product/store/effects/product.effect.ts
+++ b/projects/core/src/product/store/effects/product.effect.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, inject } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Action } from '@ngrx/store';
-import { Observable, merge, of } from 'rxjs';
+import { merge, Observable, of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 import { AuthActions } from '../../../auth/user-auth/store/actions';
 import { LoggerService } from '../../../logger';
@@ -49,7 +49,7 @@ export class ProductEffects {
             merge(
               ...this.productConnector
                 .getMany(products)
-                .map(this.productLoadEffect)
+                .map((productLoad) => this.productLoadEffect(productLoad))
             )
           ),
           withdrawOn(this.contextChange$)


### PR DESCRIPTION
Previous behavior: When `/products` endpoint returned a http error, the code broke in [this line](https://github.com/SAP/spartacus/blob/ed1e1a78c488b1e1214491ffa736612287f8cf70/projects/core/src/product/store/effects/product.effect.ts#L77), complaining that `this` is undefined.

Fix: Preserve the context of `this` which was lost in [this line](https://github.com/SAP/spartacus/blob/ed1e1a78c488b1e1214491ffa736612287f8cf70/projects/core/src/product/store/effects/product.effect.ts#L52)

The problem was revealed only after we implemented [CXSPA-2251](https://jira.tools.sap/browse/CXSPA-2251) where we referenced `this` by adding `this.logger` to the method `ProductEffects.productLoadEffect`

fixes https://jira.tools.sap/browse/CXSPA-3902