### PR TITLE
Implement Hosted-fields pattern#3 (iframe)

### DIFF
--- a/integration-libs/opf/base/core/connectors/opf-payment.adapter.ts
+++ b/integration-libs/opf/base/core/connectors/opf-payment.adapter.ts
@@ -7,6 +7,8 @@
 import {
   OpfPaymentVerificationPayload,
   OpfPaymentVerificationResponse,
+  SubmitCompleteRequest,
+  SubmitCompleteResponse,
   SubmitRequest,
   SubmitResponse,
 } from '@spartacus/opf/base/root';
@@ -31,4 +33,10 @@ export abstract class OpfPaymentAdapter {
     otpKey: string,
     paymentSessionId: string
   ): Observable<SubmitResponse>;
+
+  abstract submitCompletePayment(
+    submitRequest: SubmitCompleteRequest,
+    otpKey: string,
+    paymentSessionId: string
+  ): Observable<SubmitCompleteResponse>;
 }

--- a/integration-libs/opf/base/core/connectors/opf-payment.adapter.ts
+++ b/integration-libs/opf/base/core/connectors/opf-payment.adapter.ts
@@ -34,6 +34,10 @@ export abstract class OpfPaymentAdapter {
     paymentSessionId: string
   ): Observable<SubmitResponse>;
 
+  /**
+   * Abstract method used to submit-complete payment for hosted-fields pattern
+   */
+
   abstract submitCompletePayment(
     submitRequest: SubmitCompleteRequest,
     otpKey: string,

--- a/integration-libs/opf/base/core/connectors/opf-payment.connector.ts
+++ b/integration-libs/opf/base/core/connectors/opf-payment.connector.ts
@@ -8,6 +8,8 @@ import { Injectable } from '@angular/core';
 import {
   OpfPaymentVerificationPayload,
   OpfPaymentVerificationResponse,
+  SubmitCompleteRequest,
+  SubmitCompleteResponse,
   SubmitRequest,
   SubmitResponse,
 } from '@spartacus/opf/base/root';
@@ -32,5 +34,17 @@ export class OpfPaymentConnector {
     paymentSessionId: string
   ): Observable<SubmitResponse> {
     return this.adapter.submitPayment(submitRequest, otpKey, paymentSessionId);
+  }
+
+  public submitCompletePayment(
+    submitCompleteRequest: SubmitCompleteRequest,
+    otpKey: string,
+    paymentSessionId: string
+  ): Observable<SubmitCompleteResponse> {
+    return this.adapter.submitCompletePayment(
+      submitCompleteRequest,
+      otpKey,
+      paymentSessionId
+    );
   }
 }

--- a/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
@@ -63,6 +63,24 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
     return window.Opf.payments;
   }
 
+  protected startLoaderSpinner(vcr: ViewContainerRef) {
+    return this.launchDialogService.launch(
+      LAUNCH_CALLER.PLACE_ORDER_SPINNER,
+      vcr
+    );
+  }
+
+  protected stopLoaderSpinner(overlayedSpinner: Observable<ComponentRef<any>>) {
+    overlayedSpinner
+      .subscribe((component) => {
+        this.launchDialogService.clear(LAUNCH_CALLER.PLACE_ORDER_SPINNER);
+        if (component) {
+          component.destroy();
+        }
+      })
+      .unsubscribe();
+  }
+
   protected registerSubmit(
     paymentSessionId: string,
     vcr?: ViewContainerRef
@@ -91,10 +109,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
       return this.ngZone.run(() => {
         let overlayedSpinner: void | Observable<ComponentRef<any> | undefined>;
         if (vcr) {
-          overlayedSpinner = this.launchDialogService.launch(
-            LAUNCH_CALLER.PLACE_ORDER_SPINNER,
-            vcr
-          );
+          overlayedSpinner = this.startLoaderSpinner(vcr);
         }
         const callbackArray: [
           MerchantCallback,
@@ -114,16 +129,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
           .pipe(
             finalize(() => {
               if (overlayedSpinner) {
-                overlayedSpinner
-                  .subscribe((component) => {
-                    this.launchDialogService.clear(
-                      LAUNCH_CALLER.PLACE_ORDER_SPINNER
-                    );
-                    if (component) {
-                      component.destroy();
-                    }
-                  })
-                  .unsubscribe();
+                this.stopLoaderSpinner(overlayedSpinner);
               }
             })
           )
@@ -158,10 +164,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
       return this.ngZone.run(() => {
         let overlayedSpinner: void | Observable<ComponentRef<any> | undefined>;
         if (vcr) {
-          overlayedSpinner = this.launchDialogService.launch(
-            LAUNCH_CALLER.PLACE_ORDER_SPINNER,
-            vcr
-          );
+          overlayedSpinner = this.startLoaderSpinner(vcr);
         }
         const callbackArray: [
           MerchantCallback,
@@ -179,16 +182,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
           .pipe(
             finalize(() => {
               if (overlayedSpinner) {
-                overlayedSpinner
-                  .subscribe((component) => {
-                    this.launchDialogService.clear(
-                      LAUNCH_CALLER.PLACE_ORDER_SPINNER
-                    );
-                    if (component) {
-                      component.destroy();
-                    }
-                  })
-                  .unsubscribe();
+                this.stopLoaderSpinner(overlayedSpinner);
               }
             })
           )

--- a/integration-libs/opf/base/core/facade/opf-payment.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-payment.service.ts
@@ -5,49 +5,18 @@
  */
 
 import { Injectable } from '@angular/core';
+import { Command, CommandService, WindowRef } from '@spartacus/core';
 import {
-  Command,
-  CommandService,
-  GlobalMessageService,
-  RoutingService,
-  UserIdService,
-  WindowRef,
-} from '@spartacus/core';
-import {
-  MerchantCallback,
-  OpfOrderFacade,
-  OpfOtpFacade,
-  OpfPaymentError,
   OpfPaymentFacade,
   OpfPaymentVerificationPayload,
   OpfPaymentVerificationResponse,
-  PaymentErrorType,
-  PaymentMethod,
   SubmitCompleteInput,
-  SubmitCompleteRequest,
-  SubmitCompleteResponse,
   SubmitInput,
-  SubmitRequest,
-  SubmitResponse,
-  SubmitStatus,
-  defaultError,
 } from '@spartacus/opf/base/root';
 
-import { ActiveCartFacade } from '@spartacus/cart/base/root';
-import { Order } from '@spartacus/order/root';
-import { EMPTY, Observable, combineLatest, from, throwError } from 'rxjs';
-import {
-  catchError,
-  concatMap,
-  filter,
-  map,
-  switchMap,
-  take,
-  tap,
-} from 'rxjs/operators';
+import { Observable } from 'rxjs';
 import { OpfPaymentConnector } from '../connectors/opf-payment.connector';
-import { OpfPaymentErrorHandlerService } from '../services/opf-payment-error-handler.service';
-import { getBrowserInfo } from '../utils/opf-payment-utils';
+import { OpfPaymentHostedFieldsService } from '../services/opf-payment-hosted-fields.service';
 
 @Injectable()
 export class OpfPaymentService implements OpfPaymentFacade {
@@ -64,172 +33,11 @@ export class OpfPaymentService implements OpfPaymentFacade {
     )
   );
 
-  protected submitPaymentCommand: Command<
-    {
-      submitInput: SubmitInput;
-    },
-    boolean
-  > = this.commandService.create((payload) => {
-    const {
-      paymentMethod,
-      cartId,
-      additionalData,
-      paymentSessionId,
-      returnPath,
-    } = payload.submitInput;
-
-    const submitRequest: SubmitRequest = {
-      paymentMethod,
-      cartId,
-      additionalData,
-      channel: 'BROWSER',
-      browserInfo: getBrowserInfo(this.winRef.nativeWindow),
-    };
-    if (paymentMethod !== PaymentMethod.CREDIT_CARD) {
-      submitRequest.encryptedToken = '';
-    }
-
-    return combineLatest([
-      this.userIdService.getUserId(),
-      this.activeCartFacade.getActiveCartId(),
-    ]).pipe(
-      switchMap(([userId, activeCartId]: [string, string]) => {
-        submitRequest.cartId = activeCartId;
-        return this.opfOtpFacade.generateOtpKey(userId, activeCartId);
-      }),
-      filter((response) => Boolean(response?.value)),
-      take(1),
-      concatMap(({ value: otpKey }) =>
-        this.opfPaymentConnector.submitPayment(
-          submitRequest,
-          otpKey,
-          paymentSessionId
-        )
-      ),
-      concatMap((response: SubmitResponse) =>
-        this.paymentResponseHandler(response, payload.submitInput.callbackArray)
-      ),
-      tap((order: Order) => {
-        if (order) {
-          this.routingService.go({ cxRoute: 'orderConfirmation' });
-        }
-      }),
-      map((order: Order) => (order ? true : false)),
-      catchError((error: OpfPaymentError | undefined) => {
-        this.opfPaymentErrorHandlerService.handlePaymentError(
-          error,
-          returnPath
-        );
-        return throwError(error);
-      })
-    );
-  });
-
-  protected submitCompletePaymentCommand: Command<
-    {
-      submitCompleteInput: SubmitCompleteInput;
-    },
-    boolean
-  > = this.commandService.create((payload) => {
-    const { cartId, additionalData, paymentSessionId, returnPath } =
-      payload.submitCompleteInput;
-
-    const submitCompleteRequest: SubmitCompleteRequest = {
-      cartId,
-      additionalData,
-      paymentSessionId,
-    };
-
-    return combineLatest([
-      this.userIdService.getUserId(),
-      this.activeCartFacade.getActiveCartId(),
-    ]).pipe(
-      switchMap(([userId, activeCartId]: [string, string]) => {
-        submitCompleteRequest.cartId = activeCartId;
-        return this.opfOtpFacade.generateOtpKey(userId, activeCartId);
-      }),
-      filter((response) => Boolean(response?.value)),
-      take(1),
-      concatMap(({ value: otpKey }) =>
-        this.opfPaymentConnector.submitCompletePayment(
-          submitCompleteRequest,
-          otpKey,
-          paymentSessionId
-        )
-      ),
-      concatMap((response: SubmitCompleteResponse) =>
-        this.paymentResponseHandler(
-          response,
-          payload.submitCompleteInput.callbackArray
-        )
-      ),
-      tap((order: Order) => {
-        if (order) {
-          this.routingService.go({ cxRoute: 'orderConfirmation' });
-        }
-      }),
-      map((order: Order) => (order ? true : false)),
-      catchError((error: OpfPaymentError | undefined) => {
-        this.opfPaymentErrorHandlerService.handlePaymentError(
-          error,
-          returnPath
-        );
-        return throwError(error);
-      })
-    );
-  });
-
-  protected paymentResponseHandler(
-    response: SubmitResponse | SubmitCompleteResponse,
-    [submitSuccess, submitPending, submitFailure]: [
-      MerchantCallback,
-      MerchantCallback,
-      MerchantCallback
-    ]
-  ) {
-    if (
-      response.status === SubmitStatus.ACCEPTED ||
-      response.status === SubmitStatus.DELAYED
-    ) {
-      return from(Promise.resolve(submitSuccess(response))).pipe(
-        concatMap(() => this.opfOrderFacade.placeOpfOrder(true))
-      );
-    } else if (response.status === SubmitStatus.PENDING) {
-      return from(Promise.resolve(submitPending(response))).pipe(
-        concatMap(() => EMPTY)
-      );
-    } else if (response.status === SubmitStatus.REJECTED) {
-      return from(Promise.resolve(submitFailure(response))).pipe(
-        concatMap(() =>
-          throwError({
-            ...defaultError,
-            type: PaymentErrorType.PAYMENT_REJECTED,
-          })
-        )
-      );
-    } else {
-      return from(Promise.resolve(submitFailure(response))).pipe(
-        concatMap(() =>
-          throwError({
-            ...defaultError,
-            type: PaymentErrorType.STATUS_NOT_RECOGNIZED,
-          })
-        )
-      );
-    }
-  }
-
   constructor(
     protected commandService: CommandService,
     protected opfPaymentConnector: OpfPaymentConnector,
     protected winRef: WindowRef,
-    protected opfOtpFacade: OpfOtpFacade,
-    protected activeCartFacade: ActiveCartFacade,
-    protected userIdService: UserIdService,
-    protected routingService: RoutingService,
-    protected opfOrderFacade: OpfOrderFacade,
-    protected globalMessageService: GlobalMessageService,
-    protected opfPaymentErrorHandlerService: OpfPaymentErrorHandlerService
+    protected opfPaymentHostedFieldsService: OpfPaymentHostedFieldsService
   ) {}
 
   verifyPayment(
@@ -243,12 +51,16 @@ export class OpfPaymentService implements OpfPaymentFacade {
   }
 
   submitPayment(submitInput: SubmitInput): Observable<boolean> {
-    return this.submitPaymentCommand.execute({ submitInput });
+    return this.opfPaymentHostedFieldsService.submitPaymentCommand.execute({
+      submitInput,
+    });
   }
 
   submitCompletePayment(
     submitCompleteInput: SubmitCompleteInput
   ): Observable<boolean> {
-    return this.submitCompletePaymentCommand.execute({ submitCompleteInput });
+    return this.opfPaymentHostedFieldsService.submitCompletePaymentCommand.execute(
+      { submitCompleteInput }
+    );
   }
 }

--- a/integration-libs/opf/base/core/facade/opf-payment.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-payment.service.ts
@@ -44,7 +44,7 @@ export class OpfPaymentService implements OpfPaymentFacade {
     );
   });
 
-  submitCompletePaymentCommand: Command<
+  protected submitCompletePaymentCommand: Command<
     {
       submitCompleteInput: SubmitCompleteInput;
     },

--- a/integration-libs/opf/base/core/facade/opf-payment.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-payment.service.ts
@@ -33,6 +33,28 @@ export class OpfPaymentService implements OpfPaymentFacade {
     )
   );
 
+  protected submitPaymentCommand: Command<
+    {
+      submitInput: SubmitInput;
+    },
+    boolean
+  > = this.commandService.create((payload) => {
+    return this.opfPaymentHostedFieldsService.submitPayment(
+      payload.submitInput
+    );
+  });
+
+  submitCompletePaymentCommand: Command<
+    {
+      submitCompleteInput: SubmitCompleteInput;
+    },
+    boolean
+  > = this.commandService.create((payload) => {
+    return this.opfPaymentHostedFieldsService.submitCompletePayment(
+      payload.submitCompleteInput
+    );
+  });
+
   constructor(
     protected commandService: CommandService,
     protected opfPaymentConnector: OpfPaymentConnector,
@@ -51,7 +73,7 @@ export class OpfPaymentService implements OpfPaymentFacade {
   }
 
   submitPayment(submitInput: SubmitInput): Observable<boolean> {
-    return this.opfPaymentHostedFieldsService.submitPaymentCommand.execute({
+    return this.submitPaymentCommand.execute({
       submitInput,
     });
   }
@@ -59,8 +81,6 @@ export class OpfPaymentService implements OpfPaymentFacade {
   submitCompletePayment(
     submitCompleteInput: SubmitCompleteInput
   ): Observable<boolean> {
-    return this.opfPaymentHostedFieldsService.submitCompletePaymentCommand.execute(
-      { submitCompleteInput }
-    );
+    return this.submitCompletePaymentCommand.execute({ submitCompleteInput });
   }
 }

--- a/integration-libs/opf/base/core/services/index.ts
+++ b/integration-libs/opf/base/core/services/index.ts
@@ -6,3 +6,4 @@
 
 export * from './opf-endpoints.service';
 export * from './opf-payment-error-handler.service';
+export * from './opf-payment-hosted-fields.service';

--- a/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
+++ b/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
@@ -1,0 +1,211 @@
+import { Injectable } from '@angular/core';
+import { ActiveCartFacade } from '@spartacus/cart/base/root';
+import {
+  Command,
+  CommandService,
+  GlobalMessageService,
+  RoutingService,
+  UserIdService,
+  WindowRef,
+} from '@spartacus/core';
+import { Order } from '@spartacus/order/root';
+
+import { EMPTY, combineLatest, from, throwError } from 'rxjs';
+import {
+  catchError,
+  concatMap,
+  filter,
+  map,
+  switchMap,
+  take,
+  tap,
+} from 'rxjs/operators';
+import { OpfOrderFacade, OpfOtpFacade } from '../../root/facade';
+import {
+  MerchantCallback,
+  OpfPaymentError,
+  PaymentErrorType,
+  PaymentMethod,
+  SubmitCompleteInput,
+  SubmitCompleteRequest,
+  SubmitCompleteResponse,
+  SubmitInput,
+  SubmitRequest,
+  SubmitResponse,
+  SubmitStatus,
+  defaultError,
+} from '../../root/model';
+import { OpfPaymentConnector } from '../connectors/opf-payment.connector';
+import { OpfPaymentErrorHandlerService } from '../services/opf-payment-error-handler.service';
+import { getBrowserInfo } from '../utils/opf-payment-utils';
+
+@Injectable({ providedIn: 'root' })
+export class OpfPaymentHostedFieldsService {
+  constructor(
+    protected commandService: CommandService,
+    protected opfPaymentConnector: OpfPaymentConnector,
+    protected winRef: WindowRef,
+    protected opfOtpFacade: OpfOtpFacade,
+    protected activeCartFacade: ActiveCartFacade,
+    protected userIdService: UserIdService,
+    protected routingService: RoutingService,
+    protected opfOrderFacade: OpfOrderFacade,
+    protected globalMessageService: GlobalMessageService,
+    protected opfPaymentErrorHandlerService: OpfPaymentErrorHandlerService
+  ) {}
+
+  submitPaymentCommand: Command<
+    {
+      submitInput: SubmitInput;
+    },
+    boolean
+  > = this.commandService.create((payload) => {
+    const {
+      paymentMethod,
+      cartId,
+      additionalData,
+      paymentSessionId,
+      returnPath,
+    } = payload.submitInput;
+
+    const submitRequest: SubmitRequest = {
+      paymentMethod,
+      cartId,
+      additionalData,
+      channel: 'BROWSER',
+      browserInfo: getBrowserInfo(this.winRef.nativeWindow),
+    };
+    if (paymentMethod !== PaymentMethod.CREDIT_CARD) {
+      submitRequest.encryptedToken = '';
+    }
+
+    return combineLatest([
+      this.userIdService.getUserId(),
+      this.activeCartFacade.getActiveCartId(),
+    ]).pipe(
+      switchMap(([userId, activeCartId]: [string, string]) => {
+        submitRequest.cartId = activeCartId;
+        return this.opfOtpFacade.generateOtpKey(userId, activeCartId);
+      }),
+      filter((response) => Boolean(response?.value)),
+      take(1),
+      concatMap(({ value: otpKey }) =>
+        this.opfPaymentConnector.submitPayment(
+          submitRequest,
+          otpKey,
+          paymentSessionId
+        )
+      ),
+      concatMap((response: SubmitResponse) =>
+        this.paymentResponseHandler(response, payload.submitInput.callbackArray)
+      ),
+      tap((order: Order) => {
+        if (order) {
+          this.routingService.go({ cxRoute: 'orderConfirmation' });
+        }
+      }),
+      map((order: Order) => (order ? true : false)),
+      catchError((error: OpfPaymentError | undefined) => {
+        this.opfPaymentErrorHandlerService.handlePaymentError(
+          error,
+          returnPath
+        );
+        return throwError(error);
+      })
+    );
+  });
+
+  submitCompletePaymentCommand: Command<
+    {
+      submitCompleteInput: SubmitCompleteInput;
+    },
+    boolean
+  > = this.commandService.create((payload) => {
+    const { cartId, additionalData, paymentSessionId, returnPath } =
+      payload.submitCompleteInput;
+
+    const submitCompleteRequest: SubmitCompleteRequest = {
+      cartId,
+      additionalData,
+      paymentSessionId,
+    };
+
+    return combineLatest([
+      this.userIdService.getUserId(),
+      this.activeCartFacade.getActiveCartId(),
+    ]).pipe(
+      switchMap(([userId, activeCartId]: [string, string]) => {
+        submitCompleteRequest.cartId = activeCartId;
+        return this.opfOtpFacade.generateOtpKey(userId, activeCartId);
+      }),
+      filter((response) => Boolean(response?.value)),
+      take(1),
+      concatMap(({ value: otpKey }) =>
+        this.opfPaymentConnector.submitCompletePayment(
+          submitCompleteRequest,
+          otpKey,
+          paymentSessionId
+        )
+      ),
+      concatMap((response: SubmitCompleteResponse) =>
+        this.paymentResponseHandler(
+          response,
+          payload.submitCompleteInput.callbackArray
+        )
+      ),
+      tap((order: Order) => {
+        if (order) {
+          this.routingService.go({ cxRoute: 'orderConfirmation' });
+        }
+      }),
+      map((order: Order) => (order ? true : false)),
+      catchError((error: OpfPaymentError | undefined) => {
+        this.opfPaymentErrorHandlerService.handlePaymentError(
+          error,
+          returnPath
+        );
+        return throwError(error);
+      })
+    );
+  });
+
+  protected paymentResponseHandler(
+    response: SubmitResponse | SubmitCompleteResponse,
+    [submitSuccess, submitPending, submitFailure]: [
+      MerchantCallback,
+      MerchantCallback,
+      MerchantCallback
+    ]
+  ) {
+    if (
+      response.status === SubmitStatus.ACCEPTED ||
+      response.status === SubmitStatus.DELAYED
+    ) {
+      return from(Promise.resolve(submitSuccess(response))).pipe(
+        concatMap(() => this.opfOrderFacade.placeOpfOrder(true))
+      );
+    } else if (response.status === SubmitStatus.PENDING) {
+      return from(Promise.resolve(submitPending(response))).pipe(
+        concatMap(() => EMPTY)
+      );
+    } else if (response.status === SubmitStatus.REJECTED) {
+      return from(Promise.resolve(submitFailure(response))).pipe(
+        concatMap(() =>
+          throwError({
+            ...defaultError,
+            type: PaymentErrorType.PAYMENT_REJECTED,
+          })
+        )
+      );
+    } else {
+      return from(Promise.resolve(submitFailure(response))).pipe(
+        concatMap(() =>
+          throwError({
+            ...defaultError,
+            type: PaymentErrorType.STATUS_NOT_RECOGNIZED,
+          })
+        )
+      );
+    }
+  }
+}

--- a/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
+++ b/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
@@ -7,7 +7,6 @@
 import { Injectable } from '@angular/core';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {
-  Command,
   CommandService,
   GlobalMessageService,
   RoutingService,
@@ -16,7 +15,7 @@ import {
 } from '@spartacus/core';
 import { Order } from '@spartacus/order/root';
 
-import { EMPTY, combineLatest, from, throwError } from 'rxjs';
+import { EMPTY, Observable, combineLatest, from, throwError } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -60,19 +59,14 @@ export class OpfPaymentHostedFieldsService {
     protected opfPaymentErrorHandlerService: OpfPaymentErrorHandlerService
   ) {}
 
-  submitPaymentCommand: Command<
-    {
-      submitInput: SubmitInput;
-    },
-    boolean
-  > = this.commandService.create((payload) => {
+  submitPayment(submitInput: SubmitInput): Observable<boolean> {
     const {
       paymentMethod,
       cartId,
       additionalData,
       paymentSessionId,
       returnPath,
-    } = payload.submitInput;
+    } = submitInput;
 
     const submitRequest: SubmitRequest = {
       paymentMethod,
@@ -103,7 +97,7 @@ export class OpfPaymentHostedFieldsService {
         )
       ),
       concatMap((response: SubmitResponse) =>
-        this.paymentResponseHandler(response, payload.submitInput.callbackArray)
+        this.paymentResponseHandler(response, submitInput.callbackArray)
       ),
       tap((order: Order) => {
         if (order) {
@@ -119,16 +113,11 @@ export class OpfPaymentHostedFieldsService {
         return throwError(error);
       })
     );
-  });
+  }
 
-  submitCompletePaymentCommand: Command<
-    {
-      submitCompleteInput: SubmitCompleteInput;
-    },
-    boolean
-  > = this.commandService.create((payload) => {
+  submitCompletePayment(submitCompleteInput: SubmitCompleteInput) {
     const { cartId, additionalData, paymentSessionId, returnPath } =
-      payload.submitCompleteInput;
+      submitCompleteInput;
 
     const submitCompleteRequest: SubmitCompleteRequest = {
       cartId,
@@ -154,10 +143,7 @@ export class OpfPaymentHostedFieldsService {
         )
       ),
       concatMap((response: SubmitCompleteResponse) =>
-        this.paymentResponseHandler(
-          response,
-          payload.submitCompleteInput.callbackArray
-        )
+        this.paymentResponseHandler(response, submitCompleteInput.callbackArray)
       ),
       tap((order: Order) => {
         if (order) {
@@ -173,7 +159,7 @@ export class OpfPaymentHostedFieldsService {
         return throwError(error);
       })
     );
-  });
+  }
 
   protected paymentResponseHandler(
     response: SubmitResponse | SubmitCompleteResponse,

--- a/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
+++ b/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {

--- a/integration-libs/opf/base/core/tokens/tokens.ts
+++ b/integration-libs/opf/base/core/tokens/tokens.ts
@@ -8,6 +8,7 @@ import { InjectionToken } from '@angular/core';
 import { Converter } from '@spartacus/core';
 import {
   OpfPaymentVerificationResponse,
+  SubmitCompleteResponse,
   SubmitResponse,
 } from '@spartacus/opf/base/root';
 
@@ -20,5 +21,5 @@ export const OPF_PAYMENT_SUBMIT_NORMALIZER = new InjectionToken<
 >('OpfPaymentSubmitNormalizer');
 
 export const OPF_PAYMENT_SUBMIT_COMPLETE_NORMALIZER = new InjectionToken<
-  Converter<any, SubmitResponse>
+  Converter<any, SubmitCompleteResponse>
 >('OpfPaymentSubmitCompleteNormalizer');

--- a/integration-libs/opf/base/core/tokens/tokens.ts
+++ b/integration-libs/opf/base/core/tokens/tokens.ts
@@ -18,3 +18,7 @@ export const OPF_PAYMENT_VERIFICATION_NORMALIZER = new InjectionToken<
 export const OPF_PAYMENT_SUBMIT_NORMALIZER = new InjectionToken<
   Converter<any, SubmitResponse>
 >('OpfPaymentSubmitNormalizer');
+
+export const OPF_PAYMENT_SUBMIT_COMPLETE_NORMALIZER = new InjectionToken<
+  Converter<any, SubmitResponse>
+>('OpfPaymentSubmitCompleteNormalizer');

--- a/integration-libs/opf/base/core/utils/opf-payment-utils.ts
+++ b/integration-libs/opf/base/core/utils/opf-payment-utils.ts
@@ -19,6 +19,6 @@ export function getBrowserInfo(
     screenWidth: nativeWindow?.screen?.width,
     userAgent: nativeWindow?.navigator?.userAgent,
     originUrl: nativeWindow?.location?.origin,
-    timeZoneOffset: new Date().getTimezoneOffset(),
+    timezoneOffset: new Date().getTimezoneOffset(),
   };
 }

--- a/integration-libs/opf/base/core/utils/opf-payment-utils.ts
+++ b/integration-libs/opf/base/core/utils/opf-payment-utils.ts
@@ -19,6 +19,6 @@ export function getBrowserInfo(
     screenWidth: nativeWindow?.screen?.width,
     userAgent: nativeWindow?.navigator?.userAgent,
     originUrl: nativeWindow?.location?.origin,
-    timezoneOffset: new Date().getTimezoneOffset(),
+    timeZoneOffset: new Date().getTimezoneOffset(),
   };
 }

--- a/integration-libs/opf/base/occ/adapters/occ-opf.adapter.ts
+++ b/integration-libs/opf/base/occ/adapters/occ-opf.adapter.ts
@@ -8,6 +8,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConverterService, backOff, isJaloError } from '@spartacus/core';
 import {
+  OPF_PAYMENT_SUBMIT_COMPLETE_NORMALIZER,
   OPF_PAYMENT_SUBMIT_NORMALIZER,
   OPF_PAYMENT_VERIFICATION_NORMALIZER,
   OpfEndpointsService,
@@ -19,6 +20,8 @@ import {
   OpfConfig,
   OpfPaymentVerificationPayload,
   OpfPaymentVerificationResponse,
+  SubmitCompleteRequest,
+  SubmitCompleteResponse,
   SubmitRequest,
   SubmitResponse,
 } from '@spartacus/opf/base/root';
@@ -95,6 +98,32 @@ export class OccOpfPaymentAdapter implements OpfPaymentAdapter {
     );
   }
 
+  submitCompletePayment(
+    submitCompleteRequest: SubmitCompleteRequest,
+    otpKey: string,
+    paymentSessionId: string
+  ): Observable<SubmitResponse> {
+    const headers = new HttpHeaders(this.header)
+      .set(OPF_CC_PUBLIC_KEY, this.config.opf?.commerceCloudPublicKey || '')
+      .set(OPF_CC_OTP_KEY, otpKey || '');
+
+    const url = this.getSubmitCompletePaymentEndpoint(paymentSessionId);
+
+    return this.http
+      .post<SubmitCompleteResponse>(url, submitCompleteRequest, { headers })
+      .pipe(
+        catchError((error) => throwError(error)),
+        backOff({
+          shouldRetry: isJaloError,
+        }),
+        backOff({
+          shouldRetry: isHttp500Error,
+          maxTries: 2,
+        }),
+        this.converter.pipeable(OPF_PAYMENT_SUBMIT_COMPLETE_NORMALIZER)
+      );
+  }
+
   protected verifyPaymentEndpoint(paymentSessionId: string): string {
     return this.opfEndpointsService.buildUrl('verifyPayment', {
       urlParams: { paymentSessionId },
@@ -103,6 +132,12 @@ export class OccOpfPaymentAdapter implements OpfPaymentAdapter {
 
   protected getSubmitPaymentEndpoint(paymentSessionId: string): string {
     return this.opfEndpointsService.buildUrl('submitPayment', {
+      urlParams: { paymentSessionId },
+    });
+  }
+
+  protected getSubmitCompletePaymentEndpoint(paymentSessionId: string): string {
+    return this.opfEndpointsService.buildUrl('submitCompletePayment', {
       urlParams: { paymentSessionId },
     });
   }

--- a/integration-libs/opf/base/occ/adapters/occ-opf.adapter.ts
+++ b/integration-libs/opf/base/occ/adapters/occ-opf.adapter.ts
@@ -102,7 +102,7 @@ export class OccOpfPaymentAdapter implements OpfPaymentAdapter {
     submitCompleteRequest: SubmitCompleteRequest,
     otpKey: string,
     paymentSessionId: string
-  ): Observable<SubmitResponse> {
+  ): Observable<SubmitCompleteResponse> {
     const headers = new HttpHeaders(this.header)
       .set(OPF_CC_PUBLIC_KEY, this.config.opf?.commerceCloudPublicKey || '')
       .set(OPF_CC_OTP_KEY, otpKey || '');

--- a/integration-libs/opf/base/occ/config/default-occ-opf-config.ts
+++ b/integration-libs/opf/base/occ/config/default-occ-opf-config.ts
@@ -12,6 +12,7 @@ export const defaultOccOpfConfig: OccConfig = {
       endpoints: {
         verifyPayment: 'payments/${paymentSessionId}/verify',
         submitPayment: 'payments/${paymentSessionId}/submit',
+        submitCompletePayment: 'payments/${paymentSessionId}/submit-complete',
       },
     },
   },

--- a/integration-libs/opf/base/occ/model/occ-opf-endpoints.model.ts
+++ b/integration-libs/opf/base/occ/model/occ-opf-endpoints.model.ts
@@ -17,5 +17,9 @@ declare module '@spartacus/core' {
      * Endpoint to submit payment for Hosted Fields pattern.
      */
     submitPayment?: string | OccEndpoint;
+    /**
+     * Endpoint to submit-complete payment for Hosted Fields pattern.
+     */
+    submitCompletePayment?: string | OccEndpoint;
   }
 }

--- a/integration-libs/opf/base/root/facade/opf-payment.facade.ts
+++ b/integration-libs/opf/base/root/facade/opf-payment.facade.ts
@@ -11,6 +11,7 @@ import { OPF_BASE_FEATURE } from '../feature-name';
 import {
   OpfPaymentVerificationPayload,
   OpfPaymentVerificationResponse,
+  SubmitCompleteInput,
   SubmitInput,
 } from '../model';
 
@@ -41,4 +42,13 @@ export abstract class OpfPaymentFacade {
    * @param submitInput
    */
   abstract submitPayment(submitInput: SubmitInput): Observable<boolean>;
+
+  /**
+   * abstract method to submit-complete payment for Hosted Fields pattern.
+   *
+   * @param submitInput
+   */
+  abstract submitCompletePayment(
+    submitCompleteInput: SubmitCompleteInput
+  ): Observable<boolean>;
 }

--- a/integration-libs/opf/base/root/model/opf.model.ts
+++ b/integration-libs/opf/base/root/model/opf.model.ts
@@ -58,7 +58,7 @@ export interface PaymentBrowserInfo {
   screenHeight?: number;
   screenWidth?: number;
   userAgent?: string;
-  timezoneOffset?: number;
+  timeZoneOffset?: number;
   ipAddress?: string;
   originUrl?: string;
 }

--- a/integration-libs/opf/base/root/model/opf.model.ts
+++ b/integration-libs/opf/base/root/model/opf.model.ts
@@ -58,7 +58,7 @@ export interface PaymentBrowserInfo {
   screenHeight?: number;
   screenWidth?: number;
   userAgent?: string;
-  timeZoneOffset?: number;
+  timezoneOffset?: number;
   ipAddress?: string;
   originUrl?: string;
 }

--- a/integration-libs/opf/base/root/model/opf.model.ts
+++ b/integration-libs/opf/base/root/model/opf.model.ts
@@ -93,19 +93,19 @@ export enum PaymentMethod {
   GOOGLE_PAY = 'GOOGLE_PAY',
 }
 export interface SubmitResponse {
-  cartId?: string;
-  status?: SubmitStatus;
-  reasonCode?: string;
+  cartId: string;
+  status: SubmitStatus;
+  reasonCode: string;
   paymentMethod: PaymentMethod;
-  authorizedAmount?: number;
-  customFields?: Array<KeyValuePair>;
+  authorizedAmount: number;
+  customFields: Array<KeyValuePair>;
 }
 
 export interface SubmitCompleteResponse {
-  cartId?: string;
-  status?: SubmitStatus;
-  paymentMethod?: PaymentMethod;
-  customFields?: Array<KeyValuePair>;
+  cartId: string;
+  status: SubmitStatus;
+  reasonCode: number;
+  customFields: Array<KeyValuePair>;
 }
 
 export interface SubmitCompleteRequest {
@@ -119,5 +119,4 @@ export interface SubmitCompleteInput {
   cartId: string;
   callbackArray: [MerchantCallback, MerchantCallback, MerchantCallback];
   returnPath?: Array<string>;
-  paymentMethod?: PaymentMethod;
 }

--- a/integration-libs/opf/base/root/model/opf.model.ts
+++ b/integration-libs/opf/base/root/model/opf.model.ts
@@ -28,7 +28,7 @@ export interface KeyValuePair {
 }
 
 export type MerchantCallback = (
-  response?: SubmitResponse
+  response?: SubmitResponse | SubmitCompleteResponse
 ) => void | Promise<void>;
 
 export interface GlobalOpfPaymentMethods {
@@ -39,6 +39,13 @@ export interface GlobalOpfPaymentMethods {
     submitPending: MerchantCallback;
     submitFailure: MerchantCallback;
     paymentMethod: PaymentMethod;
+  }): Promise<boolean>;
+  submitComplete?(options: {
+    cartId: string;
+    additionalData: Array<KeyValuePair>;
+    submitSuccess: MerchantCallback;
+    submitPending: MerchantCallback;
+    submitFailure: MerchantCallback;
   }): Promise<boolean>;
 }
 
@@ -51,7 +58,7 @@ export interface PaymentBrowserInfo {
   screenHeight?: number;
   screenWidth?: number;
   userAgent?: string;
-  timeZoneOffset?: number;
+  timezoneOffset?: number;
   ipAddress?: string;
   originUrl?: string;
 }
@@ -91,7 +98,13 @@ export interface SubmitResponse {
   reasonCode?: string;
   paymentMethod: PaymentMethod;
   authorizedAmount?: number;
+  customFields?: Array<KeyValuePair>;
+}
 
+export interface SubmitCompleteResponse {
+  cartId?: string;
+  status?: SubmitStatus;
+  paymentMethod?: PaymentMethod;
   customFields?: Array<KeyValuePair>;
 }
 
@@ -99,5 +112,12 @@ export interface SubmitCompleteRequest {
   paymentSessionId?: string;
   additionalData?: Array<KeyValuePair>;
   cartId?: string;
-  otpKey?: string;
+}
+export interface SubmitCompleteInput {
+  additionalData: Array<KeyValuePair>;
+  paymentSessionId: string;
+  cartId: string;
+  callbackArray: [MerchantCallback, MerchantCallback, MerchantCallback];
+  returnPath?: Array<string>;
+  paymentMethod?: PaymentMethod;
 }

--- a/integration-libs/opf/checkout/root/model/opf-payment.model.ts
+++ b/integration-libs/opf/checkout/root/model/opf-payment.model.ts
@@ -27,7 +27,7 @@ export interface PaymentBrowserInfo {
   screenHeight?: number;
   screenWidth?: number;
   userAgent?: string;
-  timezoneOffset?: number;
+  timeZoneOffset?: number;
   ipAddress?: string;
   originUrl?: string;
 }

--- a/integration-libs/opf/checkout/root/model/opf-payment.model.ts
+++ b/integration-libs/opf/checkout/root/model/opf-payment.model.ts
@@ -27,7 +27,7 @@ export interface PaymentBrowserInfo {
   screenHeight?: number;
   screenWidth?: number;
   userAgent?: string;
-  timeZoneOffset?: number;
+  timezoneOffset?: number;
   ipAddress?: string;
   originUrl?: string;
 }


### PR DESCRIPTION
Added 'submitComplete' method to  OpfPaymentFacade
Added 'registerSubmitComplete' to opf-global-functions service.
It is the same implementation as patterm#1 with 'submit' & 'registerSubmit'. 
The only difference is the endpoint payload.
