### PR TITLE
fix: payment info still displayed when date is missing

### DIFF
--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.html
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.html
@@ -101,7 +101,7 @@
             class="cx-summary-card"
             *ngIf="
               order?.paymentInfo?.billingAddress ||
-              (getPaymentInfoCardContent(order?.paymentInfo) | async)
+              isPaymentInfoCardFull(order?.paymentInfo)
             "
           >
             <cx-card

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.html
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.html
@@ -96,18 +96,41 @@
       </div>
 
       <ng-container *ngIf="order.paymentInfo">
-        <div class="cx-summary-card">
-          <cx-card
-            [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
-          ></cx-card>
-
-          <cx-card
-            [content]="
-              getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
-                | async
+        <ng-container *cxFeatureLevel="'6.3'">
+          <div
+            class="cx-summary-card"
+            *ngIf="
+              order?.paymentInfo?.billingAddress ||
+              (getPaymentInfoCardContent(order?.paymentInfo) | async)
             "
-          ></cx-card>
-        </div>
+          >
+            <cx-card
+              [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
+            ></cx-card>
+
+            <cx-card
+              [content]="
+                getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
+                  | async
+              "
+            ></cx-card>
+          </div>
+        </ng-container>
+
+        <ng-container *cxFeatureLevel="'!6.3'">
+          <div class="cx-summary-card">
+            <cx-card
+              [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
+            ></cx-card>
+
+            <cx-card
+              [content]="
+                getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
+                  | async
+              "
+            ></cx-card>
+          </div>
+        </ng-container>
       </ng-container>
     </div>
 

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.html
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.html
@@ -104,9 +104,13 @@
               isPaymentInfoCardFull(order?.paymentInfo)
             "
           >
-            <cx-card
-              [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
-            ></cx-card>
+            <ng-container *ngIf="isPaymentInfoCardFull(order?.paymentInfo)">
+              <cx-card
+                [content]="
+                  getPaymentInfoCardContent(order?.paymentInfo) | async
+                "
+              ></cx-card>
+            </ng-container>
 
             <cx-card
               [content]="

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
@@ -411,7 +411,7 @@ describe('OrderOverviewComponent', () => {
       );
     });
 
-    it('should isPaymentInfoCardFull be falsy when partial paymentInfo ', () => {
+    it('should isPaymentInfoCardFull be falsy when paymentInfo is partial', () => {
       expect(
         component.isPaymentInfoCardFull({
           ...mockOrder.paymentInfo,

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
@@ -4,7 +4,6 @@ import { DeliveryMode, PaymentDetails } from '@spartacus/cart/base/root';
 import {
   Address,
   CmsOrderDetailOverviewComponent,
-  FeatureConfigService,
   I18nTestingModule,
   TranslationService,
 } from '@spartacus/core';
@@ -134,12 +133,6 @@ const MockCmsComponentData = <CmsComponentData<any>>{
   data$: of(mockData),
 };
 
-class MockFeatureConfigService {
-  isLevel() {
-    return true;
-  }
-}
-
 describe('OrderOverviewComponent', () => {
   let component: OrderOverviewComponent;
   let fixture: ComponentFixture<OrderOverviewComponent>;
@@ -154,7 +147,6 @@ describe('OrderOverviewComponent', () => {
         { provide: TranslationService, useClass: MockTranslationService },
         { provide: OrderDetailsService, useClass: MockOrderDetailsService },
         { provide: CmsComponentData, useValue: MockCmsComponentData },
-        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
       ],
     }).compileComponents();
   });
@@ -419,22 +411,13 @@ describe('OrderOverviewComponent', () => {
       );
     });
 
-    it('should getPaymentInfoCardContent be null when partial paymentInfo ', () => {
-      const paymentInfoPartialyEmpty = {
-        ...mockOrder.paymentInfo,
-        expiryMonth: undefined,
-      };
-
-      expect(component.isPaymentInfoCardFull(paymentInfoPartialyEmpty)).toEqual(
-        false
-      );
-
-      component
-        .getPaymentInfoCardContent(paymentInfoPartialyEmpty)
-        .subscribe((data) => {
-          expect(data).toBeFalsy();
+    it('should isPaymentInfoCardFull be falsy when partial paymentInfo ', () => {
+      expect(
+        component.isPaymentInfoCardFull({
+          ...mockOrder.paymentInfo,
+          expiryMonth: undefined,
         })
-        .unsubscribe();
+      ).toBeFalsy();
     });
 
     it('should call getBillingAddressCardContent(billingAddress: Address)', () => {

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
@@ -4,6 +4,7 @@ import { DeliveryMode, PaymentDetails } from '@spartacus/cart/base/root';
 import {
   Address,
   CmsOrderDetailOverviewComponent,
+  FeatureConfigService,
   I18nTestingModule,
   TranslationService,
 } from '@spartacus/core';
@@ -133,6 +134,12 @@ const MockCmsComponentData = <CmsComponentData<any>>{
   data$: of(mockData),
 };
 
+class MockFeatureConfigService {
+  isLevel() {
+    return true;
+  }
+}
+
 describe('OrderOverviewComponent', () => {
   let component: OrderOverviewComponent;
   let fixture: ComponentFixture<OrderOverviewComponent>;
@@ -147,6 +154,7 @@ describe('OrderOverviewComponent', () => {
         { provide: TranslationService, useClass: MockTranslationService },
         { provide: OrderDetailsService, useClass: MockOrderDetailsService },
         { provide: CmsComponentData, useValue: MockCmsComponentData },
+        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
       ],
     }).compileComponents();
   });
@@ -409,6 +417,24 @@ describe('OrderOverviewComponent', () => {
       expect(component.getPaymentInfoCardContent).toHaveBeenCalledWith(
         mockOrder.paymentInfo
       );
+    });
+
+    it('should getPaymentInfoCardContent be null when partial paymentInfo ', () => {
+      const paymentInfoPartialyEmpty = {
+        ...mockOrder.paymentInfo,
+        expiryMonth: undefined,
+      };
+
+      expect(component.isPaymentInfoCardFull(paymentInfoPartialyEmpty)).toEqual(
+        false
+      );
+
+      component
+        .getPaymentInfoCardContent(paymentInfoPartialyEmpty)
+        .subscribe((data) => {
+          expect(data).toBeFalsy();
+        })
+        .unsubscribe();
     });
 
     it('should call getBillingAddressCardContent(billingAddress: Address)', () => {

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeDetectionStrategy, Component, Optional } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { DeliveryMode, PaymentDetails } from '@spartacus/cart/base/root';
 import {
   Address,
   CmsOrderDetailOverviewComponent,
   CostCenter,
-  FeatureConfigService,
   TranslationService,
 } from '@spartacus/core';
 import { Card, CmsComponentData } from '@spartacus/storefront';
@@ -35,28 +34,9 @@ export class OrderOverviewComponent {
   );
 
   constructor(
-    translation: TranslationService,
-    orderDetailsService: OrderDetailsService,
-    component: CmsComponentData<CmsOrderDetailOverviewComponent>,
-    // eslint-disable-next-line @typescript-eslint/unified-signatures
-    featureConfig?: FeatureConfigService
-  );
-
-  /**
-   * @deprecated since 6.3
-   */
-  constructor(
-    translation: TranslationService,
-    orderDetailsService: OrderDetailsService,
-    component: CmsComponentData<CmsOrderDetailOverviewComponent>
-  );
-
-  constructor(
     protected translation: TranslationService,
     protected orderDetailsService: OrderDetailsService,
-    protected component: CmsComponentData<CmsOrderDetailOverviewComponent>,
-    // TODO:(CXSPA-3330) for next major release remove feature level
-    @Optional() protected featureConfig?: FeatureConfigService
+    protected component: CmsComponentData<CmsOrderDetailOverviewComponent>
   ) {}
 
   getReplenishmentCodeCardContent(orderCode: string): Observable<Card> {
@@ -226,13 +206,7 @@ export class OrderOverviewComponent {
     );
   }
 
-  getPaymentInfoCardContent(payment: PaymentDetails): Observable<Card | null> {
-    if (
-      this.featureConfig?.isLevel('6.3') &&
-      !this.isPaymentInfoCardFull(payment)
-    ) {
-      return of(null);
-    }
+  getPaymentInfoCardContent(payment: PaymentDetails): Observable<Card> {
     return combineLatest([
       this.translation.translate('paymentForm.payment'),
       this.translation.translate('paymentCard.expires', {


### PR DESCRIPTION
Solution using featureLevel.
need to be implemented on 6.3 then cherrypick on epic/opf