### PR TITLE
fix about service not provided

### DIFF
--- a/integration-libs/opf/base/core/facade/facade-providers.ts
+++ b/integration-libs/opf/base/core/facade/facade-providers.ts
@@ -12,6 +12,7 @@ import {
   OpfPaymentFacade,
 } from '@spartacus/opf/base/root';
 
+import { OpfPaymentHostedFieldsService } from '../services/opf-payment-hosted-fields.service';
 import { OpfGlobalFunctionsService } from './opf-global-functions.service';
 import { OpfOrderService } from './opf-order.service';
 import { OpfOtpService } from './opf-otp.service';
@@ -19,6 +20,7 @@ import { OpfPaymentService } from './opf-payment.service';
 
 export const facadeProviders: Provider[] = [
   OpfPaymentService,
+  OpfPaymentHostedFieldsService,
   OpfOrderService,
   OpfOtpService,
   OpfGlobalFunctionsService,

--- a/integration-libs/opf/base/core/facade/opf-payment.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-payment.service.ts
@@ -5,7 +5,7 @@
  */
 
 import { Injectable } from '@angular/core';
-import { Command, CommandService, WindowRef } from '@spartacus/core';
+import { Command, CommandService } from '@spartacus/core';
 import {
   OpfPaymentFacade,
   OpfPaymentVerificationPayload,
@@ -13,7 +13,6 @@ import {
   SubmitCompleteInput,
   SubmitInput,
 } from '@spartacus/opf/base/root';
-
 import { Observable } from 'rxjs';
 import { OpfPaymentConnector } from '../connectors/opf-payment.connector';
 import { OpfPaymentHostedFieldsService } from '../services/opf-payment-hosted-fields.service';
@@ -58,7 +57,6 @@ export class OpfPaymentService implements OpfPaymentFacade {
   constructor(
     protected commandService: CommandService,
     protected opfPaymentConnector: OpfPaymentConnector,
-    protected winRef: WindowRef,
     protected opfPaymentHostedFieldsService: OpfPaymentHostedFieldsService
   ) {}
 

--- a/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
+++ b/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
@@ -7,7 +7,6 @@
 import { Injectable } from '@angular/core';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {
-  CommandService,
   GlobalMessageService,
   RoutingService,
   UserIdService,
@@ -25,9 +24,11 @@ import {
   take,
   tap,
 } from 'rxjs/operators';
-import { OpfOrderFacade, OpfOtpFacade } from '../../root/facade';
+
 import {
   MerchantCallback,
+  OpfOrderFacade,
+  OpfOtpFacade,
   OpfPaymentError,
   PaymentErrorType,
   PaymentMethod,
@@ -39,15 +40,14 @@ import {
   SubmitResponse,
   SubmitStatus,
   defaultError,
-} from '../../root/model';
+} from '@spartacus/opf/base/root';
 import { OpfPaymentConnector } from '../connectors/opf-payment.connector';
 import { OpfPaymentErrorHandlerService } from '../services/opf-payment-error-handler.service';
 import { getBrowserInfo } from '../utils/opf-payment-utils';
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class OpfPaymentHostedFieldsService {
   constructor(
-    protected commandService: CommandService,
     protected opfPaymentConnector: OpfPaymentConnector,
     protected winRef: WindowRef,
     protected opfOtpFacade: OpfOtpFacade,


### PR DESCRIPTION
Error occurred when split payment.service with OpfPaymentHostedFieldsService.
OpfPaymentHostedFieldsService needs to be listed in facadeProviders to be visible on runtime