### PR TITLE
fix: change attribute binding to property binding in GenericLink

### DIFF
--- a/projects/storefrontlib/shared/components/generic-link/generic-link.component.html
+++ b/projects/storefrontlib/shared/components/generic-link/generic-link.component.html
@@ -19,7 +19,7 @@
     [routerLink]="routerUrl"
     [queryParams]="queryParams"
     [fragment]="fragment"
-    [attr.target]="target"
+    [target]="target || undefined"
     [attr.id]="id"
     [attr.class]="class"
     [attr.style]="style"


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-3978

Changed attribute binding to property binding for target property in link html element in GenericLinkComponent.
Appears that in a case of usage of routerLink directive attribute binding of target property might not work as expected. Angular routerLink directive is designed to handle navigation and it takes precedence over the "target" attribute.
This change was introduced in https://github.com/SAP/spartacus/pull/15770/files#diff-be88e447f5abfc2f491bd2620e288d65bdae23c59931bd397a3376bf97bb426f and related to "Enabling strict mode for storefrontlib" so seems like that change was introduced only to avoid errors in template after strict mode enabling.
So i changed it back to [target] with a fallback to "_self" if target was not specified.

