### PR TITLE
fix: card payment info still displayed when values are empty (#17686)

### DIFF
--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.html
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.html
@@ -96,18 +96,45 @@
       </div>
 
       <ng-container *ngIf="order.paymentInfo">
-        <div class="cx-summary-card">
-          <cx-card
-            [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
-          ></cx-card>
-
-          <cx-card
-            [content]="
-              getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
-                | async
+        <ng-container *cxFeatureLevel="'6.3'">
+          <div
+            class="cx-summary-card"
+            *ngIf="
+              order?.paymentInfo?.billingAddress ||
+              isPaymentInfoCardFull(order?.paymentInfo)
             "
-          ></cx-card>
-        </div>
+          >
+            <ng-container *ngIf="isPaymentInfoCardFull(order?.paymentInfo)">
+              <cx-card
+                [content]="
+                  getPaymentInfoCardContent(order?.paymentInfo) | async
+                "
+              ></cx-card>
+            </ng-container>
+
+            <cx-card
+              [content]="
+                getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
+                  | async
+              "
+            ></cx-card>
+          </div>
+        </ng-container>
+
+        <ng-container *cxFeatureLevel="'!6.3'">
+          <div class="cx-summary-card">
+            <cx-card
+              [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
+            ></cx-card>
+
+            <cx-card
+              [content]="
+                getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
+                  | async
+              "
+            ></cx-card>
+          </div>
+        </ng-container>
       </ng-container>
     </div>
 

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
@@ -411,6 +411,15 @@ describe('OrderOverviewComponent', () => {
       );
     });
 
+    it('should isPaymentInfoCardFull be falsy when paymentInfo is partial', () => {
+      expect(
+        component.isPaymentInfoCardFull({
+          ...mockOrder.paymentInfo,
+          expiryMonth: undefined,
+        })
+      ).toBeFalsy();
+    });
+
     it('should call getBillingAddressCardContent(billingAddress: Address)', () => {
       spyOn(component, 'getBillingAddressCardContent').and.callThrough();
 

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
@@ -13,7 +13,7 @@ import {
   TranslationService,
 } from '@spartacus/core';
 import { Card, CmsComponentData } from '@spartacus/storefront';
-import { combineLatest, Observable, of } from 'rxjs';
+import { Observable, combineLatest, of } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { OrderDetailsService } from '../order-details.service';
 
@@ -223,6 +223,12 @@ export class OrderOverviewComponent {
             text: [payment.cardNumber, textExpires],
           } as Card)
       )
+    );
+  }
+
+  isPaymentInfoCardFull(payment: PaymentDetails): boolean {
+    return (
+      !!payment?.cardNumber && !!payment?.expiryMonth && !!payment?.expiryYear
     );
   }
 


### PR DESCRIPTION
CXSPA-3330

BREAKING CHANGE:

public method has been added to verify the integrality of credit card info.