### PR TITLE
fix: Product image normalizer now properly checks for gallery index - 6.3.x

### DIFF
--- a/projects/core/src/occ/adapters/product/converters/product-image-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/product-image-normalizer.ts
@@ -37,7 +37,7 @@ export class ProductImageNormalizer implements Converter<Occ.Product, Product> {
     const images: Images = {};
     if (source) {
       for (const image of source) {
-        const isList = image.hasOwnProperty('galleryIndex');
+        const isList = !isNaN(Number(image.galleryIndex));
         if (image.imageType) {
           if (!images.hasOwnProperty(image.imageType)) {
             images[image.imageType] = isList ? [] : {};


### PR DESCRIPTION
taken from https://github.com/SAP/spartacus/pull/17701 

and closes closes https://jira.tools.sap/browse/CXSPA-4181