### PR TITLE
feat: (cherry pick) use evergreen SAPUI5 version (#17656)

### DIFF
--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.ts
@@ -32,7 +32,12 @@ export class VisualPickingTabComponent implements AfterViewInit {
     );
   }
 
-  selectedProductCodes: string[] = [];
+  public get selectedProductCodes() {
+    return this.visualPickingTabService.selectedProductCodes;
+  }
+  public set selectedProductCodes(selectedProducts: string[]) {
+    this.visualPickingTabService.selectedProductCodes = selectedProducts;
+  }
 
   @ViewChild(VisualViewerComponent, { read: VisualViewerService })
   visualViewerService: VisualViewerService;

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.service.ts
@@ -98,6 +98,15 @@ export class VisualPickingTabService implements OnDestroy {
   private getProductReferencesSubscription: Subscription;
   private getFilteredProductReferencesSubscription: Subscription;
 
+  private _selectedProductCodes: string[] = [];
+  public get selectedProductCodes() {
+    return this._selectedProductCodes;
+  }
+  public set selectedProductCodes(selectedProducts: string[]) {
+    this._selectedProductCodes = selectedProducts;
+    this.changeDetectorRef.detectChanges();
+  }
+
   /**
    * When true, error messages will be shown when visualization load/lookup failures occur.
    */

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.service.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.service.ts
@@ -1104,17 +1104,22 @@ export class VisualViewerService implements OnDestroy {
       this.windowRef.document
         .getElementsByTagName('head')[0]
         .appendChild(script);
-      script.onload = () => {
+
+      (this.windowRef.document as any).onUi5Bootstrapped = () => {
         subscriber.next();
         subscriber.complete();
       };
+
       script.onerror = (error: any) => {
         subscriber.error(error);
         subscriber.complete();
       };
+
       script.id = 'sap-ui-bootstrap';
       script.type = 'text/javascript';
       script.setAttribute('data-sap-ui-compatVersion', 'edge');
+      script.setAttribute('data-sap-ui-async', 'true');
+      script.setAttribute('data-sap-ui-onInit', 'document.onUi5Bootstrapped()');
       script.src = ui5Config.bootstrapUrl;
     });
   }

--- a/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
+++ b/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
@@ -14,8 +14,7 @@ export function getTestConfig(): EpdVisualizationConfig {
           'https://epd-acc-eu20-consumer.epdacc.cfapps.eu20.hana.ondemand.com',
       },
       ui5: {
-        bootstrapUrl:
-          'https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js',
+        bootstrapUrl: 'https://ui5.sap.com/1.108/resources/sap-ui-core.js',
       },
     },
   };

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
@@ -22,7 +22,7 @@ import { EpdVisualizationConfig, EpdVisualizationRootModule } from "@spartacus/e
   provideConfig(<EpdVisualizationConfig>{
     epdVisualization: {
       ui5: {
-        bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js"
+        bootstrapUrl: "https://ui5.sap.com/1.108/resources/sap-ui-core.js"
       },
 
       apis: {
@@ -58,7 +58,7 @@ import { EpdVisualizationConfig, EpdVisualizationRootModule } from "@spartacus/e
   provideConfig(<EpdVisualizationConfig>{
     epdVisualization: {
       ui5: {
-        bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js"
+        bootstrapUrl: "https://ui5.sap.com/1.108/resources/sap-ui-core.js"
       },
 
       apis: {
@@ -100,7 +100,7 @@ import { EpdVisualizationConfig, EpdVisualizationRootModule, EPD_VISUALIZATION_F
   provideConfig(<EpdVisualizationConfig>{
     epdVisualization: {
       ui5: {
-        bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js"
+        bootstrapUrl: "https://ui5.sap.com/1.108/resources/sap-ui-core.js"
       },
 
       apis: {

--- a/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
@@ -75,7 +75,7 @@ function buildCdsConfig(
       content: `<${EPD_VISUALIZATION_CONFIG}>{
         epdVisualization: {
           ui5: {
-            bootstrapUrl: "https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js"
+            bootstrapUrl: "https://ui5.sap.com/1.108/resources/sap-ui-core.js"
           },
 
           apis: {

--- a/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
@@ -24,8 +24,7 @@ const epdVisualizationConfig: EpdVisualizationConfig = {
     },
 
     ui5: {
-      bootstrapUrl:
-        'https://sapui5.hana.ondemand.com/1.108.14/resources/sap-ui-core.js',
+      bootstrapUrl: 'https://ui5.sap.com/1.108/resources/sap-ui-core.js',
     },
   },
 };


### PR DESCRIPTION
This will avoid the scenario where bootstrapping fails because
a specific SAPUI5 version is not available on the CDN.

JIRA: CXSPA-4116