### PR TITLE
bugfix: CXSPA-4215  testing strategy not working for integration libs

### DIFF
--- a/ci-scripts/unit-tests.sh
+++ b/ci-scripts/unit-tests.sh
@@ -4,16 +4,15 @@ set -o pipefail
 
 EXCLUDE_APPLICATIONS=storefrontapp
 EXCLUDE_JEST=storefrontstyles,schematics,setup
-EXCLUDE_INTEGRATION_LIBS=cdc,cds,digital-payments,epd-visualization,s4om
 
 echo "-----"
 
 function run_affected_unit_tests {
     echo "Running JASMINE unit tests and code coverage for AFFECTED libraries"
-    npx nx affected --target=test --exclude="$EXCLUDE_APPLICATIONS,$EXCLUDE_JEST,$EXCLUDE_INTEGRATION_LIBS" -- --no-watch --source-map --code-coverage --browsers ChromeHeadless
+    npx nx affected --target=test --exclude="$EXCLUDE_APPLICATIONS,$EXCLUDE_JEST" -- --no-watch --source-map --code-coverage --browsers ChromeHeadless
 
     echo "Running JEST (mostly schematics) unit tests and code coverage for AFFECTED libraries"
-    npx nx affected --target=test-jest --exclude="$EXCLUDE_APPLICATIONS,$EXCLUDE_INTEGRATION_LIBS" -- --coverage --runInBand
+    npx nx affected --target=test-jest --exclude="$EXCLUDE_APPLICATIONS" -- --coverage --runInBand
 }
 
 function run_all_unit_tests {

--- a/docs/libs/creating-lib.md
+++ b/docs/libs/creating-lib.md
@@ -335,7 +335,6 @@ The following files should be modified:
 - `projects/storefrontapp/src/environments/models/build.process.env.d.ts` - if creating a feature that can be toggled on/off, add your feature environment variable to the `Env` interface located in this file
 - `projects/storefrontapp/src/environments/environment.ts` - if creating a feature that can be toggled on/off, set you feature for development as enabled or disabled by default
 - `projects/storefrontapp/src/environments/environment.prod.ts` - if creating a feature that can be toggled on/off, pass the created env. variable to your feature
-- look for `EXCLUDE_INTEGRATION_LIBS` in the entire codebase, and add the new library to the comma separated string `IF AND ONLY IF` it is a new integration library.
 
 - Root `package.json`
 
@@ -352,9 +351,6 @@ Also, add the new lib to the `build:libs` and `test:libs` scripts.
 - `projects/schematics/package.json` - add the library to the package group
 
 - `ci-scripts/unit-tests.sh`
-
-`IF AND ONLY IF` you are creating a new integration-lib, then include the library's name to the command separated string for `EXCLUDE_INTEGRATION_LIBS`.
-
 
 
 ### Sample data release entry ONLY if applicable


### PR DESCRIPTION
It has been noticed that some of the PRs wor which all checks passed, causing build failures on develop branch due to failing unit tests.
The reason behind this was the exclusion of integration libs from Nx's affected strategy of running tests in CI.

To test such an issue, I've prepared a [test PR](https://github.com/SAP/spartacus/pull/17720) with [changes](https://github.com/SAP/spartacus/commit/49d83912577476ed5bf3200c3e0bb4aa95b9263c) that caused issues in `develop-6.3.x` last time.
As you may notice, [CI check](https://github.com/SAP/spartacus/actions/runs/5736149959/job/15545157307) for running unit tests didn't trigger any unit tests (even though we made changes in CDC so AT LEAST the CDC library should be affected:
![image](https://github.com/SAP/spartacus/assets/28891782/729a0c63-b691-4fc8-9d12-c176e7245e42)

After removing the excluded list of integration libs from `unit-tests.sh`, tests for CDC ([CI details](https://github.com/SAP/spartacus/actions/runs/5736335293/job/15545718860)) have been triggered (and passed, because they ran against the latest version of `develop-6.3.x` which contains the fix for failing unit tests):
![image](https://github.com/SAP/spartacus/assets/28891782/e4540243-a5e1-4a54-bd5d-f73cd3af3b77)



closes: https://jira.tools.sap/browse/CXSPA-4215