### PR TITLE
Display empty list when there are no quotes in the list

### DIFF
--- a/feature-libs/quote/assets/translations/en/quote.i18n.ts
+++ b/feature-libs/quote/assets/translations/en/quote.i18n.ts
@@ -11,7 +11,7 @@ export const quote = {
       updated: 'Updated',
       sortBy: 'Sort by',
       sortOrders: 'Sort orders',
-      empty: 'Quote list is empty',
+      empty: 'We have no quote records for this account.',
     },
     states: {
       BUYER_DRAFT: 'Draft',

--- a/feature-libs/quote/components/quote-list/quote-list.component.html
+++ b/feature-libs/quote/components/quote-list/quote-list.component.html
@@ -1,9 +1,8 @@
 <ng-container *ngIf="quotesState$ | async as quotesState">
   <div role="status" [attr.aria-label]="'common.loaded' | cxTranslate"></div>
-
   <ng-container *ngIf="quotesState.data; else loading">
     <ng-container
-      *ngIf="quotesState.data.quotes.length > 0; else emptyQuoteList"
+      *ngIf="quotesState.data.quotes?.length > 0; else emptyQuoteList"
     >
       <div class="cx-sort top">
         <label class="cx-form-group form-group"


### PR DESCRIPTION
Fix the following issue: quote list throws error when there are no quotes, yet