### PR TITLE
fix: install failing due to mismatch version

### DIFF
--- a/scripts/install/functions.sh
+++ b/scripts/install/functions.sh
@@ -82,7 +82,7 @@ function update_projects_versions {
     fi
 
     printh "Updating all library versions to ${SPARTACUS_VERSION}"
-    (cd "${CLONE_DIR}/tools/config" && pwd && sed -i -E 's/PUBLISHING_VERSION = '\'*\''/PUBLISHING_VERSION = '\'"${SPARTACUS_VERSION}"\''/g' const.ts);
+    (cd "${CLONE_DIR}/tools/config" && pwd && sed -i -E 's/PUBLISHING_VERSION = '\'.*\''/PUBLISHING_VERSION = '\'"${SPARTACUS_VERSION}"\''/g' const.ts);
     (cd "${CLONE_DIR}" && pwd && npm run config:update -- --generate-deps);
 
 }

--- a/scripts/install/functions.sh
+++ b/scripts/install/functions.sh
@@ -82,7 +82,7 @@ function update_projects_versions {
     fi
 
     printh "Updating all library versions to ${SPARTACUS_VERSION}"
-    (cd "${CLONE_DIR}/tools/config" && pwd && sed -i -E 's/PUBLISHING_VERSION = '\'\''/PUBLISHING_VERSION = '\'"${SPARTACUS_VERSION}"\''/g' const.ts);
+    (cd "${CLONE_DIR}/tools/config" && pwd && sed -i -E 's/PUBLISHING_VERSION = '\'*\''/PUBLISHING_VERSION = '\'"${SPARTACUS_VERSION}"\''/g' const.ts);
     (cd "${CLONE_DIR}" && pwd && npm run config:update -- --generate-deps);
 
 }

--- a/tools/config/const.ts
+++ b/tools/config/const.ts
@@ -10,4 +10,4 @@ export const SPARTACUS_SCOPE = '@spartacus';
 export const SAP_SCOPE = 'sap';
 export const SAPUI5_TYPES = '@sapui5/ts-types-esm';
 export const SPARTACUS_SCHEMATICS = `${SPARTACUS_SCOPE}/schematics`;
-export const PUBLISHING_VERSION = '6.4.0-1';
+export const PUBLISHING_VERSION = '';

--- a/tools/config/const.ts
+++ b/tools/config/const.ts
@@ -10,4 +10,4 @@ export const SPARTACUS_SCOPE = '@spartacus';
 export const SAP_SCOPE = 'sap';
 export const SAPUI5_TYPES = '@sapui5/ts-types-esm';
 export const SPARTACUS_SCHEMATICS = `${SPARTACUS_SCOPE}/schematics`;
-export const PUBLISHING_VERSION = '';
+export const PUBLISHING_VERSION = '6.4.0-1';


### PR DESCRIPTION
Tested successfully with both empty and pre-filled values:
in const.ts:
PUBLISHING_VERSION = '6.4.0-1';
PUBLISHING_VERSION = '';