### PR TITLE
refactor: change header from deprecated Content-language to Accept-Language

### DIFF
--- a/integration-libs/opf/base/occ/adapters/occ-opf.adapter.ts
+++ b/integration-libs/opf/base/occ/adapters/occ-opf.adapter.ts
@@ -7,24 +7,24 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
-  backOff,
   ConverterService,
+  backOff,
   isJaloError,
   normalizeHttpError,
 } from '@spartacus/core';
 import {
-  OpfEndpointsService,
-  OpfPaymentAdapter,
   OPF_PAYMENT_SUBMIT_COMPLETE_NORMALIZER,
   OPF_PAYMENT_SUBMIT_NORMALIZER,
   OPF_PAYMENT_VERIFICATION_NORMALIZER,
+  OpfEndpointsService,
+  OpfPaymentAdapter,
 } from '@spartacus/opf/base/core';
 import {
+  OPF_CC_OTP_KEY,
+  OPF_CC_PUBLIC_KEY,
   OpfConfig,
   OpfPaymentVerificationPayload,
   OpfPaymentVerificationResponse,
-  OPF_CC_OTP_KEY,
-  OPF_CC_PUBLIC_KEY,
   SubmitCompleteRequest,
   SubmitCompleteResponse,
   SubmitRequest,
@@ -46,7 +46,7 @@ export class OccOpfPaymentAdapter implements OpfPaymentAdapter {
   header: { [name: string]: string } = {
     accept: 'application/json',
     'Content-Type': 'application/json',
-    'Content-Language': 'en-us',
+    'Accept-Language': 'en-us',
   };
 
   verifyPayment(

--- a/integration-libs/opf/checkout/occ/adapters/occ-opf.adapter.ts
+++ b/integration-libs/opf/checkout/occ/adapters/occ-opf.adapter.ts
@@ -75,7 +75,7 @@ export class OccOpfAdapter implements OpfAdapter {
     paymentConfig: PaymentInitiationConfig
   ): Observable<PaymentSessionData> {
     const headers = new HttpHeaders({
-      'Content-Language': 'en-us',
+      'Accept-Language': 'en-us',
     })
       .set(OPF_CC_PUBLIC_KEY, this.config.opf?.commerceCloudPublicKey || '')
       .set(OPF_CC_OTP_KEY, paymentConfig?.otpKey || '');


### PR DESCRIPTION
[CXSPA-4688](https://jira.tools.sap/browse/CXSPA-4688)
Tested toward s1 server, see request header containing 'Accept-Language':
<img width="1750" alt="image" src="https://github.com/SAP/spartacus/assets/30024415/f58339c9-a3bb-4925-93d5-479045181937">
