### PR TITLE
fix: CXINT-2321 and CXINT-2322 Bug fixes

### DIFF
--- a/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.spec.ts
+++ b/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.spec.ts
@@ -229,6 +229,77 @@ describe('DeliveryModeDatePickerComponent', () => {
       });
   });
 
+  it('should NOT call setRequestedDeliveryDate when a date less than earliestRetrievalAt is provided', () => {
+    spyOn(component, 'setRequestedDeliveryDate');
+
+    component['requestedDelDateFacade'].setRequestedDeliveryDate = jasmine
+      .createSpy('setRequestedDeliveryDate')
+      .and.returnValue(of({}));
+
+    const requestedRetrievalAt = '2023-05-03';
+    const earliestRetrievalAt = '2023-09-15';
+    const data = TestBed.inject(OutletContextData);
+    data.context$ = of({
+      item: {
+        requestedRetrievalAt,
+        earliestRetrievalAt,
+        code: '123',
+        user: {
+          uid: 'current',
+        },
+      },
+      readonly: false,
+    });
+
+    component.ngOnInit();
+    fixture.detectChanges();
+    const newRequestedRetrievalAt = '2023-01-01';
+    component['form'].patchValue({
+      requestDeliveryDate: newRequestedRetrievalAt,
+    });
+
+    //Manually trigger change event for date picker.
+    const event = new Event('update');
+    const datePickerEl: HTMLInputElement = fixture.debugElement.query(
+      By.css('cx-date-picker')
+    )?.nativeElement;
+    datePickerEl.dispatchEvent(event);
+
+    expect(component['setRequestedDeliveryDate']).toHaveBeenCalled();
+    expect(
+      component['requestedDelDateFacade'].setRequestedDeliveryDate
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should NOT show the date picker when the component outlet value is read only', () => {
+    spyOn(component, 'setRequestedDeliveryDate');
+    const requestedRetrievalAt = '2023-05-03';
+    const earliestRetrievalAt = '2023-09-15';
+    const data = TestBed.inject(OutletContextData);
+    data.context$ = of({
+      item: {
+        requestedRetrievalAt,
+        earliestRetrievalAt,
+        code: '123',
+        user: {
+          uid: 'current',
+        },
+      },
+      readonly: true,
+    });
+
+    component.ngOnInit();
+    fixture.detectChanges();
+    const datePickerEl: HTMLInputElement = fixture.debugElement.query(
+      By.css('cx-date-picker')
+    )?.nativeElement;
+    expect(datePickerEl).toBeUndefined();
+    const datePickerReadOnlyEl: HTMLInputElement = fixture.debugElement.query(
+      By.css('cx-card')
+    )?.nativeElement;
+    expect(datePickerReadOnlyEl.innerHTML).not.toBeNull();
+  });
+
   it('should show error message when backend OCC API returns UnknownResourceError', (done) => {
     spyOn(component['globalMessageService'], 'add');
 

--- a/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.ts
+++ b/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.ts
@@ -114,10 +114,10 @@ export class DeliveryModeDatePickerComponent implements OnInit, OnDestroy {
       cartId.length === 0 ||
       requestedDate.length === 0 ||
       !this.dateValidationService.isDateStringValid(requestedDate) ||
-      this.dateValidationService.compareDateStrings(
+      !this.dateValidationService.isDateGreaterOrEqual(
         requestedDate,
         this.earliestRetrievalAt || ''
-      ) < 0
+      )
     ) {
       return;
     }

--- a/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.ts
+++ b/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.ts
@@ -48,6 +48,7 @@ export class DeliveryModeDatePickerComponent implements OnInit, OnDestroy {
     requestDeliveryDate: new FormControl(),
   });
   protected isDatePickerReadOnly: boolean = true;
+  protected readonly KEY_DEBOUNCE_TIME = 500;
 
   ngOnInit(): void {
     if (this.deliveryOutlet?.context$) {
@@ -67,6 +68,9 @@ export class DeliveryModeDatePickerComponent implements OnInit, OnDestroy {
     } else {
       //set the value of requestedRetrievalAt as earliestRetrievalAt and update occ.
       this.requestedRetrievalAt = this.earliestRetrievalAt;
+      this.form.patchValue({
+        requestDeliveryDate: this.requestedRetrievalAt,
+      });
       this.setRequestedDeliveryDate();
     }
     this.form.patchValue({
@@ -104,15 +108,17 @@ export class DeliveryModeDatePickerComponent implements OnInit, OnDestroy {
   setRequestedDeliveryDate() {
     const userId = this.cartEntry?.user?.uid || '';
     const cartId = this.cartEntry?.code || '';
-    const requestedDate =
-      this.form?.get('requestDeliveryDate')?.value ||
-      this.requestedRetrievalAt ||
-      '';
+    const requestedDate = this.form?.get('requestDeliveryDate')?.value || '';
 
     if (
       userId.length === 0 ||
       cartId.length === 0 ||
-      requestedDate.length === 0
+      requestedDate.length === 0 ||
+      !this.dateValidationService.isDateStringValid(requestedDate) ||
+      this.dateValidationService.compareDateStrings(
+        requestedDate,
+        this.earliestRetrievalAt || ''
+      ) < 0
     ) {
       return;
     }

--- a/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.ts
+++ b/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.ts
@@ -48,7 +48,6 @@ export class DeliveryModeDatePickerComponent implements OnInit, OnDestroy {
     requestDeliveryDate: new FormControl(),
   });
   protected isDatePickerReadOnly: boolean = true;
-  protected readonly KEY_DEBOUNCE_TIME = 500;
 
   ngOnInit(): void {
     if (this.deliveryOutlet?.context$) {

--- a/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.spec.ts
+++ b/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.spec.ts
@@ -6,6 +6,8 @@ const mockInvalidDate1 = '32-09-2023';
 const mockInvalidDate2 = '29-02-rddo';
 const mockInvalidDate3 = '';
 const mockInvalidDate4 = 'abcd';
+const mockValidGreaterDate = '31-12-2023';
+const mockValidLesserDate = '01-01-2023';
 
 describe('DateValidationService', () => {
   let service: DateValidationService;
@@ -22,14 +24,40 @@ describe('DateValidationService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should validate correct Dates', () => {
-    expect(service.isDateStringValid(mockValidDate)).toBeTruthy();
+  describe('isDateStringValid', () => {
+    it('should validate correct Dates', () => {
+      expect(service.isDateStringValid(mockValidDate)).toBeTruthy();
+    });
+
+    it('should invalidate wrong Dates', () => {
+      expect(service.isDateStringValid(mockInvalidDate1)).toBeFalsy();
+      expect(service.isDateStringValid(mockInvalidDate2)).toBeFalsy();
+      expect(service.isDateStringValid(mockInvalidDate3)).toBeFalsy();
+      expect(service.isDateStringValid(mockInvalidDate4)).toBeFalsy();
+    });
   });
 
-  it('should invalidate wrong Dates', () => {
-    expect(service.isDateStringValid(mockInvalidDate1)).toBeFalsy();
-    expect(service.isDateStringValid(mockInvalidDate2)).toBeFalsy();
-    expect(service.isDateStringValid(mockInvalidDate3)).toBeFalsy();
-    expect(service.isDateStringValid(mockInvalidDate4)).toBeFalsy();
+  describe('isDateGreaterOrEqual', () => {
+    it('should return false for invalid dates', () => {
+      expect(service.isDateGreaterOrEqual(mockValidDate, '')).toBeFalsy();
+    });
+
+    it('should return false when source date is less than target', () => {
+      expect(
+        service.isDateGreaterOrEqual(mockValidLesserDate, mockValidDate)
+      ).toBeFalsy();
+    });
+
+    it('should return true for equal dates', () => {
+      expect(
+        service.isDateGreaterOrEqual(mockValidDate, mockValidDate)
+      ).toBeTruthy();
+    });
+
+    it('should return true when source date is greater than target', () => {
+      expect(
+        service.isDateGreaterOrEqual(mockValidGreaterDate, mockValidDate)
+      ).toBeTruthy();
+    });
   });
 });

--- a/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
+++ b/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
@@ -28,19 +28,21 @@ export class DateValidationService {
 
   /**
    * Compares 2 Date strings in the format 'dd-mm-yyy'
-   * @param date1
-   * @param date2
+   * @param date1 Date string in the format 'dd-mm-yyy'
+   * @param date2 Date string in the format 'dd-mm-yyy'
    * @returns -1 if date2 is greater, 0 if both the dates are equal, 1 if date1 is greater, -2 for invalid inputs
    */
   compareDateStrings(date1: string, date2: string): number {
-    if (!date1 || !date2) {
+    if (date1.length === 0 || date2.length === 0) {
       return -2;
     }
-
     const d1 = this.getDateFromDateString(date1);
     const d2 = this.getDateFromDateString(date2);
+    if (d1 < d2) {
+      return -1;
+    }
 
-    return d1 < d2 ? -1 : d1 > d2 ? 1 : 0;
+    return d1 > d2 ? 1 : 0;
   }
 
   /**
@@ -49,5 +51,15 @@ export class DateValidationService {
    */
   getDateFromDateString(value: string): Date {
     return new Date(value.replace(/(\d{2})-(\d{2})-(\d{4})/, '$2/$1/$3'));
+  }
+
+  /**
+   * Checks if the source date is greater than or equal to the target
+   * @param source Date string in the format 'dd-mm-yyy'
+   * @param target Date string in the format 'dd-mm-yyy'
+   * @returns true if `source` date is greater than or equal to `target` date
+   */
+  isDateGreaterOrEqual(source: string, target: string): boolean {
+    return this.compareDateStrings(source, target) >= 0;
   }
 }

--- a/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
+++ b/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
@@ -33,7 +33,7 @@ export class DateValidationService {
    * @returns -1 if date2 is greater, 0 if both the dates are equal, 1 if date1 is greater, -2 for invalid inputs
    */
   compareDateStrings(date1: string, date2: string): number {
-    if (date1.length == 0 || date2.length == 0) {
+    if (date1.length === 0 || date2.length === 0) {
       return -2;
     }
     const d1 = this.getDateFromDateString(date1);

--- a/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
+++ b/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
@@ -33,18 +33,14 @@ export class DateValidationService {
    * @returns -1 if date2 is greater, 0 if both the dates are equal, 1 if date1 is greater, -2 for invalid inputs
    */
   compareDateStrings(date1: string, date2: string): number {
-    if (date1.length === 0 || date2.length === 0) {
+    if (!date1 || !date2) {
       return -2;
     }
+
     const d1 = this.getDateFromDateString(date1);
     const d2 = this.getDateFromDateString(date2);
-    if (d1 < d2) {
-      return -1;
-    } else if (d1 > d2) {
-      return 1;
-    } else {
-      return 0;
-    }
+
+    return d1 < d2 ? -1 : d1 > d2 ? 1 : 0;
   }
 
   /**

--- a/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
+++ b/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
@@ -27,25 +27,6 @@ export class DateValidationService {
   }
 
   /**
-   * Compares 2 Date strings in the format 'dd-mm-yyy'
-   * @param date1 Date string in the format 'dd-mm-yyy'
-   * @param date2 Date string in the format 'dd-mm-yyy'
-   * @returns -1 if date2 is greater, 0 if both the dates are equal, 1 if date1 is greater, -2 for invalid inputs
-   */
-  compareDateStrings(date1: string, date2: string): number {
-    if (date1.length === 0 || date2.length === 0) {
-      return -2;
-    }
-    const d1 = this.getDateFromDateString(date1);
-    const d2 = this.getDateFromDateString(date2);
-    if (d1 < d2) {
-      return -1;
-    }
-
-    return d1 > d2 ? 1 : 0;
-  }
-
-  /**
    * Returns a Date object from a date string in the format 'dd-mm-yyy'
    * @param value Date string in the format 'dd-mm-yyy'
    */
@@ -60,6 +41,12 @@ export class DateValidationService {
    * @returns true if `source` date is greater than or equal to `target` date
    */
   isDateGreaterOrEqual(source: string, target: string): boolean {
-    return this.compareDateStrings(source, target) >= 0;
+    if (source.length === 0 || target.length === 0) {
+      return false;
+    }
+    const d1 = this.getDateFromDateString(source);
+    const d2 = this.getDateFromDateString(target);
+
+    return d1 < d2 ? false : true;
   }
 }

--- a/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
+++ b/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
@@ -21,8 +21,37 @@ export class DateValidationService {
       value !== undefined &&
       value.length > 0 &&
       !isNaN(
-        new Date(value.replace(/(\d{2})-(\d{2})-(\d{4})/, '$2/$1/$3')).getDate() //convert 'dd-mm-yyyy' into 'mm/dd/yyyy'
+        this.getDateFromDateString(value).getDate() //convert 'dd-mm-yyyy' into 'mm/dd/yyyy'
       )
     );
+  }
+
+  /**
+   * Compares 2 Date strings in the format 'dd-mm-yyy'
+   * @param date1
+   * @param date2
+   * @returns -1 if date2 is greater, 0 if both the dates are equal, 1 if date1 is greater, -2 for invalid inputs
+   */
+  compareDateStrings(date1: string, date2: string): number {
+    if (date1.length == 0 || date2.length == 0) {
+      return -2;
+    }
+    const d1 = this.getDateFromDateString(date1);
+    const d2 = this.getDateFromDateString(date2);
+    if (d1 < d2) {
+      return -1;
+    } else if (d1 > d2) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  /**
+   * Returns a Date object from a date string in the format 'dd-mm-yyy'
+   * @param value Date string in the format 'dd-mm-yyy'
+   */
+  getDateFromDateString(value: string): Date {
+    return new Date(value.replace(/(\d{2})-(\d{2})-(\d{4})/, '$2/$1/$3'));
   }
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/requested-delivery-date/requested-delivery-date.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/requested-delivery-date/requested-delivery-date.e2e.cy.ts
@@ -74,7 +74,7 @@ describe('Requested Delivery Date', { testIsolation: false }, () => {
     });
 
     it('should show an error when an invalid delivery date is provided', () => {
-      rddHelper.updateRequestedDeliveryDate('1000-01-01');
+      rddHelper.updateRequestedDeliveryDate('10000-01-01');
       rddHelper.verifyDeliveryDateErrorMessage();
     });
 

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/requested-delivery-date/requested-delivery-date.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/requested-delivery-date/requested-delivery-date.ts
@@ -99,8 +99,10 @@ export function verifyRDDDatePickerExists() {
 export function updateRequestedDeliveryDate(date: string) {
   interceptPutRequestedRetrievalAtEndpoint();
   cy.get('cx-date-picker').within(() => {
-    cy.get('input[type="date"]', { timeout: 3000 })
+    cy.get('input', { timeout: 3000 })
       .should('not.be.disabled')
+      .invoke('removeAttr', 'type')
+      .clear()
       .type(date)
       .trigger('update');
   });


### PR DESCRIPTION
- Fixes https://jira.tools.sap/browse/CXINT-2321 and https://jira.tools.sap/browse/CXINT-2322
- Added date validation logic to handle textual inputs
- Only valid future dates are sent to the OCC APIs
- Fixed issue with clear button defaulting to the previous date

## E2ES pasing


![](https://user-images.githubusercontent.com/13379690/261300832-39daf65e-5ea7-4883-929a-427549c0eea1.png)


## Unit tests passing

```
=============================== Coverage summary ===============================
Statements   : 92.7% ( 89/96 )
Branches     : 85.71% ( 36/42 )
Functions    : 89.47% ( 34/38 )
Lines        : 92.47% ( 86/93 )
================================================================================
```