### PR TITLE
feat: fix seller submit (CXSPA-4748)

### DIFF
--- a/feature-libs/quote/assets/translations/en/quote.i18n.ts
+++ b/feature-libs/quote/assets/translations/en/quote.i18n.ts
@@ -125,6 +125,8 @@ export const quote = {
         submit: {
           title: 'Submit Quote {{ code }}?',
           confirmNote: 'Are you sure you want to submit this quote?',
+          warningNote:
+            'Based on the total value of the quote an additional approval might be required, before the buyer can checkout this quote.',
           successMessage: 'Quote submitted successfully',
         },
       },

--- a/feature-libs/quote/assets/translations/en/quote.i18n.ts
+++ b/feature-libs/quote/assets/translations/en/quote.i18n.ts
@@ -123,10 +123,9 @@ export const quote = {
       },
       seller: {
         submit: {
-          title: 'Submit Quote {{ code }} for approval?',
-          confirmNote:
-            'Are you sure you want to submit this quote for approval?',
-          successMessage: 'Quote submitted for approval successfully',
+          title: 'Submit Quote {{ code }}?',
+          confirmNote: 'Are you sure you want to submit this quote?',
+          successMessage: 'Quote submitted successfully',
         },
       },
       approver: {

--- a/feature-libs/quote/components/config/default-quote-ui.config.ts
+++ b/feature-libs/quote/components/config/default-quote-ui.config.ts
@@ -59,6 +59,7 @@ const defaultDialogMappings: ConfirmActionDialogMappingConfig = {
     SUBMIT: {
       i18nKey: 'quote.confirmActionDialog.seller.submit',
       ...defaultConfirmActionDialogConfig,
+      showWarningNote: true,
     },
   },
   SELLERAPPROVER: {

--- a/feature-libs/quote/core/facade/quote.service.spec.ts
+++ b/feature-libs/quote/core/facade/quote.service.spec.ts
@@ -408,13 +408,17 @@ describe('QuoteService', () => {
     });
 
     describe('on submit', () => {
-      it('should create new cart and navigate to quote list', (done) => {
+      it('should create new cart and navigate to quote list, but not reload', (done) => {
         service
           .performQuoteAction(quote, QuoteActionType.SUBMIT)
           .subscribe(() => {
             expect(
               cartUtilsService.createNewCartAndGoToQuoteList
             ).toHaveBeenCalled();
+            expect(eventService.dispatch).not.toHaveBeenCalledWith(
+              {},
+              QuoteDetailsReloadQueryEvent
+            );
             done();
           });
       });

--- a/feature-libs/quote/core/facade/quote.service.ts
+++ b/feature-libs/quote/core/facade/quote.service.ts
@@ -225,7 +225,7 @@ export class QuoteService implements QuoteFacade {
             payload.quoteAction === QuoteActionType.CANCEL
           ) {
             this.cartUtilsService.createNewCartAndGoToQuoteList();
-            this.triggerReloadAndCompleteAction();
+            this.isActionPerforming$.next(false);
           }
           if (
             payload.quoteAction === QuoteActionType.EDIT ||


### PR DESCRIPTION
reword confirm dialog
do not reload quote when navigating to list view, 
as causes a quote with id 'undefined' to be read which leads to 400 error