### PR TITLE
fix: install failing due to mismatch version (#17798)

### DIFF
--- a/scripts/install/functions.sh
+++ b/scripts/install/functions.sh
@@ -82,7 +82,7 @@ function update_projects_versions {
     fi
 
     printh "Updating all library versions to ${SPARTACUS_VERSION}"
-    (cd "${CLONE_DIR}/tools/config" && pwd && sed -i -E 's/PUBLISHING_VERSION = '\'\''/PUBLISHING_VERSION = '\'"${SPARTACUS_VERSION}"\''/g' const.ts);
+    (cd "${CLONE_DIR}/tools/config" && pwd && sed -i -E 's/PUBLISHING_VERSION = '\'.*\''/PUBLISHING_VERSION = '\'"${SPARTACUS_VERSION}"\''/g' const.ts);
     (cd "${CLONE_DIR}" && pwd && npm run config:update -- --generate-deps);
 
 }


### PR DESCRIPTION
CXSPA-4403

Spartacus_version specified in install config file now overwrites publishing_version.
cherrypick https://github.com/SAP/spartacus/pull/17798 from 6.4.x to 6.5.x