### PR TITLE
refactor: remove hard-coded page navigation

### DIFF
--- a/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
@@ -18,6 +18,7 @@ import {
   KeyValuePair,
   MerchantCallback,
   OpfGlobalFunctionsFacade,
+  OpfPage,
   OpfPaymentFacade,
   PaymentMethod,
   TargetPage,
@@ -289,7 +290,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
         additionalData,
         [submitSuccess, submitPending, submitFailure],
         paymentSessionId,
-        'checkoutReviewOrder',
+        OpfPage.CHECKOUT_REVIEW_PAGE,
         vcr
       );
     };

--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.component.spec.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.component.spec.ts
@@ -9,7 +9,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorModel } from '@spartacus/core';
 import { of, throwError } from 'rxjs';
-import { KeyValuePair } from '../../model';
+import { KeyValuePair, OpfPage } from '../../model';
 import { OpfPaymentVerificationComponent } from './opf-payment-verification.component';
 import { OpfPaymentVerificationService } from './opf-payment-verification.service';
 
@@ -154,14 +154,14 @@ describe('OpfPaymentVerificationComponent', () => {
   });
 
   describe('onError', () => {
-    it('should call paymentService.displayError with the provided error and paymentService.goToPage with "checkoutReviewOrder"', () => {
+    it('should call paymentService.displayError with the provided error and paymentService.goToPage with OpfPage.CHECKOUT_REVIEW_PAGE', () => {
       const mockError: HttpErrorModel = { status: 404, message: 'Not Found' };
 
       component.onError(mockError);
 
       expect(paymentServiceMock.displayError).toHaveBeenCalledWith(mockError);
       expect(paymentServiceMock.goToPage).toHaveBeenCalledWith(
-        'checkoutReviewOrder'
+        OpfPage.CHECKOUT_REVIEW_PAGE
       );
     });
   });

--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.component.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.component.ts
@@ -11,7 +11,7 @@ import { HttpErrorModel } from '@spartacus/core';
 import { Observable, Subscription } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
 
-import { KeyValuePair, TargetPage } from '../../model';
+import { KeyValuePair, OpfPage, TargetPage } from '../../model';
 import { OpfPaymentVerificationService } from './opf-payment-verification.service';
 
 @Component({
@@ -84,7 +84,7 @@ export class OpfPaymentVerificationComponent implements OnInit, OnDestroy {
 
   onError(error: HttpErrorModel | undefined): void {
     this.paymentService.displayError(error);
-    this.paymentService.goToPage('checkoutReviewOrder');
+    this.paymentService.goToPage(OpfPage.CHECKOUT_REVIEW_PAGE);
   }
 
   ngOnDestroy(): void {

--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.ts
@@ -29,6 +29,7 @@ import {
 import {
   AfterRedirectDynamicScript,
   KeyValuePair,
+  OpfPage,
   OpfPaymentMetadata,
   TargetPage,
 } from '../../model/opf.model';
@@ -76,7 +77,7 @@ export class OpfPaymentVerificationService {
     paramsMap: Array<KeyValuePair>;
     afterRedirectScriptFlag: string | undefined;
   }> {
-    return route?.routeConfig?.data?.cxRoute === 'paymentVerificationResult'
+    return route?.routeConfig?.data?.cxRoute === OpfPage.RESULT_PAGE
       ? route.queryParams.pipe(
           concatMap((params: Params) => {
             if (!params) {
@@ -169,7 +170,7 @@ export class OpfPaymentVerificationService {
         )
       )
       .subscribe(() => {
-        this.goToPage('cart');
+        this.goToPage(OpfPage.CART_PAGE);
 
         this.globalMessageService.add(
           {
@@ -188,7 +189,7 @@ export class OpfPaymentVerificationService {
       map((order) => !!order),
       tap((success: boolean) => {
         if (success) {
-          this.goToPage('orderConfirmation');
+          this.goToPage(OpfPage.CONFIRMATION_PAGE);
         }
       })
     );

--- a/integration-libs/opf/base/root/model/opf.model.ts
+++ b/integration-libs/opf/base/root/model/opf.model.ts
@@ -179,3 +179,10 @@ export const defaultErrorDialogOptions: ErrorDialogOptions = {
   messageKey: 'opf.payment.errors.proceedPayment',
   confirmKey: 'common.continue',
 };
+
+export enum OpfPage {
+  CHECKOUT_REVIEW_PAGE = 'opfCheckoutPaymentAndReview',
+  CONFIRMATION_PAGE = 'orderConfirmation',
+  RESULT_PAGE = 'paymentVerificationResult',
+  CART_PAGE = 'cart',
+}


### PR DESCRIPTION
closes: https://jira.tools.sap/browse/CXSPA-4895

remove hard-coded page name used for navigation
fix page name (from checkoutReviewOrder to opfCheckoutPaymentAndReview) that was caused by new Checkout switch mechanism.