### PR TITLE
a11y: improve aria labels for, button input and DDLB (CXSPA-4922)

### DIFF
--- a/projects/assets/src/translations/en/common.ts
+++ b/projects/assets/src/translations/en/common.ts
@@ -229,5 +229,8 @@ export const common = {
     messages: 'Messages',
     addMessagePlaceHolder: 'Start Typing...',
     characterLimitAlert: 'Characters limit reached.',
+    a11y:{
+      productListBoxLabel: 'Select to which product your message applies to.'
+    }
   },
 };

--- a/projects/assets/src/translations/en/common.ts
+++ b/projects/assets/src/translations/en/common.ts
@@ -229,8 +229,8 @@ export const common = {
     messages: 'Messages',
     addMessagePlaceHolder: 'Start Typing...',
     characterLimitAlert: 'Characters limit reached.',
-    a11y:{
-      productListBoxLabel: 'Select to which product your message applies to.'
-    }
+    a11y: {
+      productListBoxLabel: 'Select to which product your message applies to.',
+    },
   },
 };

--- a/projects/storefrontlib/shared/components/chat-messaging/messaging/messaging.component.html
+++ b/projects/storefrontlib/shared/components/chat-messaging/messaging/messaging.component.html
@@ -77,10 +77,13 @@
     *ngIf="messagingConfigs?.displayAddMessageSection | async"
   >
     <div class="cx-message-box">
-      <label class="cx-footer-label">
+      <label class="cx-footer-label" id="cx-messaging-footer-label">
         <span>
           {{ 'chatMessaging.addNewMessage' | cxTranslate }}
           <select
+            [attr.aria-label]="
+              'chatMessaging.a11y.productListBoxLabel' | cxTranslate
+            "
             *ngIf="messagingConfigs?.itemList$ | async as itemList"
             class="cx-message-item-selection"
             formControlName="item"
@@ -92,6 +95,7 @@
         </span>
         <div class="cx-message-input">
           <input
+            aria-labelledby="cx-messaging-footer-label"
             formControlName="message"
             type="text"
             class="form-control"
@@ -112,6 +116,7 @@
             {{ 'chatMessaging.characterLimitAlert' | cxTranslate }}
           </span>
           <button
+            aria-labelledby="cx-messaging-footer-label"
             class="btn btn-block cx-send"
             [ngClass]="
               !!messagingConfigs?.sendBtnIsNotPrimary


### PR DESCRIPTION
@steinsebastian tried to to a minimal solution, as this a reuse component and it should work in all contexts

- DDLB: added an aria-label to describe it
- button/input linked to existing label with aria-labelledby