### PR TITLE
CXSPA-5127: My Account Bug 1

### DIFF
--- a/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.html
+++ b/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.html
@@ -33,6 +33,7 @@
           <div class="cx-my-account-view-order-header">
             <div
               class="cx-my-account-view-status"
+              *ngIf="order.statusDisplay"
               [attr.aria-label]="
                 'myAccountV2Orders.orderStatusLabel' | cxTranslate
               "

--- a/feature-libs/order/components/order-history/my-account-v2/consolidated-information/my-account-v2-order-consolidated-information.component.html
+++ b/feature-libs/order/components/order-history/my-account-v2/consolidated-information/my-account-v2-order-consolidated-information.component.html
@@ -160,9 +160,10 @@
       Return Processed: 15, September, 2022
   -->
     <div *ngFor="let returnRequest of order.returnRequests">
-      <div *ngIf="returnRequest.rma" class="cx-order-status-critical">
+      <div class="cx-order-status-critical">
         {{ 'returnRequestList.returnRequestId' | cxTranslate }}
         <a
+          *ngIf="returnRequest.rma; else showReturnCode"
           [routerLink]="
             {
               cxRoute: 'returnRequestDetails',
@@ -174,6 +175,9 @@
           {{ returnRequest.rma }}</a
         >
       </div>
+      <ng-template #showReturnCode>
+        {{ returnRequest.code }}
+      </ng-template>
       <div
         class="cx-consignment-info"
         *ngIf="returnRequest.creationTime as creationTime"


### PR DESCRIPTION
The below issues are fixed in this PR:
1. In My Account Landing Page, [order:orderDetails.statusDisplay_undefined] is shown in UI if status is undefined. To fix this, added a *ngIf
2. When return requests are fetched from CDP system, 'rma' is not defined. Hence in such scenarios, no return requests are shown. To fix this, in case 'rma' is not defined, _Return # 'code'_  is shown in UI without any hyperlink to open return request details. User cannot navigate to return request details page for CDP return requests .