### PR TITLE
refactor: add 3 global functions domains

### DIFF
--- a/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
@@ -48,7 +48,6 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
         this.registerSubmit(domain, paymentSessionId, vcr);
         this.registerSubmitComplete(domain, paymentSessionId, vcr);
         this.registerThrowPaymentError(domain, vcr);
-
         break;
       case GlobalFunctionsDomain.REDIRECT:
         this.registerSubmitCompleteRedirect(domain, paymentSessionId, vcr);

--- a/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
@@ -30,8 +30,6 @@ import { finalize, take } from 'rxjs/operators';
 
 @Injectable()
 export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
-  protected _isGlobalServiceInit = false;
-
   constructor(
     protected winRef: WindowRef,
     private ngZone: NgZone,
@@ -50,6 +48,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
         this.registerSubmit(domain, paymentSessionId, vcr);
         this.registerSubmitComplete(domain, paymentSessionId, vcr);
         this.registerThrowPaymentError(domain, vcr);
+
         break;
       case GlobalFunctionsDomain.REDIRECT:
         this.registerSubmitCompleteRedirect(domain, paymentSessionId, vcr);
@@ -58,23 +57,12 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
       default:
         break;
     }
-
-    this._isGlobalServiceInit = true;
   }
 
   removeGlobalFunctions(domain: GlobalFunctionsDomain): void {
-    if (
-      domain === GlobalFunctionsDomain.CHECKOUT &&
-      !this._isGlobalServiceInit
-    ) {
-      return;
-    }
     const window = this.winRef.nativeWindow as any;
     if (window?.Opf?.payments[domain]) {
       window.Opf.payments[domain] = undefined;
-    }
-    if (domain === GlobalFunctionsDomain.CHECKOUT) {
-      this._isGlobalServiceInit = false;
     }
   }
 

--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.component.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.component.ts
@@ -11,7 +11,7 @@ import { HttpErrorModel } from '@spartacus/core';
 import { Observable, Subscription } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
 
-import { KeyValuePair, OpfPage, TargetPage } from '../../model';
+import { GlobalFunctionsDomain, KeyValuePair, OpfPage } from '../../model';
 import { OpfPaymentVerificationService } from './opf-payment-verification.service';
 
 @Component({
@@ -69,7 +69,7 @@ export class OpfPaymentVerificationComponent implements OnInit, OnDestroy {
     if (afterRedirectScriptFlag === 'true') {
       this.isHostedFieldPattern = true;
       return this.paymentService.runHostedFieldsPattern(
-        TargetPage.RESULT,
+        GlobalFunctionsDomain.REDIRECT,
         paymentSessionId,
         this.vcr,
         paramsMap

--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.spec.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.spec.ts
@@ -22,10 +22,10 @@ import {
 } from '../../facade';
 import {
   AfterRedirectDynamicScript,
+  GlobalFunctionsDomain,
   OpfPaymentMetadata,
   OpfPaymentVerificationResponse,
   OpfPaymentVerificationResult,
-  TargetPage,
 } from '../../model';
 import { OpfResourceLoaderService, OpfService } from '../../services';
 import { OpfPaymentVerificationService } from './opf-payment-verification.service';
@@ -306,7 +306,7 @@ describe('OpfPaymentVerificationService', () => {
 
       service
         .runHostedFieldsPattern(
-          TargetPage.RESULT,
+          GlobalFunctionsDomain.REDIRECT,
           'paymentSessionIdTest',
           {} as ViewContainerRef,
           [{ key: 'key test', value: 'value test' }]
@@ -336,7 +336,7 @@ describe('OpfPaymentVerificationService', () => {
 
       service
         .runHostedFieldsPattern(
-          TargetPage.RESULT,
+          GlobalFunctionsDomain.REDIRECT,
           'paymentSessionIdTest',
           {} as ViewContainerRef,
           [{ key: 'key test', value: 'value test' }]
@@ -366,7 +366,7 @@ describe('OpfPaymentVerificationService', () => {
 
       service
         .runHostedFieldsPattern(
-          TargetPage.RESULT,
+          GlobalFunctionsDomain.REDIRECT,
           'paymentSessionIdTest',
           {} as ViewContainerRef,
           [{ key: 'key test', value: 'value test' }]
@@ -394,7 +394,7 @@ describe('OpfPaymentVerificationService', () => {
 
       service
         .runHostedFieldsPattern(
-          TargetPage.RESULT,
+          GlobalFunctionsDomain.REDIRECT,
           'paymentSessionIdTest',
           {} as ViewContainerRef,
           [{ key: 'key test', value: 'value test' }]

--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.ts
@@ -28,10 +28,10 @@ import {
 } from '../../model';
 import {
   AfterRedirectDynamicScript,
+  GlobalFunctionsDomain,
   KeyValuePair,
   OpfPage,
   OpfPaymentMetadata,
-  TargetPage,
 } from '../../model/opf.model';
 import { OpfService } from '../../services';
 import { OpfResourceLoaderService } from '../../services/opf-resource-loader.service';
@@ -196,13 +196,13 @@ export class OpfPaymentVerificationService {
   }
 
   runHostedFieldsPattern(
-    targetPage: TargetPage,
+    domain: GlobalFunctionsDomain,
     paymentSessionId: string,
     vcr: ViewContainerRef,
     paramsMap: Array<KeyValuePair>
   ): Observable<boolean> {
     this.globalFunctionsService.registerGlobalFunctions({
-      targetPage,
+      domain,
       paymentSessionId,
       vcr,
       paramsMap,
@@ -243,7 +243,9 @@ export class OpfPaymentVerificationService {
   }
 
   removeResourcesAndGlobalFunctions(): void {
-    this.globalFunctionsService.removeGlobalFunctions();
+    this.globalFunctionsService.removeGlobalFunctions(
+      GlobalFunctionsDomain.REDIRECT
+    );
     this.opfResourceLoaderService.clearAllProviderResources();
   }
 }

--- a/integration-libs/opf/base/root/facade/opf-global-functions.facade.ts
+++ b/integration-libs/opf/base/root/facade/opf-global-functions.facade.ts
@@ -7,7 +7,10 @@
 import { Injectable } from '@angular/core';
 import { facadeFactory } from '@spartacus/core';
 import { OPF_BASE_FEATURE } from '../feature-name';
-import { GlobalFunctionsInput } from '../model/opf.model';
+import {
+  GlobalFunctionsDomain,
+  GlobalFunctionsInput,
+} from '../model/opf.model';
 
 @Injectable({
   providedIn: 'root',
@@ -31,5 +34,5 @@ export abstract class OpfGlobalFunctionsFacade {
   /**
    * Abstract method to remove global functions used in Hosted-Fields pattern
    */
-  abstract removeGlobalFunctions(): void;
+  abstract removeGlobalFunctions(domain: GlobalFunctionsDomain): void;
 }

--- a/integration-libs/opf/base/root/model/opf.model.ts
+++ b/integration-libs/opf/base/root/model/opf.model.ts
@@ -158,7 +158,7 @@ export interface GlobalFunctionsInput {
   paymentSessionId: string;
   vcr?: ViewContainerRef;
   paramsMap?: Array<KeyValuePair>;
-  targetPage: TargetPage;
+  domain: GlobalFunctionsDomain;
 }
 
 export enum TargetPage {
@@ -185,4 +185,10 @@ export enum OpfPage {
   CONFIRMATION_PAGE = 'orderConfirmation',
   RESULT_PAGE = 'paymentVerificationResult',
   CART_PAGE = 'cart',
+}
+
+export enum GlobalFunctionsDomain {
+  CHECKOUT = 'checkout',
+  GLOBAL = 'global',
+  REDIRECT = 'redirect',
 }

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.spec.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.spec.ts
@@ -3,9 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DomSanitizer } from '@angular/platform-browser';
 import { OpfGlobalFunctionsService } from '@spartacus/opf/base/core';
 import {
+  GlobalFunctionsDomain,
   GlobalFunctionsInput,
   OpfGlobalFunctionsFacade,
-  TargetPage,
 } from '@spartacus/opf/base/root';
 import { of } from 'rxjs';
 import { OpfCheckoutPaymentWrapperComponent } from './opf-checkout-payment-wrapper.component';
@@ -78,7 +78,7 @@ describe('OpfCheckoutPaymentWrapperComponent', () => {
     component.ngOnInit();
 
     const globalFunctionsInput: GlobalFunctionsInput = {
-      targetPage: TargetPage.CHECKOUT_REVIEW,
+      domain: GlobalFunctionsDomain.CHECKOUT,
       paymentSessionId: mockPaymentSessionData.paymentSessionId,
     };
 

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.ts
@@ -13,7 +13,10 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { OpfGlobalFunctionsFacade, TargetPage } from '@spartacus/opf/base/root';
+import {
+  GlobalFunctionsDomain,
+  OpfGlobalFunctionsFacade,
+} from '@spartacus/opf/base/root';
 import {
   OpfPaymentMethodType,
   PaymentPattern,
@@ -52,7 +55,9 @@ export class OpfCheckoutPaymentWrapperComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.globalFunctionsService.removeGlobalFunctions();
+    this.globalFunctionsService.removeGlobalFunctions(
+      GlobalFunctionsDomain.CHECKOUT
+    );
     this.sub.unsubscribe();
   }
 
@@ -66,13 +71,15 @@ export class OpfCheckoutPaymentWrapperComponent implements OnInit, OnDestroy {
         next: (paymentSessionData) => {
           if (this.isHostedFields(paymentSessionData)) {
             this.globalFunctionsService.registerGlobalFunctions({
-              targetPage: TargetPage.CHECKOUT_REVIEW,
+              domain: GlobalFunctionsDomain.CHECKOUT,
               paymentSessionId: (paymentSessionData as PaymentSessionData)
                 .paymentSessionId as string,
               vcr: this.vcr,
             });
           } else {
-            this.globalFunctionsService.removeGlobalFunctions();
+            this.globalFunctionsService.removeGlobalFunctions(
+              GlobalFunctionsDomain.CHECKOUT
+            );
           }
         },
       })


### PR DESCRIPTION
Domains are needed to separate global functions available for various  pages, domains split into:
window.Opf.payments.checkout
for global functions running on Checkout pages
window.Opf.payments.redirect
for global functions running on Verification page
window.Opf.payments.global
for global functions running for QuickBuy, CTA script, it would includes at least PDP, cart pages.

aggreed with Bamboo team on those domains, see:
https://sap-cx.slack.com/archives/C04JDEA9C90/p1695219327477429?thread_ts=1694785620.784269&cid=C04JDEA9C90
This logic is used for Upscale.
https://wiki.one.int.sap/wiki/pages/viewpage.action?pageId=2592032286