### PR TITLE
fix: export in public api of CDC lib missing members

### DIFF
--- a/integration-libs/cdc/core/auth/index.ts
+++ b/integration-libs/cdc/core/auth/index.ts
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './cdc-auth.module';
+export * from './facade/index';
+export * from './services/index';

--- a/integration-libs/cdc/core/auth/services/index.ts
+++ b/integration-libs/cdc/core/auth/services/index.ts
@@ -4,6 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export * from './cdc-core.module';
-export * from './events/index';
-export * from './models/cms.model';
+export * from './user-authentication/index';

--- a/integration-libs/cdc/core/auth/services/user-authentication/index.ts
+++ b/integration-libs/cdc/core/auth/services/user-authentication/index.ts
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './cdc-user-authentication-token.service';

--- a/integration-libs/cdc/core/public_api.ts
+++ b/integration-libs/cdc/core/public_api.ts
@@ -4,5 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export * from './auth/index';
 export * from './cdc-core.module';
+export * from './events/index';
 export * from './models/cms.model';


### PR DESCRIPTION
Exported:
```
CdcAuthService
CdcAuthModule
CdcEventModule
CdcEventBuilder
```

closes https://jira.tools.sap/browse/CXSPA-5210
closes https://github.com/SAP/spartacus/issues/18020