### PR TITLE
fix: adjust property and fix exception thrown

### DIFF
--- a/integration-libs/opf/base/components/opf-cta/opf-cta-scripts/opf-cta-scripts.service.ts
+++ b/integration-libs/opf/base/components/opf-cta/opf-cta-scripts/opf-cta-scripts.service.ts
@@ -104,15 +104,9 @@ export class OpfCtaScriptsService {
       [CtaScriptsLocation.PDP_QUICK_BUY]: () =>
         this.fillCtaRequestforPDP(scriptsLocation, paymentAccountIds),
       [CtaScriptsLocation.ORDER_HISTORY_PAYMENT_GUIDE]: () =>
-        this.fillCtaRequestforPagesWithOrder(
-          scriptsLocation,
-          paymentAccountIds
-        ),
+        this.fillCtaRequestforPagesWithOrder(scriptsLocation),
       [CtaScriptsLocation.ORDER_CONFIRMATION_PAYMENT_GUIDE]: () =>
-        this.fillCtaRequestforPagesWithOrder(
-          scriptsLocation,
-          paymentAccountIds
-        ),
+        this.fillCtaRequestforPagesWithOrder(scriptsLocation),
       [CtaScriptsLocation.CART_MESSAGING]: toBeImplementedException,
       [CtaScriptsLocation.CART_QUICK_BUY]: toBeImplementedException,
       [CtaScriptsLocation.CHECKOUT_QUICK_BUY]: toBeImplementedException,
@@ -127,8 +121,7 @@ export class OpfCtaScriptsService {
   }
 
   protected fillCtaRequestforPagesWithOrder(
-    scriptLocation: CtaScriptsLocation,
-    paymentAccountIds: number[]
+    scriptLocation: CtaScriptsLocation
   ): Observable<CtaScriptsRequest> {
     return this.getOrderDetails(scriptLocation).pipe(
       map((order) => {
@@ -136,9 +129,8 @@ export class OpfCtaScriptsService {
           throw new Error('OrderPaymentInfoId missing');
         }
         const ctaScriptsRequest: CtaScriptsRequest = {
-          orderId: order?.paymentInfo?.id,
+          cartId: order?.paymentInfo?.id,
           ctaProductItems: this.getProductItems(order as Order),
-          paymentAccountIds: paymentAccountIds,
           scriptLocations: [scriptLocation],
         };
 
@@ -250,7 +242,11 @@ export class OpfCtaScriptsService {
             }
           })
           .catch(() => {
+            // if (html) {
+            //   resolve(script);
+            // } else {
             resolve(undefined);
+            //  }
           });
       }
     );

--- a/integration-libs/opf/base/components/opf-cta/opf-cta-scripts/opf-cta-scripts.service.ts
+++ b/integration-libs/opf/base/components/opf-cta/opf-cta-scripts/opf-cta-scripts.service.ts
@@ -242,11 +242,7 @@ export class OpfCtaScriptsService {
             }
           })
           .catch(() => {
-            // if (html) {
-            //   resolve(script);
-            // } else {
             resolve(undefined);
-            //  }
           });
       }
     );

--- a/integration-libs/opf/base/core/facade/opf-payment.service.spec.ts
+++ b/integration-libs/opf/base/core/facade/opf-payment.service.spec.ts
@@ -75,7 +75,7 @@ const mockActiveConfigurations: ActiveConfiguration[] = [
 ];
 
 const MockCtaRequest: CtaScriptsRequest = {
-  orderId: '00259012',
+  cartId: '00259012',
   ctaProductItems: [
     {
       productId: '301233',

--- a/integration-libs/opf/base/root/model/opf-quick-buy.model.ts
+++ b/integration-libs/opf/base/root/model/opf-quick-buy.model.ts
@@ -29,7 +29,7 @@ export type CtaAdditionalDataKey =
   | 'scriptIdentifier';
 export interface CtaScriptsRequest {
   paymentAccountIds?: Array<number>;
-  orderId?: string;
+  cartId?: string;
   ctaProductItems?: Array<CTAProductItem>;
   scriptLocations?: Array<CtaScriptsLocation>;
   additionalData?: Array<{

--- a/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
+++ b/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
@@ -133,7 +133,7 @@ export class OpfResourceLoaderService extends ScriptLoader {
     if (html) {
       const element = new DOMParser().parseFromString(html, 'text/html');
       const script = element.getElementsByTagName('script');
-      if (!script?.length || !script[0]?.innerText) {
+      if (!script?.[0]?.innerText) {
         return;
       }
       Function(script[0].innerText)();

--- a/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
+++ b/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
@@ -133,6 +133,9 @@ export class OpfResourceLoaderService extends ScriptLoader {
     if (html) {
       const element = new DOMParser().parseFromString(html, 'text/html');
       const script = element.getElementsByTagName('script');
+      if (!script?.length || !script[0]?.innerText) {
+        return;
+      }
       Function(script[0].innerText)();
     }
   }


### PR DESCRIPTION
cta request model has changed:

- 'orderId' is now called'cartId'.

- enforced logic: when cartId property has a value, paymentsAccuntIds property must be undefined.

Tested succefully with steps:
login bruce.lee@pronto-hw.com/Password.123
go in order history pgae -> select order 00308007
you should see a 'goCardless' iframe displayed