### PR TITLE
fix: OPF missing Card Type (CXSPA-5221)

### DIFF
--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.spec.ts
@@ -400,9 +400,13 @@ describe('OrderOverviewComponent', () => {
           expect(data).toBeTruthy();
           expect(data.title).toEqual('test');
           expect(data.textBold).toEqual(
-            mockOrder.paymentInfo.accountHolderName
+            mockOrder.paymentInfo?.accountHolderName
           );
-          expect(data.text).toEqual([mockOrder.paymentInfo.cardNumber, 'test']);
+          expect(data.text).toEqual([
+            mockOrder.paymentInfo?.cardType?.name,
+            mockOrder.paymentInfo?.cardNumber,
+            'test',
+          ]);
         })
         .unsubscribe();
 

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
@@ -226,7 +226,7 @@ export class OrderOverviewComponent {
           ({
             title: textTitle,
             textBold: payment.accountHolderName,
-            text: [payment.cardNumber, textExpires],
+            text: [payment.cardType?.name, payment.cardNumber, textExpires],
           } as Card)
       )
     );


### PR DESCRIPTION
Closing: https://jira.tools.sap/browse/CXSPA-5221