### PR TITLE
fix: add empty list to cartOutlet if no item exists

### DIFF
--- a/feature-libs/quote/components/items/quote-items.component.html
+++ b/feature-libs/quote/components/items/quote-items.component.html
@@ -27,7 +27,7 @@
           }"
           [cxOutlet]="cartOutlets.CART_ITEM_LIST"
           [cxOutletContext]="{
-            items: quoteItemsData.entries,
+            items: quoteItemsData.entries ?? [],
             readonly: quoteItemsData.readOnly
           }"
         >

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/quote.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/quote.e2e-flaky.cy.ts
@@ -104,24 +104,21 @@ context('Quote', () => {
       );
     });
 
-    //ToDo: Bug will be fixed with CXSPA-5574
-    //see function: checkQuoteCartIsEmpty()
-    //
-    // it('should edit quantity of items within a buyer quote draft (CXSPA-3852)', () => {
-    //   let itemIndex = 1;
-    //   quote.checkItemVisible(itemIndex, TEST_PRODUCT_HAMMER_DRILLING_ID);
-    //   quote.checkItemQuantity(itemIndex, PRODUCT_AMOUNT_30.toString());
-    //   quote.changeItemQuantityByStepper(itemIndex, '+');
-    //   quote.checkItemQuantity(itemIndex, (PRODUCT_AMOUNT_30 + 1).toString());
-    //   quote.changeItemQuantityByStepper(itemIndex, '-');
-    //   quote.checkItemQuantity(itemIndex, PRODUCT_AMOUNT_30.toString());
-    //   quote.changeItemQuantityByCounter(itemIndex, '1');
-    //   quote.checkItemQuantity(itemIndex, '1');
-    //   quote.checkSubmitBtn(false);
-    //   quote.checkItemVisible(itemIndex, TEST_PRODUCT_HAMMER_DRILLING_ID);
-    //   quote.removeItem(itemIndex);
-    //   quote.checkQuoteCartIsEmpty();
-    // });
+    it('should edit quantity of items within a buyer quote draft (CXSPA-3852)', () => {
+      let itemIndex = 1;
+      quote.checkItemVisible(itemIndex, TEST_PRODUCT_HAMMER_DRILLING_ID);
+      quote.checkItemQuantity(itemIndex, PRODUCT_AMOUNT_30.toString());
+      quote.changeItemQuantityByStepper(itemIndex, '+');
+      quote.checkItemQuantity(itemIndex, (PRODUCT_AMOUNT_30 + 1).toString());
+      quote.changeItemQuantityByStepper(itemIndex, '-');
+      quote.checkItemQuantity(itemIndex, PRODUCT_AMOUNT_30.toString());
+      quote.changeItemQuantityByCounter(itemIndex, '1');
+      quote.checkItemQuantity(itemIndex, '1');
+      quote.checkSubmitBtn(false);
+      quote.checkItemVisible(itemIndex, TEST_PRODUCT_HAMMER_DRILLING_ID);
+      quote.removeItem(itemIndex);
+      quote.checkQuoteCartIsEmpty();
+    });
 
     it('should edit name and description of the quote while in buyer draft (CXSPA-3852)', () => {
       const QUOTE_NAME = 'Quote name test';


### PR DESCRIPTION
- if no item exists in the quote cart list anymore an empty list is given to the cartOutlet element. 
- re enabled tests for item quantity changes in quote cart list. 