### PR TITLE
feat: add Loader Indicator global functions

### DIFF
--- a/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
@@ -9,6 +9,7 @@ import {
   Injectable,
   NgZone,
   ViewContainerRef,
+  inject,
 } from '@angular/core';
 import { WindowRef } from '@spartacus/core';
 import {
@@ -30,12 +31,15 @@ import { finalize, take } from 'rxjs/operators';
 
 @Injectable()
 export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
-  constructor(
-    protected winRef: WindowRef,
-    private ngZone: NgZone,
-    protected opfPaymentFacade: OpfPaymentFacade,
-    protected launchDialogService: LaunchDialogService
-  ) {}
+  protected winRef = inject(WindowRef);
+  protected ngZone = inject(NgZone);
+  protected opfPaymentFacade = inject(OpfPaymentFacade);
+  protected launchDialogService = inject(LaunchDialogService);
+
+  protected loaderSpinnerCpntRef: void | Observable<
+    ComponentRef<any> | undefined
+  >;
+  protected loaderSpinnerDisplayed = false;
 
   registerGlobalFunctions({
     domain,
@@ -48,6 +52,8 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
         this.registerSubmit(domain, paymentSessionId, vcr);
         this.registerSubmitComplete(domain, paymentSessionId, vcr);
         this.registerThrowPaymentError(domain, vcr);
+        this.registerStartLoadIndicator(domain, vcr);
+        this.registerStopLoadIndicator(domain);
         break;
       case GlobalFunctionsDomain.REDIRECT:
         this.registerSubmitCompleteRedirect(domain, paymentSessionId, vcr);
@@ -75,6 +81,30 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
       window.Opf.payments[domain] = {};
     }
     return window.Opf.payments[domain];
+  }
+
+  protected registerStartLoadIndicator(
+    domain: GlobalFunctionsDomain,
+    vcr?: ViewContainerRef
+  ): void {
+    this.getGlobalFunctionContainer(domain).startLoadIndicator = (): void => {
+      if (!vcr || this.loaderSpinnerDisplayed) {
+        return;
+      }
+      this.ngZone.run(() => {
+        this.loaderSpinnerCpntRef = this.startLoaderSpinner(vcr);
+        this.loaderSpinnerDisplayed = true;
+      });
+    };
+  }
+
+  protected registerStopLoadIndicator(domain: GlobalFunctionsDomain): void {
+    this.getGlobalFunctionContainer(domain).stopLoadIndicator = (): void => {
+      this.ngZone.run(() => {
+        this.stopLoaderSpinner(this.loaderSpinnerCpntRef);
+        this.loaderSpinnerDisplayed = false;
+      });
+    };
   }
 
   protected startLoaderSpinner(

--- a/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-global-functions.service.ts
@@ -39,7 +39,6 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
   protected loaderSpinnerCpntRef: void | Observable<
     ComponentRef<any> | undefined
   >;
-  protected loaderSpinnerDisplayed = false;
 
   registerGlobalFunctions({
     domain,
@@ -88,12 +87,14 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
     vcr?: ViewContainerRef
   ): void {
     this.getGlobalFunctionContainer(domain).startLoadIndicator = (): void => {
-      if (!vcr || this.loaderSpinnerDisplayed) {
+      if (!vcr) {
         return;
       }
       this.ngZone.run(() => {
+        if (this.loaderSpinnerCpntRef) {
+          this.stopLoaderSpinner(this.loaderSpinnerCpntRef);
+        }
         this.loaderSpinnerCpntRef = this.startLoaderSpinner(vcr);
-        this.loaderSpinnerDisplayed = true;
       });
     };
   }
@@ -102,7 +103,6 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
     this.getGlobalFunctionContainer(domain).stopLoadIndicator = (): void => {
       this.ngZone.run(() => {
         this.stopLoaderSpinner(this.loaderSpinnerCpntRef);
-        this.loaderSpinnerDisplayed = false;
       });
     };
   }

--- a/integration-libs/opf/base/root/model/opf.model.ts
+++ b/integration-libs/opf/base/root/model/opf.model.ts
@@ -58,6 +58,8 @@ export interface GlobalOpfPaymentMethods {
     submitFailure: MerchantCallback;
   }): Promise<boolean>;
   throwPaymentError?(errorOptions?: ErrorDialogOptions): void;
+  startLoadIndicator?(): void;
+  stopLoadIndicator?(): void;
 }
 
 export interface PaymentBrowserInfo {


### PR DESCRIPTION
Added 2 global functions
startLoadIndicator
stopLoadIndicator
each wrapped in a registration method.
to test:
- go on checkout page, select a method with 'Hosted-filed pattern'
- in console,
to launch the functions
window.Opf.payments.checkout.startLoadIndicator()
window.Opf.payments.checkout.stopLoadIndicator()