### PR TITLE
feat: CXSPA-5521 Upgrade to Angular 17 - schematics for SSR

### DIFF
--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@angular/pwa": "^17.0.5",
-    "@nguniversal/express-engine": "^16.2.0",
+    "@angular/ssr": "^17.0.5",
     "semver": "^7.5.2",
     "ts-morph": "^9.1.0",
     "tslib": "^2.6.2"

--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -60,7 +60,7 @@ const ngExpressEngine = NgExpressEngineDecorator.get(engine);
 // The Express app is exported so that it can be used by serverless Functions.
 export function app() {
   const server = express();
-  const distFolder = join(process.cwd(), 'dist/ng-17-test-ssr-module/browser');
+  const distFolder = join(process.cwd(), 'dist/schematics-test/browser');
   const indexHtml = existsSync(join(distFolder, 'index.original.html'))
     ? 'index.original.html'
     : 'index';

--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`add-ssr app.server.module.ts should be updated 1`] = `
+exports[`add-ssr app.module.server.ts should be updated 1`] = `
 "import { NgModule } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
 
@@ -43,23 +43,24 @@ exports[`add-ssr index.html should contain occ-backend-base-url attribute in met
 `;
 
 exports[`add-ssr server.ts should be configured properly 1`] = `
-"import 'zone.js/dist/zone-node';
+"import { APP_BASE_HREF } from '@angular/common';
+import {
+  NgExpressEngineDecorator,
+  ngExpressEngine as engine,
+} from '@spartacus/setup/ssr';
 
-import { ngExpressEngine as engine } from '@nguniversal/express-engine';
-import { NgExpressEngineDecorator } from '@spartacus/setup/ssr';
-import * as express from 'express';
+import express from 'express';
 import { join } from 'path';
 
-import { AppServerModule } from './src/main.server';
-import { APP_BASE_HREF } from '@angular/common';
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
+import AppServerModule from './src/main.server';
 
 const ngExpressEngine = NgExpressEngineDecorator.get(engine);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app() {
   const server = express();
-  const distFolder = join(process.cwd(), 'dist/schematics-test/browser');
+  const distFolder = join(process.cwd(), 'dist/ng-17-test-ssr-module/browser');
   const indexHtml = existsSync(join(distFolder, 'index.original.html'))
     ? 'index.original.html'
     : 'index';
@@ -105,16 +106,6 @@ function run() {
   });
 }
 
-// Webpack will replace 'require' with '__webpack_require__'
-// '__non_webpack_require__' is a proxy to Node 'require'
-// The below code is to ensure that the server is run only when not requiring the bundle.
-declare const __non_webpack_require__: NodeRequire;
-const mainModule = __non_webpack_require__.main;
-const moduleFilename = (mainModule && mainModule.filename) || '';
-if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
-  run();
-}
-
-export * from './src/main.server';
+run();
 "
 `;

--- a/projects/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/projects/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -15,7 +15,7 @@ const ngExpressEngine = NgExpressEngineDecorator.get(engine);
 // The Express app is exported so that it can be used by serverless Functions.
 export function app() {
   const server = express();
-  const distFolder = join(process.cwd(), 'dist/ng-17-test-ssr-module/browser');
+  const distFolder = join(process.cwd(), '<%= browserDistDirectory %>');
   const indexHtml = existsSync(join(distFolder, 'index.original.html'))
     ? 'index.original.html'
     : 'index';

--- a/projects/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/projects/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -1,20 +1,21 @@
-import 'zone.js/dist/zone-node';
+import { APP_BASE_HREF } from '@angular/common';
+import {
+  NgExpressEngineDecorator,
+  ngExpressEngine as engine,
+} from '@spartacus/setup/ssr';
 
-import { ngExpressEngine as engine } from '@nguniversal/express-engine';
-import { NgExpressEngineDecorator } from '@spartacus/setup/ssr';
-import * as express from 'express';
+import express from 'express';
 import { join } from 'path';
 
-import { AppServerModule } from './src/main.server';
-import { APP_BASE_HREF } from '@angular/common';
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
+import AppServerModule from './src/main.server';
 
 const ngExpressEngine = NgExpressEngineDecorator.get(engine);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app() {
   const server = express();
-  const distFolder = join(process.cwd(), '<%= browserDistDirectory %>');
+  const distFolder = join(process.cwd(), 'dist/ng-17-test-ssr-module/browser');
   const indexHtml = existsSync(join(distFolder, 'index.original.html'))
     ? 'index.original.html'
     : 'index';
@@ -60,14 +61,4 @@ function run() {
   });
 }
 
-// Webpack will replace 'require' with '__webpack_require__'
-// '__non_webpack_require__' is a proxy to Node 'require'
-// The below code is to ensure that the server is run only when not requiring the bundle.
-declare const __non_webpack_require__: NodeRequire;
-const mainModule = __non_webpack_require__.main;
-const moduleFilename = (mainModule && mainModule.filename) || '';
-if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
-  run();
-}
-
-export * from './src/main.server';
+run();

--- a/projects/schematics/src/add-ssr/index.ts
+++ b/projects/schematics/src/add-ssr/index.ts
@@ -28,7 +28,7 @@ import {
 } from '@schematics/angular/utility/dependencies';
 import { Schema as SpartacusOptions } from '../add-spartacus/schema';
 import collectedDependencies from '../dependencies.json';
-import { NGUNIVERSAL_EXPRESS_ENGINE } from '../shared/constants';
+import { ANGULAR_SSR } from '../shared/constants';
 import { SPARTACUS_SETUP } from '../shared/libs-constants';
 import {
   commitChanges,
@@ -49,7 +49,7 @@ import {
 
 const DEPENDENCY_NAMES: string[] = [
   '@angular/platform-server',
-  NGUNIVERSAL_EXPRESS_ENGINE,
+  ANGULAR_SSR,
   'ts-loader',
 ];
 
@@ -57,13 +57,13 @@ export function modifyAppServerModuleFile(): Rule {
   return (tree: Tree, context: SchematicContext) => {
     const appServerModulePath = getPathResultsForFile(
       tree,
-      'app.server.module.ts',
+      'app.module.server.ts',
       '/src'
     )[0];
 
     if (!appServerModulePath) {
       throw new SchematicsException(
-        `Project file "app.server.module.ts" not found.`
+        `Project file "app.module.server.ts" not found.`
       );
     }
 
@@ -154,7 +154,7 @@ export function addSSR(options: SpartacusOptions): Rule {
 
     return chain([
       addPackageJsonDependencies(prepareDependencies(), packageJson),
-      externalSchematic(NGUNIVERSAL_EXPRESS_ENGINE, 'ng-add', {
+      externalSchematic(ANGULAR_SSR, 'ng-add', {
         project: options.project,
       }),
       modifyAppServerModuleFile(),

--- a/projects/schematics/src/add-ssr/index_spec.ts
+++ b/projects/schematics/src/add-ssr/index_spec.ts
@@ -9,7 +9,7 @@ import {
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
 import * as path from 'path';
 import { Schema as SpartacusOptions } from '../add-spartacus/schema';
-import { NGUNIVERSAL_EXPRESS_ENGINE } from '../shared/constants';
+import { ANGULAR_SSR } from '../shared/constants';
 import { SPARTACUS_SCHEMATICS } from '../shared/libs-constants';
 import { getPathResultsForFile } from '../shared/utils/file-utils';
 
@@ -36,6 +36,7 @@ describe('add-ssr', () => {
     style: Style.Scss,
     skipTests: false,
     projectRoot: '',
+    standalone: false,
   };
 
   const defaultOptions: SpartacusOptions = {
@@ -80,17 +81,8 @@ describe('add-ssr', () => {
       const depPackageList = Object.keys(packageObj.dependencies);
 
       expect(depPackageList.includes('@angular/platform-server')).toBe(true);
-      expect(depPackageList.includes(NGUNIVERSAL_EXPRESS_ENGINE)).toBe(true);
+      expect(depPackageList.includes(ANGULAR_SSR)).toBe(true);
       expect(depPackageList.includes('@spartacus/setup')).toBe(true);
-    });
-
-    it('should contain additional build scripts', async () => {
-      const packageJson = appTree.readContent('package.json');
-
-      const packageJsonFileObject = JSON.parse(packageJson);
-      expect(packageJsonFileObject.scripts['build:ssr']).toBeTruthy();
-      expect(packageJsonFileObject.scripts['serve:ssr']).toBeTruthy();
-      expect(packageJsonFileObject.scripts['dev:ssr']).toBeTruthy();
     });
   });
 
@@ -101,9 +93,9 @@ describe('add-ssr', () => {
     });
   });
 
-  describe('app.server.module.ts', () => {
+  describe('app.module.server.ts', () => {
     it('should be updated', () => {
-      const content = appTree.readContent('./src/app/app.server.module.ts');
+      const content = appTree.readContent('./src/app/app.module.server.ts');
       expect(content).toMatchSnapshot();
     });
   });

--- a/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 1`] = `
 "import { HttpClientModule } from "@angular/common/http";
 import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { BrowserModule, provideClientHydration } from '@angular/platform-browser';
 import { EffectsModule } from "@ngrx/effects";
 import { StoreModule } from "@ngrx/store";
 import { AppRoutingModule } from "@spartacus/storefront";
@@ -22,7 +22,9 @@ import { SpartacusModule } from './spartacus/spartacus.module';
     EffectsModule.forRoot([]),
     SpartacusModule
   ],
-  providers: [],
+  providers: [
+    provideClientHydration()
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }
@@ -39,30 +41,27 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "dev:ssr": "ng run schematics-test:serve-ssr",
-    "serve:ssr": "node dist/schematics-test/server/main.js",
-    "build:ssr": "ng build && ng run schematics-test:server",
-    "prerender": "ng run schematics-test:prerender"
+    "serve:ssr:schematics-test": "node dist/schematics-test/server/server.mjs"
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^16.2.0",
-    "@angular/common": "^16.2.0",
-    "@angular/compiler": "^16.2.0",
-    "@angular/core": "^16.2.0",
-    "@angular/forms": "^16.2.0",
-    "@angular/platform-browser": "^16.2.0",
-    "@angular/platform-browser-dynamic": "^16.2.0",
-    "@angular/platform-server": "^16.2.10",
-    "@angular/router": "^16.2.0",
-    "@angular/service-worker": "^16.2.10",
+    "@angular/animations": "^17.0.0",
+    "@angular/common": "^17.0.0",
+    "@angular/compiler": "^17.0.0",
+    "@angular/core": "^17.0.0",
+    "@angular/forms": "^17.0.0",
+    "@angular/platform-browser": "^17.0.0",
+    "@angular/platform-browser-dynamic": "^17.0.0",
+    "@angular/platform-server": "^17.0.5",
+    "@angular/router": "^17.0.0",
+    "@angular/service-worker": "^17.0.5",
+    "@angular/ssr": "^17.0.5",
     "@fontsource/open-sans": "^4.5.14",
     "@fortawesome/fontawesome-free": "6.4.2",
-    "@ng-select/ng-select": "^11.1.1",
-    "@ngrx/effects": "^16.0.1",
-    "@ngrx/router-store": "^16.0.1",
-    "@ngrx/store": "^16.0.1",
-    "@nguniversal/express-engine": "^16.2.0",
+    "@ng-select/ng-select": "^12.0.4",
+    "@ngrx/effects": "^17.0.1",
+    "@ngrx/router-store": "^17.0.1",
+    "@ngrx/store": "^17.0.1",
     "@spartacus/assets": "~6.6.0-1",
     "@spartacus/core": "~6.6.0-1",
     "@spartacus/setup": "~6.6.0-1",
@@ -70,31 +69,30 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "@spartacus/styles": "~6.6.0-1",
     "angular-oauth2-oidc": "^15.0.1",
     "bootstrap": "^4.6.2",
-    "express": "^4.15.2",
+    "express": "^4.18.2",
     "i18next": "^23.7.6",
     "i18next-http-backend": "^2.4.2",
     "i18next-resources-to-backend": "^1.2.0",
-    "ngx-infinite-scroll": "^16.0.0",
+    "ngx-infinite-scroll": "^17.0.0",
     "rxjs": "~7.8.0",
     "ts-loader": "^9.4.4",
     "tslib": "^2.3.0",
-    "zone.js": "~0.13.0"
+    "zone.js": "~0.14.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.2.8",
+    "@angular-devkit/build-angular": "^17.0.5",
     "@angular/cli": "^0.5.0",
-    "@angular/compiler-cli": "^16.2.0",
-    "@nguniversal/builders": "^16.2.0",
-    "@types/express": "^4.17.0",
-    "@types/jasmine": "~4.3.0",
-    "@types/node": "^16.11.7",
-    "jasmine-core": "~4.6.0",
+    "@angular/compiler-cli": "^17.0.0",
+    "@types/express": "^4.17.17",
+    "@types/jasmine": "~5.1.0",
+    "@types/node": "^18.18.0",
+    "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.1.3"
+    "typescript": "~5.2.2"
   }
 }"
 `;

--- a/projects/schematics/src/ng-add/index_spec.ts
+++ b/projects/schematics/src/ng-add/index_spec.ts
@@ -9,7 +9,7 @@ import {
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
 import * as path from 'path';
 import { Schema as SpartacusOptions } from '../add-spartacus/schema';
-import { NGUNIVERSAL_EXPRESS_ENGINE, UTF_8 } from '../shared/constants';
+import { ANGULAR_SSR, UTF_8 } from '../shared/constants';
 import { SPARTACUS_SCHEMATICS } from '../shared/libs-constants';
 import { getPathResultsForFile } from '../shared/utils/file-utils';
 
@@ -36,6 +36,7 @@ describe('Spartacus Schematics: ng-add', () => {
     style: Style.Scss,
     skipTests: false,
     projectRoot: '',
+    standalone: false,
   };
 
   const defaultOptions: SpartacusOptions = {
@@ -85,7 +86,7 @@ describe('Spartacus Schematics: ng-add', () => {
     expect(packageJsonBuffer).toBeTruthy();
     const appServerModulePath = getPathResultsForFile(
       tree,
-      'app.server.module.ts',
+      'app.module.server.ts',
       '/src'
     )[0];
     const appServerModuleBuffer = tree.read(appServerModulePath);
@@ -95,7 +96,7 @@ describe('Spartacus Schematics: ng-add', () => {
 
     if (packageJsonBuffer) {
       const packageJSON = JSON.parse(packageJsonBuffer.toString(UTF_8));
-      expect(packageJSON.dependencies[NGUNIVERSAL_EXPRESS_ENGINE]).toBeTruthy();
+      expect(packageJSON.dependencies[ANGULAR_SSR]).toBeTruthy();
       expect(packageJSON.dependencies['@angular/platform-server']).toBeTruthy();
     }
   });
@@ -117,7 +118,7 @@ describe('Spartacus Schematics: ng-add', () => {
     const packageJson = tree.readContent('/package.json');
     expect(packageJson).toMatchSnapshot();
 
-    const appServerModule = tree.readContent('src/app/app.server.module.ts');
+    const appServerModule = tree.readContent('src/app/app.module.server.ts');
     expect(appServerModule).toMatchSnapshot();
   });
 });

--- a/projects/schematics/src/shared/constants.ts
+++ b/projects/schematics/src/shared/constants.ts
@@ -12,6 +12,7 @@ export const ANGULAR_CORE = '@angular/core';
 export const ANGULAR_FORMS = '@angular/forms';
 export const ANGULAR_ROUTER = '@angular/router';
 export const ANGULAR_HTTP = '@angular/common/http';
+export const ANGULAR_SSR = '@angular/ssr';
 
 export const RXJS = 'rxjs';
 export const ANGULAR_COMMON = '@angular/common';
@@ -23,7 +24,6 @@ export const NGRX_STORE = '@ngrx/store';
 export const NGRX_EFFECTS = '@ngrx/effects';
 export const NGRX_ROUTER_STORE = '@ngrx/router-store';
 
-export const NGUNIVERSAL_EXPRESS_ENGINE = '@nguniversal/express-engine';
 export const NG_BOOTSTRAP = '@ng-bootstrap/ng-bootstrap';
 
 /***** Imports end *****/

--- a/projects/storefrontapp/server.ts
+++ b/projects/storefrontapp/server.ts
@@ -16,7 +16,7 @@ import { Express } from 'express';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import 'zone.js/node';
-import { AppServerModule } from './src/main.server';
+import AppServerModule from './src/main.server';
 
 // Require is used here, because we can't use `import * as express` together with TS esModuleInterop option.
 // And we need to use esModuleInterop option in ssr dev mode, because i18next enforce usage of this option for cjs module.

--- a/projects/storefrontapp/src/main.server.ts
+++ b/projects/storefrontapp/src/main.server.ts
@@ -14,4 +14,4 @@ if (environment.production) {
   enableProdMode();
 }
 export { renderModule } from '@angular/platform-server';
-export { AppServerModule } from './app/app.server.module';
+export { AppServerModule as default } from './app/app.server.module';

--- a/tools/config/manage-dependencies.ts
+++ b/tools/config/manage-dependencies.ts
@@ -811,7 +811,7 @@ function removeNotUsedDependenciesFromPackageJson(
   options: ProgramOptions
 ): void {
   // Keep these dependencies in schematics as these are used as external schematics
-  const externalSchematics = ['@angular/pwa', '@nguniversal/express-engine'];
+  const externalSchematics = ['@angular/pwa', '@angular/ssr'];
 
   if (options.fix) {
     reportProgress('Removing unused dependencies');


### PR DESCRIPTION
- [x] - adjusted schematics for ssr
- [x] - adjusted server.ts
- [x] - adjusted unit tests for 'add-ssr' and 'ng-add'
- [x] - removed a reference to "@nguniversal/express-engine" from 'constants.ts'

To run Spartacus with SSR in a fresh Angular v17 app:

- deploy Spartacus libraries locally using Verdaccio
- npx @angular/cli new my-app --standalone=false --ssr=false
- npx @angular/cli add @spartacus/schematics@latest --ssr --baseUrl="https://40.76.109.9:9002"
- in the fresh app, remove `prerender: true` from `angular.json` (temporary issue)
- run `npm run build`
- run `npm run serve:ssr:my-app`

As for now, Angular app with Spartacus are not working in development mode due to issues with new default Angular builder. As a workaround:

- run `npm watch` to run build in watch mode 
- modify `serve:ssr:my-app` script in `package.json` to:
   ```json
   "serve:ssr:my-app": "node --watch dist/my-app/server/server.mjs"
   ```
- run modified "serve:ssr:my-app" that now will watch on changes in the `dist` folder

Closes [CXSPA-5521](https://jira.tools.sap/browse/CXSPA-5521)
