### PR TITLE
chore: remove deprecated signature near UserState interface

### DIFF
--- a/projects/core/src/user/store/user-state.ts
+++ b/projects/core/src/user/store/user-state.ts
@@ -41,9 +41,6 @@ export interface StateWithUser {
   [USER_FEATURE]: UserState;
 }
 
-/**
- * @deprecated since 3.2, moved to the `@spartacus/user` package.
- */
 export interface UserState {
   addresses: StateUtils.LoaderState<Address[]>;
   consents: StateUtils.LoaderState<ConsentTemplate[]>;


### PR DESCRIPTION
It seems that for some time, we had two declarations of this interface – one in the core and another in the user library. I believe the one in the core was marked as deprecated, and the declaration in the user library was simply copied from the core, including the deprecation signature. Currently, I only see one declaration of the UserState interface, and it is declared in the user library. All usages are also confined to the user library. That's why I am removing the 'deprecated' annotation.

Closes: https://jira.tools.sap/browse/CXSPA-2639