### PR TITLE
 Upgrade to Angular 17 - docs for creating new app - use `my-app-name` consistently in all examples

### DIFF
--- a/docs/migration/2211/2211-installation.md
+++ b/docs/migration/2211/2211-installation.md
@@ -6,7 +6,11 @@ Since Angular v17, the command for creating a new app (`ng new`) must be run wit
 
 **Why**: Since Angular 17, new applications are created by default using a new so-called "standalone" mode, which has a bit *different structure of files* in the app folder then before. However Spartacus schematics installer still expects the *old files structure* in a created Angular app. That's why the flag  `new new --standalone=false` is required before running Spartacus installation schematics.
 
-## Disable SSR and Prerendering for `ng serve`
+## Workaround other issues after creating a new app
+
+After creating successfully a new Angular 17+ app, you must make additional manual changes in the app's configuration files to workaround other issues introduced by Angular 17.
+
+### Disable SSR and Prerendering for `ng serve`
 
 In `angular.json` of newly created app make the following 2 changes:
 1. in the section `projects › (my app name) › architect › build › configurations` add a new subsection `"noSsr"` _as a sibling_ to other configurations `"production"` and `"development"`:
@@ -56,9 +60,9 @@ In `angular.json` of newly created app make the following 2 changes:
             },
 ```
 
-**Why**: Since Angular 17, in freshly created new apps (not the migrated from old version ones!) Angular runs SSR and Prerendering by default a part of `ng serve` and `ng build` commands. Unfortunately Angular 17 also introduced a bug: `server.ts` file is _totally ignored_ during the `ng serve` command (see Angular issue https://github.com/angular/angular-cli/issues/26323). Spartacus to work correctly, requires `server.ts` file to be loaded. Therefore, for Spartacus to work, as a workaround, we have to disable SSR and Prerendering for `ng serve`.
+**Why**: Since Angular 17, in freshly created new apps (not migrated ones from Angular 16!) Angular runs SSR and Prerendering by default a part of `ng serve` and `ng build` commands. Unfortunately Angular 17 also introduced a new bug: *`server.ts` file is _totally ignored_ during the `ng serve` command (see Angular issue https://github.com/angular/angular-cli/issues/26323)*. Spartacus to work correctly, requires `server.ts` file to be included in the compilation and execution. Therefore, for Spartacus to work, as a workaround, you have to disable SSR and Prerendering for `ng serve` in your `angular.json`.
 
-## Disable Prerendering for `ng build`
+### Disable Prerendering for `ng build`
 In `angular.json` of newly created app make the following change:
 In the section `projects › (my app name) › architect › build › options` remove the line `prerender: true`:
 
@@ -80,26 +84,27 @@ In the section `projects › (my app name) › architect › build › options` 
             },
 ```
 
-**Why**: Since Angular 17, in freshly created new apps (not the migrated from old version ones!) Angular runs Prerendering by default a part of `ng build` commands (and transitively also for `ng serve`). But Spartacus, for Prerendering to work correctly, requires a custom Node Environment Variable `SERVER_REQUEST_ORIGIN` to be defined. Otherwise Spartacus Prerendering would fail with errors about missing `SERVER_REQUEST_ORIGIN`. So as a workaround, we exclude Prerendering from the `ng build`, to be able to build app at least for CSR or SSR. 
+**Why**: Since Angular 17, in freshly created new apps (not migrated ones from Angular 16!) Angular runs Prerendering by default a part of `ng build` commands (and transitively also for `ng serve`). But Spartacus, for Prerendering to work correctly, requires a custom Node Environment Variable `SERVER_REQUEST_ORIGIN` to be defined. Otherwise Spartacus Prerendering would fail with an error about missing `SERVER_REQUEST_ORIGIN`. So as a workaround, you have to disable Prerendering for the `ng build`, to be able to build app at least for CSR or SSR. 
 
-## Bonus: How to run SSR dev server
+### Appendix A: How to run SSR dev server
 
-Run in 2 parallel windows of terminal:
+Run in _2 separate windows_ of terminal:
 ```bash
-npm run watch  # builds the app in watch mode. It compiles `server.ts` file as well, so there are no problems later with Spartacus. It produces an output compiled file `dist/(my-app-name)/server/server.mjs`
+# Terminal 1:
+npm run watch  # builds the app in watch mode. It compiles `server.ts` file as well and produces an output compiled file `dist/(my-app-name)/server/server.mjs`
 ```
 and
 ```bash
-# run the compiled server.mjs in watch mode
-node --watch dist/(my-app-name)/server/server.mjs
+# Terminal 2:
+node --watch dist/(my-app-name)/server/server.mjs # run the compiled server.mjs in watch mode
 ```
 Note: Please mind to replace `(my-app-name)` with the real name of your app.
 
-We're actively observing the Angular issue https://github.com/angular/angular-cli/issues/26323, hoping to be able to get rid of above mentioned workarounds
+### Appendix B: How to run Prerendering
 
-## Bonus: How to run Prerendering
+Run in terminal `ng build` with the explicit flag `--prerender=true` and passing a custom Node Env Variable `SERVER_REQUEST_ORIGIN` which is required by Spartacus Prerendering.
 
 ```bash
 SERVER_REQUEST_ORIGIN="http://localhost:4200" ng build --prerender=true
 ```
-Note: Please mind to replace `"http://localhost:4200"` with a real target domain where you want to deploy your your Prerendered. Otherwise, some of Spartacus SEO features might use wrong domain e.g. [Canonical URLs](https://help.sap.com/docs/SAP_COMMERCE_COMPOSABLE_STOREFRONT/eaef8c61b6d9477daf75bff9ac1b7eb4/e712f36722c543359ed699aed9873075.html#loio98befe9ef9ae4957a4ae34669c175fd5) might point to wrong domain or [Automatic Multi-Site Configuration](https://help.sap.com/docs/SAP_COMMERCE_COMPOSABLE_STOREFRONT/eaef8c61b6d9477daf75bff9ac1b7eb4/9d2e339c2b094e4f99df1c2d7cc999a8.html) might not work correctly (e.g. if some regexes configured in CMS for base-site recognition depend on the domain name).
+Note: Please mind to replace `"http://localhost:4200"` with a real target domain where you want to deploy your your Prerendered pages, especially if you deploy for production. Otherwise, some of SEO features of Spartacus might be not work properly, e.g. [Canonical URLs](https://help.sap.com/docs/SAP_COMMERCE_COMPOSABLE_STOREFRONT/eaef8c61b6d9477daf75bff9ac1b7eb4/e712f36722c543359ed699aed9873075.html#loio98befe9ef9ae4957a4ae34669c175fd5) might point to a wrong domain or [Automatic Multi-Site Configuration](https://help.sap.com/docs/SAP_COMMERCE_COMPOSABLE_STOREFRONT/eaef8c61b6d9477daf75bff9ac1b7eb4/9d2e339c2b094e4f99df1c2d7cc999a8.html) might not recognize base-side correctly (e.g. if some regexes configured in CMS for base-site recognition depend on the domain name).

--- a/docs/migration/2211/2211-installation.md
+++ b/docs/migration/2211/2211-installation.md
@@ -8,17 +8,25 @@ Since Angular v17, the command for creating a new app (`ng new`) must be run wit
 
 ## Workaround other issues after creating a new app
 
-After creating successfully a new Angular 17+ app, you must make additional manual changes in the app's configuration files to workaround other issues introduced by Angular 17.
+After creating successfully a new Angular 17+ app, you must make additional manual changes in the app's configuration files to workaround other issues introduced by Angular 17. Otherwise you'll face the following Spartacus error when running `ng serve` or `ng build`:
+
+```error
+  Error: The request origin is not set. 
+  (...)
+```
+
+**Note: in the following code snippets please mind to replace `my-app-name` with the real name of your application.
+**
 
 ### Disable SSR and Prerendering for `ng serve`
 
 In `angular.json` of newly created app make the following 2 changes:
-1. in the section `projects › (my app name) › architect › build › configurations` add a new subsection `"noSsr"` _as a sibling_ to other configurations `"production"` and `"development"`:
+1. in the section `projects › my-app-name › architect › build › configurations` add a new subsection `"noSsr"` _as a sibling_ to other configurations `"production"` and `"development"`:
 ```diff
   {
     "projects": {
       ...
-      "(my app name)": {
+      "my-app-name": {
         ...
         "architect": {
           ...
@@ -37,12 +45,13 @@ In `angular.json` of newly created app make the following 2 changes:
 +             }
             },
 ```
-2. In the section `projects › (my app name) › architect › serve › configurations` append a string `,noSsr` (including comma) to the value of the properties `"buildTarget"` - both for 2 sections `"production"` and `"development"`:
+
+1. In the section `projects › my-app-name › architect › serve › configurations` append a string `,noSsr` (including comma) to the value of the properties `"buildTarget"` - both for 2 sections `"production"` and `"development"`:
 ```diff
   {
     "projects": {
       ...
-      "(my app name)": {
+      "my-app-name": {
         ...
         "architect": {
           ...
@@ -50,12 +59,12 @@ In `angular.json` of newly created app make the following 2 changes:
             ...
             "configurations": {
               "production": {
--               "buildTarget": "test-ng17:build:production"
-+               "buildTarget": "test-ng17:build:production,noSsr"
+-               "buildTarget": "my-app-name:build:production"
++               "buildTarget": "my-app-name:build:production,noSsr"
               },
               "development": {
--               "buildTarget": "test-ng17:build:development"
-+               "buildTarget": "test-ng17:build:development,noSsr"
+-               "buildTarget": "my-app-name:build:development"
++               "buildTarget": "my-app-name:build:development,noSsr"
               }
             },
 ```
@@ -64,13 +73,13 @@ In `angular.json` of newly created app make the following 2 changes:
 
 ### Disable Prerendering for `ng build`
 In `angular.json` of newly created app make the following change:
-In the section `projects › (my app name) › architect › build › options` remove the line `prerender: true`:
+In the section `projects › my-app-name › architect › build › options` remove the line `prerender: true`:
 
 ```diff
   {
     "projects": {
       ...
-      "(my app name)": {
+      "my-app-name": {
         ...
         "architect": {
           ...
@@ -91,14 +100,15 @@ In the section `projects › (my app name) › architect › build › options` 
 Run in _2 separate windows_ of terminal:
 ```bash
 # Terminal 1:
-npm run watch  # builds the app in watch mode. It compiles `server.ts` file as well and produces an output compiled file `dist/(my-app-name)/server/server.mjs`
+npm run watch  # builds the app in watch mode. It compiles `server.ts` file as well and produces an output compiled file `dist/my-app-name/server/server.mjs`
 ```
 and
 ```bash
 # Terminal 2:
-node --watch dist/(my-app-name)/server/server.mjs # run the compiled server.mjs in watch mode
+node --watch dist/my-app-name/server/server.mjs # run the compiled server.mjs in watch mode
 ```
-Note: Please mind to replace `(my-app-name)` with the real name of your app.
+
+Note: Please mind to replace `my-app-name` with the real name of your app.
 
 ### Appendix B: How to run Prerendering
 

--- a/docs/migration/2211/2211-installation.md
+++ b/docs/migration/2211/2211-installation.md
@@ -1,1 +1,105 @@
 # Creating a new app using Spartacus v2211
+
+## You must run `ng new` with a new flag `--standalone=false`
+
+Since Angular v17, the command for creating a new app (`ng new`) must be run with the flag `--standalone=false`. Otherwise Spartacus installer won't work (`ng add @spartacus/schematics`).
+
+**Why**: Since Angular 17, new applications are created by default using a new so-called "standalone" mode, which has a bit *different structure of files* in the app folder then before. However Spartacus schematics installer still expects the *old files structure* in a created Angular app. That's why the flag  `new new --standalone=false` is required before running Spartacus installation schematics.
+
+## Disable SSR and Prerendering for `ng serve`
+
+In `angular.json` of newly created app make the following 2 changes:
+1. in the section `projects › (my app name) › architect › build › configurations` add a new subsection `"noSsr"` _as a sibling_ to other configurations `"production"` and `"development"`:
+```diff
+  {
+    "projects": {
+      ...
+      "(my app name)": {
+        ...
+        "architect": {
+          ...
+          "build": {
+            ...
+            "configurations": {
+              "production": {
+                ...
+              },
+              "development": {
+                ...
+              },
++             "noSsr": {
++               "ssr": false,
++               "prerender": false
++             }
+            },
+```
+2. In the section `projects › (my app name) › architect › serve › configurations` append a string `,noSsr` (including comma) to the value of the properties `"buildTarget"` - both for 2 sections `"production"` and `"development"`:
+```diff
+  {
+    "projects": {
+      ...
+      "(my app name)": {
+        ...
+        "architect": {
+          ...
+          "serve": {
+            ...
+            "configurations": {
+              "production": {
+-               "buildTarget": "test-ng17:build:production"
++               "buildTarget": "test-ng17:build:production,noSsr"
+              },
+              "development": {
+-               "buildTarget": "test-ng17:build:development"
++               "buildTarget": "test-ng17:build:development,noSsr"
+              }
+            },
+```
+
+**Why**: Since Angular 17, in freshly created new apps (not the migrated from old version ones!) Angular runs SSR and Prerendering by default a part of `ng serve` and `ng build` commands. Unfortunately Angular 17 also introduced a bug: `server.ts` file is _totally ignored_ during the `ng serve` command (see Angular issue https://github.com/angular/angular-cli/issues/26323). Spartacus to work correctly, requires `server.ts` file to be loaded. Therefore, for Spartacus to work, as a workaround, we have to disable SSR and Prerendering for `ng serve`.
+
+## Disable Prerendering for `ng build`
+In `angular.json` of newly created app make the following change:
+In the section `projects › (my app name) › architect › build › options` remove the line `prerender: true`:
+
+```diff
+  {
+    "projects": {
+      ...
+      "(my app name)": {
+        ...
+        "architect": {
+          ...
+          "build": {
+            ...
+            "options": {
+              "production": {
+                ...
+-               "prerender": "true"
+              }
+            },
+```
+
+**Why**: Since Angular 17, in freshly created new apps (not the migrated from old version ones!) Angular runs Prerendering by default a part of `ng build` commands (and transitively also for `ng serve`). But Spartacus, for Prerendering to work correctly, requires a custom Node Environment Variable `SERVER_REQUEST_ORIGIN` to be defined. Otherwise Spartacus Prerendering would fail with errors about missing `SERVER_REQUEST_ORIGIN`. So as a workaround, we exclude Prerendering from the `ng build`, to be able to build app at least for CSR or SSR. 
+
+## Bonus: How to run SSR dev server
+
+Run in 2 parallel windows of terminal:
+```bash
+npm run watch  # builds the app in watch mode. It compiles `server.ts` file as well, so there are no problems later with Spartacus. It produces an output compiled file `dist/(my-app-name)/server/server.mjs`
+```
+and
+```bash
+# run the compiled server.mjs in watch mode
+node --watch dist/(my-app-name)/server/server.mjs
+```
+Note: Please mind to replace `(my-app-name)` with the real name of your app.
+
+We're actively observing the Angular issue https://github.com/angular/angular-cli/issues/26323, hoping to be able to get rid of above mentioned workarounds
+
+## Bonus: How to run Prerendering
+
+```bash
+SERVER_REQUEST_ORIGIN="http://localhost:4200" ng build --prerender=true
+```
+Note: Please mind to replace `"http://localhost:4200"` with a real target domain where you want to deploy your your Prerendered. Otherwise, some of Spartacus SEO features might use wrong domain e.g. [Canonical URLs](https://help.sap.com/docs/SAP_COMMERCE_COMPOSABLE_STOREFRONT/eaef8c61b6d9477daf75bff9ac1b7eb4/e712f36722c543359ed699aed9873075.html#loio98befe9ef9ae4957a4ae34669c175fd5) might point to wrong domain or [Automatic Multi-Site Configuration](https://help.sap.com/docs/SAP_COMMERCE_COMPOSABLE_STOREFRONT/eaef8c61b6d9477daf75bff9ac1b7eb4/9d2e339c2b094e4f99df1c2d7cc999a8.html) might not work correctly (e.g. if some regexes configured in CMS for base-site recognition depend on the domain name).


### PR DESCRIPTION
use `my-app-name` consistently in all examples

followup to https://github.com/SAP/spartacus/pull/18242
related to [CXSPA-5611](https://jira.tools.sap/browse/CXSPA-5611)