### PR TITLE
feat: CXSPA-5617 Upgrade to Angular 17 - LinkComponent refactor

### DIFF
--- a/projects/storefrontlib/cms-components/content/link/link.component.ts
+++ b/projects/storefrontlib/cms-components/content/link/link.component.ts
@@ -4,25 +4,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeDetectionStrategy, Component, HostBinding } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  OnDestroy,
+  OnInit,
+  HostBinding,
+} from '@angular/core';
 import { CmsLinkComponent } from '@spartacus/core';
-import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
-import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
+import { CmsComponentData } from '@spartacus/storefront';
+import { Observable, Subscription } from 'rxjs';
 
 @Component({
   selector: 'cx-link',
   templateUrl: './link.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LinkComponent {
+export class LinkComponent implements OnDestroy, OnInit {
   @HostBinding('class') styleClasses: string | undefined;
 
-  data$: Observable<CmsLinkComponent> = this.component.data$.pipe(
-    tap((data) => (this.styleClasses = data?.styleClasses))
-  );
+  data$: Observable<CmsLinkComponent> = this.component.data$;
+
+  protected subscriptions: Subscription = new Subscription();
 
   constructor(protected component: CmsComponentData<CmsLinkComponent>) {}
+
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.data$.subscribe((data) => {
+        this.styleClasses = data?.styleClasses;
+      })
+    );
+  }
 
   /**
    * Returns `_blank` to force opening the link in a new window whenever the
@@ -30,5 +43,9 @@ export class LinkComponent {
    */
   getTarget(data: CmsLinkComponent): string | null {
     return data.target === 'true' || data.target === true ? '_blank' : null;
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions?.unsubscribe();
   }
 }


### PR DESCRIPTION
Changes around host bindings in `OnPush` components created dynamically caused an issue when setting the CSS class received from the backend. The class set as a side effect in `tap` when subscribing `data$` property doesn't reflect in DOM. To solve this, such a logic has been moved to `ngOnInit`.

For more about `OnPush` changes, see: https://github.com/angular/angular/commit/40bb45f3297359866cab39044dba06b3e809b096

Related to [CXSPA-5617](https://jira.tools.sap/browse/CXSPA-5617)