### PR TITLE
fix: QB buttons should not be displayed when guest is disabled

### DIFF
--- a/integration-libs/opf/base/components/opf-quick-buy/opf-quick-buy.component.html
+++ b/integration-libs/opf/base/components/opf-quick-buy/opf-quick-buy.component.html
@@ -1,14 +1,16 @@
-<ng-container *ngIf="paymentGatewayConfig$ | async as paymentGatewayConfig">
-  <cx-opf-apple-pay
-    *ngIf="
-      isPaymentMethodEnabled(PAYMENT_METHODS.APPLE_PAY, paymentGatewayConfig)
-    "
-    [activeConfiguration]="paymentGatewayConfig"
-  ></cx-opf-apple-pay>
-  <cx-opf-google-pay
-    *ngIf="
-      isPaymentMethodEnabled(PAYMENT_METHODS.GOOGLE_PAY, paymentGatewayConfig)
-    "
-    [activeConfiguration]="paymentGatewayConfig"
-  ></cx-opf-google-pay>
+<ng-container *ngIf="isUserGuestOrLoggedIn$ | async">
+  <ng-container *ngIf="paymentGatewayConfig$ | async as paymentGatewayConfig">
+    <cx-opf-apple-pay
+      *ngIf="
+        isPaymentMethodEnabled(PAYMENT_METHODS.APPLE_PAY, paymentGatewayConfig)
+      "
+      [activeConfiguration]="paymentGatewayConfig"
+    ></cx-opf-apple-pay>
+    <cx-opf-google-pay
+      *ngIf="
+        isPaymentMethodEnabled(PAYMENT_METHODS.GOOGLE_PAY, paymentGatewayConfig)
+      "
+      [activeConfiguration]="paymentGatewayConfig"
+    ></cx-opf-google-pay>
+  </ng-container>
 </ng-container>

--- a/integration-libs/opf/base/components/opf-quick-buy/opf-quick-buy.component.ts
+++ b/integration-libs/opf/base/components/opf-quick-buy/opf-quick-buy.component.ts
@@ -21,14 +21,16 @@ import { OpfQuickBuyService } from './opf-quick-buy.service';
 })
 export class OpfQuickBuyComponent implements OnInit {
   protected opfQuickBuyService = inject(OpfQuickBuyService);
-
   protected paymentGatewayConfig$: Observable<ActiveConfiguration>;
+  protected isUserGuestOrLoggedIn$: Observable<boolean>;
 
   PAYMENT_METHODS = OpfProviderType;
 
   ngOnInit(): void {
     this.paymentGatewayConfig$ =
       this.opfQuickBuyService.getPaymentGatewayConfiguration();
+    this.isUserGuestOrLoggedIn$ =
+      this.opfQuickBuyService.isUserGuestOrLoggedIn();
   }
 
   isPaymentMethodEnabled(


### PR DESCRIPTION
can be tested by set on/off guest checkout in default-opf-checkout-config.ts file
```
'spa-opf': {
        steps: opfCheckoutSteps,
        guest: false/true,
      },
```