### PR TITLE
fix: CXSPA-5653 Fix for Failing My Interests e2e test

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/notification.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/notification.ts
@@ -234,7 +234,7 @@ export function navigateToPDPInCustomerInterest(productCode: string) {
   cy.get('.cx-product-interests-product-item').within(() => {
     cy.get('.cx-code').should('contain', productCode);
     cy.get(
-      '.cx-product-interests-product-image-link > .is-initialized > img'
+      '.cx-product-interests-product-image-link > .is-initialized > picture'
     ).click();
   });
 }


### PR DESCRIPTION
This PR contains a fix for failing the My Interests e2e test. Due to changes in `MediaComponent` provided in #17841, the assertion in the mentioned e2e had to be adjusted.

Closes [CXSPA-5653](https://jira.tools.sap/browse/CXSPA-5653)