### PR TITLE
feat: CXSPA-5528 Upgrade to Angular 17 - Use Angular v17 epic branch …

### DIFF
--- a/scripts/install/config.default.sh
+++ b/scripts/install/config.default.sh
@@ -43,7 +43,7 @@ SPARTACUS_PROJECTS=(
         )
 
 SPARTACUS_REPO_URL="https://github.com/SAP/spartacus.git"
-BRANCH='develop'
+BRANCH='epic/upgrade-to-angular-17' #TODO: CXSPA-5665 change to develop-next-major after merging Angualr v17
 
 # custom location for the installation output
 # BASE_DIR='/tmp/'


### PR DESCRIPTION
We need to use epic/upgrade-to-angular-17 for pipeline purposes. It should be changed after merging the epic branch to develop-next-major. ([CXSPA-5665](https://jira.tools.sap/browse/CXSPA-5665))

Followup PR for : https://github.com/SAP/spartacus/pull/18254