### PR TITLE
feat: CXSPA-5528 Upgrade to Angular 17 - add missing package to installation script

### DIFF
--- a/scripts/install/config.default.sh
+++ b/scripts/install/config.default.sh
@@ -38,6 +38,7 @@ SPARTACUS_PROJECTS=(
         "dist/epd-visualization:integration-libs/epd-visualization"
         "dist/product-configurator:feature-libs/product-configurator"
         "dist/pickup-in-store:feature-libs/pickup-in-store"
+        "dist/pdf-invoices:feature-libs/pdf-invoices"
         "projects/storefrontstyles:projects/storefrontstyles"
         "projects/schematics:projects/schematics"
         )


### PR DESCRIPTION
Adding [a fix](https://github.com/SAP/spartacus/commit/47dfc22ba1a31fe08709280532eab05140c4ebf2) that is already on `develop-6.8.x`. For the sake of avoiding synchronization with the `develop-6.8.x` branch before 6.8 CF, and for time reasons, I decided to add this one line to the code to unlock the pipeline.

Followup PR for: https://github.com/SAP/spartacus/pull/18254