### PR TITLE
feat: CXSPA-5713 Upgrade to Angular 17 - schematics for removing 'provideClientHydration' from AppModule

### DIFF
--- a/docs/migration/2211/2211-installation.md
+++ b/docs/migration/2211/2211-installation.md
@@ -6,42 +6,6 @@ Since Angular v17, the command for creating a new app (`ng new`) must be run wit
 
 **Why**: Since Angular 17, new applications are created by default using a new so-called "standalone" mode, which has a bit *different structure of files* in the app folder than before. However Spartacus schematics installer still expects the *old files structure* in a created Angular app. That's why the flag  `ng new --standalone=false` is required before running Spartacus installation schematics.
 
-## If you are using SSR, you must remove `provideClientHydration` from `AppModule`.
-
-The `provideClientHydration` feature has to be removed from the freshly created application with SSR enabled. Otherwise, the app might not work properly.
-
-```ts
-import { HttpClientModule } from "@angular/common/http";
-import { NgModule } from '@angular/core';
-import { BrowserModule, provideClientHydration } from '@angular/platform-browser';
-import { EffectsModule } from "@ngrx/effects";
-import { StoreModule } from "@ngrx/store";
-import { AppRoutingModule } from './app-routing.module';
-import { AppComponent } from './app.component';
-import { SpartacusModule } from './spartacus/spartacus.module';
-
-@NgModule({
-  declarations: [
-    AppComponent
-  ],
-  imports: [
-    BrowserModule,
-    HttpClientModule,
-    AppRoutingModule,
-    StoreModule.forRoot({}),
-    EffectsModule.forRoot([]),
-    SpartacusModule
-  ],
-  providers: [
-    provideClientHydration() // <-------- we have to remove this line
-  ],
-  bootstrap: [AppComponent]
-})
-export class AppModule {}
-```
-
-**Why**: `provideClientHydration` is the new Angular feature that improves application performance by avoiding extra work to re-create DOM nodes. Since Angular v17 it is enabled by default in fresh applications with SSR. However, Spartacus does not support fully this feature and some unexpected issues might occur.
-
 ### Appendix A: How to run SSR dev server
 
 Run in _2 separate windows_ of terminal:

--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -154,6 +154,36 @@ export class AppServerModule {}
 "
 `;
 
+exports[`add-ssr app.module.ts should be updated 1`] = `
+"import { HttpClientModule } from "@angular/common/http";
+import { NgModule } from '@angular/core';
+import { BrowserModule,  } from '@angular/platform-browser';
+import { EffectsModule } from "@ngrx/effects";
+import { StoreModule } from "@ngrx/store";
+import { AppRoutingModule } from "@spartacus/storefront";
+import { AppComponent } from './app.component';
+import { SpartacusModule } from './spartacus/spartacus.module';
+
+@NgModule({
+  declarations: [
+    AppComponent
+  ],
+  imports: [
+    BrowserModule,
+    HttpClientModule,
+    AppRoutingModule,
+    StoreModule.forRoot({}),
+    EffectsModule.forRoot([]),
+    SpartacusModule
+  ],
+  providers: [
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+"
+`;
+
 exports[`add-ssr index.html should contain occ-backend-base-url attribute in meta tags 1`] = `
 "<!doctype html>
 <html lang="en">

--- a/projects/schematics/src/add-ssr/index.ts
+++ b/projects/schematics/src/add-ssr/index.ts
@@ -6,36 +6,47 @@
 
 import { strings } from '@angular-devkit/core';
 import {
-  apply,
-  branchAndMerge,
-  chain,
-  externalSchematic,
   MergeStrategy,
-  mergeWith,
-  move,
   Rule,
   SchematicContext,
   SchematicsException,
   Source,
-  template,
   Tree,
+  apply,
+  branchAndMerge,
+  chain,
+  externalSchematic,
+  mergeWith,
+  move,
+  template,
   url,
 } from '@angular-devkit/schematics';
-import { insertImport } from '@schematics/angular/utility/ast-utils';
+import {
+  getDecoratorMetadata,
+  getMetadataField,
+  insertImport,
+} from '@schematics/angular/utility/ast-utils';
+import { RemoveChange } from '@schematics/angular/utility/change';
 import {
   NodeDependency,
   NodeDependencyType,
 } from '@schematics/angular/utility/dependencies';
+import ts from 'typescript';
 import { Schema as SpartacusOptions } from '../add-spartacus/schema';
 import collectedDependencies from '../dependencies.json';
 import { getDefaultProjectNameFromWorkspace, getWorkspace } from '../shared';
-import { ANGULAR_SSR } from '../shared/constants';
+import {
+  ANGULAR_CORE,
+  ANGULAR_PLATFORM_BROWSER,
+  ANGULAR_SSR,
+} from '../shared/constants';
 import { SPARTACUS_SETUP } from '../shared/libs-constants';
 import {
   commitChanges,
   getIndexHtmlPath,
   getPathResultsForFile,
   getTsSourceFile,
+  removeImport,
 } from '../shared/utils/file-utils';
 import { appendHtmlElementToHead } from '../shared/utils/html-utils';
 import {
@@ -337,6 +348,101 @@ function useNoSsrConfigurationInNgServe(
   };
 }
 
+/**
+ * Removes the "provideClientHydration" from "app.module.ts" file.
+ *
+ * This rule should be skipped (and removed) when Spartacus starts supporting client hydration.
+ */
+function removeClientHydration(spartacusOptions: SpartacusOptions): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    if (spartacusOptions.debug) {
+      context.logger.info(
+        `⌛️ Removing "provideClientHydration" from "app.module.ts"...`
+      );
+    }
+    const appModulePath = getPathResultsForFile(
+      tree,
+      'app.module.ts',
+      '/src'
+    )[0];
+
+    if (!appModulePath) {
+      throw new SchematicsException(`Project file "app.module.ts" not found.`);
+    }
+
+    const sourceFile = getTsSourceFile(tree, appModulePath);
+
+    // Remove import
+    const importChange = removeImport(sourceFile, {
+      className: `provideClientHydration`,
+      importPath: ANGULAR_PLATFORM_BROWSER,
+    });
+
+    // Remove provider
+    const providerChanges = removeFromModuleProviders(
+      sourceFile,
+      `provideClientHydration()`
+    );
+
+    const changes = [importChange, ...providerChanges];
+    commitChanges(tree, appModulePath, changes);
+
+    if (spartacusOptions.debug) {
+      context.logger.info(
+        `✅ Removing "provideClientHydration" from "app.module.ts" complete.`
+      );
+    }
+    return tree;
+  };
+}
+
+/**
+ * Removes provider from  module providers.
+ *
+ * removeClientHydration() function is the only place where this function is used and it's used temporarily.
+ * If needed, move this function to module-file-utils.ts
+ */
+function removeFromModuleProviders(
+  source: ts.SourceFile,
+  providerName: string
+): RemoveChange[] {
+  const nodes = getDecoratorMetadata(source, 'NgModule', ANGULAR_CORE);
+  const node = nodes[0];
+  if (!node || !ts.isObjectLiteralExpression(node)) {
+    return [];
+  }
+
+  // Find the matching metadata field.
+  const matchingProperties = getMetadataField(node, `providers`);
+  const assignment = matchingProperties[0];
+
+  // return empty array if assignment is not an array
+  if (
+    !ts.isPropertyAssignment(assignment) ||
+    !ts.isArrayLiteralExpression(assignment.initializer)
+  ) {
+    return [];
+  }
+
+  //find provider to remove
+  const providersExpression = assignment.initializer;
+  const providerToRemove = providersExpression
+    .getChildren()
+    .filter((e) => e.getText().includes(providerName));
+
+  if (!providerToRemove) {
+    return [];
+  }
+
+  return [
+    new RemoveChange(
+      source.fileName,
+      providerToRemove[0].pos,
+      `${providerToRemove[0].getFullText()}`
+    ),
+  ];
+}
+
 export function addSSR(options: SpartacusOptions): Rule {
   return (tree: Tree, context: SchematicContext) => {
     const serverTemplate = provideServerFile(options);
@@ -348,6 +454,7 @@ export function addSSR(options: SpartacusOptions): Rule {
         project: options.project,
       }),
       modifyAppServerModuleFile(),
+      removeClientHydration(options),
       modifyIndexHtmlFile(options),
       branchAndMerge(
         chain([mergeWith(serverTemplate, MergeStrategy.Overwrite)]),

--- a/projects/schematics/src/add-ssr/index_spec.ts
+++ b/projects/schematics/src/add-ssr/index_spec.ts
@@ -108,6 +108,13 @@ describe('add-ssr', () => {
     });
   });
 
+  describe('app.module.ts', () => {
+    it('should be updated', () => {
+      const content = appTree.readContent('./src/app/app.module.ts');
+      expect(content).toMatchSnapshot();
+    });
+  });
+
   describe('index.html', () => {
     it('should contain occ-backend-base-url attribute in meta tags', async () => {
       const indexHtmlPath = getPathResultsForFile(

--- a/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 1`] = `
 "import { HttpClientModule } from "@angular/common/http";
 import { NgModule } from '@angular/core';
-import { BrowserModule, provideClientHydration } from '@angular/platform-browser';
+import { BrowserModule,  } from '@angular/platform-browser';
 import { EffectsModule } from "@ngrx/effects";
 import { StoreModule } from "@ngrx/store";
 import { AppRoutingModule } from "@spartacus/storefront";
@@ -23,7 +23,6 @@ import { SpartacusModule } from './spartacus/spartacus.module';
     SpartacusModule
   ],
   providers: [
-    provideClientHydration()
   ],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
This PR contains schematics for removing `provideClientHydration` from AppModule `providers` in the fresh app.
This feature has to be removed, because Spartacus doesn't support it yet and it may cause unexpected issues.

QA steps:

- build and deploy Spartacus packages locally: 
`npx ts-node ./tools/schematics/testing.ts` in the SPA root folder
- create fresh ng17 app: 
`npx @angular/cli new my-app --standalone=false --ssr=false`
- go to project's directory and install SPA with SSR: 
`npx @angular/cli add @spartacus/schematics@latest --baseUrl="https://40.76.109.9:9002" --ssr --debug`
- verify whether `provideClientHydration` has been removed from `providers` in AppModule together with its import.
-build and run the app to verify if it works as expected: 
`npm run build` -> `npm run serve:ssr:my-app`

closes [CXSPA-5713](https://jira.tools.sap/browse/CXSPA-5713)