### PR TITLE
feat: Apple pay unit test

### DIFF
--- a/integration-libs/opf/base/components/opf-quick-buy/apple-pay/apple-pay-session/apple-pay-session.factory.spec.ts
+++ b/integration-libs/opf/base/components/opf-quick-buy/apple-pay/apple-pay-session/apple-pay-session.factory.spec.ts
@@ -1,1 +1,214 @@
-// to be done
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { WindowRef } from '@spartacus/core';
+import { ApplePaySessionFactory } from './apple-pay-session.factory';
+import { Injectable } from '@angular/core';
+
+class MockApplePaySession extends EventTarget implements ApplePaySession {
+  static readonly STATUS_SUCCESS: number = 2;
+
+  static readonly STATUS_FAILURE: number = 3;
+
+  oncancel: (event: ApplePayJS.Event) => void;
+
+  onpaymentauthorized: (
+    event: ApplePayJS.ApplePayPaymentAuthorizedEvent
+  ) => void;
+
+  onpaymentmethodselected: (
+    event: ApplePayJS.ApplePayPaymentMethodSelectedEvent
+  ) => void;
+
+  onshippingcontactselected: (
+    event: ApplePayJS.ApplePayShippingContactSelectedEvent
+  ) => void;
+
+  onshippingmethodselected: (
+    event: ApplePayJS.ApplePayShippingMethodSelectedEvent
+  ) => void;
+
+  onvalidatemerchant: (event: ApplePayJS.ApplePayValidateMerchantEvent) => void;
+
+  _stubConstructorArguments: Array<any>;
+
+  constructor(
+    version: number,
+    paymentRequest: ApplePayJS.ApplePayPaymentRequest
+  ) {
+    super();
+    this._stubConstructorArguments = [version, paymentRequest];
+  }
+
+  static canMakePayments(): boolean {
+    return true;
+  }
+
+  static canMakePaymentsWithActiveCard(
+    _merchantIdentifier: string
+  ): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  static openPaymentSetup(_merchantIdentifier: string): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  static supportsVersion(_dialogCloseversion: number): boolean {
+    return true;
+  }
+
+  abort(): void {}
+
+  begin(): void {}
+
+  completeMerchantValidation(_eventmerchantSession: any): void {}
+
+  completePayment(
+    _result: number | ApplePayJS.ApplePayPaymentAuthorizationResult
+  ): void {}
+
+  completePaymentMethodSelection(
+    _newTotal: ApplePayJS.ApplePayLineItem,
+    _newLineItems: Array<ApplePayJS.ApplePayLineItem>
+  ): void;
+  completePaymentMethodSelection(
+    _update: ApplePayJS.ApplePayPaymentMethodUpdate
+  ): void;
+  completePaymentMethodSelection(_newTotal: any, _newLineItems?: any): void {}
+
+  completeShippingContactSelection(
+    _status: number,
+    _newShippingMethods: Array<ApplePayJS.ApplePayShippingMethod>,
+    _newTotal: ApplePayJS.ApplePayLineItem,
+    _newLineItems: Array<ApplePayJS.ApplePayLineItem>
+  ): void;
+  completeShippingContactSelection(
+    _update: ApplePayJS.ApplePayShippingContactUpdate
+  ): void;
+  completeShippingContactSelection(
+    _status: any,
+    _newShippingMethods?: any,
+    _newTotal?: any,
+    _newLineItems?: any
+  ): void {}
+
+  completeShippingMethodSelection(
+    status: number,
+    newTotal: ApplePayJS.ApplePayLineItem,
+    newLineItems: Array<ApplePayJS.ApplePayLineItem>
+  ): void;
+  completeShippingMethodSelection(
+    update: ApplePayJS.ApplePayShippingMethodUpdate
+  ): void;
+  completeShippingMethodSelection(
+    _status: any,
+    _newTotal?: any,
+    _openElementnewLineItems?: any
+  ): void {}
+}
+@Injectable()
+class ApplePaySessionFactoryExt extends ApplePaySessionFactory {
+  setIsDeviceSupported(newValue: boolean) {
+    this.isDeviceSupported = newValue;
+  }
+}
+
+describe('ApplePaySessionFactory', () => {
+  let applePaySessionFactory: ApplePaySessionFactoryExt;
+  let windowRef: WindowRef;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: WindowRef,
+          useValue: { nativeWindow: { ApplePaySession: MockApplePaySession } },
+        },
+        ApplePaySessionFactoryExt,
+      ],
+    });
+
+    applePaySessionFactory = TestBed.inject(ApplePaySessionFactoryExt);
+    windowRef = TestBed.inject(WindowRef);
+  });
+
+  it('should be created', () => {
+    expect(applePaySessionFactory).toBeTruthy();
+  });
+
+  it('should create ApplePaySession if available', () => {
+    const applePaySession = applePaySessionFactory.createApplePaySession();
+    expect(applePaySession).toBeDefined();
+  });
+
+  it('should not create ApplePaySession if not available', () => {
+    windowRef.nativeWindow['ApplePaySession'] = null;
+    const applePaySession = applePaySessionFactory.createApplePaySession();
+    expect(applePaySession).not.toBeDefined();
+  });
+
+  it('should return STATUS_SUCCESS for statusSuccess when device is supported', () => {
+    applePaySessionFactory.setIsDeviceSupported(true);
+    expect(applePaySessionFactory.statusSuccess).toEqual(
+      MockApplePaySession.STATUS_SUCCESS
+    );
+  });
+
+  it('should return 1 for statusSuccess when device is not supported', () => {
+    applePaySessionFactory.setIsDeviceSupported(false);
+    expect(applePaySessionFactory.statusSuccess).toEqual(1);
+  });
+
+  it('should return STATUS_FAILURE for statusFailure when device is supported', () => {
+    applePaySessionFactory.setIsDeviceSupported(true);
+    expect(applePaySessionFactory.statusFailure).toEqual(
+      MockApplePaySession.STATUS_FAILURE
+    );
+  });
+
+  it('should return 1 for statusFailure when device is not supported', () => {
+    applePaySessionFactory.setIsDeviceSupported(false);
+    expect(applePaySessionFactory.statusFailure).toEqual(1);
+  });
+
+  it('should return true for isApplePaySupported$ when device is supported', (done: DoneFn) => {
+    applePaySessionFactory.setIsDeviceSupported(true);
+    const merchantId = 'merchantId';
+    applePaySessionFactory
+      .isApplePaySupported$(merchantId)
+      .subscribe((result) => {
+        expect(result).toEqual(true);
+        done();
+      });
+  });
+  it('should return false for isApplePaySupported$ when device is not supported', (done: DoneFn) => {
+    applePaySessionFactory.setIsDeviceSupported(false);
+    const merchantId = 'merchantId';
+    applePaySessionFactory
+      .isApplePaySupported$(merchantId)
+      .subscribe((result) => {
+        expect(result).toEqual(false);
+        done();
+      });
+  });
+
+  it('should return ApplePaySession when device is supported', () => {
+    applePaySessionFactory.setIsDeviceSupported(true);
+    const startSession = applePaySessionFactory.startApplePaySession(
+      {} as ApplePayJS.ApplePayPaymentRequest
+    );
+    expect(startSession).not.toEqual(undefined);
+  });
+
+  it('should not return ApplePaySession when device is not supported', () => {
+    applePaySessionFactory.setIsDeviceSupported(false);
+    const startSession = applePaySessionFactory.startApplePaySession(
+      {} as ApplePayJS.ApplePayPaymentRequest
+    );
+    expect(startSession).toEqual(undefined);
+  });
+});

--- a/integration-libs/opf/base/components/opf-quick-buy/apple-pay/apple-pay.component.spec.ts
+++ b/integration-libs/opf/base/components/opf-quick-buy/apple-pay/apple-pay.component.spec.ts
@@ -1,1 +1,204 @@
-// to be done
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ApplePayComponent } from './apple-pay.component';
+import {
+  CurrentProductService,
+  ItemCounterService,
+} from '@spartacus/storefront';
+import { ApplePayService } from './apple-pay.service';
+import { ApplePaySessionFactory } from './apple-pay-session';
+import {
+  OpfCartHandlerService,
+  OpfPaymentErrorHandlerService,
+} from '@spartacus/opf/base/core';
+import {
+  ActiveConfiguration,
+  DigitalWalletQuickBuy,
+  OpfPaymentError,
+  OpfProviderType,
+} from '@spartacus/opf/base/root';
+import { of, throwError } from 'rxjs';
+import { Product } from '@spartacus/core';
+
+const mockProduct: Product = {
+  name: 'mockProduct',
+  code: 'code1',
+  stock: {
+    stockLevel: 333,
+    stockLevelStatus: 'inStock',
+  },
+};
+
+const mockActiveConfiguration: ActiveConfiguration = {
+  digitalWalletQuickBuy: [
+    {
+      merchantId: 'merchant.com.adyen.upscale.test',
+      provider: OpfProviderType.APPLE_PAY,
+      countryCode: 'US',
+    },
+    { merchantId: 'merchant.test.example' },
+  ],
+};
+
+describe('ApplePayComponent', () => {
+  let component: ApplePayComponent;
+  let fixture: ComponentFixture<ApplePayComponent>;
+  let mockApplePayService: jasmine.SpyObj<ApplePayService>;
+  let mockCurrentProductService: jasmine.SpyObj<CurrentProductService>;
+  let mockItemCounterService: jasmine.SpyObj<ItemCounterService>;
+  let mockCartHandlerService: jasmine.SpyObj<OpfCartHandlerService>;
+  let mockApplePaySessionFactory: jasmine.SpyObj<ApplePaySessionFactory>;
+  let mockOpfPaymentErrorHandlerService: jasmine.SpyObj<OpfPaymentErrorHandlerService>;
+  const mockCountryCode = 'US';
+  const mockCounter = 2;
+
+  beforeEach(() => {
+    mockApplePayService = jasmine.createSpyObj('ApplePayService', ['start']);
+    mockCurrentProductService = jasmine.createSpyObj('CurrentProductService', [
+      'getProduct',
+    ]);
+    mockItemCounterService = jasmine.createSpyObj('ItemCounterService', [
+      'getCounter',
+    ]);
+    mockCartHandlerService = jasmine.createSpyObj('OpfCartHandlerService', [
+      'checkStableCart',
+    ]);
+    mockApplePaySessionFactory = jasmine.createSpyObj(
+      'ApplePaySessionFactory',
+      ['isApplePaySupported$']
+    );
+    mockOpfPaymentErrorHandlerService = jasmine.createSpyObj(
+      'OpfPaymentErrorHandlerService',
+      ['handlePaymentError']
+    );
+
+    TestBed.configureTestingModule({
+      declarations: [ApplePayComponent],
+      providers: [
+        { provide: ApplePayService, useValue: mockApplePayService },
+        { provide: CurrentProductService, useValue: mockCurrentProductService },
+        { provide: ItemCounterService, useValue: mockItemCounterService },
+        { provide: OpfCartHandlerService, useValue: mockCartHandlerService },
+        {
+          provide: ApplePaySessionFactory,
+          useValue: mockApplePaySessionFactory,
+        },
+        {
+          provide: OpfPaymentErrorHandlerService,
+          useValue: mockOpfPaymentErrorHandlerService,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplePayComponent);
+    component = fixture.componentInstance;
+
+    const mockProductObservable = of(mockProduct);
+    const mockCartCheckObservable = of(true);
+
+    mockCurrentProductService.getProduct.and.returnValue(mockProductObservable);
+    mockItemCounterService.getCounter.and.returnValue(mockCounter);
+    mockCartHandlerService.checkStableCart.and.returnValue(
+      mockCartCheckObservable
+    );
+  });
+  afterEach(() => {
+    component.ngOnDestroy();
+  });
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize isApplePaySupported$ provider is Apple pay', () => {
+    const digitalWallet: DigitalWalletQuickBuy = {
+      provider: OpfProviderType.APPLE_PAY,
+      countryCode: mockCountryCode,
+      merchantId: 'merchant.com.adyen.upscale.test',
+    };
+    component.activeConfiguration = { digitalWalletQuickBuy: [digitalWallet] };
+
+    const mockObservable = of(true);
+    mockApplePaySessionFactory.isApplePaySupported$.and.returnValue(
+      mockObservable
+    );
+
+    fixture.detectChanges();
+    expect(component.isApplePaySupported$).toBe(mockObservable);
+  });
+
+  it('should not initialize isApplePaySupported$ provider is not Apple pay', () => {
+    const digitalWallet: DigitalWalletQuickBuy = {
+      provider: OpfProviderType.GOOGLE_PAY,
+      countryCode: mockCountryCode,
+      merchantId: 'merchant.com.adyen.upscale.test',
+    };
+    component.activeConfiguration = { digitalWalletQuickBuy: [digitalWallet] };
+
+    const mockObservable = of(true);
+    mockApplePaySessionFactory.isApplePaySupported$.and.returnValue(
+      mockObservable
+    );
+
+    fixture.detectChanges();
+    expect(
+      mockApplePaySessionFactory.isApplePaySupported$
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should start applePayService', () => {
+    mockApplePayService.start.and.returnValue(
+      of(<ApplePayJS.ApplePayPaymentAuthorizationResult>{ status: 1 })
+    );
+    component.activeConfiguration = {
+      digitalWalletQuickBuy: [
+        {
+          provider: OpfProviderType.APPLE_PAY,
+          countryCode: mockCountryCode,
+          merchantId: 'merchant.com.adyen.upscale.test',
+        },
+      ],
+    };
+    component.activeConfiguration = mockActiveConfiguration;
+    fixture.detectChanges();
+
+    component.quickBuyProduct();
+    expect(
+      mockOpfPaymentErrorHandlerService.handlePaymentError
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should call applePayService with correct parameters', () => {
+    const mockError: OpfPaymentError = { message: 'Payment error' };
+    mockApplePayService.start.and.returnValue(throwError(mockError));
+
+    component.activeConfiguration = {
+      digitalWalletQuickBuy: [
+        {
+          provider: OpfProviderType.APPLE_PAY,
+          countryCode: mockCountryCode,
+          merchantId: 'merchant.com.adyen.upscale.test',
+        },
+      ],
+    };
+    component.activeConfiguration = mockActiveConfiguration;
+    fixture.detectChanges();
+
+    component.quickBuyProduct();
+    expect(mockCurrentProductService.getProduct).toHaveBeenCalled();
+    expect(mockItemCounterService.getCounter).toHaveBeenCalled();
+    expect(mockCartHandlerService.checkStableCart).toHaveBeenCalled();
+    expect(mockApplePayService.start).toHaveBeenCalledWith(
+      mockProduct,
+      mockCounter,
+      mockCountryCode
+    );
+    expect(
+      mockOpfPaymentErrorHandlerService.handlePaymentError
+    ).toHaveBeenCalledWith(mockError);
+  });
+});

--- a/integration-libs/opf/base/components/opf-quick-buy/apple-pay/apple-pay.service.spec.ts
+++ b/integration-libs/opf/base/components/opf-quick-buy/apple-pay/apple-pay.service.spec.ts
@@ -1,1 +1,545 @@
-// to be done
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ApplePayService } from './apple-pay.service';
+import {
+  ApplePayObservableConfig,
+  OpfPaymentFacade,
+} from '@spartacus/opf/base/root';
+import { Product, WindowRef } from '@spartacus/core';
+import { OpfCartHandlerService } from '@spartacus/opf/base/core';
+import { ApplePayObservableFactory } from './observable/apple-pay-observable.factory';
+import { ApplePaySessionFactory } from './apple-pay-session/apple-pay-session.factory';
+import { Subject, of, throwError } from 'rxjs';
+import { DeliveryMode } from '@spartacus/cart/base/root';
+import { map } from 'rxjs/operators';
+
+interface ApplePaySessionVerificationResponse {
+  epochTimestamp: number;
+  expiresAt: number;
+  merchantSessionIdentifier: string;
+  nonce: string;
+  merchantIdentifier: string;
+  domainName: string;
+  displayName: string;
+  signature: string;
+}
+const mockApplePaySessionVerificationResponse: ApplePaySessionVerificationResponse =
+  {
+    epochTimestamp: 123,
+    expiresAt: 123,
+    merchantSessionIdentifier: '123',
+    nonce: '123',
+    merchantIdentifier: '123',
+    domainName: '123',
+    displayName: '123',
+    signature: '123',
+  };
+
+const mocProduct: Product = {
+  name: 'Product Name',
+  code: 'PRODUCT_CODE',
+  images: {
+    PRIMARY: {
+      thumbnail: {
+        url: 'url',
+        altText: 'alt',
+      },
+    },
+  },
+  price: {
+    formattedValue: '$1.500',
+    value: 1.5,
+  },
+  priceRange: {
+    maxPrice: {
+      formattedValue: '$1.500',
+    },
+    minPrice: {
+      formattedValue: '$1.000',
+    },
+  },
+};
+
+const mockDeliveryMode: DeliveryMode = {
+  code: '01',
+  deliveryCost: {
+    currencyIso: 'us',
+    formattedValue: '$100.00',
+    value: 100,
+  },
+  description: 'UPS ground',
+  name: 'UPS',
+};
+
+const mockCart = {
+  totalPrice: {
+    formattedValue: '$1.500',
+    value: 1.5,
+  },
+};
+
+const MockWindowRef = {
+  nativeWindow: {
+    location: {
+      hostname: 'testHost',
+    },
+  },
+};
+
+const mockApplePayPaymentContact: ApplePayJS.ApplePayPaymentContact = {
+  givenName: 'mock-first-name',
+  familyName: 'mock-last-name',
+  addressLines: ['mock-address-line-1'],
+  administrativeArea: 'mock-state',
+  country: 'mock-country',
+  countryCode: 'US',
+  emailAddress: 'mock-email',
+  locality: 'mock-city',
+  phoneNumber: 'mock-phone',
+  postalCode: 'mock-postal-code',
+};
+
+describe('ApplePayService', () => {
+  let service: ApplePayService;
+  let opfPaymentServiceMock: jasmine.SpyObj<OpfPaymentFacade>;
+  let cartHandlerServiceMock: jasmine.SpyObj<OpfCartHandlerService>;
+  let applePayObservableFactoryMock: jasmine.SpyObj<ApplePayObservableFactory>;
+  let applePaySessionFactoryMock: jasmine.SpyObj<ApplePaySessionFactory>;
+  let applePayObservableTestController: Subject<ApplePayJS.ApplePayPaymentAuthorizationResult>;
+  beforeEach(() => {
+    applePaySessionFactoryMock = jasmine.createSpyObj(
+      'ApplePaySessionFactory',
+      ['startApplePaySession']
+    );
+    opfPaymentServiceMock = jasmine.createSpyObj('OpfPaymentFacade', [
+      'submitPayment',
+      'getApplePayWebSession',
+    ]);
+    applePayObservableFactoryMock = jasmine.createSpyObj(
+      'ApplePayObservableFactory',
+      ['initApplePayEventsHandler']
+    );
+    cartHandlerServiceMock = jasmine.createSpyObj('OpfCartHandlerService', [
+      'deleteCurrentCart',
+      'deleteUserAddresses',
+      'addProductToCart',
+      'checkStableCart',
+      'getSupportedDeliveryModes',
+      'setDeliveryAddress',
+      'setBillingAddress',
+      'getDeliveryAddress',
+      'getCurrentCart',
+      'getCurrentCartId',
+      'getCurrentCartTotalPrice',
+      'setDeliveryMode',
+      'getSelectedDeliveryMode',
+      'deleteUserAddresses',
+    ]);
+    TestBed.configureTestingModule({
+      providers: [
+        ApplePayService,
+        { provide: OpfPaymentFacade, useValue: opfPaymentServiceMock },
+        { provide: WindowRef, useValue: MockWindowRef },
+        { provide: OpfCartHandlerService, useValue: cartHandlerServiceMock },
+        {
+          provide: ApplePayObservableFactory,
+          useValue: applePayObservableFactoryMock,
+        },
+        {
+          provide: ApplePaySessionFactory,
+          useValue: applePaySessionFactoryMock,
+        },
+      ],
+    });
+    service = TestBed.inject(ApplePayService);
+
+    applePayObservableTestController = new Subject();
+    applePayObservableFactoryMock.initApplePayEventsHandler.and.returnValue(
+      applePayObservableTestController
+    );
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('observable callbacks', () => {
+    let config: ApplePayObservableConfig;
+    beforeEach(() => {
+      (
+        applePayObservableFactoryMock.initApplePayEventsHandler as jasmine.Spy
+      ).and.callFake((actualConfig: any) => {
+        config = actualConfig;
+        return applePayObservableTestController;
+      });
+    });
+
+    it('should handle validateMerchant change', () => {
+      let event: ApplePayJS.ApplePayValidateMerchantEvent;
+
+      event = <ApplePayJS.ApplePayValidateMerchantEvent>{};
+
+      cartHandlerServiceMock.deleteCurrentCart.and.returnValue(of(true));
+      cartHandlerServiceMock.addProductToCart.and.returnValue(of(true));
+      cartHandlerServiceMock.getCurrentCartId.and.returnValue(of('cartId01'));
+      opfPaymentServiceMock.getApplePayWebSession.and.returnValue(
+        of(mockApplePaySessionVerificationResponse)
+      );
+
+      service.start(mocProduct, 2, 'us').subscribe();
+      config.validateMerchant(event).subscribe(() => {});
+
+      expect(cartHandlerServiceMock.deleteCurrentCart).toHaveBeenCalled();
+      expect(cartHandlerServiceMock.addProductToCart).toHaveBeenCalled();
+      expect(cartHandlerServiceMock.getCurrentCartId).toHaveBeenCalled();
+    });
+
+    it('should handle shipping address changes', () => {
+      let shippingAddressChangeResult: ApplePayJS.ApplePayShippingContactUpdate =
+        {
+          newLineItems: undefined,
+          newTotal: { label: '', amount: '' },
+        };
+      let event: ApplePayJS.ApplePayShippingContactSelectedEvent;
+      event = <ApplePayJS.ApplePayShippingContactSelectedEvent>{
+        shippingContact: mockApplePayPaymentContact,
+      };
+      cartHandlerServiceMock.deleteCurrentCart.and.returnValue(of(true));
+      cartHandlerServiceMock.setDeliveryAddress.and.returnValue(
+        of('addresId01')
+      );
+      cartHandlerServiceMock.addProductToCart.and.returnValue(of(true));
+      cartHandlerServiceMock.getCurrentCartId.and.returnValue(of('cartId01'));
+      opfPaymentServiceMock.getApplePayWebSession.and.returnValue(
+        of(mockApplePaySessionVerificationResponse)
+      );
+      cartHandlerServiceMock.getSupportedDeliveryModes.and.returnValue(
+        of([mockDeliveryMode])
+      );
+      cartHandlerServiceMock.getCurrentCartTotalPrice.and.returnValue(of(100));
+
+      service.start(mocProduct, 1, 'us').subscribe();
+      config
+        .validateMerchant(<ApplePayJS.ApplePayValidateMerchantEvent>{})
+        .subscribe();
+      config
+        .shippingContactSelected(event)
+        .subscribe((actual) => (shippingAddressChangeResult = actual));
+
+      expect(shippingAddressChangeResult.newShippingMethods?.[0]).toEqual({
+        identifier: mockDeliveryMode.code,
+        label: mockDeliveryMode.name,
+        amount: '100.00',
+        detail: mockDeliveryMode.description,
+      });
+    });
+
+    it('should return the order totals', () => {
+      let event: ApplePayJS.ApplePayPaymentMethodSelectedEvent;
+      let paymentMethodChangeResult: ApplePayJS.ApplePayPaymentMethodUpdate = {
+        newLineItems: undefined,
+        newTotal: { amount: '', label: '' },
+      };
+      const quantity = 1;
+      event = <ApplePayJS.ApplePayPaymentMethodSelectedEvent>{
+        paymentMethod: {
+          displayName: 'Test Visa 1111',
+          type: 'credit',
+          network: 'Visa',
+        },
+      };
+
+      service.start(mocProduct, quantity, 'us').subscribe();
+      config
+        .paymentMethodSelected(event)
+        .subscribe((actual) => (paymentMethodChangeResult = actual));
+
+      expect(paymentMethodChangeResult.newTotal).toEqual({
+        amount: mocProduct.price?.value?.toString(),
+        label: mocProduct.name,
+      });
+    });
+
+    it('should handle shippingMethodSelected changes', () => {
+      let shippingMethodChangeResult: ApplePayJS.ApplePayShippingMethodUpdate =
+        {
+          newTotal: { amount: '', label: '' },
+        };
+      let event: ApplePayJS.ApplePayShippingMethodSelectedEvent = <
+        ApplePayJS.ApplePayShippingMethodSelectedEvent
+      >{
+        shippingMethod: {
+          identifier: 'mock-shipping-method-id-2',
+          amount: '2.00',
+          label: 'mock-shipping-method-name-2',
+          detail: '',
+        },
+      };
+      cartHandlerServiceMock.setDeliveryMode.and.returnValue(
+        of(mockDeliveryMode)
+      );
+      cartHandlerServiceMock.getCurrentCart.and.returnValue(of(mockCart));
+
+      service.start(mocProduct, 1, 'us').subscribe();
+      config
+        .shippingMethodSelected(event)
+        .subscribe((actural) => (shippingMethodChangeResult = actural));
+      expect(shippingMethodChangeResult.newTotal).toEqual({
+        amount: mockCart.totalPrice?.value?.toString(),
+        label: mocProduct.name,
+      });
+    });
+
+    it('should handle paymentAuthorized changes', () => {
+      let paymentAuthorizedChangeResult: ApplePayJS.ApplePayPaymentAuthorizationResult =
+        {
+          status: 1,
+        };
+      let event: ApplePayJS.ApplePayPaymentAuthorizedEvent;
+      event = <ApplePayJS.ApplePayPaymentAuthorizedEvent>{
+        payment: {
+          billingContact: mockApplePayPaymentContact,
+          shippingContact: mockApplePayPaymentContact,
+          token: {
+            paymentData: '',
+            paymentMethod: {
+              displayName: 'Test Visa 1111',
+              type: 'credit',
+              network: 'Visa',
+            },
+            transactionIdentifier: 'identifierId01',
+          },
+        },
+      };
+
+      cartHandlerServiceMock.setDeliveryAddress.and.returnValue(
+        of('addresId01')
+      );
+      cartHandlerServiceMock.getCurrentCart.and.returnValue(of(mockCart));
+      cartHandlerServiceMock.setBillingAddress.and.returnValue(of(true));
+      cartHandlerServiceMock.getCurrentCartId.and.returnValue(of('cartId01'));
+      opfPaymentServiceMock.submitPayment.and.returnValue(of(true));
+
+      service.start(mocProduct, 1, 'us').subscribe();
+      config
+        .paymentAuthorized(event)
+        .subscribe((actural) => (paymentAuthorizedChangeResult = actural));
+
+      expect(opfPaymentServiceMock.submitPayment).toHaveBeenCalled();
+      expect(paymentAuthorizedChangeResult).toBeTruthy();
+      expect(paymentAuthorizedChangeResult?.errors).toBeFalsy;
+    });
+
+    it('should handle error on paymentAuthorized changes', () => {
+      let paymentAuthorizedChangeResult: ApplePayJS.ApplePayPaymentAuthorizationResult =
+        {
+          status: 1,
+        };
+      let event: ApplePayJS.ApplePayPaymentAuthorizedEvent;
+      event = <ApplePayJS.ApplePayPaymentAuthorizedEvent>{
+        payment: {
+          billingContact: mockApplePayPaymentContact,
+          shippingContact: mockApplePayPaymentContact,
+          token: {
+            paymentData: '',
+            paymentMethod: {
+              displayName: 'Test Visa 1111',
+              type: 'credit',
+              network: 'Visa',
+            },
+            transactionIdentifier: 'identifierId01',
+          },
+        },
+      };
+
+      cartHandlerServiceMock.setDeliveryAddress.and.returnValue(
+        of('addresId01')
+      );
+      cartHandlerServiceMock.getCurrentCart.and.returnValue(of(mockCart));
+      cartHandlerServiceMock.setBillingAddress.and.returnValue(of(true));
+      cartHandlerServiceMock.getCurrentCartId.and.returnValue(of('cartId01'));
+      opfPaymentServiceMock.submitPayment.and.returnValue(throwError('error'));
+
+      service.start(mocProduct, 1, 'us').subscribe();
+      config
+        .paymentAuthorized(event)
+        .subscribe((actural) => (paymentAuthorizedChangeResult = actural));
+
+      expect(paymentAuthorizedChangeResult?.errors).toBeTruthy();
+    });
+
+    it('should call error handler when product code is unknown', () => {
+      let event: ApplePayJS.ApplePayValidateMerchantEvent;
+      event = <ApplePayJS.ApplePayValidateMerchantEvent>{};
+      applePayObservableFactoryMock.initApplePayEventsHandler.and.callFake(
+        (config: ApplePayObservableConfig) => {
+          return config
+            .validateMerchant(event)
+            .pipe(map(() => <ApplePayJS.ApplePayPaymentAuthorizationResult>{}));
+        }
+      );
+
+      cartHandlerServiceMock.deleteCurrentCart.and.returnValue(of(true));
+      cartHandlerServiceMock.addProductToCart.and.returnValue(of(true));
+      cartHandlerServiceMock.getCurrentCartId.and.returnValue(of('cartId01'));
+      opfPaymentServiceMock.getApplePayWebSession.and.returnValue(
+        of(mockApplePaySessionVerificationResponse)
+      );
+      const newmocProduct = { ...mocProduct };
+      newmocProduct.code = '';
+      service.start(newmocProduct, 2, 'us').subscribe({
+        error: () => {},
+      });
+
+      expect(cartHandlerServiceMock.deleteCurrentCart).toHaveBeenCalled();
+      expect(cartHandlerServiceMock.addProductToCart).not.toHaveBeenCalled();
+      expect(cartHandlerServiceMock.getCurrentCartId).not.toHaveBeenCalled();
+    });
+
+    it('should call error handler when product quntity is 0', () => {
+      let event: ApplePayJS.ApplePayValidateMerchantEvent;
+      event = <ApplePayJS.ApplePayValidateMerchantEvent>{};
+      applePayObservableFactoryMock.initApplePayEventsHandler.and.callFake(
+        (config: ApplePayObservableConfig) => {
+          return config
+            .validateMerchant(event)
+            .pipe(map(() => <ApplePayJS.ApplePayPaymentAuthorizationResult>{}));
+        }
+      );
+
+      cartHandlerServiceMock.deleteCurrentCart.and.returnValue(of(true));
+      cartHandlerServiceMock.addProductToCart.and.returnValue(of(true));
+      cartHandlerServiceMock.getCurrentCartId.and.returnValue(of('cartId01'));
+      opfPaymentServiceMock.getApplePayWebSession.and.returnValue(
+        of(mockApplePaySessionVerificationResponse)
+      );
+
+      service.start(mocProduct, 0, 'us').subscribe({
+        error: () => {},
+      });
+
+      expect(cartHandlerServiceMock.deleteCurrentCart).toHaveBeenCalled();
+      expect(cartHandlerServiceMock.addProductToCart).not.toHaveBeenCalled();
+      expect(cartHandlerServiceMock.getCurrentCartId).not.toHaveBeenCalled();
+    });
+
+    it('should handle error when supported delivery methods are empty', () => {
+      let shippingAddressChangeResult: ApplePayJS.ApplePayShippingContactUpdate =
+        {
+          newLineItems: undefined,
+          newTotal: { label: '', amount: '' },
+        };
+      let event: ApplePayJS.ApplePayShippingContactSelectedEvent;
+      event = <ApplePayJS.ApplePayShippingContactSelectedEvent>{};
+      applePayObservableFactoryMock.initApplePayEventsHandler.and.callFake(
+        (config: ApplePayObservableConfig) => {
+          return config
+            .shippingContactSelected(event)
+            .pipe(map(() => <ApplePayJS.ApplePayPaymentAuthorizationResult>{}));
+        }
+      );
+
+      cartHandlerServiceMock.deleteCurrentCart.and.returnValue(of(true));
+      cartHandlerServiceMock.setDeliveryAddress.and.returnValue(
+        of('addresId01')
+      );
+      cartHandlerServiceMock.addProductToCart.and.returnValue(of(true));
+      cartHandlerServiceMock.getCurrentCartId.and.returnValue(of('cartId01'));
+      opfPaymentServiceMock.getApplePayWebSession.and.returnValue(
+        of(mockApplePaySessionVerificationResponse)
+      );
+      cartHandlerServiceMock.getSupportedDeliveryModes.and.returnValue(of([]));
+      cartHandlerServiceMock.getCurrentCartTotalPrice.and.returnValue(of(100));
+
+      service.start(mocProduct, 1, 'us').subscribe({ error: () => {} });
+
+      expect(cartHandlerServiceMock.setDeliveryAddress).toHaveBeenCalled();
+      expect(shippingAddressChangeResult.newShippingMethods).toBeFalsy();
+    });
+
+    it('should handle error when price is not defined', () => {
+      const totalPriceResult = undefined;
+      let event: ApplePayJS.ApplePayShippingContactSelectedEvent;
+      event = <ApplePayJS.ApplePayShippingContactSelectedEvent>{};
+      applePayObservableFactoryMock.initApplePayEventsHandler.and.callFake(
+        (config: ApplePayObservableConfig) => {
+          return config
+            .shippingContactSelected(event)
+            .pipe(map(() => <ApplePayJS.ApplePayPaymentAuthorizationResult>{}));
+        }
+      );
+
+      cartHandlerServiceMock.deleteCurrentCart.and.returnValue(of(true));
+      cartHandlerServiceMock.setDeliveryAddress.and.returnValue(
+        of('addresId01')
+      );
+      cartHandlerServiceMock.addProductToCart.and.returnValue(of(true));
+      cartHandlerServiceMock.getCurrentCartId.and.returnValue(of('cartId01'));
+      opfPaymentServiceMock.getApplePayWebSession.and.returnValue(
+        of(mockApplePaySessionVerificationResponse)
+      );
+      cartHandlerServiceMock.getSupportedDeliveryModes.and.returnValue(of([]));
+      cartHandlerServiceMock.getCurrentCartTotalPrice.and.returnValue(
+        of(totalPriceResult)
+      );
+
+      service.start(mocProduct, 0, 'us').subscribe({
+        error: () => {},
+      });
+
+      expect(cartHandlerServiceMock.setDeliveryAddress).toHaveBeenCalled();
+      expect(cartHandlerServiceMock.deleteCurrentCart).toHaveBeenCalled();
+    });
+
+    it('should handle error when total price value is 0', () => {
+      let event: ApplePayJS.ApplePayShippingMethodSelectedEvent;
+      event = <ApplePayJS.ApplePayShippingMethodSelectedEvent>{
+        shippingMethod: {
+          identifier: 'mock-shipping-method-id-2',
+          amount: '2.00',
+          label: 'mock-shipping-method-name-2',
+          detail: '',
+        },
+      };
+      cartHandlerServiceMock.setDeliveryMode.and.returnValue(
+        of(mockDeliveryMode)
+      );
+      const mockCartExt = {
+        totalPrice: {
+          formattedValue: '0',
+          value: 0,
+        },
+      };
+      cartHandlerServiceMock.getCurrentCart.and.returnValue(of(mockCartExt));
+      applePayObservableFactoryMock.initApplePayEventsHandler.and.callFake(
+        (configx: ApplePayObservableConfig) => {
+          return configx
+            .shippingMethodSelected(event)
+            .pipe(map(() => <ApplePayJS.ApplePayPaymentAuthorizationResult>{}));
+        }
+      );
+      service.start(mocProduct, 1, 'us').subscribe({ error: () => {} });
+      expect(cartHandlerServiceMock.deleteCurrentCart).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle errors during Apple Pay session start', () => {
+    service = TestBed.inject(ApplePayService);
+    cartHandlerServiceMock.deleteCurrentCart.and.returnValue(of(true));
+    applePayObservableFactoryMock.initApplePayEventsHandler.and.returnValue(
+      throwError('Error')
+    );
+
+    service.start(mocProduct, 1, 'us').subscribe({
+      error: (err) => {
+        expect(err).toBe('Error');
+      },
+    });
+    expect(cartHandlerServiceMock.deleteCurrentCart).toHaveBeenCalled();
+  });
+});

--- a/integration-libs/opf/base/components/opf-quick-buy/apple-pay/observable/apple-pay-observable.factory.spec.ts
+++ b/integration-libs/opf/base/components/opf-quick-buy/apple-pay/observable/apple-pay-observable.factory.spec.ts
@@ -1,1 +1,497 @@
-// to be done
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ApplePayObservableFactory } from './apple-pay-observable.factory';
+import { ApplePaySessionFactory } from '../apple-pay-session/apple-pay-session.factory';
+import { Observable, of, throwError } from 'rxjs';
+import { ApplePayObservableConfig } from '@spartacus/opf/base/root';
+
+class MockEventTarget implements EventTarget {
+  _stubEventListeners: Array<{ type: string; listener: Function }> = [];
+
+  /** Method to call registered events of specified type with provided arguments */
+  _stubMockEvent(type: string, ...args: Array<any>): void {
+    this._stubEventListeners.forEach((listener) => {
+      if (listener.type === type) {
+        listener.listener(...args);
+      }
+    });
+  }
+
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    _options?: boolean | AddEventListenerOptions
+  ): void {
+    this._stubEventListeners.push({ type, listener: listener as Function });
+  }
+
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    _options?: boolean | EventListenerOptions
+  ): void {
+    const index = this._stubEventListeners.findIndex(
+      (registeredListener) =>
+        registeredListener.type === type &&
+        registeredListener.listener === listener
+    );
+
+    if (index > -1) {
+      this._stubEventListeners.splice(index, 1);
+    }
+  }
+
+  dispatchEvent(_evt: Event): boolean {
+    return true;
+  }
+}
+
+class MockApplePaySession extends MockEventTarget implements ApplePaySession {
+  static readonly STATUS_SUCCESS: number;
+
+  static readonly STATUS_FAILURE: number;
+
+  oncancel: (event: ApplePayJS.Event) => void;
+
+  onpaymentauthorized: (
+    event: ApplePayJS.ApplePayPaymentAuthorizedEvent
+  ) => void;
+
+  onpaymentmethodselected: (
+    event: ApplePayJS.ApplePayPaymentMethodSelectedEvent
+  ) => void;
+
+  onshippingcontactselected: (
+    event: ApplePayJS.ApplePayShippingContactSelectedEvent
+  ) => void;
+
+  onshippingmethodselected: (
+    event: ApplePayJS.ApplePayShippingMethodSelectedEvent
+  ) => void;
+
+  onvalidatemerchant: (event: ApplePayJS.ApplePayValidateMerchantEvent) => void;
+
+  _stubConstructorArguments: Array<any>;
+
+  constructor(
+    version: number,
+    paymentRequest: ApplePayJS.ApplePayPaymentRequest
+  ) {
+    super();
+    this._stubConstructorArguments = [version, paymentRequest];
+  }
+
+  static canMakePayments(): boolean {
+    return true;
+  }
+
+  static canMakePaymentsWithActiveCard(
+    _merchantIdentifier: string
+  ): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  static openPaymentSetup(_merchantIdentifier: string): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  static supportsVersion(_version: number): boolean {
+    return true;
+  }
+
+  abort(): void {}
+
+  begin(): void {}
+
+  completeMerchantValidation(_merchantSession: any): void {}
+
+  completePayment(
+    _result: number | ApplePayJS.ApplePayPaymentAuthorizationResult
+  ): void {}
+
+  completePaymentMethodSelection(
+    newTotal: ApplePayJS.ApplePayLineItem,
+    newLineItems: Array<ApplePayJS.ApplePayLineItem>
+  ): void;
+  completePaymentMethodSelection(
+    update: ApplePayJS.ApplePayPaymentMethodUpdate
+  ): void;
+  completePaymentMethodSelection(_newTotal: any, _newLineItems?: any): void {}
+
+  completeShippingContactSelection(
+    _status: number,
+    _newShippingMethods: Array<ApplePayJS.ApplePayShippingMethod>,
+    _newTotal: ApplePayJS.ApplePayLineItem,
+    _newLineItems: Array<ApplePayJS.ApplePayLineItem>
+  ): void;
+  completeShippingContactSelection(
+    _update: ApplePayJS.ApplePayShippingContactUpdate
+  ): void;
+  completeShippingContactSelection(
+    _status: any,
+    _newShippingMethods?: any,
+    _newTotal?: any,
+    _newLineItems?: any
+  ): void {}
+
+  completeShippingMethodSelection(
+    _status: number,
+    _newTotal: ApplePayJS.ApplePayLineItem,
+    _newLineItems: Array<ApplePayJS.ApplePayLineItem>
+  ): void;
+  completeShippingMethodSelection(
+    _update: ApplePayJS.ApplePayShippingMethodUpdate
+  ): void;
+  completeShippingMethodSelection(
+    _status: any,
+    _newTotal?: any,
+    _newLineItems?: any
+  ): void {}
+}
+
+interface ApplePayObservableConfigExt extends ApplePayObservableConfig {
+  [key: string]: any;
+}
+
+describe('ApplePayObservableFactory', () => {
+  let factory: ApplePayObservableFactory;
+  let mockApplePaySessionFactory: jasmine.SpyObj<ApplePaySessionFactory>;
+  let mockApplePaySession: MockApplePaySession;
+
+  const mockRequest: ApplePayJS.ApplePayPaymentRequest = {
+    countryCode: '',
+    currencyCode: '',
+    merchantCapabilities: [],
+    supportedNetworks: [],
+    total: {
+      label: '',
+      amount: '',
+    },
+  };
+  const mockConfig: ApplePayObservableConfig = {
+    request: mockRequest,
+    validateMerchant: () => of({}),
+    paymentMethodSelected: () =>
+      of({} as ApplePayJS.ApplePayPaymentMethodUpdate),
+    shippingContactSelected: () =>
+      of({} as ApplePayJS.ApplePayShippingContactUpdate),
+    shippingMethodSelected: () =>
+      of({} as ApplePayJS.ApplePayShippingMethodUpdate),
+    paymentAuthorized: () =>
+      of({} as ApplePayJS.ApplePayPaymentAuthorizationResult),
+  };
+
+  beforeEach(() => {
+    const MockApplePaySessionFactory = jasmine.createSpyObj(
+      'ApplePaySessionFactory',
+      ['startApplePaySession']
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        ApplePayObservableFactory,
+        {
+          provide: ApplePaySessionFactory,
+          useValue: MockApplePaySessionFactory,
+        },
+      ],
+    });
+
+    factory = TestBed.inject(ApplePayObservableFactory);
+    mockApplePaySessionFactory = TestBed.inject(
+      ApplePaySessionFactory
+    ) as jasmine.SpyObj<ApplePaySessionFactory>;
+
+    mockApplePaySession = new MockApplePaySession(
+      1,
+      {} as ApplePayJS.ApplePayPaymentRequest
+    );
+    spyOn(mockApplePaySession, 'addEventListener').and.callThrough();
+  });
+
+  it('should be created', () => {
+    expect(factory).toBeTruthy();
+  });
+
+  it('should return an observable that creates an apple pay session', () => {
+    const actual = factory.initApplePayEventsHandler({
+      ...mockConfig,
+    });
+
+    mockApplePaySessionFactory.startApplePaySession.and.returnValue(
+      mockApplePaySession
+    );
+    expect(actual instanceof Observable).toBe(true);
+    expect(
+      mockApplePaySessionFactory.startApplePaySession
+    ).not.toHaveBeenCalled();
+
+    actual.subscribe();
+
+    expect(
+      mockApplePaySessionFactory.startApplePaySession
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      mockApplePaySessionFactory.startApplePaySession
+    ).toHaveBeenCalledWith(mockRequest);
+  });
+
+  it('should bind config event handlers to ApplePaySession', () => {
+    mockApplePaySessionFactory.startApplePaySession.and.returnValue(
+      mockApplePaySession
+    );
+    factory.initApplePayEventsHandler(mockConfig).subscribe();
+
+    expect(mockApplePaySession.addEventListener).toHaveBeenCalledTimes(6);
+    expect(mockApplePaySession.addEventListener).toHaveBeenCalledWith(
+      'cancel',
+      jasmine.any(Function)
+    );
+    expect(mockApplePaySession.addEventListener).toHaveBeenCalledWith(
+      'paymentauthorized',
+      jasmine.any(Function)
+    );
+    expect(mockApplePaySession.addEventListener).toHaveBeenCalledWith(
+      'paymentmethodselected',
+      jasmine.any(Function)
+    );
+    expect(mockApplePaySession.addEventListener).toHaveBeenCalledWith(
+      'shippingcontactselected',
+      jasmine.any(Function)
+    );
+    expect(mockApplePaySession.addEventListener).toHaveBeenCalledWith(
+      'shippingmethodselected',
+      jasmine.any(Function)
+    );
+    expect(mockApplePaySession.addEventListener).toHaveBeenCalledWith(
+      'validatemerchant',
+      jasmine.any(Function)
+    );
+  });
+
+  it('should complete if the session is cancelled', () => {
+    let complete = false;
+    let actualEmit: any;
+    let actualError: any;
+    spyOn(mockApplePaySession, 'abort').and.stub();
+
+    mockApplePaySessionFactory.startApplePaySession.and.returnValue(
+      mockApplePaySession
+    );
+    factory.initApplePayEventsHandler(mockConfig).subscribe(
+      (next) => (actualEmit = next),
+      (error) => (actualError = error),
+      () => (complete = true)
+    );
+    expect(complete).toBe(false);
+    expect(actualError).toEqual(undefined);
+    expect(actualEmit).toEqual(undefined);
+
+    mockApplePaySession._stubMockEvent('cancel');
+
+    expect(complete).toBe(false);
+    expect(actualError).toEqual({ type: 'PAYMENT_CANCELLED' });
+    expect(actualEmit).toEqual(undefined);
+  });
+
+  describe('callback behavior', () => {
+    let actual: Observable<ApplePayJS.ApplePayPaymentAuthorizationResult>;
+    let configuration: ApplePayObservableConfigExt;
+
+    let paymentAuthorizedReturnValue: ApplePayJS.ApplePayPaymentAuthorizationResult;
+    let validateMerchantReturnValue: Object;
+    let shippingContactSelectedReturnValue: ApplePayJS.ApplePayShippingContactUpdate;
+    let paymentMethodSelectedReturnValue: ApplePayJS.ApplePayPaymentMethodUpdate;
+    let shippingMethodSelectedReturnValue: ApplePayJS.ApplePayShippingMethodUpdate;
+    let actualEmit: any;
+    let actualError: any;
+    let actualComplete: boolean;
+    beforeEach(() => {
+      configuration = {
+        request: mockRequest,
+        paymentAuthorized: jasmine.createSpy('paymentAuthorized'),
+        validateMerchant: jasmine.createSpy('validateMerchant'),
+        shippingContactSelected: jasmine.createSpy('shippingContactSelected'),
+        paymentMethodSelected: jasmine.createSpy('paymentMethodSelected'),
+        shippingMethodSelected: jasmine.createSpy('shippingMethodSelected'),
+      };
+
+      paymentAuthorizedReturnValue = { status: 0 };
+      validateMerchantReturnValue = {};
+      shippingContactSelectedReturnValue = {
+        newTotal: { amount: '5.00', label: 'Shipping' },
+      };
+      paymentMethodSelectedReturnValue = {
+        newTotal: { amount: '5.00', label: 'Payment' },
+      };
+      shippingMethodSelectedReturnValue = {
+        newTotal: { amount: '5.00', label: 'Shipping' },
+      };
+
+      (configuration.paymentAuthorized as jasmine.Spy).and.returnValue(
+        of(paymentAuthorizedReturnValue)
+      );
+      (configuration.validateMerchant as jasmine.Spy).and.returnValue(
+        of(validateMerchantReturnValue)
+      );
+      (configuration.shippingContactSelected as jasmine.Spy).and.returnValue(
+        of(shippingContactSelectedReturnValue)
+      );
+      (configuration.paymentMethodSelected as jasmine.Spy).and.returnValue(
+        of(paymentMethodSelectedReturnValue)
+      );
+      (configuration.shippingMethodSelected as jasmine.Spy).and.returnValue(
+        of(shippingMethodSelectedReturnValue)
+      );
+      mockApplePaySessionFactory.startApplePaySession.and.returnValue(
+        mockApplePaySession
+      );
+      actual = factory.initApplePayEventsHandler(configuration);
+      actualEmit = undefined;
+      actualError = undefined;
+      actualComplete = false;
+      actual.subscribe(
+        (next) => (actualEmit = next),
+        (error) => (actualError = error),
+        () => (actualComplete = true)
+      );
+
+      spyOn(mockApplePaySession, 'completeMerchantValidation').and.stub();
+      spyOn(mockApplePaySession, 'completePayment').and.stub();
+      spyOn(mockApplePaySession, 'completePaymentMethodSelection').and.stub();
+      spyOn(mockApplePaySession, 'completeShippingContactSelection').and.stub();
+      spyOn(mockApplePaySession, 'completeShippingMethodSelection').and.stub();
+    });
+
+    it('should use validateMerchant callback to fill validateMerchant', () => {
+      const event = <ApplePayJS.ApplePayValidateMerchantEvent>{
+        validationURL: '',
+      };
+
+      mockApplePaySession._stubMockEvent('validatemerchant', event);
+      expect(actualComplete).toBe(false);
+      expect(configuration.validateMerchant).toHaveBeenCalledWith(event);
+      expect(
+        mockApplePaySession.completeMerchantValidation
+      ).toHaveBeenCalledWith(validateMerchantReturnValue);
+    });
+
+    it('should use shippingContactSelected callback to fill shippingContactSelected', () => {
+      const event = <ApplePayJS.ApplePayShippingContactSelectedEvent>{
+        shippingContact: {},
+      };
+
+      mockApplePaySession._stubMockEvent('shippingcontactselected', event);
+
+      expect(configuration.shippingContactSelected).toHaveBeenCalledWith(event);
+      expect(
+        mockApplePaySession.completeShippingContactSelection
+      ).toHaveBeenCalledWith(shippingContactSelectedReturnValue);
+    });
+
+    it('should use shippingMethodSelected callback to fill shippingMethodSelected', () => {
+      const event = <ApplePayJS.ApplePayShippingMethodSelectedEvent>{
+        shippingMethod: {},
+      };
+
+      mockApplePaySession._stubMockEvent('shippingmethodselected', event);
+
+      expect(configuration.shippingMethodSelected).toHaveBeenCalledWith(event);
+      expect(
+        mockApplePaySession.completeShippingMethodSelection
+      ).toHaveBeenCalledWith(shippingMethodSelectedReturnValue);
+    });
+
+    it('should use paymentMethodSelected callback to fill paymentMethodSelected', () => {
+      const event = <ApplePayJS.ApplePayPaymentMethodSelectedEvent>{
+        paymentMethod: {},
+      };
+
+      mockApplePaySession._stubMockEvent('paymentmethodselected', event);
+
+      expect(configuration.paymentMethodSelected).toHaveBeenCalledWith(event);
+      expect(
+        mockApplePaySession.completePaymentMethodSelection
+      ).toHaveBeenCalledWith(paymentMethodSelectedReturnValue);
+    });
+
+    it('should use paymentAuthorized callback to fill completePayment', () => {
+      const event = <ApplePayJS.ApplePayPaymentAuthorizedEvent>{
+        payment: {},
+      };
+      mockApplePaySession._stubMockEvent('paymentauthorized', event);
+
+      expect(configuration.paymentAuthorized).toHaveBeenCalledWith(event);
+      expect(mockApplePaySession.completePayment).toHaveBeenCalledWith(
+        paymentAuthorizedReturnValue
+      );
+    });
+
+    describe('on callback error', () => {
+      it('should emit an error when validateMerchant failed', () => {
+        const event = <ApplePayJS.ApplePayValidateMerchantEvent>{
+          validationURL: '',
+        };
+        (configuration.validateMerchant as jasmine.Spy).and.returnValue(
+          throwError(new Error('Validation Error'))
+        );
+
+        mockApplePaySession._stubMockEvent('validatemerchant', event);
+
+        expect(configuration.validateMerchant).toHaveBeenCalledWith(event);
+        expect(
+          mockApplePaySession.completeMerchantValidation
+        ).not.toHaveBeenCalled();
+        expect(actualError).toBeDefined();
+      });
+
+      it('should abort when paymentauthorized failed with errors', () => {
+        spyOn(mockApplePaySession, 'abort').and.stub();
+        const event = <ApplePayJS.ApplePayPaymentAuthorizedEvent>{
+          payment: {},
+        };
+        const paymentAuthorizedReturnValue = {
+          status: 0,
+          errors: [{ message: 'paymentauthorized failed' }],
+        };
+        (configuration.paymentAuthorized as jasmine.Spy).and.returnValue(
+          of(paymentAuthorizedReturnValue)
+        );
+
+        mockApplePaySession._stubMockEvent('paymentauthorized', event);
+
+        expect(configuration.paymentAuthorized).toHaveBeenCalledWith(event);
+        expect(mockApplePaySession.abort).toHaveBeenCalled();
+      });
+
+      [
+        ['paymentAuthorized', 'paymentauthorized'],
+        ['paymentMethodSelected', 'paymentmethodselected'],
+        ['shippingContactSelected', 'shippingcontactselected'],
+        ['shippingMethodSelected', 'shippingmethodselected'],
+        ['validateMerchant', 'validatemerchant'],
+      ].forEach(([callback, eventType]) => {
+        it(`should abort the session on an error in ${callback}`, () => {
+          const event = {};
+          const callbackError = new Error('Error');
+          (configuration[callback] as jasmine.Spy).and.returnValue(
+            throwError(callbackError)
+          );
+          spyOn(mockApplePaySession, 'abort').and.stub();
+
+          mockApplePaySession._stubMockEvent(eventType, event);
+
+          expect(configuration[callback]).toHaveBeenCalledWith(event);
+          expect(mockApplePaySession.abort).toHaveBeenCalled();
+          expect(actualEmit).toBeUndefined();
+          expect(actualError).toBe(callbackError);
+        });
+      });
+    });
+  });
+});

--- a/integration-libs/opf/base/core/facade/opf-global-functions.service.spec.ts
+++ b/integration-libs/opf/base/core/facade/opf-global-functions.service.spec.ts
@@ -1,0 +1,277 @@
+/*
+ * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { OpfGlobalFunctionsService } from './opf-global-functions.service';
+import { WindowRef } from '@spartacus/core';
+import {
+  Component,
+  ComponentRef,
+  ElementRef,
+  InjectionToken,
+  ViewContainerRef,
+} from '@angular/core';
+import { LAUNCH_CALLER, LaunchDialogService } from '@spartacus/storefront';
+
+import {
+  GlobalFunctionsDomain,
+  OpfPaymentFacade,
+  PaymentMethod,
+  defaultErrorDialogOptions,
+} from '@spartacus/opf/base/root';
+import { EMPTY, Observable, of } from 'rxjs';
+export const WINDOW = new InjectionToken<Window>('window');
+@Component({
+  template: '',
+})
+class TestContainerComponent {
+  constructor(public vcr: ViewContainerRef) {}
+}
+class MockLaunchDialogService implements Partial<LaunchDialogService> {
+  closeDialog(_reason: any) {}
+  openDialogAndSubscribe() {
+    return EMPTY;
+  }
+  launch() {}
+  clear() {}
+  openDialog(
+    _caller: LAUNCH_CALLER,
+    _openElement?: ElementRef,
+    _vcr?: ViewContainerRef
+  ) {
+    return EMPTY;
+  }
+}
+
+describe('OpfGlobalFunctionsService', () => {
+  let service: OpfGlobalFunctionsService;
+  let opfPaymentFacadeMock: jasmine.SpyObj<OpfPaymentFacade>;
+  let windowRef: WindowRef;
+  opfPaymentFacadeMock = jasmine.createSpyObj('OpfPaymentFacade', [
+    'submitPayment',
+    'submitCompletePayment',
+    'getActiveConfigurationsState',
+  ]);
+  let componentRef: ComponentRef<TestContainerComponent>;
+  let launchDialogService: LaunchDialogService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestContainerComponent],
+      providers: [
+        OpfGlobalFunctionsService,
+        WindowRef,
+        { provide: OpfPaymentFacade, useValue: opfPaymentFacadeMock },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+      ],
+    });
+    service = TestBed.inject(OpfGlobalFunctionsService);
+    windowRef = TestBed.inject(WindowRef);
+    componentRef = TestBed.createComponent(TestContainerComponent).componentRef;
+    launchDialogService = TestBed.inject(LaunchDialogService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('should register global functions for CHECKOUT domain', () => {
+    const mockPaymentSessionId = 'mockSessionId';
+    let windowOpf: any;
+
+    beforeEach(() => {
+      service.registerGlobalFunctions({
+        domain: GlobalFunctionsDomain.CHECKOUT,
+        paymentSessionId: mockPaymentSessionId,
+        vcr: {} as ViewContainerRef,
+      });
+      windowOpf = windowRef.nativeWindow['Opf'];
+    });
+
+    it('should register global functions for CHECKOUT', () => {
+      expect(windowOpf['payments']['checkout']['submit']).toBeDefined();
+      expect(
+        windowOpf['payments']['checkout']['throwPaymentError']
+      ).toBeDefined();
+      expect(
+        windowOpf['payments']['checkout']['startLoadIndicator']
+      ).toBeDefined();
+      expect(
+        windowOpf['payments']['checkout']['stopLoadIndicator']
+      ).toBeDefined();
+    });
+
+    it('should handle registerSubmit event', () => {
+      opfPaymentFacadeMock.submitPayment.and.returnValue(of(true));
+      spyOn(launchDialogService, 'launch').and.returnValue(of(componentRef));
+      spyOn(launchDialogService, 'clear').and.callThrough();
+
+      const submitSuccess = (): void => {};
+      const submitPending = (): void => {};
+      const submitFailure = (): void => {};
+      const additionalData = [
+        { key: 'returnUrl', value: 'https://returnUrl/' },
+        { key: 'allow3DS2', value: 'true' },
+        { key: 'originUrl', value: 'https://originUrl/' },
+      ];
+      const cartId = 'mock-cart';
+
+      windowOpf.payments['checkout'].submit({
+        cartId,
+        additionalData,
+        submitSuccess,
+        submitPending,
+        submitFailure,
+        paymentMethod: PaymentMethod.APPLE_PAY,
+      });
+      expect(opfPaymentFacadeMock.submitPayment).toHaveBeenCalled();
+    });
+
+    it('should handle registerSubmitComplete event', () => {
+      opfPaymentFacadeMock.submitCompletePayment.and.returnValue(of(true));
+      spyOn(launchDialogService, 'launch').and.returnValue(of(componentRef));
+      spyOn(launchDialogService, 'clear').and.callThrough();
+
+      const submitSuccess = (): void => {};
+      const submitPending = (): void => {};
+      const submitFailure = (): void => {};
+      const additionalData = [
+        { key: 'returnUrl', value: 'https://returnUrl/' },
+        { key: 'allow3DS2', value: 'true' },
+        { key: 'originUrl', value: 'https://originUrl/' },
+      ];
+      const cartId = 'mock-cart';
+
+      windowOpf.payments['checkout'].submitComplete({
+        cartId,
+        additionalData,
+        submitSuccess,
+        submitPending,
+        submitFailure,
+        paymentMethod: PaymentMethod.APPLE_PAY,
+      });
+      expect(opfPaymentFacadeMock.submitCompletePayment).toHaveBeenCalled();
+    });
+
+    it('should handle throwPaymentError event', () => {
+      opfPaymentFacadeMock.submitCompletePayment.and.returnValue(of(true));
+      spyOn(launchDialogService, 'launch').and.returnValue(of(componentRef));
+
+      const dialog$: Observable<number> = of(1);
+      const dialogSubscribeSpy = spyOn(dialog$, 'subscribe');
+      spyOn(launchDialogService, 'openDialog').and.returnValue(dialog$);
+
+      windowOpf.payments['checkout'].throwPaymentError(
+        defaultErrorDialogOptions
+      );
+      expect(launchDialogService.openDialog).toHaveBeenCalled();
+      expect(dialogSubscribeSpy).toHaveBeenCalled();
+    });
+
+    it('should handle startLoadIndicator event', () => {
+      opfPaymentFacadeMock.submitCompletePayment.and.returnValue(of(true));
+      spyOn(launchDialogService, 'launch').and.returnValue(of(componentRef));
+      spyOn(launchDialogService, 'clear').and.callThrough();
+
+      windowOpf.payments['checkout'].startLoadIndicator();
+      expect(launchDialogService.launch).toHaveBeenCalled();
+
+      windowOpf.payments['checkout'].startLoadIndicator();
+      expect(launchDialogService.clear).toHaveBeenCalled();
+    });
+
+    it('should handle stopLoadIndicator event', () => {
+      spyOn(launchDialogService, 'launch').and.returnValue(of(componentRef));
+      spyOn(launchDialogService, 'clear').and.callThrough();
+
+      windowOpf.payments['checkout'].startLoadIndicator();
+      windowOpf.payments['checkout'].stopLoadIndicator();
+      expect(launchDialogService.clear).toHaveBeenCalled();
+    });
+
+    it('should remove global function for REDIRECT', () => {
+      expect(
+        windowOpf['payments'][GlobalFunctionsDomain.CHECKOUT]
+      ).toBeDefined();
+
+      service.removeGlobalFunctions(GlobalFunctionsDomain.CHECKOUT);
+
+      expect(
+        windowOpf['payments'][GlobalFunctionsDomain.CHECKOUT]
+      ).not.toBeDefined();
+    });
+  });
+
+  describe('should register global functions for REDIRECT domain', () => {
+    const mockPaymentSessionId = 'mockSessionId';
+    const paramsMap = [
+      { key: 'key1', value: 'value1' },
+      { key: 'key2', value: 'value2' },
+    ];
+    let windowOpf: any;
+    beforeEach(() => {
+      service.registerGlobalFunctions({
+        domain: GlobalFunctionsDomain.REDIRECT,
+        paymentSessionId: mockPaymentSessionId,
+        vcr: {} as ViewContainerRef,
+        paramsMap,
+      });
+      windowOpf = windowRef.nativeWindow['Opf'];
+    });
+
+    it('should handle submitCompleteRedirect event', () => {
+      opfPaymentFacadeMock.submitCompletePayment.and.returnValue(of(true));
+
+      spyOn(launchDialogService, 'launch').and.returnValue(of(componentRef));
+      spyOn(launchDialogService, 'clear').and.callThrough();
+
+      const submitSuccess = (): void => {};
+      const submitPending = (): void => {};
+      const submitFailure = (): void => {};
+      const additionalData = [
+        { key: 'returnUrl', value: 'https://returnUrl/' },
+        { key: 'allow3DS2', value: 'true' },
+        { key: 'originUrl', value: 'https://originUrl/' },
+      ];
+      const cartId = 'mock-cart';
+
+      windowOpf.payments[GlobalFunctionsDomain.REDIRECT].submitCompleteRedirect(
+        {
+          cartId,
+          additionalData,
+          submitSuccess,
+          submitPending,
+          submitFailure,
+        }
+      );
+      expect(opfPaymentFacadeMock.submitCompletePayment).toHaveBeenCalled();
+    });
+
+    it('should handle getRedirectParams event', () => {
+      const redirectParams =
+        windowOpf.payments[GlobalFunctionsDomain.REDIRECT].getRedirectParams();
+      expect(redirectParams).toEqual(paramsMap);
+    });
+
+    it('should remove global function for REDIRECT', () => {
+      expect(
+        windowOpf['payments'][GlobalFunctionsDomain.REDIRECT][
+          'submitCompleteRedirect'
+        ]
+      ).toBeDefined();
+      expect(
+        windowOpf['payments'][GlobalFunctionsDomain.REDIRECT][
+          'getRedirectParams'
+        ]
+      ).toBeDefined();
+
+      service.removeGlobalFunctions(GlobalFunctionsDomain.REDIRECT);
+
+      expect(
+        windowOpf['payments'][GlobalFunctionsDomain.REDIRECT]
+      ).not.toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-5546

notes:
Should remove the 'protected canMakePayments' method from 'apple-pay-session.factory.ts' since it is currently not being utilized. If we plan to use it in the future, we can reconsider its implementation then