### PR TITLE
Update function updateNameInPackageJson for angular 17

### DIFF
--- a/tools/breaking-changes/extract.ts
+++ b/tools/breaking-changes/extract.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -56,19 +55,21 @@ function runExtractor(libPath: string) {
   } else {
     console.error(
       `API Extractor completed with ${extractorResult.errorCount} errors` +
-        ` and ${extractorResult.warningCount} warnings`
+      ` and ${extractorResult.warningCount} warnings`
     );
     process.exitCode = 1;
   }
 }
 
-export function updateNameInPackageJson(filePath: string): {
+export function updateNameInPackageJson(libPath: string): {
   name: string;
   newName: string;
 } {
+  const filePath = `${libPath}/package.json`;
   const packageContent = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  const name: string = packageContent.name;
+  const name: string = packageContent.name ?? getEntryPointName(libPath);
   const newName = escapePackageName(name);
+
   fs.writeFileSync(
     filePath,
     JSON.stringify({ ...packageContent, name: newName }, undefined, 2)
@@ -87,13 +88,14 @@ function preparePackageJson(libPath: string): void {
 
   // Update the package.json file
   console.log(`update package name in file ${libPath}/package.json`);
-  updateNameInPackageJson(`${libPath}/package.json`);
+  updateNameInPackageJson(libPath);
 }
 
 function createPackageJsonFile(libPath: string) {
   const beginIdx = libPath.indexOf(distFolderPath) + distFolderPath.length + 1;
   const entryPointNameFromPath = `@spartacus/${libPath.substring(beginIdx)}`;
   const entryPointNameGenerated = getEntryPointName(libPath);
+
   if (entryPointNameFromPath !== entryPointNameGenerated) {
     console.log(
       `INFO: Module name ${entryPointNameGenerated} differs from path name ${libPath}`


### PR DESCRIPTION
Closes: [CXSPA-5635](https://jira.tools.sap/browse/CXSPA-5635)
Libraries built with Angular 17 have a slight difference: the assets folder now includes a package.json file, whereas it did not previously. The breaking changes script contains a function responsible for updating or creating a new package.json in that folder. Consequently, I needed to enhance the "updateNameInPackageJson" function to ensure it creates a "name" property in the existing package.json file.