### PR TITLE
feat: CXSPA-5711 Upgrade to Angular 17 - adjust schematics to detect apps with standalone components

### DIFF
--- a/docs/migration/2211/2211-installation.md
+++ b/docs/migration/2211/2211-installation.md
@@ -1,11 +1,5 @@
 # Creating a new app using Spartacus v2211
 
-## You must run `ng new` with a new flag `--standalone=false`
-
-Since Angular v17, the command for creating a new app (`ng new`) must be run with the flag `--standalone=false`. Otherwise Spartacus installer won't work (`ng add @spartacus/schematics`).
-
-**Why**: Since Angular 17, new applications are created by default using a new so-called "standalone" mode, which has a bit *different structure of files* in the app folder than before. However Spartacus schematics installer still expects the *old files structure* in a created Angular app. That's why the flag  `ng new --standalone=false` is required before running Spartacus installation schematics.
-
 ### Appendix A: How to run SSR dev server
 
 Run in _2 separate windows_ of terminal:

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -295,7 +295,7 @@ function increaseBudgets(options: SpartacusOptions): Rule {
 function verifyAppModuleExists(options: SpartacusOptions): Rule {
   return (tree: Tree, context: SchematicContext): Tree => {
     if (options.debug) {
-      context.logger.info(`⌛️ Checking if app uses standalone components...`);
+      context.logger.info(`⌛️ Checking if the file "app.module.ts" exists...`);
     }
 
     // get tsconfig file paths
@@ -312,14 +312,13 @@ function verifyAppModuleExists(options: SpartacusOptions): Rule {
 
     if (!appModule) {
       throw new SchematicsException(
-        `
-        File "app.module.ts" not found. Please re-create your application:
-        1. remove your application code
-        2. make sure to pass the flag "--standalone=false" to the command "ng new". For more, see https://angular.io/cli/new#options
-        3. try again installing Spartacus with a command "ng add @spartacus/schematics" ...
+        `File "app.module.ts" not found. Please re-create your application:
+1. remove your application code
+2. make sure to pass the flag "--standalone=false" to the command "ng new". For more, see https://angular.io/cli/new#options
+3. try again installing Spartacus with a command "ng add @spartacus/schematics" ...
         
-        Note: Since version 17, Angular's command "ng new" by default creates an app without a file "app.module.ts" (in a so-called "standalone" mode). But Spartacus installer requires this file to be present.
-        `
+Note: Since version 17, Angular's command "ng new" by default creates an app without a file "app.module.ts" (in a so-called "standalone" mode). But Spartacus installer requires this file to be present.
+`
       );
     }
     if (options.debug) {

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -292,7 +292,7 @@ function increaseBudgets(options: SpartacusOptions): Rule {
  * @param options - The Spartacus options.
  * @returns A Rule function that checks if the app has an app configuration file.
  */
-function hasAppConfigFile(options: SpartacusOptions): Rule {
+function verifyAppModuleExists(options: SpartacusOptions): Rule {
   return (tree: Tree, context: SchematicContext): Tree => {
     if (options.debug) {
       context.logger.info(`⌛️ Checking if app uses standalone components...`);
@@ -312,7 +312,14 @@ function hasAppConfigFile(options: SpartacusOptions): Rule {
 
     if (!appModule) {
       throw new SchematicsException(
-        'File "app.module.ts" not found. Application uses unsupported standalone components. Please remove the application and generate a new one with by running "ng new" with "--standalone=false" flag'
+        `
+        File "app.module.ts" not found. Please re-create your application:
+        1. remove your application code
+        2. make sure to pass the flag "--standalone=false" to the command "ng new". For more, see https://angular.io/cli/new#options
+        3. try again installing Spartacus with a command "ng add @spartacus/schematics" ...
+        
+        Note: Since version 17, Angular's command "ng new" by default creates an app without a file "app.module.ts" (in a so-called "standalone" mode). But Spartacus installer requires this file to be present.
+        `
       );
     }
     if (options.debug) {
@@ -486,7 +493,7 @@ export function addSpartacus(options: SpartacusOptions): Rule {
     ];
     const packageJsonFile = readPackageJson(tree);
     return chain([
-      hasAppConfigFile(options),
+      verifyAppModuleExists(options),
 
       analyzeApplication(options, features),
 

--- a/projects/schematics/src/add-spartacus/index_spec.ts
+++ b/projects/schematics/src/add-spartacus/index_spec.ts
@@ -70,6 +70,39 @@ describe('add-spartacus', () => {
     );
   });
 
+  it('should throw an error if app.module.ts not found', async () => {
+    let standaloneAppTree: UnitTestTree;
+
+    standaloneAppTree = await schematicRunner.runExternalSchematic(
+      '@schematics/angular',
+      'workspace',
+      workspaceOptions
+    );
+    standaloneAppTree = await schematicRunner.runExternalSchematic(
+      '@schematics/angular',
+      'application',
+      { ...appOptions, standalone: true },
+      standaloneAppTree
+    );
+
+    await expect(
+      schematicRunner.runSchematic(
+        'add-spartacus',
+        defaultOptions,
+        standaloneAppTree
+      )
+    ).rejects.toMatchInlineSnapshot(`
+        [Error: 
+                File "app.module.ts" not found. Please re-create your application:
+                1. remove your application code
+                2. make sure to pass the flag "--standalone=false" to the command "ng new". For more, see https://angular.io/cli/new#options
+                3. try again installing Spartacus with a command "ng add @spartacus/schematics" ...
+                
+                Note: Since version 17, Angular's command "ng new" by default creates an app without a file "app.module.ts" (in a so-called "standalone" mode). But Spartacus installer requires this file to be present.
+                ]
+      `);
+  });
+
   it('should add spartacus deps', async () => {
     const tree = await schematicRunner.runSchematic(
       'add-spartacus',
@@ -107,34 +140,6 @@ describe('add-spartacus', () => {
     appModuleImports.forEach((appImport) =>
       expect(appModule.includes(appImport)).toBe(true)
     );
-  });
-
-  describe('Verify if target app is standalone', () => {
-    it('should throw an error if app.module.ts not found', async () => {
-      let standaloneAppTree: UnitTestTree;
-
-      standaloneAppTree = await schematicRunner.runExternalSchematic(
-        '@schematics/angular',
-        'workspace',
-        workspaceOptions
-      );
-      standaloneAppTree = await schematicRunner.runExternalSchematic(
-        '@schematics/angular',
-        'application',
-        { ...appOptions, standalone: true },
-        standaloneAppTree
-      );
-
-      await expect(
-        schematicRunner.runSchematic(
-          'add-spartacus',
-          defaultOptions,
-          standaloneAppTree
-        )
-      ).rejects.toMatchInlineSnapshot(
-        `[Error: File "app.module.ts" not found. Application uses unsupported standalone components. Please remove the application and generate a new one with by running "ng new" with "--standalone=false" flag]`
-      );
-    });
   });
 
   describe('Setup configuration', () => {

--- a/projects/schematics/src/add-spartacus/index_spec.ts
+++ b/projects/schematics/src/add-spartacus/index_spec.ts
@@ -92,15 +92,14 @@ describe('add-spartacus', () => {
         standaloneAppTree
       )
     ).rejects.toMatchInlineSnapshot(`
-        [Error: 
-                File "app.module.ts" not found. Please re-create your application:
-                1. remove your application code
-                2. make sure to pass the flag "--standalone=false" to the command "ng new". For more, see https://angular.io/cli/new#options
-                3. try again installing Spartacus with a command "ng add @spartacus/schematics" ...
-                
-                Note: Since version 17, Angular's command "ng new" by default creates an app without a file "app.module.ts" (in a so-called "standalone" mode). But Spartacus installer requires this file to be present.
-                ]
-      `);
+      [Error: File "app.module.ts" not found. Please re-create your application:
+      1. remove your application code
+      2. make sure to pass the flag "--standalone=false" to the command "ng new". For more, see https://angular.io/cli/new#options
+      3. try again installing Spartacus with a command "ng add @spartacus/schematics" ...
+              
+      Note: Since version 17, Angular's command "ng new" by default creates an app without a file "app.module.ts" (in a so-called "standalone" mode). But Spartacus installer requires this file to be present.
+      ]
+    `);
   });
 
   it('should add spartacus deps', async () => {

--- a/projects/schematics/src/add-spartacus/index_spec.ts
+++ b/projects/schematics/src/add-spartacus/index_spec.ts
@@ -109,6 +109,34 @@ describe('add-spartacus', () => {
     );
   });
 
+  describe('Verify if target app is standalone', () => {
+    it('should throw an error if app.module.ts not found', async () => {
+      let standaloneAppTree: UnitTestTree;
+
+      standaloneAppTree = await schematicRunner.runExternalSchematic(
+        '@schematics/angular',
+        'workspace',
+        workspaceOptions
+      );
+      standaloneAppTree = await schematicRunner.runExternalSchematic(
+        '@schematics/angular',
+        'application',
+        { ...appOptions, standalone: true },
+        standaloneAppTree
+      );
+
+      await expect(
+        schematicRunner.runSchematic(
+          'add-spartacus',
+          defaultOptions,
+          standaloneAppTree
+        )
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: File "app.module.ts" not found. Application uses unsupported standalone components. Please remove the application and generate a new one with by running "ng new" with "--standalone=false" flag]`
+      );
+    });
+  });
+
   describe('Setup configuration', () => {
     it('should set baseUrl', async () => {
       const tree = await schematicRunner.runSchematic(


### PR DESCRIPTION
This PR contains an adjustment for Spartacus installation schematics to detect whether the target app uses standalone components. 

Because Spartacus is not ready yet to work with this kind of component, we should detect this type of application and inform the customer to generate a fresh Angular application by running "ng new" with a flag "--standalone=false"

QA steps:


* build and deploy Spartacus packages locally:
`npx ts-node ./tools/schematics/testing.ts` in the SPA root folder
* generate fresh ng17 application with standalone components: 
`npx @angular/cli new my-app` 
* go to project's directory and install SPA with SSR:
`npx @angular/cli add @spartacus/schematics@latest --debug`
* verify whether error message occurs during installation process:
![image](https://github.com/SAP/spartacus/assets/28891782/42619029-e253-46fe-afbf-d7ef23c7b4ae)

closes [CXSPA-5711](https://jira.tools.sap/browse/CXSPA-5711)