### PR TITLE
refactor: Make checkoutConfigService a required dependency

### DIFF
--- a/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.ts
@@ -32,7 +32,7 @@ import {
   UserCostCenterService,
 } from '@spartacus/core';
 import { Card } from '@spartacus/storefront';
-import { Observable, Subscription, combineLatest, of } from 'rxjs';
+import { combineLatest, Observable, of, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
 
 export interface CardWithAddress {

--- a/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.ts
@@ -9,6 +9,7 @@ import {
   Component,
   OnDestroy,
   OnInit,
+  inject,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
@@ -17,6 +18,7 @@ import {
   CheckoutPaymentTypeFacade,
 } from '@spartacus/checkout/b2b/root';
 import {
+  CheckoutConfigService,
   CheckoutDeliveryAddressComponent,
   CheckoutStepService,
 } from '@spartacus/checkout/base/components';
@@ -32,7 +34,7 @@ import {
   UserCostCenterService,
 } from '@spartacus/core';
 import { Card } from '@spartacus/storefront';
-import { combineLatest, Observable, of, Subscription } from 'rxjs';
+import { Observable, Subscription, combineLatest, of } from 'rxjs';
 import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
 
 export interface CardWithAddress {
@@ -49,6 +51,7 @@ export class B2BCheckoutDeliveryAddressComponent
   extends CheckoutDeliveryAddressComponent
   implements OnInit, OnDestroy
 {
+  protected checkoutConfigService = inject(CheckoutConfigService);
   protected subscriptions = new Subscription();
 
   protected isAccountPayment$: Observable<boolean> =

--- a/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.ts
@@ -9,7 +9,6 @@ import {
   Component,
   OnDestroy,
   OnInit,
-  inject,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
@@ -18,7 +17,6 @@ import {
   CheckoutPaymentTypeFacade,
 } from '@spartacus/checkout/b2b/root';
 import {
-  CheckoutConfigService,
   CheckoutDeliveryAddressComponent,
   CheckoutStepService,
 } from '@spartacus/checkout/base/components';
@@ -51,7 +49,6 @@ export class B2BCheckoutDeliveryAddressComponent
   extends CheckoutDeliveryAddressComponent
   implements OnInit, OnDestroy
 {
-  protected checkoutConfigService = inject(CheckoutConfigService);
   protected subscriptions = new Subscription();
 
   protected isAccountPayment$: Observable<boolean> =

--- a/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.ts
@@ -8,7 +8,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   OnInit,
-  Optional,
+  inject,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
@@ -18,14 +18,14 @@ import {
 } from '@spartacus/checkout/base/root';
 import {
   Address,
-  getLastValueSync,
   GlobalMessageService,
   GlobalMessageType,
   TranslationService,
   UserAddressService,
+  getLastValueSync,
 } from '@spartacus/core';
 import { Card, getAddressNumbers } from '@spartacus/storefront';
-import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest } from 'rxjs';
 import {
   distinctUntilChanged,
   filter,
@@ -47,6 +47,7 @@ export interface CardWithAddress {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CheckoutDeliveryAddressComponent implements OnInit {
+  protected checkoutConfigService = inject(CheckoutConfigService);
   protected busy$ = new BehaviorSubject<boolean>(false);
 
   cards$: Observable<CardWithAddress[]>;
@@ -73,32 +74,6 @@ export class CheckoutDeliveryAddressComponent implements OnInit {
     );
   }
 
-  // TODO(CXSPA-5657): make checkoutConfigService a required dependency
-  constructor(
-    userAddressService: UserAddressService,
-    checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
-    activatedRoute: ActivatedRoute,
-    translationService: TranslationService,
-    activeCartFacade: ActiveCartFacade,
-    checkoutStepService: CheckoutStepService,
-    checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade,
-    globalMessageService: GlobalMessageService,
-    // eslint-disable-next-line @typescript-eslint/unified-signatures
-    checkoutConfigService: CheckoutConfigService
-  );
-  /**
-   * @deprecated since 6.2
-   */
-  constructor(
-    userAddressService: UserAddressService,
-    checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
-    activatedRoute: ActivatedRoute,
-    translationService: TranslationService,
-    activeCartFacade: ActiveCartFacade,
-    checkoutStepService: CheckoutStepService,
-    checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade,
-    globalMessageService: GlobalMessageService
-  );
   constructor(
     protected userAddressService: UserAddressService,
     protected checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
@@ -107,8 +82,7 @@ export class CheckoutDeliveryAddressComponent implements OnInit {
     protected activeCartFacade: ActiveCartFacade,
     protected checkoutStepService: CheckoutStepService,
     protected checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade,
-    protected globalMessageService: GlobalMessageService,
-    @Optional() protected checkoutConfigService?: CheckoutConfigService
+    protected globalMessageService: GlobalMessageService
   ) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
got around the required dependancy by using inject function.
It allows other class extendingCheckoutDeliveryAddressComponent  (eg: B2BCheckoutDeliveryAddressComponent) to not have constructor modif.