### PR TITLE
fix: remove $useLatestStyles: true from pickup-in-store lib

### DIFF
--- a/feature-libs/pickup-in-store/_index.scss
+++ b/feature-libs/pickup-in-store/_index.scss
@@ -1,4 +1,3 @@
-$useLatestStyles: true;
 $cx-color-link-primary: #1672b7;
 
 @import '@spartacus/styles/scss/core';


### PR DESCRIPTION
closes: [CXSPA-5779](https://jira.tools.sap/browse/CXSPA-5779)