### PR TITLE
feat: CXSPA-5904 - Remove HttpClinetModule from ClientAuthStoreModule

### DIFF
--- a/projects/core/src/auth/client-auth/store/client-auth-store.module.ts
+++ b/projects/core/src/auth/client-auth/store/client-auth-store.module.ts
@@ -5,7 +5,6 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
@@ -17,7 +16,6 @@ import { reducerProvider, reducerToken } from './reducers/index';
 @NgModule({
   imports: [
     CommonModule,
-    HttpClientModule,
     StateModule,
     StoreModule.forFeature(CLIENT_AUTH_FEATURE, reducerToken),
     EffectsModule.forFeature(effects),


### PR DESCRIPTION
This PR is removing the redundant import of HttpClientModule from ClientAutStoreModule.

closes [CXSPA-5904](https://jira.tools.sap/browse/CXSPA-5904)