### PR TITLE
chore: CXSPA-5902 Update TypeScript version in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
         "ts-jest": "^29.1.1",
         "ts-morph": "^9.1.0",
         "ts-node": "^10.6.0",
-        "typescript": "5.2.2",
+        "typescript": "^5.2.2",
         "webpack": "~5.76.1",
         "webpack-cli": "^4.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "ts-jest": "^29.1.1",
     "ts-morph": "^9.1.0",
     "ts-node": "^10.6.0",
-    "typescript": "5.2.2",
+    "typescript": "^5.2.2",
     "webpack": "~5.76.1",
     "webpack-cli": "^4.10.0"
   },

--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -29,7 +29,7 @@
     "@schematics/angular": "^17.0.5",
     "jsonc-parser": "^3.2.0",
     "parse5": "^7.1.2",
-    "typescript": "5.2.2"
+    "typescript": "^5.2.2"
   },
   "peerDependenciesMeta": {
     "canvas": {

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -21,7 +21,7 @@
     "@schematics/angular": "^17.0.5",
     "jsonc-parser": "^3.2.0",
     "parse5": "^7.1.2",
-    "typescript": "5.2.2"
+    "typescript": "^5.2.2"
   },
   "storefrontapp-e2e-cypress": {},
   "@spartacus/storefront": {


### PR DESCRIPTION
This PR updates the Typescript version with caret(^) to support the version of the library used in Angular 17.1 and the next <18 versions

closes [CXSPA-5902](https://jira.tools.sap/browse/CXSPA-5902)