### PR TITLE
Change import paths in server.ts

### DIFF
--- a/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files.ts
+++ b/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files.ts
@@ -4,8 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { chain, Rule } from '@angular-devkit/schematics';
+import {
+  chain,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  NEW_ZONE_IMPORT,
+  NGUNIVERSAL_IMPORT,
+  OLD_ZONE_IMPORT,
+  SERVER_FILENAME,
+  SSR_SETUP_IMPORT,
+} from '../../../shared/constants';
 
 export function updateServerFiles(): Rule {
-  return chain([]);
+  return chain([modifyServerImports]);
+}
+
+function modifyServerImports(): Rule {
+  return (tree: Tree, _context: SchematicContext) => {
+    let updateContent = tree.read(SERVER_FILENAME)?.toString('utf-8') ?? '';
+    if (
+      updateContent.includes(OLD_ZONE_IMPORT) ||
+      updateContent.includes(NGUNIVERSAL_IMPORT)
+    ) {
+      updateContent = updateContent.includes(OLD_ZONE_IMPORT)
+        ? updateContent.replace(OLD_ZONE_IMPORT, NEW_ZONE_IMPORT)
+        : updateContent;
+      updateContent = updateContent.includes(NGUNIVERSAL_IMPORT)
+        ? updateContent.replace(NGUNIVERSAL_IMPORT, SSR_SETUP_IMPORT)
+        : updateContent;
+      tree.overwrite(SERVER_FILENAME, updateContent);
+    }
+    return tree;
+  };
 }

--- a/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files.ts
+++ b/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files.ts
@@ -24,17 +24,20 @@ export function updateServerFiles(): Rule {
 
 function modifyServerImports(): Rule {
   return (tree: Tree, _context: SchematicContext) => {
-    let updateContent = tree.read(SERVER_FILENAME)?.toString('utf-8') ?? '';
-    if (
+    let serverFileBuffer = tree.read(SERVER_FILENAME);
+    if (!serverFileBuffer) {
+      return tree;
+    }
+    let updateContent = serverFileBuffer.toString('utf-8');
+    const hasOldImport =
       updateContent.includes(OLD_ZONE_IMPORT) ||
-      updateContent.includes(NGUNIVERSAL_IMPORT)
-    ) {
-      updateContent = updateContent.includes(OLD_ZONE_IMPORT)
-        ? updateContent.replace(OLD_ZONE_IMPORT, NEW_ZONE_IMPORT)
-        : updateContent;
-      updateContent = updateContent.includes(NGUNIVERSAL_IMPORT)
-        ? updateContent.replace(NGUNIVERSAL_IMPORT, SSR_SETUP_IMPORT)
-        : updateContent;
+      updateContent.includes(NGUNIVERSAL_IMPORT);
+    if (hasOldImport) {
+      updateContent = updateContent.replace(OLD_ZONE_IMPORT, NEW_ZONE_IMPORT);
+      updateContent = updateContent.replace(
+        NGUNIVERSAL_IMPORT,
+        SSR_SETUP_IMPORT
+      );
       tree.overwrite(SERVER_FILENAME, updateContent);
     }
     return tree;

--- a/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files_spec.ts
+++ b/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files_spec.ts
@@ -10,7 +10,7 @@ import {
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as SpartacusOptions } from '../../../add-spartacus/schema';
-import { NEW_ZONE_IMPORT, OLD_ZONE_IMPORT } from '../../../shared/constants';
+import { NEW_ZONE_IMPORT, NGUNIVERSAL_IMPORT, OLD_ZONE_IMPORT, SSR_SETUP_IMPORT } from "../../../shared/constants";
 
 const updateSsrCollectionPath = path.join(
   __dirname,
@@ -88,7 +88,8 @@ describe('Update SSR', () => {
       );
 
       const updatedContent = tree.read('./server.ts')!.toString();
-      expect(updatedContent).toContain('@spartacus/setup/ssr');
+      expect(updatedContent).toContain(SSR_SETUP_IMPORT);
+      expect(updatedContent).not.toContain(NGUNIVERSAL_IMPORT)
     });
 
     it('should change zone.js import in server.ts', async () => {
@@ -106,6 +107,7 @@ describe('Update SSR', () => {
 
       const updatedServerContent = tree.read('./server.ts')!.toString();
       expect(updatedServerContent).toContain(NEW_ZONE_IMPORT);
+      expect(updatedServerContent).not.toContain(OLD_ZONE_IMPORT)
     });
   });
 });

--- a/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files_spec.ts
+++ b/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files_spec.ts
@@ -10,6 +10,7 @@ import {
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as SpartacusOptions } from '../../../add-spartacus/schema';
+import { NEW_ZONE_IMPORT, OLD_ZONE_IMPORT } from '../../../shared/constants';
 
 const updateSsrCollectionPath = path.join(
   __dirname,
@@ -76,5 +77,35 @@ describe('Update SSR', () => {
       { ...defaultOptions, name: 'schematics-test' },
       tree
     );
+  });
+
+  describe('updateServerFile', () => {
+    it('should change nguniversal import in server.ts', async () => {
+      tree = await updateSsrSchematicRunner.runSchematic(
+        'update-ssr',
+        { name: 'schematics-test' },
+        tree
+      );
+
+      const updatedContent = tree.read('./server.ts')!.toString();
+      expect(updatedContent).toContain('@spartacus/setup/ssr');
+    });
+
+    it('should change zone.js import in server.ts', async () => {
+      let serverContent = tree.read('./server.ts')!.toString();
+
+      if (!serverContent.includes('zone.js')) {
+        serverContent = serverContent + `import "${OLD_ZONE_IMPORT}"`;
+        tree.overwrite('./server.ts', serverContent);
+      }
+      tree = await updateSsrSchematicRunner.runSchematic(
+        'update-ssr',
+        { name: 'schematics-test' },
+        tree
+      );
+
+      const updatedServerContent = tree.read('./server.ts')!.toString();
+      expect(updatedServerContent).toContain(NEW_ZONE_IMPORT);
+    });
   });
 });

--- a/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files_spec.ts
+++ b/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files_spec.ts
@@ -11,9 +11,12 @@ import {
 } from '@schematics/angular/application/schema';
 import { Schema as SpartacusOptions } from '../../../add-spartacus/schema';
 import {
+  EXPRESS_TOKENS,
   NEW_ZONE_IMPORT,
   NGUNIVERSAL_IMPORT,
   OLD_ZONE_IMPORT,
+  SERVER_BAK_FILENAME,
+  SERVER_FILENAME,
   SSR_SETUP_IMPORT,
 } from '../../../shared/constants';
 

--- a/projects/schematics/src/shared/constants.ts
+++ b/projects/schematics/src/shared/constants.ts
@@ -1144,3 +1144,9 @@ export const GENERIC_LINK_COMPONENT = 'GenericLinkComponent';
 export const GENERIC_LINK_COMPONENT_SERVICE = 'GenericLinkComponentService';
 
 export const CDC_JS_SERVICE = 'CdcJsService';
+export const SERVER_FILENAME = 'server.ts';
+export const SERVER_BAK_FILENAME = 'server.ts.bak';
+export const OLD_ZONE_IMPORT = 'zone.js/dist/zone-node';
+export const NEW_ZONE_IMPORT = 'zone.js/node';
+export const NGUNIVERSAL_IMPORT = '@nguniversal/express-engine';
+export const SSR_SETUP_IMPORT = '@spartacus/setup/ssr';


### PR DESCRIPTION
closes: [CXSPA-5856](https://jira.tools.sap/browse/CXSPA-5856)

- updateServerFiles(): This is a schematic rule that calls another rule named modifyServerImports.

- modifyServerImports(): It reads the content of a server file ('server.ts') from the file tree. Checks if the content includes references to two specific imports ('zone.js/dist/zone-node' and '@nguniversal/express-engine').
If either of these imports is found, it updates the content by replacing the old import with a new one. The replacements are specified by constants ('zone.js/node' and '@spartacus/setup/ssr').
Finally, it overwrites the original server file with the updated content.