### PR TITLE
Remove local REQUEST/RESPONSE definitions

### DIFF
--- a/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files.ts
+++ b/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files.ts
@@ -3,9 +3,77 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { chain, Rule } from '@angular-devkit/schematics';
+import {
+  chain,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import { Path } from '@angular-devkit/core';
+import * as ts from 'typescript';
+import { EXPRESS_TOKENS, SSR_SETUP_IMPORT } from '../../../shared/constants';
 
 export function updateServerFiles(): Rule {
-  return chain([]);
+  return chain([removeExpressTokensFile, updateTokenImportPaths]);
+}
+
+function removeExpressTokensFile(): Rule {
+  return (tree: Tree, _context: SchematicContext) => {
+    tree.visit((filePath: Path) => {
+      if (filePath.endsWith(`${EXPRESS_TOKENS}.ts`)) {
+        tree.delete(filePath);
+      }
+    });
+    return tree;
+  };
+}
+
+function getExpressImportPaths(source: ts.SourceFile): string[] {
+  const importPaths: string[] = [];
+  source.statements.map((node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const importPath = node.moduleSpecifier.text;
+      if (importPath.includes(EXPRESS_TOKENS)) {
+        importPaths.push(importPath);
+      }
+    }
+    return node;
+  });
+
+  return importPaths;
+}
+
+function updateTokenImportPaths(): Rule {
+  return (tree: Tree, _context: SchematicContext) => {
+    tree.visit((filePath) => {
+      if (filePath.endsWith('.ts')) {
+        const fileContent = tree.read(filePath);
+        if (fileContent) {
+          const source = ts.createSourceFile(
+            filePath,
+            fileContent.toString(),
+            ts.ScriptTarget.Latest,
+            true
+          );
+          const importPaths = getExpressImportPaths(source);
+          let updatedFileContent = fileContent.toString('utf-8');
+
+          if (importPaths.length) {
+            importPaths.forEach((path: string) => {
+              updatedFileContent = updatedFileContent.replace(
+                path,
+                SSR_SETUP_IMPORT
+              );
+            });
+
+            tree.overwrite(filePath, updatedFileContent);
+          }
+        }
+      }
+    });
+    return tree;
+  };
 }

--- a/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files.ts
+++ b/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files.ts
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import {
   chain,
   Rule,

--- a/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files_spec.ts
+++ b/projects/schematics/src/migrations/mechanism/update-ssr/update-ssr-files_spec.ts
@@ -10,6 +10,7 @@ import {
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as SpartacusOptions } from '../../../add-spartacus/schema';
+import { EXPRESS_TOKENS, SSR_SETUP_IMPORT } from '../../../shared/constants';
 
 const updateSsrCollectionPath = path.join(
   __dirname,
@@ -76,5 +77,40 @@ describe('Update SSR', () => {
       { ...defaultOptions, name: 'schematics-test' },
       tree
     );
+  });
+
+  describe('updateTokensSchematic', () => {
+    it('should remove express.tokens.ts file', async () => {
+      const tokensPath = `./${EXPRESS_TOKENS}.ts`;
+      tree.create(tokensPath, 'request response');
+      expect(tree.exists(tokensPath)).toBeTruthy();
+
+      tree = await updateSsrSchematicRunner.runSchematic(
+        'update-ssr',
+        { name: 'schematics-test' },
+        tree
+      );
+
+      expect(tree.exists(tokensPath)).toBeFalsy();
+    });
+
+    it('should update token import paths in .ts files', async () => {
+      const filePath = './src/test-tokens.ts';
+
+      tree.create(
+        filePath,
+        `import { REQUEST, RESPONSE } from './${EXPRESS_TOKENS}';`
+      );
+      tree = await updateSsrSchematicRunner.runSchematic(
+        'update-ssr',
+        { name: 'schematics-test' },
+        tree
+      );
+
+      const updatedContent = tree.read(filePath)!.toString();
+      expect(updatedContent).toContain(
+        `import { REQUEST, RESPONSE } from '${SSR_SETUP_IMPORT}';`
+      );
+    });
   });
 });

--- a/projects/schematics/src/shared/constants.ts
+++ b/projects/schematics/src/shared/constants.ts
@@ -1144,3 +1144,5 @@ export const GENERIC_LINK_COMPONENT = 'GenericLinkComponent';
 export const GENERIC_LINK_COMPONENT_SERVICE = 'GenericLinkComponentService';
 
 export const CDC_JS_SERVICE = 'CdcJsService';
+export const SSR_SETUP_IMPORT = '@spartacus/setup/ssr';
+export const EXPRESS_TOKENS = 'express.tokens';


### PR DESCRIPTION
closes: [CXSPA-5857](https://jira.tools.sap/browse/CXSPA-5857)

The main function, **updateServerFiles()**, is a schematic rule that executes two sub-rules: removeExpressTokensFile() and updateTokenImportPaths().

- removeExpressTokensFile(): This rule goes through the file tree and looks for files ending with the express.tokens.ts, and removes them from the tree.

- getExpressImportPaths(source: ts.SourceFile): string[]: This utility function extracts import paths from a TypeScript source file that include the **express.tokens**. It returns an array of these import paths.

- updateTokenImportPaths(): This rule, similar to the first one, traverses the file tree, reads TypeScript files, and updates import paths. It uses the getExpressImportPaths utility to identify import paths related to **express.tokens**. It then replaces these paths with a different one "@spartacus/setup/ssr" in the TypeScript file content and overwrites the file in the tree.
