### PR TITLE
fix consignmentTracking feature flag

### DIFF
--- a/feature-libs/order/components/order-details/order-details.module.ts
+++ b/feature-libs/order/components/order-details/order-details.module.ts
@@ -12,6 +12,7 @@ import {
   AuthGuard,
   CmsConfig,
   FeaturesConfig,
+  FeaturesConfigModule,
   I18nModule,
   MODULE_INITIALIZER,
   provideDefaultConfig,
@@ -96,7 +97,7 @@ const moduleComponents = [
     CardModule,
     CommonModule,
     I18nModule,
-
+    FeaturesConfigModule,
     PromotionsModule,
     UrlModule,
     SpinnerModule,


### PR DESCRIPTION
closes: [CXSPA-6104](https://jira.tools.sap/browse/CXSPA-6104)
The exact location of the flag is in `OrderConsignedEntriesComponent`