### PR TITLE
PoC: live stock updates [ DO NOT MERGE ]

### DIFF
--- a/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.html
+++ b/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.html
@@ -1,4 +1,11 @@
 <form *ngIf="productCode" [formGroup]="addToCartForm" (submit)="addToCart()">
+  <b
+    >SPIKE STOCK LEVEL:
+    <span style="display: inline-block" [@glowAnimation]="stockLevel">{{
+      stockLevel
+    }}</span></b
+  >
+
   <div class="quantity" *ngIf="showQuantity">
     <label>{{ 'addToCart.quantity' | cxTranslate }}</label>
     <div class="cx-counter-stock">

--- a/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.ts
+++ b/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { animate, style, transition, trigger } from '@angular/animations';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -24,8 +25,8 @@ import {
 import {
   CmsAddToCartComponent,
   EventService,
-  isNotNullable,
   Product,
+  isNotNullable,
 } from '@spartacus/core';
 import {
   CmsComponentData,
@@ -40,6 +41,27 @@ import { filter, map, take } from 'rxjs/operators';
   selector: 'cx-add-to-cart',
   templateUrl: './add-to-cart.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
+
+  animations: [
+    trigger('glowAnimation', [
+      transition('* => *', [
+        animate(
+          '1s ease-out',
+          style({
+            transform: 'scale(1.3)',
+            textShadow: '0 0 10px red',
+          })
+        ),
+        animate(
+          '.5s ease-out',
+          style({
+            transform: 'scale(1)',
+            textShadow: 'none',
+          })
+        ),
+      ]),
+    ]),
+  ],
 })
 export class AddToCartComponent implements OnInit, OnDestroy {
   @Input() productCode: string;
@@ -56,6 +78,8 @@ export class AddToCartComponent implements OnInit, OnDestroy {
 
   hasStock: boolean = false;
   inventoryThreshold: boolean = false;
+
+  stockLevel: number = 0; // SPIKE
 
   showInventory$: Observable<boolean | undefined> | undefined =
     this.component?.data$.pipe(map((data) => data.inventoryDisplay));
@@ -101,6 +125,9 @@ export class AddToCartComponent implements OnInit, OnDestroy {
       )
         .pipe(filter(isNotNullable))
         .subscribe((product) => {
+          console.log('SPIKE add-to-cart component receives data:', {
+            product,
+          });
           this.productCode = product.code ?? '';
           this.setStockInfo(product);
           this.cd.markForCheck();
@@ -114,6 +141,8 @@ export class AddToCartComponent implements OnInit, OnDestroy {
     this.addToCartForm.controls['quantity'].setValue(1);
 
     this.hasStock = Boolean(product.stock?.stockLevelStatus !== 'outOfStock');
+
+    this.stockLevel = product.stock?.stockLevel ?? 0; // SPIKE
 
     this.inventoryThreshold = product.stock?.isValueRounded ?? false;
 

--- a/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.ts
+++ b/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.ts
@@ -42,6 +42,7 @@ import { filter, map, take } from 'rxjs/operators';
   templateUrl: './add-to-cart.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 
+  // SPIKE - for visual demo purposes only
   animations: [
     trigger('glowAnimation', [
       transition('* => *', [

--- a/http-proxy.js
+++ b/http-proxy.js
@@ -5,9 +5,9 @@
 // ```
 
 // WHAT IT DOES:
-// - proxies all requests to the OCC dev server, generating random `stockLevel`
-//     if the request includes `fields=stock`. Random stock level is between 1-100.
-// - also runs a fake server that returns random stock levels between 100_001-100_100.
+// [localhost:9002] -proxies all requests to the OCC dev server, generating random `stockLevel`
+//                    if the request includes `fields=stock`. Random stock level is between 1-100.
+// [localhost:9003] - also runs a fake server that returns random stock levels between 100_001-100_100.
 
 const httpProxy = require('http-proxy');
 const http = require('http');

--- a/http-proxy.js
+++ b/http-proxy.js
@@ -1,0 +1,99 @@
+// HOW TO RUN IT:
+// ```
+// npm install -g http-server
+// node --watch http-proxy.js
+// ```
+
+// WHAT IT DOES:
+// - proxies all requests to the OCC dev server, generating random `stockLevel`
+//     if the request includes `fields=stock`. Random stock level is between 1-100.
+// - also runs a fake server that returns random stock levels between 100_001-100_100.
+
+const httpProxy = require('http-proxy');
+const http = require('http');
+const url = require('url');
+
+const proxy = httpProxy.createProxyServer({
+  secure: false,
+  changeOrigin: true,
+  selfHandleResponse: true,
+});
+
+const BACKEND_BASE_URL = 'https://40.76.109.9:9002'; // OCC dev server
+const LISTEN_ON_PORT = 9002;
+
+/**
+ * returns true if the request includes `fields=stock`
+ */
+isStockRequest = (req) => {
+  const { query } = url.parse(req.url, true);
+  return query?.fields?.includes('stock');
+};
+
+/**
+ * returns random number between 1-100
+ */
+getRandom = () => Math.floor(Math.random() * 100) + 1;
+
+// PROXY SERVER
+proxy.on('proxyRes', function (proxyRes, req, res) {
+  var body = [];
+  proxyRes.on('data', function (chunk) {
+    body.push(chunk);
+  });
+  proxyRes.on('end', function () {
+    body = Buffer.concat(body).toString();
+
+    if (isStockRequest(req)) {
+      try {
+        const object = JSON.parse(body);
+        object.spike_modified = true;
+
+        object.stock.stockLevel = getRandom();
+        console.log('Proxy mutated the stock level:', object.stock.stockLevel);
+
+        body = JSON.stringify(object);
+      } catch (error) {
+        console.error('Error parsing body:', { url: req.url, error, body });
+      }
+    }
+
+    // simulate artificial delay in response
+    setTimeout(() => {
+      res.end(body);
+    }, 1000);
+  });
+});
+
+// FAKE SERVER
+http
+  .createServer(function (req, res) {
+    proxy.web(req, res, { target: BACKEND_BASE_URL });
+  })
+  .listen(LISTEN_ON_PORT);
+console.log('Proxy server listening on port ' + LISTEN_ON_PORT);
+
+FAKE_LISTEN_ON_PORT = 9003;
+http
+  .createServer(function (req, res) {
+    // respond with JSON object
+    const spikeResponse = {
+      stock: {
+        stockLevel: getRandom() + 100_000,
+        stockLevelStatus: 'inStock',
+        isValueRounded: false,
+      },
+    };
+    console.log(
+      'Fake server generated stock level:',
+      spikeResponse.stock.stockLevel
+    );
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+
+    // simulate artificial delay in response
+    setTimeout(() => {
+      res.end(JSON.stringify(spikeResponse));
+    }, 1000);
+  })
+  .listen(FAKE_LISTEN_ON_PORT);
+console.log('Spike server listening on port ' + FAKE_LISTEN_ON_PORT);

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -5,31 +5,50 @@
  */
 
 import { registerLocaleData } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import localeDe from '@angular/common/locales/de';
 import localeJa from '@angular/common/locales/ja';
 import localeZh from '@angular/common/locales/zh';
-import { NgModule } from '@angular/core';
+import {
+  APP_INITIALIZER,
+  Injectable,
+  NgModule,
+  OnDestroy,
+  Provider,
+  inject,
+} from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { translationChunksConfig, translations } from '@spartacus/assets';
 import {
+  CxEvent,
+  EventService,
   FeaturesConfig,
   I18nConfig,
   OccConfig,
+  OccProductAdapter,
+  Product,
+  ProductAdapter,
+  ProductScope,
   RoutingConfig,
+  ScopedProductData,
+  Stock,
   TestConfigModule,
-  provideConfig,
+  WindowRef,
+  provideConfig
 } from '@spartacus/core';
 import { StoreFinderConfig } from '@spartacus/storefinder/core';
 import { GOOGLE_MAPS_DEVELOPMENT_KEY_CONFIG } from '@spartacus/storefinder/root';
 import {
   AppRoutingModule,
+  NavigationEvent,
   StorefrontComponent,
-  USE_LEGACY_MEDIA_COMPONENT,
+  USE_LEGACY_MEDIA_COMPONENT
 } from '@spartacus/storefront';
+import { Observable, Subscription, interval } from 'rxjs';
 import { environment } from '../environments/environment';
 import { TestOutletModule } from '../test-outlets/test-outlet.module';
 import { SpartacusModule } from './spartacus/spartacus.module';
@@ -43,9 +62,180 @@ if (!environment.production) {
   devImports.push(StoreDevtoolsModule.instrument());
 }
 
+/**
+ * Command event to reload stock of all products that are currently used
+ * e.g. displayed on the page.
+ * 
+ * - on PDP it will reload 1 product's stock
+ * - on homepage showing many miniatures of products - it might reload many products' stocks
+ */
+export class ReloadProductStockEvent extends CxEvent {
+  static readonly type = 'ReloadProductStock';
+}
+
+/**
+ * Subscribes to some source events (e.g. page navigation, timer, or global window
+ * function invocation) and dispatches the `ReloadProductStockEvent` when it's time.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ProductStockReloadService implements OnDestroy {
+  protected windowRef = inject(WindowRef);
+  protected eventService = inject(EventService);
+
+  protected sub = new Subscription();
+
+  initialize() {
+    if (this.windowRef.isBrowser()) {
+      // RELOAD PERIODICALLY
+      this.sub.add(interval(3_000).subscribe(() => this.reloadStock()));
+
+      // RELOAD ON DEMAND
+      (window as any).reloadStock = ()=>this.reloadStock();
+
+      // RELOAD ON ROUTE CHANGE
+      this.sub.add(this.eventService.get(NavigationEvent).subscribe((_event) => {
+        this.reloadStock();
+      }));
+    }
+  }
+
+  protected reloadStock(){
+    this.eventService.dispatch(new ReloadProductStockEvent());
+    console.log('Product stock reload event dispatched');
+  }
+
+  ngOnDestroy() {
+    if (this.sub) {
+      this.sub.unsubscribe();
+    }
+  }
+}
+
+
+/**
+ * Fixes issues with the default product occ config, where STOCK is not semantically
+ * declared as a part of the DETAILS scope.
+ * 
+ * See projects/core/src/occ/adapters/product/default-occ-product-config.ts
+ * 
+ * Moreover, it configures reloading of STOCK scope on event `ReloadProductStockEvent`.
+ */
+export const customBackendConfig: OccConfig = {
+  backend: {
+    occ: {
+      endpoints: {
+        product: {
+          // removed ",stock(DEFAULT)" from default config: 
+          [ProductScope.DETAILS]:
+            'products/${productCode}?fields=averageRating,description,availableForPickup,code,url,price(DEFAULT),numberOfReviews,manufacturer,categories(FULL),priceRange,multidimensional,tags,images(FULL)',
+        },
+      },
+    },
+    loadingScopes: {
+      product: {
+        [ProductScope.DETAILS]: {
+          include: [
+            ProductScope.LIST,
+            ProductScope.VARIANTS,
+            ProductScope.STOCK, // it was missing in the default config
+          ],
+        },
+
+        // configure reloading of STOCK scope on event `ReloadProductStockEvent`
+        [ProductScope.STOCK]: {
+          reloadOn: [ReloadProductStockEvent],
+        },
+      },
+    },
+  },
+};
+
+
+/**
+ * Makes actual HTTP requests to the fake server, to get stock data.
+ */
+@Injectable({ providedIn: 'root' })
+export class FakeServerService {
+  protected httpClient = inject(HttpClient);
+  protected getUrl(productCode: string): string {
+    return `http://localhost:9003/fake-server/get-stock/${productCode}`;
+  }
+
+  getStock(productCode: string): Observable<{stock: Stock}> {
+    return this.httpClient.get<{stock: Stock}>(this.getUrl(productCode));
+  }
+}
+
+/**
+ * Customized product adapter that uses the fake server to get product's stock data,
+ * but the default OCC adapter for other product's data.
+ */
+@Injectable({providedIn: 'root'})
+export class CustomOccProductAdapter extends OccProductAdapter {
+  protected fakeServer = inject(FakeServerService)
+
+
+  load(productCode: string, scope?: string): Observable<Product> {
+    if (scope === ProductScope.STOCK) {
+      return this.fakeServer.getStock(productCode);
+    }
+    return super.load(productCode, scope);
+  }
+
+  loadMany(products: ScopedProductData[]): ScopedProductData[] {
+    const products_withoutScopeStock = products.filter(
+      (product) => product.scope !== ProductScope.STOCK
+    );
+    const products_withScopeStock = products.filter(
+      (product) => product.scope === ProductScope.STOCK
+    );
+
+    const responses_withoutScopeStock: ScopedProductData[] = super.loadMany(
+      products_withoutScopeStock
+    );
+    const responses_withScopeStock: ScopedProductData[] =
+      products_withScopeStock.map((product) => {
+        return {
+          ...product,
+          data$: this.fakeServer.getStock(product.code),
+        } satisfies ScopedProductData;
+      });
+
+    // let's preserve original order!
+    return products.map((product) => {
+      if (product.scope === ProductScope.STOCK) {
+        return responses_withScopeStock.shift();
+      } else {
+        return responses_withoutScopeStock.shift();
+      }
+    }) as ScopedProductData[];
+  }
+}
+
+/**
+ * Bundle all custom providers together for easier providing in the AppModule.
+ */
+export const customProviders: Provider[] = [
+  provideConfig(customBackendConfig),
+  
+  {
+    provide: APP_INITIALIZER,
+    useFactory: () => {
+      const service = inject(ProductStockReloadService);
+      return () => service.initialize();
+    },
+    multi: true,
+  },
+
+  { provide: ProductAdapter, useExisting: CustomOccProductAdapter },
+];
+
 @NgModule({
   imports: [
     BrowserModule,
+    BrowserAnimationsModule, // SPIKE - for visual demo purposes only
     HttpClientModule,
     AppRoutingModule,
     StoreModule.forRoot({}),
@@ -57,10 +247,11 @@ if (!environment.production) {
     ...devImports,
   ],
   providers: [
+    customProviders, // SPIKE - normally, import a separate module, e.g. OmsaModule or OmsaRootModule
     provideConfig(<OccConfig>{
       backend: {
         occ: {
-          baseUrl: environment.occBaseUrl,
+          baseUrl: 'http://localhost:9002', // SPIKE - for visual demo purposes only - to use proxy server
           prefix: environment.occApiPrefix,
         },
       },


### PR DESCRIPTION
## Reloading STOCK product scope

- fix configuration of loading scopes, so `DETAILS` scope semantically _includes_ `STOCK` scope
- bind reloading of `STOCK` scope on the custom event `ReloadProductStockEvent`
- subscribe to various events (e.g. route change, timer or manual invocation) and dispatch `ReloadProductStockEvent`

## Calling different endpoint for STOCK product scope
- provide custom `ProductAdapter`, which calls a fake endpoint for `STOCK` product scope, but the original `OccProductAdapter` for all other scopes

## Proxy server and fake server for demo purposes only
## How to run it
Install:
```
npm install -g http-server
```
and then run:
```
node --watch http-proxy.js
```
## What it does
```
[localhost:9002] - proxies all requests to the OCC dev server, generating random `stockLevel`
                   if the request includes `fields=stock`. Random stock level is between 1-100.
[localhost:9003] - also runs a fake server that returns random stock levels between 100_001-100_100.
```