### PR TITLE
Add paymentSessionId in storage state

### DIFF
--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.spec.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.spec.ts
@@ -125,6 +125,38 @@ describe('OpfPaymentVerificationService', () => {
       });
     });
 
+    it('should return paymentSessionId from local storage if not in params', (done) => {
+      const mockPaymentSessionId = 'sessionIdFromLocalStorage';
+      const mockRouteSnapshot: ActivatedRoute = {
+        routeConfig: {
+          data: {
+            cxRoute: 'paymentVerificationResult',
+          },
+        },
+        queryParams: of({ afterRedirectScriptFlag: 'true' }),
+      } as unknown as ActivatedRoute;
+
+      const mockOpfPaymentMetadata: OpfPaymentMetadata = {
+        isPaymentInProgress: true,
+        selectedPaymentOptionId: 111,
+        termsAndConditionsChecked: true,
+        paymentSessionId: mockPaymentSessionId,
+      };
+
+      opfServiceMock.getOpfMetadataState.and.returnValue(
+        of(mockOpfPaymentMetadata)
+      );
+
+      service.verifyResultUrl(mockRouteSnapshot).subscribe((result) => {
+        expect(result.paymentSessionId).toEqual(mockPaymentSessionId);
+        expect(result.paramsMap).toEqual([
+          { key: 'afterRedirectScriptFlag', value: 'true' },
+        ]);
+        expect(result.afterRedirectScriptFlag).toEqual('true');
+        done();
+      });
+    });
+
     it('should throw an error if the route cxRoute is not "paymentVerificationResult"', (done) => {
       const mockOtherRouteSnapshot: ActivatedRoute = {
         routeConfig: {
@@ -142,7 +174,18 @@ describe('OpfPaymentVerificationService', () => {
       );
     });
 
-    it('should throw an error if queryParams is undefined', (done) => {
+    it('should throw an error if queryParams is undefined and paymentSessionId not in local storage', (done) => {
+      const mockOpfPaymentMetadata: OpfPaymentMetadata = {
+        isPaymentInProgress: true,
+        selectedPaymentOptionId: 111,
+        termsAndConditionsChecked: true,
+        paymentSessionId: undefined,
+      };
+
+      opfServiceMock.getOpfMetadataState.and.returnValue(
+        of(mockOpfPaymentMetadata)
+      );
+
       const mockRoute: ActivatedRoute = {
         routeConfig: {
           data: {
@@ -162,7 +205,18 @@ describe('OpfPaymentVerificationService', () => {
       );
     });
 
-    it('should throw an error if paymentSessionId is missing', (done) => {
+    it('should throw an error if paymentSessionId is missing in url params and local storage', (done) => {
+      const mockOpfPaymentMetadata: OpfPaymentMetadata = {
+        isPaymentInProgress: true,
+        selectedPaymentOptionId: 111,
+        termsAndConditionsChecked: true,
+        paymentSessionId: undefined,
+      };
+
+      opfServiceMock.getOpfMetadataState.and.returnValue(
+        of(mockOpfPaymentMetadata)
+      );
+
       const mockRoute: ActivatedRoute = {
         routeConfig: {
           data: {
@@ -455,6 +509,7 @@ describe('OpfPaymentVerificationService', () => {
         isPaymentInProgress: true,
         selectedPaymentOptionId: 111,
         termsAndConditionsChecked: true,
+        paymentSessionId: '111111',
       };
 
       opfServiceMock.getOpfMetadataState.and.returnValue(
@@ -473,6 +528,7 @@ describe('OpfPaymentVerificationService', () => {
         isPaymentInProgress: false,
         selectedPaymentOptionId: 111,
         termsAndConditionsChecked: true,
+        paymentSessionId: '111111',
       };
 
       opfServiceMock.getOpfMetadataState.and.returnValue(

--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.ts
@@ -57,9 +57,11 @@ export class OpfPaymentVerificationService {
   };
 
   protected getParamsMap(params: Params): Array<KeyValuePair> {
-    return Object.entries(params).map((pair) => {
-      return { key: pair[0], value: pair[1] as string };
-    });
+    return params
+      ? Object.entries(params).map((pair) => {
+          return { key: pair[0], value: pair[1] as string };
+        })
+      : [];
   }
 
   protected findInParamsMap(

--- a/integration-libs/opf/base/root/model/opf.model.ts
+++ b/integration-libs/opf/base/root/model/opf.model.ts
@@ -11,6 +11,7 @@ export interface OpfPaymentMetadata {
   selectedPaymentOptionId: number | undefined;
   defaultSelectedPaymentOptionId?: number | undefined;
   isPaymentInProgress: boolean;
+  paymentSessionId: string | undefined;
 }
 
 export interface KeyValuePair {

--- a/integration-libs/opf/base/root/services/opf-payment-metadata-store.service.spec.ts
+++ b/integration-libs/opf/base/root/services/opf-payment-metadata-store.service.spec.ts
@@ -11,12 +11,14 @@ const initialState = {
   termsAndConditionsChecked: false,
   selectedPaymentOptionId: undefined,
   isPaymentInProgress: false,
+  paymentSessionId: undefined,
 };
 
 const state: OpfPaymentMetadata = {
   isPaymentInProgress: true,
   selectedPaymentOptionId: 111,
   termsAndConditionsChecked: true,
+  paymentSessionId: '111111',
 };
 
 describe('OpfPaymentMetadataStoreService', () => {
@@ -73,6 +75,7 @@ describe('OpfPaymentMetadataStoreService', () => {
       isPaymentInProgress: true,
       termsAndConditionsChecked: true,
       selectedPaymentOptionId: 111,
+      paymentSessionId: '111111',
     };
 
     service.opfPaymentMetadataState.next(state);

--- a/integration-libs/opf/base/root/services/opf-payment-metadata-store.service.ts
+++ b/integration-libs/opf/base/root/services/opf-payment-metadata-store.service.ts
@@ -8,10 +8,11 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { OpfPaymentMetadata } from '../model/opf.model';
 
-const initialState = {
+const initialState: OpfPaymentMetadata = {
   termsAndConditionsChecked: false,
   selectedPaymentOptionId: undefined,
   isPaymentInProgress: false,
+  paymentSessionId: undefined,
 };
 
 @Injectable({ providedIn: 'root' })

--- a/integration-libs/opf/base/root/services/opf-state-persistence.service.spec.ts
+++ b/integration-libs/opf/base/root/services/opf-state-persistence.service.spec.ts
@@ -17,6 +17,7 @@ const mockOpfMetadata: OpfPaymentMetadata = {
   isPaymentInProgress: true,
   selectedPaymentOptionId: 111,
   termsAndConditionsChecked: true,
+  paymentSessionId: '111111',
 };
 
 describe('OpfStatePersistenceService', () => {

--- a/integration-libs/opf/base/root/services/opf.service.spec.ts
+++ b/integration-libs/opf/base/root/services/opf.service.spec.ts
@@ -68,6 +68,7 @@ describe('OpfService', () => {
       isPaymentInProgress: true,
       selectedPaymentOptionId: 111,
       termsAndConditionsChecked: true,
+      paymentSessionId: '111111',
     };
 
     const mockObservable = new BehaviorSubject<OpfPaymentMetadata>(

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.spec.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.spec.ts
@@ -18,6 +18,7 @@ import { OpfCheckoutFacade } from '../../root/facade';
 import {
   OPF_PAYMENT_AND_REVIEW_SEMANTIC_ROUTE,
   OpfPaymentMethodType,
+  PaymentPattern,
   PaymentSessionData,
 } from '../../root/model';
 import { OpfCheckoutPaymentWrapperService } from './opf-checkout-payment-wrapper.service';
@@ -147,6 +148,7 @@ describe('OpfCheckoutPaymentWrapperService', () => {
       Promise.resolve()
     );
     spyOn(service, 'renderPaymentGateway').and.callThrough();
+    spyOn<any>(service, 'storePaymentSessionId');
 
     service.initiatePayment(mockPaymentOptionId).subscribe(() => {
       expect(opfCheckoutFacadeMock.initiatePayment).toHaveBeenCalledWith({
@@ -193,6 +195,8 @@ describe('OpfCheckoutPaymentWrapperService', () => {
           ],
         },
       });
+
+      expect((service as any).storePaymentSessionId).toHaveBeenCalled();
 
       done();
     });
@@ -293,6 +297,24 @@ describe('OpfCheckoutPaymentWrapperService', () => {
       renderType: OpfPaymentMethodType.DESTINATION,
       data: mockUrl,
       destination: { url: mockUrl, form: [] },
+    });
+  });
+
+  it('should handle paymentSessionId', () => {
+    const mockPaymentSessionId = 'mockPaymentSessionId';
+    const mockPaymentSessionData: PaymentSessionData = {
+      pattern: PaymentPattern.FULL_PAGE,
+      paymentSessionId: mockPaymentSessionId,
+    };
+    (service as any).storePaymentSessionId(mockPaymentSessionData);
+    expect(opfServiceMock.updateOpfMetadataState).toHaveBeenCalledWith({
+      paymentSessionId: mockPaymentSessionId,
+    });
+
+    mockPaymentSessionData.pattern = PaymentPattern.HOSTED_FIELDS;
+    (service as any).storePaymentSessionId(mockPaymentSessionData);
+    expect(opfServiceMock.updateOpfMetadataState).toHaveBeenCalledWith({
+      paymentSessionId: undefined,
     });
   });
 

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
@@ -129,7 +129,7 @@ export class OpfCheckoutPaymentWrapperService {
 
   protected storePaymentSessionId(paymentOptionConfig: PaymentSessionData) {
     const paymentSessionId =
-      paymentOptionConfig.pattern == PaymentPattern.FULL_PAGE &&
+      paymentOptionConfig.pattern === PaymentPattern.FULL_PAGE &&
       paymentOptionConfig.paymentSessionId
         ? paymentOptionConfig.paymentSessionId
         : undefined;

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
@@ -25,6 +25,7 @@ import {
   OpfCheckoutFacade,
   OpfPaymentMethodType,
   OpfRenderPaymentMethodEvent,
+  PaymentPattern,
   PaymentSessionData,
 } from '@spartacus/opf/checkout/root';
 import {
@@ -115,6 +116,7 @@ export class OpfCheckoutPaymentWrapperService {
       switchMap((params) => this.opfCheckoutService.initiatePayment(params)),
       tap((paymentOptionConfig: PaymentSessionData | Error) => {
         if (!(paymentOptionConfig instanceof Error)) {
+          this.storePaymentSessionId(paymentOptionConfig);
           this.renderPaymentGateway(paymentOptionConfig);
         }
       }),
@@ -123,6 +125,15 @@ export class OpfCheckoutPaymentWrapperService {
       ),
       take(1)
     );
+  }
+
+  protected storePaymentSessionId(paymentOptionConfig: PaymentSessionData) {
+    const paymentSessionId =
+      paymentOptionConfig.pattern == PaymentPattern.FULL_PAGE &&
+      paymentOptionConfig.paymentSessionId
+        ? paymentOptionConfig.paymentSessionId
+        : undefined;
+    this.opfService.updateOpfMetadataState({ paymentSessionId });
   }
 
   reloadPaymentMode(): void {

--- a/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.spec.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.spec.ts
@@ -65,6 +65,7 @@ const mockOpfPaymentMetadata: OpfPaymentMetadata = {
   selectedPaymentOptionId: 111,
   termsAndConditionsChecked: true,
   defaultSelectedPaymentOptionId: 1,
+  paymentSessionId: '111111',
 };
 
 describe('OpfCheckoutPaymentsComponent', () => {
@@ -160,6 +161,7 @@ describe('OpfCheckoutPaymentsComponent', () => {
         selectedPaymentOptionId: undefined,
         termsAndConditionsChecked: true,
         defaultSelectedPaymentOptionId,
+        paymentSessionId: '111111',
       })
     );
 


### PR DESCRIPTION
context:
FULL_PAGE pattern needs a new sub-pattern:
some PSP have predefined redirect url: eg: https://spartacus/redirect/success , means without parameters so without paymentSessionId value.
Thus we need to handle :
- url without params becomes valid
- a new way to retrieve paymentSessionId -> set in localStorage from CheckoutPage then get it from localStorage in VerificationPage.