### PR TITLE
fix: CXSPA-6327 Use ExpressServerLogger type when logger is initialized in OptimizedSsrEngine

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -11,7 +11,6 @@ import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-d
 import { getRequestUrl } from '../express-utils/express-request-url';
 import {
   EXPRESS_SERVER_LOGGER,
-  ExpressLoggerService,
   ExpressServerLogger,
   ExpressServerLoggerContext,
 } from '../logger';
@@ -78,7 +77,7 @@ export class OptimizedSsrEngine {
         }
       : undefined;
 
-    this.logger = this.ssrOptions?.logger as ExpressLoggerService; // we are sure the logger is defined in this place
+    this.logger = this.ssrOptions?.logger as ExpressServerLogger; // we are sure the logger is defined in this place
     this.logOptions();
   }
 

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -77,7 +77,10 @@ export class OptimizedSsrEngine {
         }
       : undefined;
 
-    this.logger = this.ssrOptions?.logger as ExpressServerLogger; // we are sure the logger is defined in this place
+    if (!this.ssrOptions?.logger) {
+      throw new Error('`SsrOptimizationOptions.logger` is not defined');
+    }
+    this.logger = this.ssrOptions?.logger;
     this.logOptions();
   }
 


### PR DESCRIPTION
closes [CXSPA-6327](https://jira.tools.sap/browse/CXSPA-6327)