### PR TITLE
bugfix: CXSPA-6445 OCC_BACKEND_BASE_URL_VALUE not mapped to value in new SPA 2211.19 app with SSR

### DIFF
--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -218,7 +218,7 @@ export function app(): express.Express {
   const server = express();
   const serverDistFolder = dirname(fileURLToPath(import.meta.url));
   const browserDistFolder = resolve(serverDistFolder, '../browser');
-  const indexHtml = join(serverDistFolder, 'index.server.html');
+  const indexHtml = join(browserDistFolder, 'index.html');
 
   server.set('trust proxy', 'loopback');
 

--- a/projects/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/projects/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -15,7 +15,7 @@ export function app(): express.Express {
   const server = express();
   const serverDistFolder = dirname(fileURLToPath(import.meta.url));
   const browserDistFolder = resolve(serverDistFolder, '../browser');
-  const indexHtml = join(serverDistFolder, 'index.server.html');
+  const indexHtml = join(browserDistFolder, 'index.html');
 
   server.set('trust proxy', 'loopback');
 


### PR DESCRIPTION
This pull request contains a fix for an issue with mapping `OCC_BACKEND_BASE_URL_VALUE` to the proper value in fresh SPA 2211.19 with SSR deployed on CCv2.

QA steps (locally):
- build and deploy Spartacus packages locally:
```npx ts-node ./tools/schematics/testing.ts in the SPA root folder```
- generate fresh ng17 application:
```npx @angular/cli new my-app --standalone=false --ssr=false --style=scss```
- go to the project's directory and install Spartacus with SSR from local packages:
```npx @angular/cli add @spartacus/schematics@latest --ssr```
- verify whether `server.ts` contains line:
```const indexHtml = join(browserDistFolder, 'index.html');```
- run `npm run build` and `npm run serve:ssr:my-app` to verify if the app works

To verify whether `OCC_BACKEND_BASE_URL_VALUE` has been mapped to the proper value, an app with the applied change has to be deployed on CCv2.

closes [CXSPA-6445](https://jira.tools.sap/browse/CXSPA-6445)