### PR TITLE
bugfix: CXSPA-6456 Missing  script in SSR app causes errors during the CCv2 build

### DIFF
--- a/projects/schematics/src/add-ssr/index.ts
+++ b/projects/schematics/src/add-ssr/index.ts
@@ -170,6 +170,29 @@ function prepareDependencies(): NodeDependency[] {
   return spartacusDependencies.concat(thirdPartyDependencies);
 }
 
+function addBuildSsrScript(spartacusOptions: SpartacusOptions): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    if (spartacusOptions.debug) {
+      context.logger.info(
+        `⌛️ Adding "build:ssr" script to "package.json"... (CCv2 purposes)`
+      );
+    }
+    const pkgPath = '/package.json';
+    const pkg = tree.readJson(pkgPath) as {
+      scripts?: Record<string, string>;
+    } | null;
+    if (pkg === null) {
+      throw new SchematicsException('Could not find package.json');
+    }
+    pkg.scripts = {
+      ...pkg.scripts,
+      'build:ssr': 'ng build',
+    };
+
+    tree.overwrite(pkgPath, JSON.stringify(pkg, null, 2));
+  };
+}
+
 /**
  * Fixes the configuration for SSR and Prerendering to be able to work with Spartacus.
  */
@@ -467,6 +490,7 @@ export function addSSR(options: SpartacusOptions): Rule {
       externalSchematic(ANGULAR_SSR, 'ng-add', {
         project: options.project,
       }),
+      addBuildSsrScript(options),
       modifyAppServerModuleFile(),
       removeClientHydration(options),
       modifyIndexHtmlFile(options),

--- a/projects/schematics/src/add-ssr/index.ts
+++ b/projects/schematics/src/add-ssr/index.ts
@@ -170,6 +170,11 @@ function prepareDependencies(): NodeDependency[] {
   return spartacusDependencies.concat(thirdPartyDependencies);
 }
 
+/**
+ * Adds `build:ssr` script to `package.json` as it's required for CCv2 build - process fails when script is missing.
+ *
+ * TODO: CXSPA-6466 Can be removed if Model T adjust their build process to not require this script.
+ */
 function addBuildSsrScript(spartacusOptions: SpartacusOptions): Rule {
   return (tree: Tree, context: SchematicContext) => {
     if (spartacusOptions.debug) {

--- a/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -38,7 +38,8 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "serve:ssr:schematics-test": "node dist/schematics-test/server/server.mjs"
+    "serve:ssr:schematics-test": "node dist/schematics-test/server/server.mjs",
+    "build:ssr": "ng build"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
closes [CXSPA-6456](https://jira.tools.sap/browse/CXSPA-6456)