### PR TITLE
fix: CXSPA-6445 OCC_BACKEND_BASE_URL_VALUE not mapped to value in new SPA 2211.19 app with SSR - 2211.20.1 backport

### DIFF
--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -218,7 +218,7 @@ export function app(): express.Express {
   const server = express();
   const serverDistFolder = dirname(fileURLToPath(import.meta.url));
   const browserDistFolder = resolve(serverDistFolder, '../browser');
-  const indexHtml = join(serverDistFolder, 'index.server.html');
+  const indexHtml = join(browserDistFolder, 'index.html');
 
   server.set('trust proxy', 'loopback');
 

--- a/projects/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/projects/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -15,7 +15,7 @@ export function app(): express.Express {
   const server = express();
   const serverDistFolder = dirname(fileURLToPath(import.meta.url));
   const browserDistFolder = resolve(serverDistFolder, '../browser');
-  const indexHtml = join(serverDistFolder, 'index.server.html');
+  const indexHtml = join(browserDistFolder, 'index.html');
 
   server.set('trust proxy', 'loopback');
 


### PR DESCRIPTION
closes CXSPA-6445