### PR TITLE
fix: CXSPA-6456 Missing  script in SSR app causes errors during the CCv2 build - 2211.20.1 backport

### DIFF
--- a/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -38,7 +38,8 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "serve:ssr:schematics-test": "node dist/schematics-test/server/server.mjs"
+    "serve:ssr:schematics-test": "node dist/schematics-test/server/server.mjs",
+    "build:ssr": "ng build"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
closes CXSPA-6456