### PR TITLE
fix: (CXSPA-3368) - misplaced aria hidden attrs on focusable elements

### DIFF
--- a/projects/storefrontlib/cms-components/misc/message/message.component.html
+++ b/projects/storefrontlib/cms-components/misc/message/message.component.html
@@ -12,7 +12,6 @@
           (click)="showBody = !showBody"
           [attr.aria-expanded]="showBody"
           [attr.aria-label]="accordionText"
-          aria-hidden="true"
           class="cx-message-accordion-button link cx-action-link"
           type="button"
         >
@@ -27,7 +26,6 @@
           *ngIf="actionButtonText"
           (click)="buttonAction.emit()"
           [cxAtMessage]="actionButtonMessage"
-          aria-hidden="true"
           class="btn btn-link cx-action-link"
           type="button"
         >
@@ -40,7 +38,6 @@
         (click)="closeMessage.emit()"
         [attr.aria-label]="'common.close' | cxTranslate"
         [cxAtMessage]="'common.close' | cxTranslate"
-        aria-hidden="true"
         class="close"
         type="button"
       >


### PR DESCRIPTION
https://jira.tools.sap/browse/CXSPA-3368

There were 3 buttons with aria-hidden attributes in message.component, there is only one of them mentioned in the task, but since all other buttons are also focusable I've remove aria-hidden from them as well