### PR TITLE
fix: Moved featureConfig import to the correct quick order module

### DIFF
--- a/feature-libs/cart/quick-order/components/cart-quick-order-form/cart-quick-order-form.module.ts
+++ b/feature-libs/cart/quick-order/components/cart-quick-order-form/cart-quick-order-form.module.ts
@@ -7,12 +7,23 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { CmsConfig, I18nModule, provideDefaultConfig } from '@spartacus/core';
+import {
+  CmsConfig,
+  FeaturesConfigModule,
+  I18nModule,
+  provideDefaultConfig,
+} from '@spartacus/core';
 import { FormErrorsModule } from '@spartacus/storefront';
 import { CartQuickOrderFormComponent } from './cart-quick-order-form.component';
 
 @NgModule({
-  imports: [CommonModule, ReactiveFormsModule, I18nModule, FormErrorsModule],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    I18nModule,
+    FormErrorsModule,
+    FeaturesConfigModule,
+  ],
   providers: [
     provideDefaultConfig(<CmsConfig>{
       cmsComponents: {

--- a/feature-libs/cart/quick-order/quick-order.module.ts
+++ b/feature-libs/cart/quick-order/quick-order.module.ts
@@ -7,13 +7,8 @@
 import { NgModule } from '@angular/core';
 import { QuickOrderComponentsModule } from '@spartacus/cart/quick-order/components';
 import { QuickOrderCoreModule } from '@spartacus/cart/quick-order/core';
-import { FeaturesConfigModule } from '@spartacus/core';
 
 @NgModule({
-  imports: [
-    QuickOrderCoreModule,
-    QuickOrderComponentsModule,
-    FeaturesConfigModule,
-  ],
+  imports: [QuickOrderCoreModule, QuickOrderComponentsModule],
 })
 export class QuickOrderModule {}


### PR DESCRIPTION
Fixes a misplaced module, introduced by: https://github.com/SAP/spartacus/pull/18264
