### PR TITLE
fix: Overview page not loading for CPQ Configurator [CXSPA-6590]

### DIFF
--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-variant.effect.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-variant.effect.spec.ts
@@ -198,5 +198,25 @@ describe('ConfiguratorVariantEffect', () => {
         expected
       );
     });
+
+    it('should emit success in case it is called with the variant feature enabled but for wrong configurator type (in order to reset loading status)', () => {
+      const action = new ConfiguratorActions.SearchVariants(
+        productConfiguration
+      );
+      action.payload.owner.configuratorType = ConfiguratorType.CPQ;
+      if (configuratorCoreConfig.productConfigurator) {
+        configuratorCoreConfig.productConfigurator.enableVariantSearch = true;
+      }
+      const completion = new ConfiguratorActions.SearchVariantsSuccess({
+        ownerKey: productConfiguration.owner.key,
+        variants: [],
+      });
+      actions$ = cold('-a', { a: action });
+      const expected = cold('-b', { b: completion });
+
+      expect(configEffects.searchVariantsInCaseNotActive$).toBeObservable(
+        expected
+      );
+    });
   });
 });

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-variant.effect.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-variant.effect.ts
@@ -58,7 +58,7 @@ export class ConfiguratorVariantEffects {
     )
   );
   /**
-   * Effect for handling the variant search action in case the feature is not active.
+   * Effect for handling the variant search action in case the feature is not active or the configurator type does not support it.
    * We return the corresponding success action in this case in order to reset the loading state.
    */
   searchVariantsInCaseNotActive$: Observable<ConfiguratorActions.SearchVariantsSuccess> =
@@ -66,9 +66,10 @@ export class ConfiguratorVariantEffects {
       this.actions$.pipe(
         ofType(ConfiguratorActions.SEARCH_VARIANTS),
         filter(
-          () =>
+          (action: ConfiguratorActions.SearchVariants) =>
             this.configuratorCoreConfig.productConfigurator
-              ?.enableVariantSearch === false
+              ?.enableVariantSearch === false ||
+            action.payload.owner.configuratorType !== ConfiguratorType.VARIANT
         ),
         map(
           (action: ConfiguratorActions.SearchVariants) =>


### PR DESCRIPTION
CPQ Configurator does not support variant search. In case this feature is active we must throw a dummy success event, similar to when the feature is not enabled, so that the loading state is always reset to false. Otherwise the overview page never stops loading.