### PR TITLE
feat: CXSPA-6575 Introduce MULTI_ERROR_HANDLERS to CxErrorHandler

### DIFF
--- a/core-libs/setup/ssr/error-handling/multi-error-handlers/index.ts
+++ b/core-libs/setup/ssr/error-handling/multi-error-handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './server-responding-error-handler';

--- a/core-libs/setup/ssr/error-handling/multi-error-handlers/index.ts
+++ b/core-libs/setup/ssr/error-handling/multi-error-handlers/index.ts
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './server-responding-error-handler';

--- a/core-libs/setup/ssr/error-handling/multi-error-handlers/server-responding-error-handler.ts
+++ b/core-libs/setup/ssr/error-handling/multi-error-handlers/server-responding-error-handler.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { MultiErrorHandler } from '@spartacus/core';
 

--- a/core-libs/setup/ssr/error-handling/multi-error-handlers/server-responding-error-handler.ts
+++ b/core-libs/setup/ssr/error-handling/multi-error-handlers/server-responding-error-handler.ts
@@ -8,7 +8,7 @@ import { Injectable } from '@angular/core';
 import { MultiErrorHandler } from '@spartacus/core';
 
 /**
- * Error handler responsible for responsible for handling server responding errors.
+ * Error handler responsible for sending an error response to the incoming request in the server.
  * Intended to be used as part of a multi-error handler strategy.
  *
  * @see MultiErrorHandler

--- a/core-libs/setup/ssr/error-handling/multi-error-handlers/server-responding-error-handler.ts
+++ b/core-libs/setup/ssr/error-handling/multi-error-handlers/server-responding-error-handler.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { MultiErrorHandler } from '@spartacus/core';
+
+/**
+ * Error handler responsible for responsible for handling server responding errors.
+ * Intended to be used as part of a multi-error handler strategy.
+ *
+ * @see MultiErrorHandler
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ServerRespondingErrorHandler implements MultiErrorHandler {
+  handleError(_error: Error): void {
+    // TODO: CXSPA-6576 use SEVER_ERROR_RESPONSE_TRANSFORMERS
+  }
+}

--- a/core-libs/setup/ssr/providers/ssr-providers.ts
+++ b/core-libs/setup/ssr/providers/ssr-providers.ts
@@ -40,7 +40,7 @@ export function provideServer(options?: ServerOptions): Provider[] {
     },
     {
       provide: MULTI_ERROR_HANDLERS,
-      useClass: ServerRespondingErrorHandler,
+      useExisting: ServerRespondingErrorHandler,
       multi: true,
     },
   ];

--- a/core-libs/setup/ssr/providers/ssr-providers.ts
+++ b/core-libs/setup/ssr/providers/ssr-providers.ts
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { StaticProvider } from '@angular/core';
+import { Provider, StaticProvider } from '@angular/core';
 import {
   LoggerService,
+  MULTI_ERROR_HANDLERS,
   SERVER_REQUEST_ORIGIN,
   SERVER_REQUEST_URL,
 } from '@spartacus/core';
+
+import { ServerRespondingErrorHandler } from '../error-handling/multi-error-handlers';
 import { getRequestOrigin } from '../express-utils/express-request-origin';
 import { getRequestUrl } from '../express-utils/express-request-url';
 import { serverLoggerServiceFactory } from '../logger';
@@ -21,7 +24,7 @@ import { serverRequestUrlFactory } from './server-request-url';
 /**
  * Returns the providers used for SSR and pre-rendering processes.
  */
-export function provideServer(options?: ServerOptions): StaticProvider[] {
+export function provideServer(options?: ServerOptions): Provider[] {
   return [
     {
       provide: SERVER_REQUEST_ORIGIN,
@@ -34,6 +37,11 @@ export function provideServer(options?: ServerOptions): StaticProvider[] {
     {
       provide: LoggerService,
       useFactory: serverLoggerServiceFactory,
+    },
+    {
+      provide: MULTI_ERROR_HANDLERS,
+      useClass: ServerRespondingErrorHandler,
+      multi: true,
     },
   ];
 }

--- a/projects/core/src/error-handling/cx-error-handler.ts
+++ b/projects/core/src/error-handling/cx-error-handler.ts
@@ -6,13 +6,13 @@
 
 import { ErrorHandler, Injectable, inject } from '@angular/core';
 import { LoggerService } from '../logger';
-import { ErrorInterceptorService } from './error-interceptors/error-interceptor.service';
+import { MULTI_ERROR_HANDLERS } from './multi-error-handlers';
 
 /**
  * The CxErrorHandler is the default ErrorHandler for Spartacus.
- * It is responsible for handling errors and passing them to the registered error interceptors.
+ * It is responsible for handling errors and passing them to the registered multi error handlers.
  *
- * @method handleError - Handles the error by passing it to the registered error interceptors.
+ * @method handleError - Handles the error by passing it to the registered multi error handlers.
  *
  * @public
  */
@@ -20,16 +20,18 @@ import { ErrorInterceptorService } from './error-interceptors/error-interceptor.
 export class CxErrorHandler implements ErrorHandler {
   //TODO: Keep it updated with the latest version of Spartacus
   /**
-   * @deprecated Since 6.6 - `LoggerService` is unused here. Instead it's now used in `LoggerErrorInterceptor`
+   * @deprecated Since 6.6 - `LoggerService` is unused here. Instead it's now used in `LoggingErrorHandler`.
    */
   protected logger = inject(LoggerService);
-  protected errorInterceptorService = inject(ErrorInterceptorService);
+  protected errorHandlers = inject(MULTI_ERROR_HANDLERS);
 
   /**
-   * Error handler method. Handles the error by passing it to the registered error interceptors.
+   * Error handler method. Handles the error by passing it to the registered multi error handlers.
    * @param error - The error to be handled.
    */
   handleError(error: unknown): void {
-    this.errorInterceptorService.interceptorsChain(error);
+    this.errorHandlers.forEach((handler) => {
+      handler.handleError(error);
+    });
   }
 }

--- a/projects/core/src/error-handling/effects-error-handler/cx-error-handler.effect.ts
+++ b/projects/core/src/error-handling/effects-error-handler/cx-error-handler.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/effects-error-handler/effects-error-handler.module.ts
+++ b/projects/core/src/error-handling/effects-error-handler/effects-error-handler.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/effects-error-handler/effects-error-handler.service.ts
+++ b/projects/core/src/error-handling/effects-error-handler/effects-error-handler.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/effects-error-handler/index.ts
+++ b/projects/core/src/error-handling/effects-error-handler/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/error-handling.module.ts
+++ b/projects/core/src/error-handling/error-handling.module.ts
@@ -8,14 +8,13 @@ import { ErrorHandler, ModuleWithProviders, NgModule } from '@angular/core';
 import { CxErrorHandler } from './cx-error-handler';
 import { provideMultiErrorHandlers } from './multi-error-handlers';
 
-@NgModule({
-  providers: [provideMultiErrorHandlers()],
-})
+@NgModule()
 export class ErrorHandlingModule {
   static forRoot(): ModuleWithProviders<ErrorHandlingModule> {
     return {
       ngModule: ErrorHandlingModule,
       providers: [
+        provideMultiErrorHandlers(),
         {
           provide: ErrorHandler,
           useClass: CxErrorHandler,

--- a/projects/core/src/error-handling/error-handling.module.ts
+++ b/projects/core/src/error-handling/error-handling.module.ts
@@ -6,20 +6,16 @@
 
 import { ErrorHandler, ModuleWithProviders, NgModule } from '@angular/core';
 import { CxErrorHandler } from './cx-error-handler';
-import { ERROR_INTERCEPTORS } from './error-interceptors/error-interceptor';
-import { LoggerErrorInterceptor } from './error-interceptors/logger-error.interceptor';
+import { provideMultiErrorHandlers } from './multi-error-handlers';
 
-@NgModule()
+@NgModule({
+  providers: [provideMultiErrorHandlers()],
+})
 export class ErrorHandlingModule {
   static forRoot(): ModuleWithProviders<ErrorHandlingModule> {
     return {
       ngModule: ErrorHandlingModule,
       providers: [
-        {
-          provide: ERROR_INTERCEPTORS,
-          useClass: LoggerErrorInterceptor,
-          multi: true,
-        },
         {
           provide: ErrorHandler,
           useClass: CxErrorHandler,

--- a/projects/core/src/error-handling/error-interceptors/error-interceptor.service.ts
+++ b/projects/core/src/error-handling/error-interceptors/error-interceptor.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/error-interceptors/error-interceptor.ts
+++ b/projects/core/src/error-handling/error-interceptors/error-interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/error-interceptors/index.ts
+++ b/projects/core/src/error-handling/error-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/error-interceptors/logger-error.interceptor.ts
+++ b/projects/core/src/error-handling/error-interceptors/logger-error.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.ts
+++ b/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/http-error-handler/http-error-handler.module.ts
+++ b/projects/core/src/error-handling/http-error-handler/http-error-handler.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/http-error-handler/index.ts
+++ b/projects/core/src/error-handling/http-error-handler/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/index.ts
+++ b/projects/core/src/error-handling/index.ts
@@ -5,7 +5,8 @@
  */
 
 export * from './cx-error-handler';
-export * from './error-handling.module';
-export * from './error-interceptors';
-export * from './http-error-handler';
 export * from './effects-error-handler';
+export * from './error-handling.module';
+// export * from './error-interceptors'; TODO: not used, to be removed in separate ticket
+export * from './http-error-handler';
+export * from './multi-error-handlers';

--- a/projects/core/src/error-handling/multi-error-handlers/index.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/index.ts
@@ -1,0 +1,3 @@
+export * from './logging-error-handler';
+export * from './multi-error-handlers';
+export * from './provide-multi-error-handlers';

--- a/projects/core/src/error-handling/multi-error-handlers/index.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/index.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './logging-error-handler';
 export * from './multi-error-handlers';
 export * from './provide-multi-error-handlers';

--- a/projects/core/src/error-handling/multi-error-handlers/logging-error-handler.spec.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/logging-error-handler.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { LoggerService } from '../../logger';
+import { LoggingErrorHandler } from './logging-error-handler';
+
+class MockLoggerService implements Partial<LoggerService> {
+  error = jasmine.createSpy('error');
+}
+
+describe('LoggingErrorHandler', () => {
+  let errorHandler: LoggingErrorHandler;
+  let loggerService: LoggerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LoggingErrorHandler,
+        { provide: LoggerService, useClass: MockLoggerService },
+      ],
+    });
+
+    loggerService = TestBed.inject(LoggerService);
+    errorHandler = TestBed.inject(LoggingErrorHandler);
+  });
+
+  it('should log the error using the logger service', () => {
+    const error = new Error('Test error');
+    errorHandler.handleError(error);
+    expect(loggerService.error).toHaveBeenCalledWith(error);
+  });
+});

--- a/projects/core/src/error-handling/multi-error-handlers/logging-error-handler.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/logging-error-handler.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable, inject } from '@angular/core';
 import { LoggerService } from '../../logger';
 import { MultiErrorHandler } from './multi-error-handlers';

--- a/projects/core/src/error-handling/multi-error-handlers/logging-error-handler.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/logging-error-handler.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { LoggerService } from '../../logger';
+import { MultiErrorHandler } from './multi-error-handlers';
+
+/**
+ * An error handler that logs errors using a logger service.
+ * Intended to be used as part of a multi-error handler strategy.
+ *
+ * @see MultiErrorHandler
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class LoggingErrorHandler implements MultiErrorHandler {
+  protected logger = inject(LoggerService);
+
+  handleError(error: Error): void {
+    this.logger.error(error);
+  }
+}

--- a/projects/core/src/error-handling/multi-error-handlers/multi-error-handlers.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/multi-error-handlers.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { InjectionToken } from '@angular/core';
 
 /**

--- a/projects/core/src/error-handling/multi-error-handlers/multi-error-handlers.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/multi-error-handlers.ts
@@ -20,9 +20,6 @@ export interface MultiErrorHandler {
 /**
  * Injection token for multi error handlers.
  * Are multi provided error handlers will be called in the order they are provided.
- * Spartacus is providing one multi error handler by default:
- * - LoggerMultiErrorHandler - responsible for logging errors to the LoggerService.
- * - ServerRespondingErrorHandler - responsible for handling server responding errors.
  *
  */
 

--- a/projects/core/src/error-handling/multi-error-handlers/multi-error-handlers.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/multi-error-handlers.ts
@@ -1,0 +1,25 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Multi error handlers are responsible for act with errors handled by the CxErrorHandler.
+ *
+ * @method handleError - Handles the error.
+ *
+ * @public
+ */
+export interface MultiErrorHandler {
+  handleError(error: unknown): void;
+}
+
+/**
+ * Injection token for multi error handlers.
+ * Are multi provided error handlers will be called in the order they are provided.
+ * Spartacus is providing one multi error handler by default:
+ * - LoggerMultiErrorHandler - responsible for logging errors to the LoggerService.
+ * - ServerRespondingErrorHandler - responsible for handling server responding errors.
+ *
+ */
+
+export const MULTI_ERROR_HANDLERS = new InjectionToken<MultiErrorHandler[]>(
+  'MULTI_ERROR_HANDLERS'
+);

--- a/projects/core/src/error-handling/multi-error-handlers/provide-multi-error-handlers.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/provide-multi-error-handlers.ts
@@ -1,0 +1,13 @@
+import { StaticProvider } from '@angular/core';
+import { LoggingErrorHandler } from './logging-error-handler';
+import { MULTI_ERROR_HANDLERS } from './multi-error-handlers';
+
+export function provideMultiErrorHandlers(): StaticProvider[] {
+  return [
+    {
+      provide: MULTI_ERROR_HANDLERS,
+      useExisting: LoggingErrorHandler,
+      multi: true,
+    },
+  ];
+}

--- a/projects/core/src/error-handling/multi-error-handlers/provide-multi-error-handlers.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/provide-multi-error-handlers.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { StaticProvider } from '@angular/core';
+import { Provider } from '@angular/core';
 import { LoggingErrorHandler } from './logging-error-handler';
 import { MULTI_ERROR_HANDLERS } from './multi-error-handlers';
 
-export function provideMultiErrorHandlers(): StaticProvider[] {
+export function provideMultiErrorHandlers(): Provider[] {
   return [
     {
       provide: MULTI_ERROR_HANDLERS,

--- a/projects/core/src/error-handling/multi-error-handlers/provide-multi-error-handlers.ts
+++ b/projects/core/src/error-handling/multi-error-handlers/provide-multi-error-handlers.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { StaticProvider } from '@angular/core';
 import { LoggingErrorHandler } from './logging-error-handler';
 import { MULTI_ERROR_HANDLERS } from './multi-error-handlers';

--- a/projects/core/src/model/error-action.ts
+++ b/projects/core/src/model/error-action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/try-normalize-http-error.ts
+++ b/projects/core/src/util/try-normalize-http-error.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
This PR introduces the MULTI_ERROR_HANDLERS strategy to CxErrorHandler to decide about the destination of caught errors depending on the platform. As part of this PR, only one error handler - LoggingErrorHandler - has been implemented.

QA steps:

- call HTTP error that may be caught during server-side rendering (e.g use HTTP proxy OR modify `pages` property in `default-cms-config.ts`)
- run `npm run dev:ssr`
- open the application in the browser
- verify whether the caught error is visible in the terminal running the server


closes [CXSPA-6575](https://jira.tools.sap/browse/CXSPA-6575)