### PR TITLE
Handle read-only

### DIFF
--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
@@ -53,7 +53,7 @@
       <cx-configure-cart-entry
         *ngIf="(shouldShowButton$ | async) && orderEntry?.product?.configurable"
         [cartEntry]="orderEntry"
-        [readOnly]="(readonly$ | async) ?? true"
+        [readOnly]="(readonly$ | async) ?? false"
         [msgBanner]="false"
         [disabled]="quantityControl.disabled"
       ></cx-configure-cart-entry

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
@@ -598,6 +598,61 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
           ],
         });
       });
+
+      describe('readonly$', () => {
+        beforeEach(() => {
+          mockCartItemContext.location$.next(PromotionLocation.ActiveCart);
+        });
+
+        it('should expose readonly$ as false in case readonly$ is undefined', () => {
+          mockCartItemContext.readonly$?.next(undefined);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('false');
+        });
+
+        it('should expose readonly$ as false in case readonly$ is null', () => {
+          mockCartItemContext.readonly$?.next(null);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('false');
+        });
+
+        it('should expose readonly$ as false in case readonly$ is false', () => {
+          mockCartItemContext.readonly$?.next(false);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('false');
+        });
+
+        it('should expose readonly$ as true in case readonly$ is true', () => {
+          mockCartItemContext.readonly$?.next(true);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('true');
+        });
+      });
+
       it('should prevent the rendering of "edit configuration" if context is SaveForLater', () => {
         mockCartItemContext.location$?.next(PromotionLocation.SaveForLater);
         fixture.detectChanges();

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.html
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.html
@@ -37,7 +37,7 @@
       <cx-configure-cart-entry
         *ngIf="(shouldShowButton$ | async) && orderEntry?.product?.configurable"
         [cartEntry]="orderEntry"
-        [readOnly]="(readonly$ | async) ?? true"
+        [readOnly]="(readonly$ | async) ?? false"
         [msgBanner]="false"
         [disabled]="quantityControl.disabled"
       ></cx-configure-cart-entry

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.spec.ts
@@ -37,6 +37,7 @@ class MockConfigureCartEntryComponent {
   @Input() msgBanner: boolean;
   @Input() disabled: boolean;
 }
+
 describe('ConfiguratorCartEntryInfoComponent', () => {
   let component: ConfiguratorCartEntryInfoComponent;
   let fixture: ComponentFixture<ConfiguratorCartEntryInfoComponent>;
@@ -99,7 +100,6 @@ describe('ConfiguratorCartEntryInfoComponent', () => {
       expect(values).toEqual([true, false]);
       done();
     });
-
     mockCartItemContext.readonly$.next(true);
     mockCartItemContext.readonly$.next(false);
   });
@@ -217,6 +217,61 @@ describe('ConfiguratorCartEntryInfoComponent', () => {
           ],
         });
       });
+
+      describe('readonly$', () => {
+        beforeEach(() => {
+          mockCartItemContext.location$.next(PromotionLocation.ActiveCart);
+        });
+
+        it('should expose readonly$ as false in case readonly$ is undefined', () => {
+          mockCartItemContext.readonly$?.next(undefined);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('false');
+        });
+
+        it('should expose readonly$ as false in case readonly$ is null', () => {
+          mockCartItemContext.readonly$?.next(null);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('false');
+        });
+
+        it('should expose readonly$ as false in case readonly$ is false', () => {
+          mockCartItemContext.readonly$?.next(false);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('false');
+        });
+
+        it('should expose readonly$ as true in case readonly$ is true', () => {
+          mockCartItemContext.readonly$?.next(true);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('true');
+        });
+      });
+
       it('should prevent the rendering of "edit configuration" if context is SaveForLater', () => {
         mockCartItemContext.location$.next(PromotionLocation.SaveForLater);
         fixture.detectChanges();
@@ -230,6 +285,7 @@ describe('ConfiguratorCartEntryInfoComponent', () => {
 
       it('should allow the rendering of "edit configuration" if context is active cart', () => {
         mockCartItemContext.location$.next(PromotionLocation.ActiveCart);
+        mockCartItemContext.readonly$.next(null);
         fixture.detectChanges();
 
         const htmlElementAfterChanges = fixture.nativeElement;

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.html
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.html
@@ -13,11 +13,11 @@
             (shouldShowButton$ | async) && orderEntry?.product?.configurable
           "
           [cartEntry]="orderEntry"
-          [readOnly]="(readonly$ | async) ?? true"
+          [readOnly]="(readonly$ | async) ?? false"
           [msgBanner]="true"
           [disabled]="quantityControl.disabled"
-        ></cx-configure-cart-entry
-      ></ng-container>
+        ></cx-configure-cart-entry>
+      </ng-container>
     </div>
   </ng-container>
 </ng-container>

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.spec.ts
@@ -194,6 +194,49 @@ describe('ConfigureIssuesNotificationComponent', () => {
           product: { configurable: true },
         });
       });
+
+      describe('readonly$', () => {
+        beforeEach(() => {
+          mockCartItemContext.location$.next(PromotionLocation.ActiveCart);
+        });
+
+        it('should expose readonly$ as false in case readonly$ is undefined', () => {
+          mockCartItemContext.readonly$?.next(undefined);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('false');
+        });
+
+        it('should expose readonly$ as false in case readonly$ is null', () => {
+          mockCartItemContext.readonly$?.next(null);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('false');
+        });
+
+        it('should expose readonly$ as false in case readonly$ is false', () => {
+          mockCartItemContext.readonly$?.next(false);
+          fixture.detectChanges();
+          const element = CommonConfiguratorTestUtilsService.getHTMLElement(
+            htmlElem,
+            'cx-configure-cart-entry'
+          );
+
+          expect(element.hasAttribute('ng-reflect-read-only')).toBe(true);
+          expect(element.getAttribute('ng-reflect-read-only')).toBe('false');
+        });
+      });
+
       it('should prevent the rendering of "edit configuration" if context is SaveForLater', () => {
         mockCartItemContext.location$?.next(PromotionLocation.SaveForLater);
         fixture.detectChanges();
@@ -214,6 +257,19 @@ describe('ConfigureIssuesNotificationComponent', () => {
           htmlElementAfterChanges.querySelectorAll('cx-configure-cart-entry')
             .length
         ).toBe(1);
+      });
+
+      it('should prevent the rendering of "edit configuration" in case readonly$ is true', () => {
+        mockCartItemContext.location$?.next(PromotionLocation.ActiveCart);
+        mockCartItemContext.readonly$?.next(true);
+
+        fixture.detectChanges();
+
+        const htmlElementAfterChanges = fixture.nativeElement;
+        expect(
+          htmlElementAfterChanges.querySelectorAll('.cx-configure-cart-entry')
+            .length
+        ).toBe(0);
       });
     });
 

--- a/feature-libs/product-configurator/common/testing/common-configurator-test-utils.service.ts
+++ b/feature-libs/product-configurator/common/testing/common-configurator-test-utils.service.ts
@@ -145,7 +145,7 @@ export class CommonConfiguratorTestUtilsService {
     );
   }
 
-  protected static getHTMLElement(
+  static getHTMLElement(
     htmlElements: HTMLElement,
     tag: string,
     tagClass?: string,

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-interactive.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-interactive.e2e.cy.ts
@@ -8,6 +8,7 @@ import * as configuration from '../../../helpers/product-configurator';
 import { clickAllowAllFromBanner } from '../../../helpers/anonymous-consents';
 import * as configurationOverviewVc from '../../../helpers/product-configurator-overview-vc';
 import * as configurationVc from '../../../helpers/product-configurator-vc';
+import * as configurationCart from '../../../helpers/product-configurator-cart';
 import * as common from '../../../helpers/common';
 
 const electronicsShop = 'electronics-spa';
@@ -99,6 +100,13 @@ context('Product Configuration', () => {
       clickAllowAllFromBanner();
       common.goToPDPage(electronicsShop, testProduct);
       configurationVc.clickOnConfigureBtnInCatalog(testProduct);
+    });
+
+    it('should be able to navigate from the add-to-cart dialog on the product detail page', () => {
+      clickAllowAllFromBanner();
+      common.goToPDPage(electronicsShop, testProduct);
+      common.clickOnAddToCartBtnOnPD();
+      configurationCart.clickOnEditConfigurationLinkInAddToCartDialog();
     });
 
     it('should be able to navigate from the overview page', () => {

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-interactive.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-interactive.e2e.cy.ts
@@ -10,6 +10,8 @@ import * as configurationOverviewVc from '../../../helpers/product-configurator-
 import * as configurationVc from '../../../helpers/product-configurator-vc';
 import * as configurationCart from '../../../helpers/product-configurator-cart';
 import * as common from '../../../helpers/common';
+import { clickOnConfigurationLink } from '../../../helpers/common';
+import { checkConfigPageDisplayed } from '../../../helpers/product-configurator-vc';
 
 const electronicsShop = 'electronics-spa';
 const testProduct = 'CONF_CAMERA_SL';
@@ -102,11 +104,20 @@ context('Product Configuration', () => {
       configurationVc.clickOnConfigureBtnInCatalog(testProduct);
     });
 
-    it('should be able to navigate from the add-to-cart dialog on the product detail page', () => {
+    it('should be able to navigate from the add-to-cart dialog by clicking on "Edit Configuration" link', () => {
       clickAllowAllFromBanner();
       common.goToPDPage(electronicsShop, testProduct);
       common.clickOnAddToCartBtnOnPD();
-      configurationCart.clickOnEditConfigurationLinkInAddToCartDialog();
+      common.clickOnConfigurationLink();
+      configurationVc.checkConfigPageDisplayed();
+    });
+
+    it('should be able to navigate from the add-to-cart dialog by clicking on "Resolve Issues" link', () => {
+      clickAllowAllFromBanner();
+      common.goToPDPage(electronicsShop, testProduct);
+      common.clickOnAddToCartBtnOnPD();
+      common.clickOnResolveIssuesLink();
+      configurationVc.checkConfigPageDisplayed();
     });
 
     it('should be able to navigate from the overview page', () => {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/common.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/common.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const addToCartDialog = 'cx-added-to-cart-dialog';
+
 /**
  * Clicks on 'Add to cart' on the product details page.
  */
@@ -12,7 +14,7 @@ export function clickOnAddToCartBtnOnPD(): void {
     .contains('Add to cart')
     .click()
     .then(() => {
-      cy.get('cx-added-to-cart-dialog').should('be.visible');
+      cy.get(addToCartDialog).should('be.visible');
       cy.get('div.cx-dialog-body').should('be.visible');
       cy.get('div.cx-dialog-buttons a.btn-primary')
         .contains('view cart')
@@ -57,4 +59,40 @@ export function goToPDPage(shopName: string, productId: string): void {
 export function checkLoadingMsgNotDisplayed(): void {
   cy.log('Wait until the loading notification is not displayed anymore');
   cy.get('cx-storefront').should('not.contain.value', 'Loading');
+}
+
+/**
+ * Clicks on 'Edit Configuration' or 'Display Configuration' link in the add-to-cart dialog.
+ *
+ * @param isReadOnly - if 'isReadOnly' is false then 'Edit Configuration' link is displayed, otherwise 'Display Configuration' link.
+ */
+export function clickOnConfigurationLink(isReadOnly = false): void {
+  let linkText = isReadOnly ? 'Display' : 'Edit';
+
+  cy.get(addToCartDialog).within(() => {
+    cy.get('cx-configurator-cart-entry-info').within(() => {
+      cy.get('cx-configure-cart-entry')
+        .find(`a:contains(${linkText})`)
+        .click()
+        .then(() => {
+          cy.location('pathname').should('contain', '/cartEntry/entityKey/');
+        });
+    });
+  });
+}
+
+/**
+ * Clicks on 'Resolve Issues' link in the add-to-cart dialog.
+ */
+export function clickOnResolveIssuesLink(): void {
+  cy.get(addToCartDialog).within(() => {
+    cy.get('cx-configurator-issues-notification').within(() => {
+      cy.get('cx-configure-cart-entry')
+        .find('a:contains("Resolve")')
+        .click()
+        .then(() => {
+          cy.location('pathname').should('contain', '/cartEntry/entityKey/');
+        });
+    });
+  });
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart.ts
@@ -24,6 +24,23 @@ export function clickOnEditConfigurationLink(cartItemIndex: number): void {
 }
 
 /**
+ * Clicks on the 'Edit Configuration' link in add-to-cart dialog.
+ *
+ */
+export function clickOnEditConfigurationLinkInAddToCartDialog(): void {
+  cy.get('cx-added-to-cart-dialog').within(() => {
+    cy.get('cx-configurator-cart-entry-info').within(() => {
+      cy.get('cx-configure-cart-entry')
+        .find('a:contains("Edit")')
+        .click()
+        .then(() => {
+          cy.location('pathname').should('contain', '/cartEntry/entityKey/');
+        });
+    });
+  });
+}
+
+/**
  * Clicks on the 'Display Configuration' link in cart/order or quote for a certain item.
  *
  * @param {number} cartItemIndex - Index of cart item

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart.ts
@@ -24,23 +24,6 @@ export function clickOnEditConfigurationLink(cartItemIndex: number): void {
 }
 
 /**
- * Clicks on the 'Edit Configuration' link in add-to-cart dialog.
- *
- */
-export function clickOnEditConfigurationLinkInAddToCartDialog(): void {
-  cy.get('cx-added-to-cart-dialog').within(() => {
-    cy.get('cx-configurator-cart-entry-info').within(() => {
-      cy.get('cx-configure-cart-entry')
-        .find('a:contains("Edit")')
-        .click()
-        .then(() => {
-          cy.location('pathname').should('contain', '/cartEntry/entityKey/');
-        });
-    });
-  });
-}
-
-/**
  * Clicks on the 'Display Configuration' link in cart/order or quote for a certain item.
  *
  * @param {number} cartItemIndex - Index of cart item


### PR DESCRIPTION
If `read-only` is **undefined**, **null** or **false**, then `Edit Configuration` link should be displayed and one can navigate to the editable configuration.
Otherwise, `Display Configuration` link should be displayed and one can navigate to the red.only configuration.