### PR TITLE
fix: opf add-to-cart not displayed below product summary on b2b

### DIFF
--- a/integration-libs/opf/base/styles/components/_opf-add-to-cart.scss
+++ b/integration-libs/opf/base/styles/components/_opf-add-to-cart.scss
@@ -1,4 +1,7 @@
+@import '@spartacus/cart/base/styles/components/add-to-cart';
 %cx-opf-add-to-cart {
+  @extend %cx-add-to-cart;
+
   @include media-breakpoint-up(lg) {
     grid-column: 2;
     grid-row: 3;

--- a/integration-libs/opf/base/styles/components/_opf-add-to-cart.scss
+++ b/integration-libs/opf/base/styles/components/_opf-add-to-cart.scss
@@ -1,5 +1,6 @@
 %cx-opf-add-to-cart {
   @include media-breakpoint-up(lg) {
     padding: 20px;
+    display: contents;
   }
 }

--- a/integration-libs/opf/base/styles/components/_opf-add-to-cart.scss
+++ b/integration-libs/opf/base/styles/components/_opf-add-to-cart.scss
@@ -1,6 +1,8 @@
 %cx-opf-add-to-cart {
   @include media-breakpoint-up(lg) {
-    padding: 20px;
-    display: contents;
+    grid-column: 2;
+    grid-row: 3;
+    display: flex;
+    flex-direction: column;
   }
 }

--- a/integration-libs/opf/base/styles/components/_opf-cart-proceed-to-checkout.scss
+++ b/integration-libs/opf/base/styles/components/_opf-cart-proceed-to-checkout.scss
@@ -1,3 +1,9 @@
 %cx-opf-cart-proceed-to-checkout {
-  display: contents;
+  @include media-breakpoint-up(lg) {
+    display: flex;
+    flex-direction: column;
+  }
+  @include media-breakpoint-down(lg) {
+    order: 3;
+  }
 }

--- a/integration-libs/opf/base/styles/components/_opf-cart-proceed-to-checkout.scss
+++ b/integration-libs/opf/base/styles/components/_opf-cart-proceed-to-checkout.scss
@@ -1,9 +1,15 @@
+@import '@spartacus/cart/base/styles/components/cart-proceed-to-checkout';
 %cx-opf-cart-proceed-to-checkout {
-  @include media-breakpoint-up(lg) {
-    display: flex;
-    flex-direction: column;
+  @extend %cx-cart-proceed-to-checkout;
+
+  @include media-breakpoint-down(sm) {
+    max-width: 100%;
+    padding-inline-end: 0;
+    padding-inline-start: 0;
   }
-  @include media-breakpoint-down(lg) {
-    order: 3;
+
+  @include media-breakpoint-down(md) {
+    min-width: 100%;
+    order: 5;
   }
 }

--- a/integration-libs/opf/base/styles/components/_opf-cart-proceed-to-checkout.scss
+++ b/integration-libs/opf/base/styles/components/_opf-cart-proceed-to-checkout.scss
@@ -1,15 +1,3 @@
-@import '@spartacus/cart/base/styles/components/cart-proceed-to-checkout';
 %cx-opf-cart-proceed-to-checkout {
-  @extend %cx-cart-proceed-to-checkout;
-
-  @include media-breakpoint-down(sm) {
-    max-width: 100%;
-    padding-inline-end: 0;
-    padding-inline-start: 0;
-  }
-
-  @include media-breakpoint-down(md) {
-    min-width: 100%;
-    order: 5;
-  }
+  display: contents;
 }


### PR DESCRIPTION
Issue happens only on b2b due to presence of 'cx-bulk-pricing-table' tag, Fix also tested successfully with b2c, no side effect.
cx-opf-add-to-cart is a tag wrapper, we want it to have no impact on styling, thus adding _display: contents_;
![image](https://github.com/SAP/spartacus/assets/30024415/ee7d518f-3276-47ab-8690-67cf64bcbe1d)
