### PR TITLE
feat: CXSPA-6765 Add LOCATION_INITIALIZED_MULTI to public API

### DIFF
--- a/projects/core/src/routing/index.ts
+++ b/projects/core/src/routing/index.ts
@@ -8,6 +8,7 @@ export * from './configurable-routes/index';
 export * from './external-routes/index';
 export * from './facade/routing-params.service';
 export * from './facade/routing.service';
+export * from './location-initialized-multi/location-initialized-multi';
 export * from './models/cms-route';
 export * from './models/page-context.model';
 export * from './protected-routes/index';

--- a/projects/core/src/routing/location-initialized-multi/location-initialized-multi.ts
+++ b/projects/core/src/routing/location-initialized-multi/location-initialized-multi.ts
@@ -8,6 +8,9 @@ import { InjectionToken } from '@angular/core';
 
 /**
  * Wrapper InjectionToken for LOCATION_INITIALIZED token to allow multiple initializers.
+ *
+ * CAUTION: Don't use Router and don't perform any Router navigation in its implementations.
+ * Only access the class `Location` from '@angular/common' if access to URL is needed.
  */
 export const LOCATION_INITIALIZED_MULTI = new InjectionToken<
   (() => Promise<any>)[]


### PR DESCRIPTION
this PR intoduces LOCATION_INITIALIZED_MULTI injection token to public API.

QA steps:

- go to `app.module.ts`
- verify whether the token can be imported from `@spartacus/core` module

closes [CXSPA-6765](https://jira.tools.sap/browse/CXSPA-6765)