### PR TITLE
fix: (CXSPA-1109) - Styles of links for cart table items

### DIFF
--- a/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.ts
@@ -15,6 +15,7 @@ import {
 } from '@spartacus/cart/base/root';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { CartItemContextSource } from './model/cart-item-context-source.model';
+import { useFeatureStyles } from '@spartacus/core';
 
 @Component({
   selector: 'cx-cart-item',
@@ -42,7 +43,9 @@ export class CartItemComponent implements OnChanges {
   iconTypes = ICON_TYPE;
   readonly CartOutlets = CartOutlets;
 
-  constructor(protected cartItemContextSource: CartItemContextSource) {}
+  constructor(protected cartItemContextSource: CartItemContextSource) {
+    useFeatureStyles('a11yCartItemsLinksStyles');
+  }
 
   ngOnChanges(changes?: SimpleChanges) {
     if (changes?.compact) {

--- a/feature-libs/cart/base/styles/components/_cart-item-list.scss
+++ b/feature-libs/cart/base/styles/components/_cart-item-list.scss
@@ -65,6 +65,12 @@
     text-decoration: none;
     color: var(--cx-color-text);
     font-weight: var(--cx-font-weight-bold);
+
+    // TODO: (CXSPA-6903) - Remove feature flag next major release
+    @include forFeature('a11yCartItemsLinksStyles') {
+      text-decoration: underline;
+      color: var(--cx-color-primary);
+    }
   }
 
   .cx-total {

--- a/feature-libs/cart/quick-order/components/quick-order/table/item/quick-order-item.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/table/item/quick-order-item.component.ts
@@ -15,6 +15,7 @@ import {
 import { UntypedFormControl } from '@angular/forms';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import { QuickOrderFacade } from '@spartacus/cart/quick-order/root';
+import { useFeatureStyles } from '@spartacus/core';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -48,7 +49,9 @@ export class QuickOrderItemComponent implements OnInit, OnDestroy {
   constructor(
     protected cd: ChangeDetectorRef,
     protected quickOrderService: QuickOrderFacade
-  ) {}
+  ) {
+    useFeatureStyles('a11yCartItemsLinksStyles');
+  }
 
   ngOnInit(): void {
     this.subscription.add(

--- a/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.ts
+++ b/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.ts
@@ -14,7 +14,7 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import { OrderEntry } from '@spartacus/cart/base/root';
-import { Product } from '@spartacus/core';
+import { Product, useFeatureStyles } from '@spartacus/core';
 import {
   ProductListItemContext,
   ProductListItemContextSource,
@@ -42,7 +42,9 @@ export class WishListItemComponent implements OnChanges {
 
   constructor(
     protected productListItemContextSource: ProductListItemContextSource
-  ) {}
+  ) {
+    useFeatureStyles('a11yCartItemsLinksStyles');
+  }
 
   ngOnChanges(changes?: SimpleChanges): void {
     if (changes?.cartEntry) {

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -152,6 +152,13 @@ export interface FeatureTogglesInterface {
    * Corrects heading order inside 'OrderSummaryComponent' template.
    */
   a11yCartSummaryHeadingOrder?: boolean;
+
+  /**
+   * When set to `true`, product titles in `CartItemComponent`, `QuickOrderItemComponent`, `WishListItemComponent`
+   * adopt a more link-like style, appearing blue with an underline. This enhances visual cues for clickable elements,
+   * providing a more intuitive user experience.
+   */
+  a11yCartItemsLinksStyles?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -181,4 +188,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yListOversizedFocus: false,
   a11yStoreFinderOverflow: false,
   a11yCartSummaryHeadingOrder: false,
+  a11yCartItemsLinksStyles: false,
 };

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -287,6 +287,7 @@ if (environment.requestedDeliveryDate) {
         a11yListOversizedFocus: true,
         a11yStoreFinderOverflow: true,
         a11yCartSummaryHeadingOrder: true,
+        a11yCartItemsLinksStyles: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
The same styles are shared between quick order, cart and wishlist tables therefore I've fixed this issue for all of those occurrences:
<img width="1169" alt="image" src="https://github.com/SAP/spartacus/assets/163305268/45a29d40-ab07-404c-971f-0a30493baaf4">

<img width="1119" alt="image" src="https://github.com/SAP/spartacus/assets/163305268/5587cb53-b583-458f-a206-ddc006ac5b6a">
<img width="1158" alt="image" src="https://github.com/SAP/spartacus/assets/163305268/9c39c5b7-5978-410d-8e6d-f539a89e3d35">
