### PR TITLE
chore: fix test of schematics in individual libraries, when running it in isolation from the core schematics build/test

### DIFF
--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -11,9 +11,9 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "build": "npm run clean && npm run copy-feature-toggles && npm --prefix ../../ run generate:deps && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
-    "clean": "../../node_modules/.bin/rimraf --glob \"index.js*\" \"index.d.ts\" \"src/**/*.js\" \"src/**/*.js.map\" \"src/**/*.d.ts\"",
-    "test": "npm run clean && npm run copy-feature-toggles && ../../node_modules/.bin/jest --config ./jest.schematics.config.js",
+    "build": "npm run clean && npm --prefix ../../ run generate:deps && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
+    "clean": "../../node_modules/.bin/rimraf --glob \"index.js*\" \"index.d.ts\" \"src/**/*.js\" \"src/**/*.js.map\" \"src/**/*.d.ts\" && npm run copy-feature-toggles",
+    "test": "npm run clean && ../../node_modules/.bin/jest --config ./jest.schematics.config.js",
     "copy-feature-toggles": "node copy-feature-toggles"
   },
   "dependencies": {


### PR DESCRIPTION
Previously we're run the script "copy-feature-toggles" only as a pre-build (and a pre-test) step only of the core schematics. 

Now we run script "copy-feature-toggles" inside the script "clean" of the core schematics.

Why: All individual libraries' "test:schematics" commands run the core's schematics "clean" script before executing their tests. So now we're sure that the script "copy-feature-toggles" will be run before "test:schematics" of any individual library. Such an individual run of tests might happen due to `Nx` choosing to build only the selective changed libraries.

**QA steps:**
Verify you can run tests of schematics of an individual lib, e.g. QuotesL
1. checkout to this branch locally
2. make sure you DO NOT HAVE a file `projects/schematics/src/feature-toggles.copied-from-core-lib.ts` - otherwise please delete it.
3. `cd feature-libs/quote`
4. `npm run test:schematics`
5. Verify the tests passed. Especially no such error occured like there: https://github.com/SAP/spartacus/actions/runs/8815031194/job/24196138821?pr=18768