### PR TITLE
fix: tag event shouldn't trigger if consent is unavailable (CXSPA-6932)

### DIFF
--- a/integration-libs/cds/src/profiletag/services/profile-tag-lifecycle.service.ts
+++ b/integration-libs/cds/src/profiletag/services/profile-tag-lifecycle.service.ts
@@ -6,7 +6,7 @@
 
 import { Injectable } from '@angular/core';
 import { ActionsSubject } from '@ngrx/store';
-import { AuthActions, ConsentService, isNotUndefined } from '@spartacus/core';
+import { AuthActions, ConsentService } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { CdsConfig } from '../../config/cds-config';
@@ -26,9 +26,12 @@ export class ProfileTagLifecycleService {
     return this.consentService
       .getConsent(this.config.cds?.consentTemplateId ?? '')
       .pipe(
-        filter(isNotUndefined),
         map((profileConsent) => {
-          return this.consentService.isConsentGiven(profileConsent);
+          if (profileConsent) {
+            return this.consentService.isConsentGiven(profileConsent);
+          } else {
+            return false;
+          }
         }),
         map((granted) => {
           return new ConsentChangedPushEvent(granted);

--- a/projects/core/src/anonymous-consents/store/effects/anonymous-consents.effect.ts
+++ b/projects/core/src/anonymous-consents/store/effects/anonymous-consents.effect.ts
@@ -15,6 +15,7 @@ import {
   map,
   mergeMap,
   switchMap,
+  take,
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
@@ -205,6 +206,7 @@ export class AnonymousConsentsEffects {
       ),
       concatMap(() =>
         this.userConsentService.getConsentsResultSuccess().pipe(
+          take(1),
           withLatestFrom(
             this.userIdService.getUserId(),
             this.userConsentService.getConsents(),


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-6932 & https://jira.tools.sap/browse/CXSPA-6933
