### PR TITLE
test: Failing scroll-position-restoration spec

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/scrolling/scroll-position-restoration.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/scrolling/scroll-position-restoration.e2e.cy.ts
@@ -6,28 +6,47 @@
 
 context('scroll Position Restoration', () => {
   it('should restore scroll position', () => {
+    cy.intercept({
+      method: 'GET',
+      pathname: `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
+        'BASE_SITE'
+      )}/cms/pages`,
+      query: {
+        pageType: 'ProductPage',
+      },
+    }).as('getPage');
+
     cy.visit('/');
 
     cy.log('Go to category page');
     cy.get('cx-category-navigation a').eq(0).click();
 
     cy.get('cx-product-list-item').should('exist');
-    cy.get('cx-product-list-item').eq(3).scrollIntoView();
-    cy.get('cx-product-list-item .cx-product-name').eq(3).click();
+    cy.get('cx-product-list-item .cx-product-name')
+      .eq(3)
+      .then(($productItem) => {
+        const productName = $productItem.text();
+        cy.wrap($productItem).scrollIntoView().click();
 
-    cy.log('Go to product details page');
-    cy.get('.ProductDetailsPageTemplate').should('exist');
-    cy.window().scrollTo('bottom');
+        cy.log('Go to product details page');
+        verifyProductPageLoaded(productName);
+        cy.window().scrollTo('bottom');
 
-    cy.log('Go back to product list');
-    cy.go(-1);
-    cy.window().its('scrollY').should('be.greaterThan', 0);
+        cy.log('Go back to product list');
+        cy.go(-1);
+        cy.window().its('scrollY').should('be.greaterThan', 0);
 
-    cy.log('Go forward to product details');
-    cy.go(1);
-    cy.get('.ProductDetailsPageTemplate').should('exist');
-    cy.window().then(($window) => {
-      expect($window.scrollY).to.be.greaterThan(0);
-    });
+        cy.log('Go forward to product details');
+        cy.go(1);
+        verifyProductPageLoaded(productName);
+        cy.window().then(($window) => {
+          expect($window.scrollY).to.be.greaterThan(0);
+        });
+      });
   });
 });
+
+const verifyProductPageLoaded = (productName: string) => {
+  cy.wait('@getPage').its('response.statusCode').should('eq', 200);
+  cy.get(`cx-breadcrumb h1`).should('contain', productName);
+};


### PR DESCRIPTION
In some cases Cypress was trying to scroll to the bottom of the page before it was fully rendered. Additional condition for determining if the content appeared on the page should make it more stable. After these changes I've executed this test 50 consecutive times and no error happened