### PR TITLE
feat: Support date based UITypes with additional value [CXSPA-6640]

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.spec.ts
@@ -435,6 +435,13 @@ describe('ConfiguratorAttributeSingleSelectionBaseComponent', () => {
       component.attribute.validationType = Configurator.ValidationType.NUMERIC;
       expect(component.isAdditionalValueNumeric).toBe(true);
     });
+
+    it('should return false for UI type Radio button additional input and validation type sap date', () => {
+      component.attribute.uiType =
+        Configurator.UiType.DROPDOWN_ADDITIONAL_INPUT;
+      component.attribute.validationType = Configurator.ValidationType.SAP_DATE;
+      expect(component.isAdditionalValueNumeric).toBe(false);
+    });
   });
 
   describe('IsAdditionalValueAlphaNumeric', () => {
@@ -449,6 +456,13 @@ describe('ConfiguratorAttributeSingleSelectionBaseComponent', () => {
       component.attribute.uiType =
         Configurator.UiType.DROPDOWN_ADDITIONAL_INPUT;
       component.attribute.validationType = Configurator.ValidationType.NONE;
+      expect(component.isAdditionalValueAlphaNumeric).toBe(true);
+    });
+
+    it('should return true for UI type Radio button additional input and validation type sap date', () => {
+      component.attribute.uiType =
+        Configurator.UiType.DROPDOWN_ADDITIONAL_INPUT;
+      component.attribute.validationType = Configurator.ValidationType.SAP_DATE;
       expect(component.isAdditionalValueAlphaNumeric).toBe(true);
     });
   });

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.ts
@@ -215,7 +215,7 @@ export abstract class ConfiguratorAttributeSingleSelectionBaseComponent extends 
   get isAdditionalValueAlphaNumeric(): boolean {
     return (
       this.isWithAdditionalValues(this.attribute) &&
-      this.attribute.validationType === Configurator.ValidationType.NONE
+      this.attribute.validationType !== Configurator.ValidationType.NUMERIC
     );
   }
 

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
@@ -422,5 +422,26 @@ describe('ConfiguratorAttributeInputFieldComponent', () => {
       component.attribute.uiType = Configurator.UiType.SAP_DATE;
       expect(component.inputType).toBe('date');
     });
+
+    it('should return "date" for UI type DDLB with additional value and validation type sap date', () => {
+      component.attribute.uiType =
+        Configurator.UiType.DROPDOWN_ADDITIONAL_INPUT;
+      component.attribute.validationType = Configurator.ValidationType.SAP_DATE;
+      expect(component.inputType).toBe('date');
+    });
+
+    it('should return "date" for UI type RB with additional value and validation type sap date', () => {
+      component.attribute.uiType =
+        Configurator.UiType.RADIOBUTTON_ADDITIONAL_INPUT;
+      component.attribute.validationType = Configurator.ValidationType.SAP_DATE;
+      expect(component.inputType).toBe('date');
+    });
+
+    it('should return "text" for UI type DDLB with additional value and validation type NONE', () => {
+      component.attribute.uiType =
+        Configurator.UiType.DROPDOWN_ADDITIONAL_INPUT;
+      component.attribute.validationType = Configurator.ValidationType.NONE;
+      expect(component.inputType).toBe('text');
+    });
   });
 });

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
@@ -123,9 +123,15 @@ export class ConfiguratorAttributeInputFieldComponent
    * Returns the type for the input field. Depending on the UI type, that is text or date.
    */
   get inputType(): string {
-    return this.attribute.uiType === Configurator.UiType.SAP_DATE
-      ? 'date'
-      : 'text';
+    return this.isDateBased(this.attribute) ? 'date' : 'text';
+  }
+
+  protected isDateBased(attribute: Configurator.Attribute) {
+    return (
+      attribute.uiType === Configurator.UiType.SAP_DATE ||
+      (this.isWithAdditionalValues(attribute) &&
+        attribute.validationType === Configurator.ValidationType.SAP_DATE)
+    );
   }
 
   protected compileShowRequiredErrorMessage(): void {

--- a/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
+++ b/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
@@ -274,6 +274,7 @@ export namespace Configurator {
   export enum ValidationType {
     NONE = 'NONE',
     NUMERIC = 'NUMERIC',
+    SAP_DATE = 'SAP_DATE',
   }
   export enum OverviewFilter {
     VISIBLE = 'PRIMARY',


### PR DESCRIPTION
* make sure date picker is rendered as input for date based types with additional values.

closes [CXSPA-6640](https://jira.tools.sap/browse/CXSPA-6640)