### PR TITLE
fix: (CXSPA-950) - Close product image button focus is visible

### DIFF
--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-dialog/product-image-zoom-dialog.component.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-dialog/product-image-zoom-dialog.component.ts
@@ -11,6 +11,7 @@ import {
   HostListener,
   Input,
 } from '@angular/core';
+import { useFeatureStyles } from '@spartacus/core';
 import {
   FocusConfig,
   ICON_TYPE,
@@ -45,7 +46,9 @@ export class ProductImageZoomDialogComponent {
   constructor(
     protected launchDialogService: LaunchDialogService,
     protected el: ElementRef
-  ) {}
+  ) {
+    useFeatureStyles('a11yCloseProductImageBtnFocus');
+  }
 
   close(reason = ''): void {
     this.launchDialogService.closeDialog(reason);

--- a/feature-libs/product/image-zoom/styles/_product-image-zoom-dialog.scss
+++ b/feature-libs/product/image-zoom/styles/_product-image-zoom-dialog.scss
@@ -38,6 +38,13 @@ cx-product-image-zoom-dialog {
         @media only screen and (max-width: 900px) and (orientation: landscape) {
           padding: 1rem;
         }
+
+        // TODO: (CXSPA-7212) - Remove feature flag next major release
+        @include forFeature('a11yCloseProductImageBtnFocus') {
+          .close {
+            outline-offset: -4px;
+          }
+        }
       }
       .cx-dialog-body {
         @extend .modal-body;

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -213,6 +213,12 @@ export interface FeatureTogglesInterface {
    * In `LoginComponent` the outline of "My Account" link when focused will not cover the user name
    */
   a11yMyAccountLinkOutline?: boolean;
+
+  /**
+   * When enabled focus outline on the close button inside `ProductImageZoomDialogComponent`
+   * will be fully visible
+   */
+  a11yCloseProductImageBtnFocus?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -251,4 +257,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   cartQuickOrderRemoveListeningToFailEvent: false,
   a11yTruncatedTextForResponsiveView: false,
   a11yMyAccountLinkOutline: false,
+  a11yCloseProductImageBtnFocus: false,
 };

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -300,6 +300,7 @@ if (environment.requestedDeliveryDate) {
         cartQuickOrderRemoveListeningToFailEvent: true,
         a11yTruncatedTextForResponsiveView: true,
         a11yMyAccountLinkOutline: true,
+        a11yCloseProductImageBtnFocus: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
<img width="454" alt="image" src="https://github.com/SAP/spartacus/assets/163305268/ec9e0515-04cc-4133-95cb-166927722544">
