### PR TITLE
refactor(opf): use inject for DI instead of constructor

### DIFF
--- a/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.component.ts
+++ b/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.component.ts
@@ -11,6 +11,7 @@ import {
   ElementRef,
   HostListener,
   OnInit,
+  inject,
 } from '@angular/core';
 import { ErrorDialogOptions } from '@spartacus/opf/base/root';
 import { FocusConfig, LaunchDialogService } from '@spartacus/storefront';
@@ -24,6 +25,11 @@ import { OpfErrorModalService } from './opf-error-modal.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpfErrorModalComponent implements OnInit {
+  protected launchDialogService = inject(LaunchDialogService);
+  protected el = inject(ElementRef);
+  protected cd = inject(ChangeDetectorRef);
+  protected opfErrorModalService = inject(OpfErrorModalService);
+
   focusConfig: FocusConfig = {
     trap: true,
     block: true,
@@ -40,12 +46,7 @@ export class OpfErrorModalComponent implements OnInit {
     }
   }
 
-  constructor(
-    protected launchDialogService: LaunchDialogService,
-    protected el: ElementRef,
-    protected cd: ChangeDetectorRef,
-    protected opfErrorModalService: OpfErrorModalService
-  ) {
+  constructor() {
     // Mechanism needed to trigger the cpnt life cycle hooks.
     timer(1).subscribe({
       complete: () => {

--- a/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.service.ts
+++ b/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { TranslationService } from '@spartacus/core';
 import {
   ErrorDialogOptions,
@@ -17,7 +17,7 @@ import { map, switchMap } from 'rxjs/operators';
   providedIn: 'root',
 })
 export class OpfErrorModalService {
-  constructor(protected translationService: TranslationService) {}
+  protected translationService = inject(TranslationService);
 
   getMessageAndConfirmTranslations(dialogOptions: ErrorDialogOptions) {
     return combineLatest([

--- a/integration-libs/opf/base/core/connectors/opf-order.connector.ts
+++ b/integration-libs/opf/base/core/connectors/opf-order.connector.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Order } from '@spartacus/order/root';
 import { Observable } from 'rxjs';
 import { OpfOrderAdapter } from './opf-order.adapter';
 
 @Injectable()
 export class OpfOrderConnector {
-  constructor(protected adapter: OpfOrderAdapter) {}
+  protected adapter = inject(OpfOrderAdapter);
 
   public placeOpfOrder(
     userId: string,

--- a/integration-libs/opf/base/core/connectors/opf-payment.connector.ts
+++ b/integration-libs/opf/base/core/connectors/opf-payment.connector.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   ActiveConfiguration,
   AfterRedirectScriptResponse,
@@ -25,7 +25,7 @@ import { OpfPaymentAdapter } from './opf-payment.adapter';
 
 @Injectable()
 export class OpfPaymentConnector {
-  constructor(protected adapter: OpfPaymentAdapter) {}
+  protected adapter = inject(OpfPaymentAdapter);
 
   public verifyPayment(
     paymentSessionId: string,

--- a/integration-libs/opf/base/core/connectors/otp.connector.ts
+++ b/integration-libs/opf/base/core/connectors/otp.connector.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OtpAdapter } from './otp.adapter';
 
 @Injectable()
 export class OtpConnector {
-  constructor(protected adapter: OtpAdapter) {}
+  protected adapter = inject(OtpAdapter);
 
   public generateOtpKey(
     userId: string,

--- a/integration-libs/opf/base/core/facade/opf-global-functions.service.spec.ts
+++ b/integration-libs/opf/base/core/facade/opf-global-functions.service.spec.ts
@@ -12,6 +12,7 @@ import {
   ElementRef,
   InjectionToken,
   ViewContainerRef,
+  inject,
 } from '@angular/core';
 import { LAUNCH_CALLER, LaunchDialogService } from '@spartacus/storefront';
 
@@ -27,7 +28,7 @@ export const WINDOW = new InjectionToken<Window>('window');
   template: '',
 })
 class TestContainerComponent {
-  constructor(public vcr: ViewContainerRef) {}
+  public vcr = inject(ViewContainerRef);
 }
 class MockLaunchDialogService implements Partial<LaunchDialogService> {
   closeDialog(_reason: any) {}

--- a/integration-libs/opf/base/core/facade/opf-order.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-order.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {
   Command,
@@ -17,12 +17,19 @@ import {
 import { OpfOrderFacade } from '@spartacus/opf/base/root';
 import { Order, OrderFacade, OrderPlacedEvent } from '@spartacus/order/root';
 
-import { combineLatest, Observable } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
 import { map, switchMap, take, tap } from 'rxjs/operators';
 import { OpfOrderConnector } from '../connectors/opf-order.connector';
 
 @Injectable()
 export class OpfOrderService implements OpfOrderFacade {
+  protected activeCartFacade = inject(ActiveCartFacade);
+  protected orderFacade = inject(OrderFacade);
+  protected userIdService = inject(UserIdService);
+  protected commandService = inject(CommandService);
+  protected opfOrderConnector = inject(OpfOrderConnector);
+  protected eventService = inject(EventService);
+
   protected placeOpfOrderCommand: Command<boolean, Order> =
     this.commandService.create<boolean, Order>(
       (payload) =>
@@ -52,15 +59,6 @@ export class OpfOrderService implements OpfOrderFacade {
         strategy: CommandStrategy.CancelPrevious,
       }
     );
-
-  constructor(
-    protected activeCartFacade: ActiveCartFacade,
-    protected orderFacade: OrderFacade,
-    protected userIdService: UserIdService,
-    protected commandService: CommandService,
-    protected opfOrderConnector: OpfOrderConnector,
-    protected eventService: EventService
-  ) {}
 
   /**
    * Performs the necessary checkout preconditions.

--- a/integration-libs/opf/base/core/facade/opf-otp.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-otp.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Command, CommandService, QueryService } from '@spartacus/core';
 import { OpfOtpFacade } from '@spartacus/opf/base/root';
 import { Observable } from 'rxjs';
@@ -12,6 +12,10 @@ import { OtpConnector } from '../connectors/otp.connector';
 
 @Injectable()
 export class OpfOtpService implements OpfOtpFacade {
+  protected queryService = inject(QueryService);
+  protected commandService = inject(CommandService);
+  protected otpConnector = inject(OtpConnector);
+
   protected generateOtpKeyCommand: Command<
     {
       userId: string;
@@ -21,12 +25,6 @@ export class OpfOtpService implements OpfOtpFacade {
   > = this.commandService.create(({ userId, cartId }) =>
     this.otpConnector.generateOtpKey(userId, cartId)
   );
-
-  constructor(
-    protected queryService: QueryService,
-    protected commandService: CommandService,
-    protected otpConnector: OtpConnector
-  ) {}
 
   generateOtpKey(
     userId: string,

--- a/integration-libs/opf/base/core/facade/opf-payment.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-payment.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   Command,
   CommandService,
@@ -32,6 +32,14 @@ import { OpfPaymentHostedFieldsService } from '../services/opf-payment-hosted-fi
 
 @Injectable()
 export class OpfPaymentService implements OpfPaymentFacade {
+  protected queryService = inject(QueryService);
+  protected commandService = inject(CommandService);
+  protected opfPaymentConnector = inject(OpfPaymentConnector);
+  protected opfPaymentHostedFieldsService = inject(
+    OpfPaymentHostedFieldsService
+  );
+  protected opfPaymentApplePayService = inject(OpfPaymentApplePayService);
+
   protected verifyPaymentCommand: Command<
     {
       paymentSessionId: string;
@@ -102,14 +110,6 @@ export class OpfPaymentService implements OpfPaymentFacade {
     this.queryService.create<ActiveConfiguration[]>(() =>
       this.opfPaymentConnector.getActiveConfigurations()
     );
-
-  constructor(
-    protected queryService: QueryService,
-    protected commandService: CommandService,
-    protected opfPaymentConnector: OpfPaymentConnector,
-    protected opfPaymentHostedFieldsService: OpfPaymentHostedFieldsService,
-    protected opfPaymentApplePayService: OpfPaymentApplePayService
-  ) {}
 
   verifyPayment(
     paymentSessionId: string,

--- a/integration-libs/opf/base/core/services/opf-endpoints.service.ts
+++ b/integration-libs/opf/base/core/services/opf-endpoints.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, inject } from '@angular/core';
+import { Injectable } from '@angular/core';
 import {
   BaseSiteService,
   Config,
@@ -16,11 +16,12 @@ import {
   providedIn: 'root',
 })
 export class OpfEndpointsService {
-  private config = inject(Config);
-  private baseSiteService = inject(BaseSiteService);
   private _activeBaseSite: string;
 
-  constructor() {
+  constructor(
+    private config: Config,
+    private baseSiteService: BaseSiteService
+  ) {
     if (this.baseSiteService) {
       this.baseSiteService
         .getActive()

--- a/integration-libs/opf/base/core/services/opf-endpoints.service.ts
+++ b/integration-libs/opf/base/core/services/opf-endpoints.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   BaseSiteService,
   Config,
@@ -16,12 +16,11 @@ import {
   providedIn: 'root',
 })
 export class OpfEndpointsService {
+  private config = inject(Config);
+  private baseSiteService = inject(BaseSiteService);
   private _activeBaseSite: string;
 
-  constructor(
-    private config: Config,
-    private baseSiteService: BaseSiteService
-  ) {
+  constructor() {
     if (this.baseSiteService) {
       this.baseSiteService
         .getActive()

--- a/integration-libs/opf/base/core/services/opf-payment-error-handler.service.ts
+++ b/integration-libs/opf/base/core/services/opf-payment-error-handler.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   GlobalMessageService,
   GlobalMessageType,
@@ -19,10 +19,8 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class OpfPaymentErrorHandlerService {
-  constructor(
-    protected globalMessageService: GlobalMessageService,
-    protected routingService: RoutingService
-  ) {}
+  protected globalMessageService = inject(GlobalMessageService);
+  protected routingService = inject(RoutingService);
 
   protected displayError(error: OpfPaymentError | undefined): void {
     this.globalMessageService.add(

--- a/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
+++ b/integration-libs/opf/base/core/services/opf-payment-hosted-fields.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {
   backOff,
@@ -52,17 +52,17 @@ import { getBrowserInfo } from '../utils/opf-payment-utils';
 
 @Injectable()
 export class OpfPaymentHostedFieldsService {
-  constructor(
-    protected opfPaymentConnector: OpfPaymentConnector,
-    protected winRef: WindowRef,
-    protected opfOtpFacade: OpfOtpFacade,
-    protected activeCartFacade: ActiveCartFacade,
-    protected userIdService: UserIdService,
-    protected routingService: RoutingService,
-    protected opfOrderFacade: OpfOrderFacade,
-    protected globalMessageService: GlobalMessageService,
-    protected opfPaymentErrorHandlerService: OpfPaymentErrorHandlerService
-  ) {}
+  protected opfPaymentConnector = inject(OpfPaymentConnector);
+  protected winRef = inject(WindowRef);
+  protected opfOtpFacade = inject(OpfOtpFacade);
+  protected activeCartFacade = inject(ActiveCartFacade);
+  protected userIdService = inject(UserIdService);
+  protected routingService = inject(RoutingService);
+  protected opfOrderFacade = inject(OpfOrderFacade);
+  protected globalMessageService = inject(GlobalMessageService);
+  protected opfPaymentErrorHandlerService = inject(
+    OpfPaymentErrorHandlerService
+  );
 
   submitPayment(submitInput: SubmitInput): Observable<boolean> {
     const {

--- a/integration-libs/opf/base/occ/adapters/occ-opf-order.adapter.ts
+++ b/integration-libs/opf/base/occ/adapters/occ-opf-order.adapter.ts
@@ -29,13 +29,10 @@ import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class OccOpfOrderAdapter implements OpfOrderAdapter {
+  protected http = inject(HttpClient);
+  protected occEndpoints = inject(OccEndpointsService);
+  protected converter = inject(ConverterService);
   protected logger = inject(LoggerService);
-
-  constructor(
-    protected http: HttpClient,
-    protected occEndpoints: OccEndpointsService,
-    protected converter: ConverterService
-  ) {}
 
   public placeOpfOrder(
     userId: string,

--- a/integration-libs/opf/base/occ/adapters/occ-opf.adapter.ts
+++ b/integration-libs/opf/base/occ/adapters/occ-opf.adapter.ts
@@ -47,14 +47,11 @@ import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class OccOpfPaymentAdapter implements OpfPaymentAdapter {
+  protected http = inject(HttpClient);
+  protected converter = inject(ConverterService);
+  protected opfEndpointsService = inject(OpfEndpointsService);
+  protected config = inject(OpfConfig);
   protected logger = inject(LoggerService);
-
-  constructor(
-    protected http: HttpClient,
-    protected converter: ConverterService,
-    protected opfEndpointsService: OpfEndpointsService,
-    protected config: OpfConfig
-  ) {}
 
   protected headerWithNoLanguage: { [name: string]: string } = {
     accept: 'application/json',

--- a/integration-libs/opf/base/occ/adapters/occ-otp.adapter.ts
+++ b/integration-libs/opf/base/occ/adapters/occ-otp.adapter.ts
@@ -22,13 +22,10 @@ import { Observable, catchError, throwError } from 'rxjs';
 
 @Injectable()
 export class OccOtpAdapter implements OtpAdapter {
+  protected http = inject(HttpClient);
+  protected occEndpointsService = inject(OccEndpointsService);
+  protected converterService = inject(ConverterService);
   protected logger = inject(LoggerService);
-
-  constructor(
-    protected http: HttpClient,
-    protected occEndpointsService: OccEndpointsService,
-    protected converterService: ConverterService
-  ) {}
 
   generateOtpKey(
     userId: string,

--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.component.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.component.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Component, OnDestroy, OnInit, ViewContainerRef } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewContainerRef,
+  inject,
+} from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorModel } from '@spartacus/core';
 
@@ -19,14 +25,12 @@ import { OpfPaymentVerificationService } from './opf-payment-verification.servic
   templateUrl: './opf-payment-verification.component.html',
 })
 export class OpfPaymentVerificationComponent implements OnInit, OnDestroy {
+  protected route = inject(ActivatedRoute);
+  protected paymentService = inject(OpfPaymentVerificationService);
+  protected vcr = inject(ViewContainerRef);
+
   protected subscription?: Subscription;
   protected isHostedFieldPattern = false;
-
-  constructor(
-    protected route: ActivatedRoute,
-    protected paymentService: OpfPaymentVerificationService,
-    protected vcr: ViewContainerRef
-  ) {}
 
   ngOnInit(): void {
     this.paymentService.checkIfProcessingCartIdExist();

--- a/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.ts
+++ b/integration-libs/opf/base/root/components/opf-payment-verification/opf-payment-verification.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, ViewContainerRef } from '@angular/core';
+import { Injectable, ViewContainerRef, inject } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import {
   GlobalMessageService,
@@ -40,15 +40,13 @@ import { OpfResourceLoaderService } from '../../services/opf-resource-loader.ser
   providedIn: 'root',
 })
 export class OpfPaymentVerificationService {
-  constructor(
-    protected opfOrderFacade: OpfOrderFacade,
-    protected routingService: RoutingService,
-    protected globalMessageService: GlobalMessageService,
-    protected opfPaymentService: OpfPaymentFacade,
-    protected opfService: OpfService,
-    protected opfResourceLoaderService: OpfResourceLoaderService,
-    protected globalFunctionsService: OpfGlobalFunctionsFacade
-  ) {}
+  protected opfOrderFacade = inject(OpfOrderFacade);
+  protected routingService = inject(RoutingService);
+  protected globalMessageService = inject(GlobalMessageService);
+  protected opfPaymentService = inject(OpfPaymentFacade);
+  protected opfService = inject(OpfService);
+  protected opfResourceLoaderService = inject(OpfResourceLoaderService);
+  protected globalFunctionsService = inject(OpfGlobalFunctionsFacade);
 
   defaultError: HttpErrorModel = {
     statusText: 'Payment Verification Error',

--- a/integration-libs/opf/base/root/events/opf-event.listener.ts
+++ b/integration-libs/opf/base/root/events/opf-event.listener.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { CreateCartEvent } from '@spartacus/cart/base/root';
 import { EventService, LoginEvent } from '@spartacus/core';
 import { OrderPlacedEvent } from '@spartacus/order/root';
@@ -15,12 +15,12 @@ import { OpfService } from '../services';
   providedIn: 'root',
 })
 export class OpfEventListenerService implements OnDestroy {
+  protected eventService = inject(EventService);
+  protected opfService = inject(OpfService);
+
   protected subscriptions = new Subscription();
 
-  constructor(
-    protected eventService: EventService,
-    protected opfService: OpfService
-  ) {
+  constructor() {
     this.onOpfPaymentMetadataResetConditionsMet();
   }
 

--- a/integration-libs/opf/base/root/services/opf-global-message.service.ts
+++ b/integration-libs/opf/base/root/services/opf-global-message.service.ts
@@ -5,11 +5,9 @@
  */
 
 import { Injectable } from '@angular/core';
-import { Store } from '@ngrx/store';
 import {
   GlobalMessageService,
   GlobalMessageType,
-  StateWithGlobalMessage,
   Translatable,
 } from '@spartacus/core';
 import { timer } from 'rxjs';
@@ -22,9 +20,6 @@ export class OpfGlobalMessageService extends GlobalMessageService {
   protected isGlobalMessageDisabled = false;
   protected disabledKeys: string[] = [];
   protected defaultTimeout = 2000;
-  constructor(protected store: Store<StateWithGlobalMessage>) {
-    super(store);
-  }
   /**
    * Add one message into store
    * @param text: string | Translatable

--- a/integration-libs/opf/base/root/services/opf-mini-cart-component.service.ts
+++ b/integration-libs/opf/base/root/services/opf-mini-cart-component.service.ts
@@ -6,13 +6,6 @@
 
 import { Injectable } from '@angular/core';
 import { MiniCartComponentService } from '@spartacus/cart/base/components/mini-cart';
-import { ActiveCartFacade } from '@spartacus/cart/base/root';
-import {
-  AuthService,
-  EventService,
-  SiteContextParamsService,
-  StatePersistenceService,
-} from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -27,21 +20,6 @@ export class OpfMiniCartComponentService extends MiniCartComponentService {
 
   blockUpdate(decision: boolean) {
     this.isUpdateBlocked = decision;
-  }
-  constructor(
-    protected activeCartFacade: ActiveCartFacade,
-    protected authService: AuthService,
-    protected statePersistenceService: StatePersistenceService,
-    protected siteContextParamsService: SiteContextParamsService,
-    protected eventService: EventService
-  ) {
-    super(
-      activeCartFacade,
-      authService,
-      statePersistenceService,
-      siteContextParamsService,
-      eventService
-    );
   }
 
   getQuantity(): Observable<number> {

--- a/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
+++ b/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DOCUMENT, isPlatformServer } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Injectable } from '@angular/core';
 import { ScriptLoader } from '@spartacus/core';
 
 import { throwError } from 'rxjs';
@@ -18,13 +18,6 @@ import {
   providedIn: 'root',
 })
 export class OpfResourceLoaderService extends ScriptLoader {
-  constructor(
-    @Inject(DOCUMENT) protected document: any,
-    @Inject(PLATFORM_ID) protected platformId: Object
-  ) {
-    super(document, platformId);
-  }
-
   protected readonly OPF_RESOURCE_ATTRIBUTE_KEY = 'data-opf-resource';
 
   protected loadedResources: OpfDynamicScriptResource[] = [];

--- a/integration-libs/opf/base/root/services/opf-state-persistence.service.ts
+++ b/integration-libs/opf/base/root/services/opf-state-persistence.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { StatePersistenceService } from '@spartacus/core';
 import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -24,13 +24,12 @@ export interface SyncedOpfState {
  */
 @Injectable({ providedIn: 'root' })
 export class OpfStatePersistenceService implements OnDestroy {
+  protected statePersistenceService = inject(StatePersistenceService);
+  protected opfPaymentMetadataStoreService = inject(
+    OpfPaymentMetadataStoreService
+  );
+
   protected subscription = new Subscription();
-
-  constructor(
-    protected statePersistenceService: StatePersistenceService,
-    protected opfPaymentMetadataStoreService: OpfPaymentMetadataStoreService
-  ) {}
-
   /**
    * Identifier used for storage key.
    */

--- a/integration-libs/opf/base/root/services/opf.service.ts
+++ b/integration-libs/opf/base/root/services/opf.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { Observable } from 'rxjs';
 import { OpfPaymentMetadata } from '../model';
@@ -14,9 +14,9 @@ import { OpfPaymentMetadataStoreService } from './opf-payment-metadata-store.ser
   providedIn: 'root',
 })
 export class OpfService {
-  constructor(
-    protected opfPaymentMetadataStoreService: OpfPaymentMetadataStoreService
-  ) {}
+  protected opfPaymentMetadataStoreService = inject(
+    OpfPaymentMetadataStoreService
+  );
 
   /**
    * Updates the state of the OPF metadata

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+} from '@angular/core';
 import { Address, Country } from '@spartacus/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
@@ -16,6 +21,8 @@ import { OpfCheckoutBillingAddressFormService } from './opf-checkout-billing-add
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpfCheckoutBillingAddressFormComponent implements OnInit {
+  protected service = inject(OpfCheckoutBillingAddressFormService);
+
   iconTypes = ICON_TYPE;
 
   billingAddress$ = this.service.billingAddress$;
@@ -26,8 +33,6 @@ export class OpfCheckoutBillingAddressFormComponent implements OnInit {
   isAddingBillingAddressInProgress = false;
 
   countries$: Observable<Country[]>;
-
-  constructor(protected service: OpfCheckoutBillingAddressFormService) {}
 
   ngOnInit() {
     this.countries$ = this.service.getCountries();

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ActiveCartFacade, Cart } from '@spartacus/cart/base/root';
 import {
   CheckoutBillingAddressFacade,
@@ -21,9 +21,9 @@ import {
 } from '@spartacus/core';
 import {
   BehaviorSubject,
-  combineLatest,
   EMPTY,
   Observable,
+  combineLatest,
   throwError,
 } from 'rxjs';
 import {
@@ -40,6 +40,16 @@ import { OpfCheckoutPaymentWrapperService } from '../opf-checkout-payment-wrappe
 
 @Injectable()
 export class OpfCheckoutBillingAddressFormService {
+  protected checkoutDeliveryAddressFacade = inject(
+    CheckoutDeliveryAddressFacade
+  );
+  protected checkoutBillingAddressFacade = inject(CheckoutBillingAddressFacade);
+  protected userPaymentService = inject(UserPaymentService);
+  protected checkoutPaymentService = inject(CheckoutPaymentFacade);
+  protected activeCartService = inject(ActiveCartFacade);
+  protected globalMessageService = inject(GlobalMessageService);
+  protected opfService = inject(OpfCheckoutPaymentWrapperService);
+
   protected readonly billingAddressSub = new BehaviorSubject<
     Address | undefined
   >(undefined);
@@ -50,16 +60,6 @@ export class OpfCheckoutBillingAddressFormService {
   billingAddress$ = this.billingAddressSub.asObservable();
   isLoadingAddress$ = this.isLoadingAddressSub.asObservable();
   isSameAsDelivery$ = this.isSameAsDeliverySub.asObservable();
-
-  constructor(
-    protected checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
-    protected checkoutBillingAddressFacade: CheckoutBillingAddressFacade,
-    protected userPaymentService: UserPaymentService,
-    protected checkoutPaymentService: CheckoutPaymentFacade,
-    protected activeCartService: ActiveCartFacade,
-    protected globalMessageService: GlobalMessageService,
-    protected opfService: OpfCheckoutPaymentWrapperService
-  ) {}
 
   getCountries(): Observable<Country[]> {
     return this.userPaymentService.getAllBillingCountries().pipe(

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.ts
@@ -4,23 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+} from '@angular/core';
 import {
   UntypedFormBuilder,
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
-import { ActiveCartFacade, PaymentType, Cart } from '@spartacus/cart/base/root';
-import {
-  CheckoutReviewSubmitComponent,
-  CheckoutStepService,
-} from '@spartacus/checkout/base/components';
-import {
-  CheckoutDeliveryAddressFacade,
-  CheckoutDeliveryModesFacade,
-  CheckoutPaymentFacade,
-} from '@spartacus/checkout/base/root';
-import { TranslationService } from '@spartacus/core';
+import { Cart, PaymentType } from '@spartacus/cart/base/root';
+import { CheckoutReviewSubmitComponent } from '@spartacus/checkout/base/components';
 import { OpfService } from '@spartacus/opf/base/root';
 
 import { Observable } from 'rxjs';
@@ -35,6 +31,9 @@ export class OpfCheckoutPaymentAndReviewComponent
   extends CheckoutReviewSubmitComponent
   implements OnInit
 {
+  protected fb = inject(UntypedFormBuilder);
+  protected opfService = inject(OpfService);
+
   protected defaultTermsAndConditionsFieldValue = false;
 
   checkoutSubmitForm: UntypedFormGroup = this.fb.group({
@@ -56,26 +55,6 @@ export class OpfCheckoutPaymentAndReviewComponent
     return this.activeCartFacade
       .getActive()
       .pipe(map((cart: Cart) => cart.paymentType));
-  }
-
-  constructor(
-    protected fb: UntypedFormBuilder,
-    protected checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
-    protected checkoutPaymentFacade: CheckoutPaymentFacade,
-    protected activeCartFacade: ActiveCartFacade,
-    protected translationService: TranslationService,
-    protected checkoutStepService: CheckoutStepService,
-    protected checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade,
-    protected opfService: OpfService
-  ) {
-    super(
-      checkoutDeliveryAddressFacade,
-      checkoutPaymentFacade,
-      activeCartFacade,
-      translationService,
-      checkoutStepService,
-      checkoutDeliveryModesFacade
-    );
   }
 
   protected updateTermsAndConditionsState() {

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.ts
@@ -11,6 +11,7 @@ import {
   OnDestroy,
   OnInit,
   ViewContainerRef,
+  inject,
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
@@ -31,6 +32,11 @@ import { OpfCheckoutPaymentWrapperService } from './opf-checkout-payment-wrapper
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpfCheckoutPaymentWrapperComponent implements OnInit, OnDestroy {
+  protected service = inject(OpfCheckoutPaymentWrapperService);
+  protected sanitizer = inject(DomSanitizer);
+  protected globalFunctionsService = inject(OpfGlobalFunctionsFacade);
+  protected vcr = inject(ViewContainerRef);
+
   @Input() selectedPaymentId: number;
 
   renderPaymentMethodEvent$ = this.service.getRenderPaymentMethodEvent();
@@ -38,13 +44,6 @@ export class OpfCheckoutPaymentWrapperComponent implements OnInit, OnDestroy {
   RENDER_TYPES = OpfPaymentMethodType;
 
   sub: Subscription = new Subscription();
-
-  constructor(
-    protected service: OpfCheckoutPaymentWrapperService,
-    protected sanitizer: DomSanitizer,
-    protected globalFunctionsService: OpfGlobalFunctionsFacade,
-    protected vcr: ViewContainerRef
-  ) {}
 
   renderHtml(html: string): SafeHtml {
     return this.sanitizer.bypassSecurityTrustHtml(html);

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ActiveCartService } from '@spartacus/cart/base/core';
 import {
   GlobalMessageService,
@@ -44,6 +44,16 @@ import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
 
 @Injectable()
 export class OpfCheckoutPaymentWrapperService {
+  protected opfCheckoutService = inject(OpfCheckoutFacade);
+  protected opfOtpService = inject(OpfOtpFacade);
+  protected opfResourceLoaderService = inject(OpfResourceLoaderService);
+  protected userIdService = inject(UserIdService);
+  protected activeCartService = inject(ActiveCartService);
+  protected routingService = inject(RoutingService);
+  protected globalMessageService = inject(GlobalMessageService);
+  protected opfOrderFacade = inject(OpfOrderFacade);
+  protected opfService = inject(OpfService);
+
   protected lastPaymentOptionId?: number;
 
   protected activeCartId?: string;
@@ -53,18 +63,6 @@ export class OpfCheckoutPaymentWrapperService {
       isLoading: false,
       isError: false,
     });
-
-  constructor(
-    protected opfCheckoutService: OpfCheckoutFacade,
-    protected opfOtpService: OpfOtpFacade,
-    protected opfResourceLoaderService: OpfResourceLoaderService,
-    protected userIdService: UserIdService,
-    protected activeCartService: ActiveCartService,
-    protected routingService: RoutingService,
-    protected globalMessageService: GlobalMessageService,
-    protected opfOrderFacade: OpfOrderFacade,
-    protected opfService: OpfService
-  ) {}
 
   protected executeScriptFromHtml(html: string): void {
     /**

--- a/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.ts
@@ -10,6 +10,7 @@ import {
   Input,
   OnDestroy,
   OnInit,
+  inject,
 } from '@angular/core';
 import {
   GlobalMessageService,
@@ -32,6 +33,10 @@ import { tap } from 'rxjs/operators';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpfCheckoutPaymentsComponent implements OnInit, OnDestroy {
+  protected opfPaymentervice = inject(OpfPaymentFacade);
+  protected opfService = inject(OpfService);
+  protected globalMessageService = inject(GlobalMessageService);
+
   protected subscription = new Subscription();
 
   activeConfigurations$ = this.opfPaymentervice
@@ -56,12 +61,6 @@ export class OpfCheckoutPaymentsComponent implements OnInit, OnDestroy {
   disabled = true;
 
   selectedPaymentId?: number;
-
-  constructor(
-    protected opfPaymentervice: OpfPaymentFacade,
-    protected opfService: OpfService,
-    protected globalMessageService: GlobalMessageService
-  ) {}
 
   /**
    * Method pre-selects (based on terms and conditions state)

--- a/integration-libs/opf/checkout/core/connectors/opf-checkout.connector.ts
+++ b/integration-libs/opf/checkout/core/connectors/opf-checkout.connector.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   PaymentInitiationConfig,
   PaymentSessionData,
@@ -15,7 +15,7 @@ import { OpfAdapter } from './opf.adapter';
 
 @Injectable()
 export class OpfCheckoutConnector {
-  constructor(protected adapter: OpfAdapter) {}
+  protected adapter = inject(OpfAdapter);
 
   public initiatePayment(
     paymentConfig: PaymentInitiationConfig

--- a/integration-libs/opf/checkout/core/facade/opf-checkout.service.ts
+++ b/integration-libs/opf/checkout/core/facade/opf-checkout.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Command, CommandService, QueryService } from '@spartacus/core';
 import {
   OpfCheckoutFacade,
@@ -17,6 +17,10 @@ import { OpfCheckoutConnector } from '../connectors/opf-checkout.connector';
 
 @Injectable()
 export class OpfCheckoutService implements OpfCheckoutFacade {
+  protected queryService = inject(QueryService);
+  protected commandService = inject(CommandService);
+  protected opfCheckoutConnector = inject(OpfCheckoutConnector);
+
   protected initiatePaymentCommand: Command<
     {
       paymentConfig: PaymentInitiationConfig;
@@ -25,12 +29,6 @@ export class OpfCheckoutService implements OpfCheckoutFacade {
   > = this.commandService.create((payload) =>
     this.opfCheckoutConnector.initiatePayment(payload.paymentConfig)
   );
-
-  constructor(
-    protected queryService: QueryService,
-    protected commandService: CommandService,
-    protected opfCheckoutConnector: OpfCheckoutConnector
-  ) {}
 
   initiatePayment(
     paymentConfig: PaymentInitiationConfig

--- a/integration-libs/opf/checkout/core/services/opf-endpoints.service.ts
+++ b/integration-libs/opf/checkout/core/services/opf-endpoints.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, inject } from '@angular/core';
+import { Injectable } from '@angular/core';
 import {
   BaseSiteService,
   Config,
@@ -16,11 +16,12 @@ import {
   providedIn: 'root',
 })
 export class OpfEndpointsService {
-  private config = inject(Config);
-  private baseSiteService = inject(BaseSiteService);
   private _activeBaseSite: string;
 
-  constructor() {
+  constructor(
+    private config: Config,
+    private baseSiteService: BaseSiteService
+  ) {
     if (this.baseSiteService) {
       this.baseSiteService
         .getActive()

--- a/integration-libs/opf/checkout/core/services/opf-endpoints.service.ts
+++ b/integration-libs/opf/checkout/core/services/opf-endpoints.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   BaseSiteService,
   Config,
@@ -16,12 +16,11 @@ import {
   providedIn: 'root',
 })
 export class OpfEndpointsService {
+  private config = inject(Config);
+  private baseSiteService = inject(BaseSiteService);
   private _activeBaseSite: string;
 
-  constructor(
-    private config: Config,
-    private baseSiteService: BaseSiteService
-  ) {
+  constructor() {
     if (this.baseSiteService) {
       this.baseSiteService
         .getActive()

--- a/integration-libs/opf/checkout/occ/adapters/occ-opf.adapter.ts
+++ b/integration-libs/opf/checkout/occ/adapters/occ-opf.adapter.ts
@@ -29,14 +29,11 @@ import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class OccOpfAdapter implements OpfAdapter {
+  protected http = inject(HttpClient);
+  protected converter = inject(ConverterService);
+  protected opfEndpointsService = inject(OpfEndpointsService);
+  protected config = inject(OpfConfig);
   protected logger = inject(LoggerService);
-
-  constructor(
-    protected http: HttpClient,
-    protected converter: ConverterService,
-    protected opfEndpointsService: OpfEndpointsService,
-    protected config: OpfConfig
-  ) {}
 
   /**
    * TODO: Let's consider splitting this code into other files,


### PR DESCRIPTION
- temporarily install `npm install -D ngxtension`
- run migration `npx nx g ngxtension:convert-di-to-inject --project=opf`
- reverted changes for `opf-endpoints.service`(s) due to issues with TS module augmentation
- uninstall `ngxtension`

For more, see https://ngxtension.netlify.app/utilities/migrations/inject-migration/