### PR TITLE
Fix failing CPQ cypress tests

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
@@ -555,7 +555,7 @@ testConfig.forEach((config) => {
     });
 
     describe('Configuration Process', () => {
-      it('should support configuration aspect in product search, cart, checkout and order history', () => {
+      it.only('should support configuration aspect in product search, cart, checkout and order history', () => {
         common.goToPDPage(POWERTOOLS, PROD_CODE_CAM);
         common.clickOnAddToCartBtnOnPD();
         common.clickOnViewCartBtnOnPD();

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
@@ -555,7 +555,7 @@ testConfig.forEach((config) => {
     });
 
     describe('Configuration Process', () => {
-      it.only('should support configuration aspect in product search, cart, checkout and order history', () => {
+      it('should support configuration aspect in product search, cart, checkout and order history', () => {
         common.goToPDPage(POWERTOOLS, PROD_CODE_CAM);
         common.clickOnAddToCartBtnOnPD();
         common.clickOnViewCartBtnOnPD();

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart-cpq.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart-cpq.ts
@@ -216,38 +216,6 @@ function checkShipToThisAddressDisplayed(): void {
     cy.get('.cx-card-body').should('be.visible');
     cy.get('.cx-card-container').should('be.visible');
     cy.get('.cx-card-actions').should('be.visible');
-    cy.get('.cx-card-actions').within(() => {
-      checkLoadingSpinnerNotDisplayed();
-      cy.get('button.link.cx-action-link').should('exist');
-      cy.get('button.link.cx-action-link').should('be.visible');
-      cy.get('button.link.cx-action-link').contains('Ship');
-      checkLoadingSpinnerNotDisplayed();
-    });
-  });
-}
-
-/**
- * Clicks on 'Ship to this address' button.
- */
-function clickOnShipToThisAddressBtn(): void {
-  cy.log("🛒 Click to the link 'Ship to this address'");
-  cy.get('.cx-delivery-address-card').should('be.visible');
-  cy.get('.cx-delivery-address-card').within(() => {
-    checkLoadingSpinnerNotDisplayed();
-    cy.get('.cx-card-actions').should('be.visible');
-    cy.get('.cx-card-actions').within(() => {
-      checkLoadingSpinnerNotDisplayed();
-      cy.get('button.link.cx-action-link').should('exist');
-      cy.get('button.link.cx-action-link').should('be.visible');
-      cy.get('button.link.cx-action-link').contains('Ship');
-      checkLoadingSpinnerNotDisplayed();
-      cy.get('button.link.cx-action-link')
-        .wait(Cypress.config('defaultCommandTimeout'))
-        .click()
-        .then(() => {
-          checkLoadingSpinnerNotDisplayed();
-        });
-    });
   });
 }
 
@@ -267,7 +235,6 @@ function proceedWithDeliveryAddress(): void {
       checkCostCenterDisplayed();
       checkDeliveryAddressDisplayed();
       checkShipToThisAddressDisplayed();
-      clickOnShipToThisAddressBtn();
     });
 }
 


### PR DESCRIPTION
Both CPQ cypress tests were failing because `Ship to this address` link is not available anymore in the delivery address tile during the checkout process due to this the corresponding method has been removed.
For `POWERTOOLS-SPA`:
![image](https://github.com/SAP/spartacus/assets/61147963/58344baa-afb8-4b12-bc27-946b336c2be1)



`ELECTRONICS-SPA`:
![image](https://github.com/SAP/spartacus/assets/61147963/19ef6d9c-4cd2-40fe-83fe-0f54ef799207)
