### PR TITLE
fix: (CXSPA-987) - Hide stores list buttons from screen reader.

### DIFF
--- a/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.html
+++ b/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.html
@@ -20,6 +20,7 @@
     data-text="setPreferredStore.myStore"
     [attr.data-preferred-store]="pointOfServiceName.name"
     class="set-preferred-heading"
+    aria-hidden="true"
   >
     {{
       pointOfServiceName.name === (storeSelected$ | async)?.name

--- a/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.html
+++ b/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.html
@@ -51,6 +51,7 @@
       target="_blank"
       rel="noopener noreferrer"
       class="btn btn-sm btn-secondary btn-block cx-button"
+      aria-hidden="true"
       (click)="$event.stopPropagation()"
       [attr.aria-label]="'storeFinder.ariaLabelGetDirections' | cxTranslate"
       >{{ 'storeFinder.getDirections' | cxTranslate }}</a


### PR DESCRIPTION
Ticket: [CXSPA-987](https://jira.tools.sap/browse/CXSPA-987)

Stopping excess information from being read in aria-live area proves to be quite tricky. I have just used aria-hidden since the component already uses it to hide the address. This may not be a good idea since we are hiding intractable elements. It may be better to get rid of aria-live here altogether. @developpeurweb 