### PR TITLE
fix: workaround for the features option schematics error

### DIFF
--- a/feature-libs/asm/schematics/add-asm/index.ts
+++ b/feature-libs/asm/schematics/add-asm/index.ts
@@ -18,7 +18,7 @@ import {
   finalizeInstallation,
   LibraryOptions as SpartacusAsmOptions,
   readPackageJson,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
 import { peerDependencies } from '../../package.json';
@@ -27,7 +27,7 @@ export function addAsmFeatures(options: SpartacusAsmOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/asm/schematics/add-asm/index.ts
+++ b/feature-libs/asm/schematics/add-asm/index.ts
@@ -18,6 +18,7 @@ import {
   finalizeInstallation,
   LibraryOptions as SpartacusAsmOptions,
   readPackageJson,
+  getFeaturesOptions,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
 import { peerDependencies } from '../../package.json';
@@ -26,6 +27,7 @@ export function addAsmFeatures(options: SpartacusAsmOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/asm/schematics/add-asm/schema.json
+++ b/feature-libs/asm/schematics/add-asm/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["ASM"]
     }

--- a/feature-libs/cart/schematics/add-cart/index.ts
+++ b/feature-libs/cart/schematics/add-cart/index.ts
@@ -18,7 +18,7 @@ import {
   finalizeInstallation,
   LibraryOptions as SpartacusCartOptions,
   readPackageJson,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
 import { peerDependencies } from '../../package.json';
@@ -27,7 +27,7 @@ export function addCartFeatures(options: SpartacusCartOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/cart/schematics/add-cart/index.ts
+++ b/feature-libs/cart/schematics/add-cart/index.ts
@@ -18,6 +18,7 @@ import {
   finalizeInstallation,
   LibraryOptions as SpartacusCartOptions,
   readPackageJson,
+  getFeaturesOptions,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
 import { peerDependencies } from '../../package.json';
@@ -26,6 +27,7 @@ export function addCartFeatures(options: SpartacusCartOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/cart/schematics/add-cart/schema.json
+++ b/feature-libs/cart/schematics/add-cart/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "items": {
         "enum": [

--- a/feature-libs/checkout/schematics/add-checkout/index.ts
+++ b/feature-libs/checkout/schematics/add-checkout/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusCheckoutOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -26,6 +27,7 @@ export function addCheckoutFeatures(options: SpartacusCheckoutOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/checkout/schematics/add-checkout/index.ts
+++ b/feature-libs/checkout/schematics/add-checkout/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusCheckoutOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -27,7 +27,7 @@ export function addCheckoutFeatures(options: SpartacusCheckoutOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/checkout/schematics/add-checkout/schema.json
+++ b/feature-libs/checkout/schematics/add-checkout/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "items": {
         "enum": [

--- a/feature-libs/customer-ticketing/schematics/add-customer-ticketing/index.ts
+++ b/feature-libs/customer-ticketing/schematics/add-customer-ticketing/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusCustomerTicketingOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -29,7 +29,7 @@ export function addCustomerTicketingFeatures(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/customer-ticketing/schematics/add-customer-ticketing/index.ts
+++ b/feature-libs/customer-ticketing/schematics/add-customer-ticketing/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusCustomerTicketingOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -28,6 +29,7 @@ export function addCustomerTicketingFeatures(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/customer-ticketing/schematics/add-customer-ticketing/schema.json
+++ b/feature-libs/customer-ticketing/schematics/add-customer-ticketing/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Customer-Ticketing"]
     }

--- a/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/index.ts
+++ b/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusEstimatedDeliveryDateOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -28,6 +29,7 @@ export function addEstimatedDeliveryDateFeature(
   return (tree: Tree, _context: SchematicContext) => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/index.ts
+++ b/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusEstimatedDeliveryDateOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -29,7 +29,7 @@ export function addEstimatedDeliveryDateFeature(
   return (tree: Tree, _context: SchematicContext) => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/schema.json
+++ b/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Estimated-Delivery-Date"]
     }

--- a/feature-libs/order/schematics/add-order/index.ts
+++ b/feature-libs/order/schematics/add-order/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusOrderOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -26,6 +27,7 @@ export function addOrderFeatures(options: SpartacusOrderOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/order/schematics/add-order/index.ts
+++ b/feature-libs/order/schematics/add-order/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusOrderOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -27,7 +27,7 @@ export function addOrderFeatures(options: SpartacusOrderOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/order/schematics/add-order/schema.json
+++ b/feature-libs/order/schematics/add-order/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Order"]
     }

--- a/feature-libs/organization/schematics/add-organization/index.ts
+++ b/feature-libs/organization/schematics/add-organization/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusOrganizationOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -28,6 +29,7 @@ export function addSpartacusOrganization(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/organization/schematics/add-organization/index.ts
+++ b/feature-libs/organization/schematics/add-organization/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusOrganizationOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -29,7 +29,7 @@ export function addSpartacusOrganization(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/organization/schematics/add-organization/schema.json
+++ b/feature-libs/organization/schematics/add-organization/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "items": {
         "enum": [

--- a/feature-libs/pdf-invoices/schematics/add-pdf-invoices/index.ts
+++ b/feature-libs/pdf-invoices/schematics/add-pdf-invoices/index.ts
@@ -17,7 +17,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusPDFInvoicesOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -30,7 +30,7 @@ export function addPDFInvoicesFeature(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/pdf-invoices/schematics/add-pdf-invoices/index.ts
+++ b/feature-libs/pdf-invoices/schematics/add-pdf-invoices/index.ts
@@ -17,6 +17,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusPDFInvoicesOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -29,6 +30,7 @@ export function addPDFInvoicesFeature(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/pdf-invoices/schematics/add-pdf-invoices/schema.json
+++ b/feature-libs/pdf-invoices/schematics/add-pdf-invoices/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["PDF-Invoices"]
     }

--- a/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index.ts
+++ b/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusPickupInStoreOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -28,6 +29,7 @@ export function addPickupInStoreFeatures(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index.ts
+++ b/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusPickupInStoreOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -29,7 +29,7 @@ export function addPickupInStoreFeatures(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/pickup-in-store/schematics/add-pickup-in-store/schema.json
+++ b/feature-libs/pickup-in-store/schematics/add-pickup-in-store/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Pickup-In-Store"]
     }

--- a/feature-libs/product-configurator/schematics/add-product-configurator/index.ts
+++ b/feature-libs/product-configurator/schematics/add-product-configurator/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusProductConfiguratorOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -29,7 +29,7 @@ export function addProductConfiguratorFeatures(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/product-configurator/schematics/add-product-configurator/index.ts
+++ b/feature-libs/product-configurator/schematics/add-product-configurator/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusProductConfiguratorOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -28,6 +29,7 @@ export function addProductConfiguratorFeatures(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/product-configurator/schematics/add-product-configurator/schema.json
+++ b/feature-libs/product-configurator/schematics/add-product-configurator/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "items": {
         "enum": [

--- a/feature-libs/product/schematics/add-product/index.ts
+++ b/feature-libs/product/schematics/add-product/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusProductOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -27,7 +27,7 @@ export function addSpartacusProduct(options: SpartacusProductOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/product/schematics/add-product/index.ts
+++ b/feature-libs/product/schematics/add-product/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusProductOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -26,6 +27,7 @@ export function addSpartacusProduct(options: SpartacusProductOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/product/schematics/add-product/schema.json
+++ b/feature-libs/product/schematics/add-product/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "items": {
         "enum": [

--- a/feature-libs/qualtrics/schematics/add-qualtrics/index.ts
+++ b/feature-libs/qualtrics/schematics/add-qualtrics/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusQualtricsOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -27,7 +27,7 @@ export function addQualtricsFeatures(options: SpartacusQualtricsOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/qualtrics/schematics/add-qualtrics/index.ts
+++ b/feature-libs/qualtrics/schematics/add-qualtrics/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusQualtricsOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -26,6 +27,7 @@ export function addQualtricsFeatures(options: SpartacusQualtricsOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/qualtrics/schematics/add-qualtrics/schema.json
+++ b/feature-libs/qualtrics/schematics/add-qualtrics/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Qualtrics"]
     }

--- a/feature-libs/quote/schematics/add-quote/index.ts
+++ b/feature-libs/quote/schematics/add-quote/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusQuoteOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -26,6 +27,7 @@ export function addQuoteFeatures(options: SpartacusQuoteOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/quote/schematics/add-quote/index.ts
+++ b/feature-libs/quote/schematics/add-quote/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusQuoteOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -27,7 +27,7 @@ export function addQuoteFeatures(options: SpartacusQuoteOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/quote/schematics/add-quote/schema.json
+++ b/feature-libs/quote/schematics/add-quote/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Quote"]
     }

--- a/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/index.ts
+++ b/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/index.ts
@@ -17,6 +17,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusRequestedDeliveryDateOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -29,6 +30,7 @@ export function addRequestedDeliveryDateFeature(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/index.ts
+++ b/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/index.ts
@@ -17,7 +17,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusRequestedDeliveryDateOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -30,7 +30,7 @@ export function addRequestedDeliveryDateFeature(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/schema.json
+++ b/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Requested-Delivery-Date"]
     }

--- a/feature-libs/smartedit/schematics/add-smartedit/index.ts
+++ b/feature-libs/smartedit/schematics/add-smartedit/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   readPackageJson,
   SpartacusSmartEditOptions,
   validateSpartacusInstallation,
@@ -26,6 +27,7 @@ export function addSmartEditFeatures(options: SpartacusSmartEditOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/smartedit/schematics/add-smartedit/index.ts
+++ b/feature-libs/smartedit/schematics/add-smartedit/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   readPackageJson,
   SpartacusSmartEditOptions,
   validateSpartacusInstallation,
@@ -27,7 +27,7 @@ export function addSmartEditFeatures(options: SpartacusSmartEditOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/smartedit/schematics/add-smartedit/schema.json
+++ b/feature-libs/smartedit/schematics/add-smartedit/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["SmartEdit"]
     },

--- a/feature-libs/storefinder/schematics/add-storefinder/index.ts
+++ b/feature-libs/storefinder/schematics/add-storefinder/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusStorefinderOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -28,6 +29,7 @@ export function addStorefinderFeatures(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/storefinder/schematics/add-storefinder/index.ts
+++ b/feature-libs/storefinder/schematics/add-storefinder/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusStorefinderOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -29,7 +29,7 @@ export function addStorefinderFeatures(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/storefinder/schematics/add-storefinder/schema.json
+++ b/feature-libs/storefinder/schematics/add-storefinder/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Store-Finder"]
     }

--- a/feature-libs/tracking/schematics/add-tracking/index.ts
+++ b/feature-libs/tracking/schematics/add-tracking/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusTrackingOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -27,7 +27,7 @@ export function addTrackingFeatures(options: SpartacusTrackingOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/tracking/schematics/add-tracking/index.ts
+++ b/feature-libs/tracking/schematics/add-tracking/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusTrackingOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -26,6 +27,7 @@ export function addTrackingFeatures(options: SpartacusTrackingOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/tracking/schematics/add-tracking/schema.json
+++ b/feature-libs/tracking/schematics/add-tracking/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "items": {
         "enum": ["Personalization", "TMS-GTM", "TMS-AEPL"],

--- a/feature-libs/user/schematics/add-user/index.ts
+++ b/feature-libs/user/schematics/add-user/index.ts
@@ -18,7 +18,7 @@ import {
   finalizeInstallation,
   LibraryOptions as SpartacusUserOptions,
   readPackageJson,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
 import { peerDependencies } from '../../package.json';
@@ -27,7 +27,7 @@ export function addUserFeatures(options: SpartacusUserOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/user/schematics/add-user/index.ts
+++ b/feature-libs/user/schematics/add-user/index.ts
@@ -18,6 +18,7 @@ import {
   finalizeInstallation,
   LibraryOptions as SpartacusUserOptions,
   readPackageJson,
+  getFeaturesOptions,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
 import { peerDependencies } from '../../package.json';
@@ -26,6 +27,7 @@ export function addUserFeatures(options: SpartacusUserOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/feature-libs/user/schematics/add-user/schema.json
+++ b/feature-libs/user/schematics/add-user/schema.json
@@ -23,7 +23,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "items": {
         "enum": ["User-Account", "User-Profile"],

--- a/integration-libs/cdc/schematics/add-cdc/index.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   readPackageJson,
   SpartacusCdcOptions,
   validateSpartacusInstallation,
@@ -28,7 +28,7 @@ export function addCdcFeature(options: SpartacusCdcOptions): Rule {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
 
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/cdc/schematics/add-cdc/index.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   readPackageJson,
   SpartacusCdcOptions,
   validateSpartacusInstallation,
@@ -26,6 +27,8 @@ export function addCdcFeature(options: SpartacusCdcOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/cdc/schematics/add-cdc/schema.json
+++ b/integration-libs/cdc/schematics/add-cdc/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "items": {
         "enum": ["CDC", "CDC-B2B"],

--- a/integration-libs/cdp/schematics/add-cdp/index.ts
+++ b/integration-libs/cdp/schematics/add-cdp/index.ts
@@ -17,6 +17,7 @@ import {
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
   readPackageJson,
+  getFeaturesOptions,
   LibraryOptions as SpartacusCdpOptions,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
@@ -26,6 +27,7 @@ export function addCdpFeature(options: SpartacusCdpOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/cdp/schematics/add-cdp/index.ts
+++ b/integration-libs/cdp/schematics/add-cdp/index.ts
@@ -17,7 +17,7 @@ import {
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
   readPackageJson,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusCdpOptions,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
@@ -27,7 +27,7 @@ export function addCdpFeature(options: SpartacusCdpOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/cdp/schematics/add-cdp/schema.json
+++ b/integration-libs/cdp/schematics/add-cdp/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["CDP"]
     }

--- a/integration-libs/cds/src/schematics/add-cds/index.ts
+++ b/integration-libs/cds/src/schematics/add-cds/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   readPackageJson,
   SpartacusCdsOptions,
   validateSpartacusInstallation,
@@ -26,6 +27,7 @@ export function addCdsFeature(options: SpartacusCdsOptions): Rule {
   return (tree: Tree, _context: SchematicContext) => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/cds/src/schematics/add-cds/index.ts
+++ b/integration-libs/cds/src/schematics/add-cds/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   readPackageJson,
   SpartacusCdsOptions,
   validateSpartacusInstallation,
@@ -27,7 +27,7 @@ export function addCdsFeature(options: SpartacusCdsOptions): Rule {
   return (tree: Tree, _context: SchematicContext) => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/cds/src/schematics/add-cds/schema.json
+++ b/integration-libs/cds/src/schematics/add-cds/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["CDS"]
     },

--- a/integration-libs/digital-payments/schematics/add-digital-payments/index.ts
+++ b/integration-libs/digital-payments/schematics/add-digital-payments/index.ts
@@ -18,7 +18,7 @@ import {
   finalizeInstallation,
   LibraryOptions as SpartacusDigitalPaymentsOptions,
   readPackageJson,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
 import { peerDependencies } from '../../package.json';
@@ -29,7 +29,7 @@ export function addDigitalPaymentsFeature(
   return (tree: Tree, _context: SchematicContext) => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/digital-payments/schematics/add-digital-payments/index.ts
+++ b/integration-libs/digital-payments/schematics/add-digital-payments/index.ts
@@ -18,6 +18,7 @@ import {
   finalizeInstallation,
   LibraryOptions as SpartacusDigitalPaymentsOptions,
   readPackageJson,
+  getFeaturesOptions,
   validateSpartacusInstallation,
 } from '@spartacus/schematics';
 import { peerDependencies } from '../../package.json';
@@ -28,6 +29,7 @@ export function addDigitalPaymentsFeature(
   return (tree: Tree, _context: SchematicContext) => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/digital-payments/schematics/add-digital-payments/schema.json
+++ b/integration-libs/digital-payments/schematics/add-digital-payments/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Digital-Payments"]
     }

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/index.ts
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   readPackageJson,
   SpartacusEpdVisualizationOptions,
   validateSpartacusInstallation,
@@ -28,6 +29,7 @@ export function addEpdVisualizationFeature(
   return (tree: Tree, _context: SchematicContext) => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/index.ts
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   readPackageJson,
   SpartacusEpdVisualizationOptions,
   validateSpartacusInstallation,
@@ -29,7 +29,7 @@ export function addEpdVisualizationFeature(
   return (tree: Tree, _context: SchematicContext) => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/schema.json
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/schema.json
@@ -12,7 +12,7 @@
       }
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["EPD-Visualization"]
     },

--- a/integration-libs/opps/schematics/add-opps/index.ts
+++ b/integration-libs/opps/schematics/add-opps/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   readPackageJson,
   validateSpartacusInstallation,
   LibraryOptions as SpartacusOppsOptions,
@@ -26,6 +27,7 @@ export function addOppsFeature(options: SpartacusOppsOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/opps/schematics/add-opps/index.ts
+++ b/integration-libs/opps/schematics/add-opps/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   readPackageJson,
   validateSpartacusInstallation,
   LibraryOptions as SpartacusOppsOptions,
@@ -27,7 +27,7 @@ export function addOppsFeature(options: SpartacusOppsOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/opps/schematics/add-opps/schema.json
+++ b/integration-libs/opps/schematics/add-opps/schema.json
@@ -17,7 +17,7 @@
       "default": false
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["OPPS"]
     }

--- a/integration-libs/s4om/schematics/add-s4om/index.ts
+++ b/integration-libs/s4om/schematics/add-s4om/index.ts
@@ -16,6 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
+  getFeaturesOptions,
   LibraryOptions as SpartacusOrganizationOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -26,6 +27,7 @@ export function addS4OMFeature(options: SpartacusOrganizationOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/s4om/schematics/add-s4om/index.ts
+++ b/integration-libs/s4om/schematics/add-s4om/index.ts
@@ -16,7 +16,7 @@ import {
   analyzeApplication,
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   LibraryOptions as SpartacusOrganizationOptions,
   readPackageJson,
   validateSpartacusInstallation,
@@ -27,7 +27,7 @@ export function addS4OMFeature(options: SpartacusOrganizationOptions): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/s4om/schematics/add-s4om/schema.json
+++ b/integration-libs/s4om/schematics/add-s4om/schema.json
@@ -22,7 +22,7 @@
       "default": true
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["S4HANA-Order-Management"],
       "x-prompt": {

--- a/integration-libs/segment-refs/schematics/add-segment-refs/index.ts
+++ b/integration-libs/segment-refs/schematics/add-segment-refs/index.ts
@@ -17,7 +17,7 @@ import {
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
   readPackageJson,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
   validateSpartacusInstallation,
   LibraryOptions as SpartacusSegmentRefsOptions,
 } from '@spartacus/schematics';
@@ -29,7 +29,7 @@ export function addSegmentRefsFeature(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
-    options.features = getFeaturesOptions(options);
+    options.features = normalizeOptionsFeatures(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/segment-refs/schematics/add-segment-refs/index.ts
+++ b/integration-libs/segment-refs/schematics/add-segment-refs/index.ts
@@ -17,6 +17,7 @@ import {
   analyzeCrossFeatureDependencies,
   finalizeInstallation,
   readPackageJson,
+  getFeaturesOptions,
   validateSpartacusInstallation,
   LibraryOptions as SpartacusSegmentRefsOptions,
 } from '@spartacus/schematics';
@@ -28,6 +29,7 @@ export function addSegmentRefsFeature(
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);
     validateSpartacusInstallation(packageJson);
+    options.features = getFeaturesOptions(options);
 
     const features = analyzeCrossFeatureDependencies(
       options.features as string[]

--- a/integration-libs/segment-refs/schematics/add-segment-refs/schema.json
+++ b/integration-libs/segment-refs/schematics/add-segment-refs/schema.json
@@ -17,7 +17,7 @@
       "default": false
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "default": ["Segment-Refs"]
     }

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -561,9 +561,8 @@ function addAppRoutingModuleImport(
 
 export function addSpartacus(options: SpartacusOptions): Rule {
   return (tree: Tree, context: SchematicContext) => {
-    const features = analyzeCrossFeatureDependencies(
-      normalizeOptionsFeatures(options)
-    );
+    options.features = normalizeOptionsFeatures(options);
+    const features = analyzeCrossFeatureDependencies(options.features);
     const dependencies = prepareDependencies(features);
     const spartacusRxjsDependency: NodeDependency[] = [
       dependencies.find((dep) => dep.name === RXJS) as NodeDependency,

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -28,7 +28,11 @@ import {
   analyzeCrossFeatureDependencies,
   analyzeCrossLibraryDependenciesByFeatures,
 } from '../shared/utils/dependency-utils';
-import { addFeatures, analyzeApplication } from '../shared/utils/feature-utils';
+import {
+  addFeatures,
+  analyzeApplication,
+  getFeaturesOptions,
+} from '../shared/utils/feature-utils';
 import { getIndexHtmlPath } from '../shared/utils/file-utils';
 import { appendHtmlElementToHead } from '../shared/utils/html-utils';
 import {
@@ -328,7 +332,7 @@ function verifyAppModuleExists(options: SpartacusOptions): Rule {
 1. remove your application code
 2. make sure to pass the flag "--standalone=false" to the command "ng new". For more, see https://angular.io/cli/new#options
 3. try again installing Spartacus with a command "ng add @spartacus/schematics" ...
-        
+
 Note: Since version 17, Angular's command "ng new" by default creates an app without a file "app.module.ts" (in a so-called "standalone" mode). But Spartacus installer requires this file to be present.
 `
       );
@@ -557,7 +561,9 @@ function addAppRoutingModuleImport(
 
 export function addSpartacus(options: SpartacusOptions): Rule {
   return (tree: Tree, context: SchematicContext) => {
-    const features = analyzeCrossFeatureDependencies(options.features ?? []);
+    const features = analyzeCrossFeatureDependencies(
+      getFeaturesOptions(options)
+    );
     const dependencies = prepareDependencies(features);
     const spartacusRxjsDependency: NodeDependency[] = [
       dependencies.find((dep) => dep.name === RXJS) as NodeDependency,

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -31,7 +31,7 @@ import {
 import {
   addFeatures,
   analyzeApplication,
-  getFeaturesOptions,
+  normalizeOptionsFeatures,
 } from '../shared/utils/feature-utils';
 import { getIndexHtmlPath } from '../shared/utils/file-utils';
 import { appendHtmlElementToHead } from '../shared/utils/html-utils';
@@ -562,7 +562,7 @@ function addAppRoutingModuleImport(
 export function addSpartacus(options: SpartacusOptions): Rule {
   return (tree: Tree, context: SchematicContext) => {
     const features = analyzeCrossFeatureDependencies(
-      getFeaturesOptions(options)
+      normalizeOptionsFeatures(options)
     );
     const dependencies = prepareDependencies(features);
     const spartacusRxjsDependency: NodeDependency[] = [

--- a/projects/schematics/src/add-spartacus/index_spec.ts
+++ b/projects/schematics/src/add-spartacus/index_spec.ts
@@ -97,7 +97,7 @@ describe('add-spartacus', () => {
       1. remove your application code
       2. make sure to pass the flag "--standalone=false" to the command "ng new". For more, see https://angular.io/cli/new#options
       3. try again installing Spartacus with a command "ng add @spartacus/schematics" ...
-              
+
       Note: Since version 17, Angular's command "ng new" by default creates an app without a file "app.module.ts" (in a so-called "standalone" mode). But Spartacus installer requires this file to be present.
       ]
     `);

--- a/projects/schematics/src/add-spartacus/schema.json
+++ b/projects/schematics/src/add-spartacus/schema.json
@@ -12,7 +12,7 @@
       }
     },
     "features": {
-      "type": "array",
+      "type": ["array", "string"],
       "uniqueItems": true,
       "items": {
         "enum": [

--- a/projects/schematics/src/shared/utils/feature-utils.ts
+++ b/projects/schematics/src/shared/utils/feature-utils.ts
@@ -484,3 +484,29 @@ function createDependentFeaturesLog(
     ', '
   )}: ${notSelectedFeatures.join(', ')}\n`;
 }
+
+/**
+ * This function is a workaround for the GitHub issue
+ * https://github.com/angular/angular-cli/issues/16320.
+ * Using `ng add` with options of type array (--features)
+ * may not work correctly in some situations, and might only work on the
+ * second attempt.
+ */
+export function getFeaturesOptions<OPTIONS extends LibraryOptions>(
+  options: OPTIONS
+): string[] {
+  return getArrayOptions(options.features ?? []);
+}
+
+export function getArrayOptions(values: string[] | string): string[] {
+  let optionsArray: string[] = [];
+  if (values && Array.isArray(values)) {
+    optionsArray = values;
+  } else if (values.includes(',')) {
+    optionsArray = values.split(',');
+  } else {
+    optionsArray = [values];
+  }
+
+  return optionsArray;
+}

--- a/projects/schematics/src/shared/utils/feature-utils.ts
+++ b/projects/schematics/src/shared/utils/feature-utils.ts
@@ -492,13 +492,13 @@ function createDependentFeaturesLog(
  * may not work correctly in some situations, and might only work on the
  * second attempt.
  */
-export function getFeaturesOptions<OPTIONS extends LibraryOptions>(
+export function normalizeOptionsFeatures<OPTIONS extends LibraryOptions>(
   options: OPTIONS
 ): string[] {
-  return getArrayOptions(options.features ?? []);
+  return convertToArray(options.features ?? []);
 }
 
-export function getArrayOptions(values: string[] | string): string[] {
+export function convertToArray(values: string[] | string): string[] {
   let optionsArray: string[] = [];
   if (Array.isArray(values)) {
     optionsArray = values;

--- a/projects/schematics/src/shared/utils/feature-utils.ts
+++ b/projects/schematics/src/shared/utils/feature-utils.ts
@@ -500,7 +500,7 @@ export function getFeaturesOptions<OPTIONS extends LibraryOptions>(
 
 export function getArrayOptions(values: string[] | string): string[] {
   let optionsArray: string[] = [];
-  if (values && Array.isArray(values)) {
+  if (Array.isArray(values)) {
     optionsArray = values;
   } else if (values.includes(',')) {
     optionsArray = values.split(',');


### PR DESCRIPTION
closes: [CXSPA-7456](https://jira.tools.sap/browse/CXSPA-7456)

This pull request addresses the issue detailed in [Angular CLI GitHub issue #16320](https://github.com/angular/angular-cli/issues/16320). The problem is that using ng add with options of type array may not function correctly in some cases, and might only work on the second attempt.

To resolve this, we have implemented a workaround in the form of a new utility function, getFeaturesOptions. This function ensures that feature options are handled correctly, mitigating the problem described in the issue.

Changes:
- Added `getFeaturesOptions` function to work around the issue with ng add and array options.
- Changed the features type in schema.json