### PR TITLE
Display filter button on the overview page

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.html
@@ -6,7 +6,7 @@
 >
   <ng-container
     *ngIf="
-      !(isDisplayOnlyVariant() | async) &&
+      !(isDisplayOnlyVariant() | async) ||
       configurationWithOv.overview.possibleGroups?.length !== 1
     "
   >

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.spec.ts
@@ -143,9 +143,21 @@ describe('ConfigurationOverviewFilterButtonComponent', () => {
     expect(htmlElem.classList.contains('ghost')).toBeFalsy();
   });
 
-  it('should render no filter button for variant', () => {
+  it('should render filter button for variant in case there is more than one group', () => {
     isDisplayOnlyVariant = true;
-    ovConfig.overview.possibleGroups = [];
+    fixture.detectChanges();
+
+    CommonConfiguratorTestUtilsService.expectElementPresent(
+      expect,
+      htmlElem,
+      '.cx-config-filter-button'
+    );
+  });
+
+  it('should render no filter button for variant in case there is only one group', () => {
+    isDisplayOnlyVariant = true;
+    ovConfig.overview.possibleGroups =
+      ovConfig.overview.possibleGroups.slice(1);
     fixture.detectChanges();
 
     CommonConfiguratorTestUtilsService.expectElementNotPresent(


### PR DESCRIPTION
The **filter** button should be displayed on the overview page when the configuration contains only one group and is not in the read-only view.

After clicking on the **filter** button the dialog should appear and contain only the following options:
1. Price-Relevant Options
2. My Selections

because there is only one group in the configuration. Otherwise, the options to filter by the groups should be visible as well.

Closes [CXSPA-7601](https://jira.tools.sap/browse/CXSPA-7601)