### PR TITLE
Fix visibility of add-to-cart button on mobile

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.spec.ts
@@ -81,7 +81,7 @@ class MockConfiguratorStorefrontUtilsService {
   removeStyling(): void {}
 }
 
-fdescribe('ConfiguratorGroupTitleComponent', () => {
+describe('ConfiguratorGroupTitleComponent', () => {
   let component: ConfiguratorGroupTitleComponent;
   let fixture: ComponentFixture<ConfiguratorGroupTitleComponent>;
   let htmlElem: HTMLElement;

--- a/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.spec.ts
@@ -81,7 +81,7 @@ class MockConfiguratorStorefrontUtilsService {
   removeStyling(): void {}
 }
 
-describe('ConfiguratorGroupTitleComponent', () => {
+fdescribe('ConfiguratorGroupTitleComponent', () => {
   let component: ConfiguratorGroupTitleComponent;
   let fixture: ComponentFixture<ConfiguratorGroupTitleComponent>;
   let htmlElem: HTMLElement;
@@ -171,10 +171,19 @@ describe('ConfiguratorGroupTitleComponent', () => {
     spyOn(breakpointService, 'isDown').and.returnValue(of(true));
     fixture.detectChanges();
     expect(component).toBeDefined();
-    expect(configuratorStorefrontUtilsService.changeStyling).toHaveBeenCalled();
+    expect(
+      configuratorStorefrontUtilsService.changeStyling
+    ).toHaveBeenCalledTimes(2);
     expect(
       configuratorStorefrontUtilsService.changeStyling
     ).toHaveBeenCalledWith('.PreHeader', 'display', 'block');
+    expect(
+      configuratorStorefrontUtilsService.changeStyling
+    ).toHaveBeenCalledWith(
+      'cx-configurator-add-to-cart-button',
+      'z-index',
+      '0'
+    );
     expect(
       configuratorStorefrontUtilsService.focusFirstActiveElement
     ).toHaveBeenCalledWith('cx-hamburger-menu');
@@ -189,10 +198,19 @@ describe('ConfiguratorGroupTitleComponent', () => {
       htmlElem,
       'cx-hamburger-menu'
     );
-    expect(configuratorStorefrontUtilsService.changeStyling).toHaveBeenCalled();
+    expect(
+      configuratorStorefrontUtilsService.changeStyling
+    ).toHaveBeenCalledTimes(2);
     expect(
       configuratorStorefrontUtilsService.changeStyling
     ).toHaveBeenCalledWith('.PreHeader', 'display', 'none');
+    expect(
+      configuratorStorefrontUtilsService.changeStyling
+    ).toHaveBeenCalledWith(
+      'cx-configurator-add-to-cart-button',
+      'z-index',
+      'calc(var(--cx-popover-z-index) + 10)'
+    );
     expect(
       configuratorStorefrontUtilsService.focusFirstActiveElement
     ).toHaveBeenCalledWith('.cx-group-title');

--- a/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.ts
@@ -35,6 +35,7 @@ export class ConfiguratorGroupTitleComponent implements OnInit, OnDestroy {
   @HostBinding('class.ghost') ghostStyle = true;
   protected subscription = new Subscription();
   protected readonly PRE_HEADER = '.PreHeader';
+  protected readonly ADD_TO_CART_BUTTON = 'cx-configurator-add-to-cart-button';
 
   displayedGroup$: Observable<Configurator.Group> =
     this.configRouterExtractorService.extractRouterData().pipe(
@@ -67,6 +68,12 @@ export class ConfiguratorGroupTitleComponent implements OnInit, OnDestroy {
             'display',
             'none'
           );
+          this.configuratorStorefrontUtilsService.changeStyling(
+            this.ADD_TO_CART_BUTTON,
+            'z-index',
+            'calc(var(--cx-popover-z-index) + 10)'
+          );
+
           this.configuratorStorefrontUtilsService.focusFirstActiveElement(
             '.cx-group-title'
           );
@@ -75,6 +82,11 @@ export class ConfiguratorGroupTitleComponent implements OnInit, OnDestroy {
             this.PRE_HEADER,
             'display',
             'block'
+          );
+          this.configuratorStorefrontUtilsService.changeStyling(
+            this.ADD_TO_CART_BUTTON,
+            'z-index',
+            '0'
           );
           this.configuratorStorefrontUtilsService.focusFirstActiveElement(
             'cx-hamburger-menu'


### PR DESCRIPTION
**Add-to-cart** button should not be visible when one opens the hamburger menu.
![image-2024-06-18-08-32-30-799](https://github.com/SAP/spartacus/assets/61147963/448277d4-cc3a-4215-8fc8-19aed82e7cdd)

Closes [CXSPA-7598](https://jira.tools.sap/browse/CXSPA-7598)