### PR TITLE
Dialog for immediate conflict resolution is broken for mobile

### DIFF
--- a/feature-libs/product-configurator/rulebased/styles/_configurator-conflict-solver-dialog.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-conflict-solver-dialog.scss
@@ -33,10 +33,6 @@
       }
 
       .cx-modal-content {
-        @include media-breakpoint-down(md) {
-          height: 100vh !important;
-        }
-
         .cx-dialog-header {
           outline: 0;
           padding-inline-start: 16px;
@@ -72,7 +68,6 @@
             display: flex;
             flex-direction: row;
             align-items: center;
-            padding-inline-start: 0px;
             padding-inline-end: 5px;
             margin-block-start: 12px;
             margin-block-end: 12px;
@@ -83,27 +78,18 @@
               align-self: center;
               font-size: 30px;
               padding-inline-start: 15px;
-              padding-inline-end: 18px;
+              padding-inline-end: 15px;
               padding-block-start: 5px;
               padding-block-end: 15px;
             }
           }
 
+          .cx-msg-warning,
           cx-configurator-conflict-description {
             padding-inline-start: 0px;
-            padding-block-start: 0px;
-            padding-block-end: 0px;
+            padding-block-start: 5px;
+            padding-block-end: 5px;
           }
-        }
-
-        .cx-modal-footer {
-          display: flex;
-          justify-content: center;
-          margin-block-start: 15px;
-          padding-inline-start: 16px;
-          padding-inline-end: 16px;
-          padding-block-start: 16px;
-          padding-block-end: 16px;
         }
       }
     }


### PR DESCRIPTION
1. Search for **CONF_CAMERA_SL** product,
2. Navigate to  **Specification**  group,
3. Set **f/3.5** value for **Maximum Aperture** attribute,
4. Set **25600** value for **Maximum ISO** attribute,
5. The dialog should appear.
6. Toggle device to mobile
7. Scroll down and you will see that the dialog does not cover the whole screen and and not contains all infos.

![image-2024-06-18-08-35-57-274](https://github.com/SAP/spartacus/assets/61147963/54289d3d-72e0-4b00-88de-38318b0c584f)
 
Closes [CXSPA-7599](https://jira.tools.sap/browse/CXSPA-7599)