### PR TITLE
chore: upgrade prettierrc to 3.2.5 (CXSPA-7333)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "es5"
 }

--- a/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.component.html
+++ b/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.component.html
@@ -102,19 +102,13 @@
         <div class="modal-footer">
           <button
             type="submit"
-            class="
-              btn
-              cx-asm-create-customer-btn cx-asm-create-customer-btn-create
-            "
+            class="btn cx-asm-create-customer-btn cx-asm-create-customer-btn-create"
           >
             {{ 'asm.createCustomerForm.createAccount' | cxTranslate }}
           </button>
           <button
             type="button"
-            class="
-              btn
-              cx-asm-create-customer-btn cx-asm-create-customer-btn-cancel
-            "
+            class="btn cx-asm-create-customer-btn cx-asm-create-customer-btn-cancel"
             (click)="closeModal('Cancel click')"
           >
             {{ 'asm.createCustomerForm.cancel' | cxTranslate }}

--- a/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.component.spec.ts
+++ b/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.component.spec.ts
@@ -111,29 +111,27 @@ describe('AsmCreateCustomerFormComponent', () => {
   let launchDialogService: LaunchDialogService;
   let asmCreateCustomerFacade: AsmCreateCustomerFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          AsmCreateCustomerFormComponent,
-          MockCxIconComponent,
-          MockKeyboadFocusDirective,
-        ],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: AsmCreateCustomerFacade,
-            useClass: MockAsmCreateCustomerFacade,
-          },
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        AsmCreateCustomerFormComponent,
+        MockCxIconComponent,
+        MockKeyboadFocusDirective,
+      ],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: AsmCreateCustomerFacade,
+          useClass: MockAsmCreateCustomerFacade,
+        },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
-      launchDialogService = TestBed.inject(LaunchDialogService);
-      asmCreateCustomerFacade = TestBed.inject(AsmCreateCustomerFacade);
-    })
-  );
+    launchDialogService = TestBed.inject(LaunchDialogService);
+    asmCreateCustomerFacade = TestBed.inject(AsmCreateCustomerFacade);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AsmCreateCustomerFormComponent);

--- a/feature-libs/asm/components/asm-main-ui/asm-main-ui.component.spec.ts
+++ b/feature-libs/asm/components/asm-main-ui/asm-main-ui.component.spec.ts
@@ -179,32 +179,30 @@ describe('AsmMainUiComponent', () => {
   let asmEnablerService: AsmEnablerService;
   const testCustomerId: string = 'test.customer@hybris.com';
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          AsmMainUiComponent,
-          MockAsmToggleUiComponent,
-          MockCSAgentLoginFormComponent,
-          MockCustomerSelectionComponent,
-          MockAsmSessionTimerComponent,
-          MockCustomerEmulationComponent,
-          MockCxIconComponent,
-        ],
-        providers: [
-          { provide: AuthService, useClass: MockAuthService },
-          { provide: CsAgentAuthService, useClass: MockCsAgentAuthService },
-          { provide: UserAccountFacade, useClass: MockUserAccountFacade },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: AsmComponentService, useClass: MockAsmComponentService },
-          { provide: AsmService, useClass: MockAsmService },
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        AsmMainUiComponent,
+        MockAsmToggleUiComponent,
+        MockCSAgentLoginFormComponent,
+        MockCustomerSelectionComponent,
+        MockAsmSessionTimerComponent,
+        MockCustomerEmulationComponent,
+        MockCxIconComponent,
+      ],
+      providers: [
+        { provide: AuthService, useClass: MockAuthService },
+        { provide: CsAgentAuthService, useClass: MockCsAgentAuthService },
+        { provide: UserAccountFacade, useClass: MockUserAccountFacade },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: AsmComponentService, useClass: MockAsmComponentService },
+        { provide: AsmService, useClass: MockAsmService },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AsmMainUiComponent);

--- a/feature-libs/asm/components/asm-session-timer/asm-session-timer.component.spec.ts
+++ b/feature-libs/asm/components/asm-session-timer/asm-session-timer.component.spec.ts
@@ -62,24 +62,22 @@ describe('AsmSessionTimerComponent', () => {
   let routingService: RoutingService;
   let userIdService: UserIdService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [AsmSessionTimerComponent, MockFormatTimerPipe],
-        providers: [
-          {
-            provide: ChangeDetectorRef,
-            useValue: { markForCheck: createSpy('markForCheck') },
-          },
-          { provide: AsmConfig, useValue: MockAsmConfig },
-          { provide: AsmComponentService, useClass: MockAsmComponentService },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: UserIdService, useClass: MockUserIdService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [AsmSessionTimerComponent, MockFormatTimerPipe],
+      providers: [
+        {
+          provide: ChangeDetectorRef,
+          useValue: { markForCheck: createSpy('markForCheck') },
+        },
+        { provide: AsmConfig, useValue: MockAsmConfig },
+        { provide: AsmComponentService, useClass: MockAsmComponentService },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: UserIdService, useClass: MockUserIdService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AsmSessionTimerComponent);

--- a/feature-libs/asm/components/asm-toggle-ui/asm-toggle-ui.component.spec.ts
+++ b/feature-libs/asm/components/asm-toggle-ui/asm-toggle-ui.component.spec.ts
@@ -25,15 +25,13 @@ describe('AsmToggleuUiComponent', () => {
   let asmService: AsmService;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [AsmToggleUiComponent],
-        providers: [{ provide: AsmService, useClass: MockAsmService }],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [AsmToggleUiComponent],
+      providers: [{ provide: AsmService, useClass: MockAsmService }],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AsmToggleUiComponent);

--- a/feature-libs/asm/components/csagent-login-form/csagent-login-form.component.spec.ts
+++ b/feature-libs/asm/components/csagent-login-form/csagent-login-form.component.spec.ts
@@ -21,23 +21,21 @@ describe('CSAgentLoginFormComponent', () => {
   const validUserId = 'asagent';
   const validPassword = 'testPass123!';
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          PasswordVisibilityToggleModule,
-        ],
-        declarations: [
-          CSAgentLoginFormComponent,
-          DotSpinnerComponent,
-          MockFeatureDirective,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        PasswordVisibilityToggleModule,
+      ],
+      declarations: [
+        CSAgentLoginFormComponent,
+        DotSpinnerComponent,
+        MockFeatureDirective,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CSAgentLoginFormComponent);

--- a/feature-libs/asm/components/customer-emulation/customer-emulation.component.spec.ts
+++ b/feature-libs/asm/components/customer-emulation/customer-emulation.component.spec.ts
@@ -59,33 +59,31 @@ describe('CustomerEmulationComponent', () => {
   let el: DebugElement;
   let featureModulesService: FeatureModulesService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          CustomerEmulationComponent,
-          MockFeatureLevelDirective,
-          MockAsmBindCartComponent,
-        ],
-        providers: [
-          {
-            provide: FeatureModulesService,
-            useClass: mockFeatureModulesService,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        CustomerEmulationComponent,
+        MockFeatureLevelDirective,
+        MockAsmBindCartComponent,
+      ],
+      providers: [
+        {
+          provide: FeatureModulesService,
+          useClass: mockFeatureModulesService,
+        },
+        { provide: UserAccountFacade, useClass: MockUserAccountFacade },
+        { provide: AsmComponentService, useClass: MockAsmComponentService },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '6.3' },
           },
-          { provide: UserAccountFacade, useClass: MockUserAccountFacade },
-          { provide: AsmComponentService, useClass: MockAsmComponentService },
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '6.3' },
-            },
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CustomerEmulationComponent);

--- a/feature-libs/asm/components/customer-list/customer-list.component.spec.ts
+++ b/feature-libs/asm/components/customer-list/customer-list.component.spec.ts
@@ -215,43 +215,41 @@ describe('CustomerListComponent', () => {
   let config: AsmConfig;
   let asmCustomerListFacade: AsmCustomerListFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          CustomerListComponent,
-          MockCxIconComponent,
-          MockKeyboadFocusDirective,
-        ],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: BreakpointService,
-            useClass: MockBreakpointService,
-          },
-          { provide: AsmConfig, useClass: MockAsmConfig },
-          {
-            provide: AsmCustomerListFacade,
-            useClass: MockAsmCustomerListFacade,
-          },
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
-      }).compileComponents();
-      launchDialogService = TestBed.inject(LaunchDialogService);
-      config = TestBed.inject(AsmConfig);
-      breakpointService = TestBed.inject(BreakpointService);
-      asmCustomerListFacade = TestBed.inject(AsmCustomerListFacade);
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        CustomerListComponent,
+        MockCxIconComponent,
+        MockKeyboadFocusDirective,
+      ],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: BreakpointService,
+          useClass: MockBreakpointService,
+        },
+        { provide: AsmConfig, useClass: MockAsmConfig },
+        {
+          provide: AsmCustomerListFacade,
+          useClass: MockAsmCustomerListFacade,
+        },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
+    }).compileComponents();
+    launchDialogService = TestBed.inject(LaunchDialogService);
+    config = TestBed.inject(AsmConfig);
+    breakpointService = TestBed.inject(BreakpointService);
+    asmCustomerListFacade = TestBed.inject(AsmCustomerListFacade);
 
-      spyOn(
-        asmCustomerListFacade,
-        'getCustomerListCustomersSearchResultsLoading'
-      ).and.returnValue(of(true));
-      spyOnProperty(breakpointService, 'breakpoint$').and.returnValue(
-        new BehaviorSubject(BREAKPOINT.md)
-      );
-    })
-  );
+    spyOn(
+      asmCustomerListFacade,
+      'getCustomerListCustomersSearchResultsLoading'
+    ).and.returnValue(of(true));
+    spyOnProperty(breakpointService, 'breakpoint$').and.returnValue(
+      new BehaviorSubject(BREAKPOINT.md)
+    );
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CustomerListComponent);

--- a/feature-libs/asm/components/customer-selection/customer-selection.component.spec.ts
+++ b/feature-libs/asm/components/customer-selection/customer-selection.component.spec.ts
@@ -110,41 +110,39 @@ describe('CustomerSelectionComponent', () => {
 
   const validSearchTerm = 'cUstoMer@test.com';
 
-  beforeEach(
-    waitForAsync(() => {
-      customerSearchResults = new BehaviorSubject<CustomerSearchPage>({
-        entries: [],
-      });
-      customerSearchResultsLoading = new BehaviorSubject<boolean>(false);
+  beforeEach(waitForAsync(() => {
+    customerSearchResults = new BehaviorSubject<CustomerSearchPage>({
+      entries: [],
+    });
+    customerSearchResultsLoading = new BehaviorSubject<boolean>(false);
 
-      TestBed.configureTestingModule({
-        imports: [ReactiveFormsModule, I18nTestingModule, FormErrorsModule],
-        declarations: [
-          CustomerSelectionComponent,
-          DotSpinnerComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          { provide: AsmService, useClass: MockAsmService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          { provide: AsmConfig, useValue: MockAsmConfig },
-          {
-            provide: DirectionService,
-            useClass: MockDirectionService,
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, I18nTestingModule, FormErrorsModule],
+      declarations: [
+        CustomerSelectionComponent,
+        DotSpinnerComponent,
+        MockFeatureDirective,
+      ],
+      providers: [
+        { provide: AsmService, useClass: MockAsmService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        { provide: AsmConfig, useValue: MockAsmConfig },
+        {
+          provide: DirectionService,
+          useClass: MockDirectionService,
+        },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '*' },
           },
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '*' },
-            },
-          },
-        ],
-      }).compileComponents();
+        },
+      ],
+    }).compileComponents();
 
-      launchDialogService = TestBed.inject(LaunchDialogService);
-    })
-  );
+    launchDialogService = TestBed.inject(LaunchDialogService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CustomerSelectionComponent);

--- a/feature-libs/asm/core/store/effects/customer.effect.ts
+++ b/feature-libs/asm/core/store/effects/customer.effect.ts
@@ -62,5 +62,8 @@ export class CustomerEffects {
       )
     );
 
-  constructor(private actions$: Actions, private asmConnector: AsmConnector) {}
+  constructor(
+    private actions$: Actions,
+    private asmConnector: AsmConnector
+  ) {}
 }

--- a/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.component.html
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.component.html
@@ -49,7 +49,8 @@
           [class.asc]="listSortOrder === SortOrder.ASC"
           [class.desc]="listSortOrder !== SortOrder.ASC"
           [attr.aria-sort]="
-            sortDirection | cxArgs: column.property:sortProperty:listSortOrder
+            sortDirection
+              | cxArgs: column.property : sortProperty : listSortOrder
           "
           [ngClass]="{
             'text-start':

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-section-context-source.model.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-section-context-source.model.ts
@@ -15,7 +15,7 @@ import { AsmCustomer360SectionContext } from './asm-customer-360-section-context
 
 @Injectable()
 export class AsmCustomer360SectionContextSource<
-  Data
+  Data,
 > extends AsmCustomer360SectionContext<Data> {
   readonly customer$ = new ReplaySubject<User>(1);
 

--- a/feature-libs/asm/customer-360/styles/components/_asm-customer-360-promotion-listing.component.scss
+++ b/feature-libs/asm/customer-360/styles/components/_asm-customer-360-promotion-listing.component.scss
@@ -88,7 +88,8 @@
       position: relative;
       &-input {
         border: none;
-        box-shadow: 0 0 0 1px rgba(85, 107, 130, 0.0625),
+        box-shadow:
+          0 0 0 1px rgba(85, 107, 130, 0.0625),
           0 1px 0 rgba(85, 107, 129, 1);
         height: 48px;
         width: 100%;
@@ -100,7 +101,8 @@
           color: #6c7079;
         }
         &:hover {
-          box-shadow: 0 0 0 1px rgba(104, 174, 255, 0.25),
+          box-shadow:
+            0 0 0 1px rgba(104, 174, 255, 0.25),
             0 1px 0 rgba(0, 100, 217, 1);
           & ~ .cx-asm-customer-360-promotion-listing-search-icon-reset {
             display: inline;

--- a/feature-libs/asm/styles/components/_asm-bind-cart-dialog.component.scss
+++ b/feature-libs/asm/styles/components/_asm-bind-cart-dialog.component.scss
@@ -38,7 +38,9 @@ $sapFiori_Button_Emphasized_Active_BorderColor: #0070f2;
     border-width: 0;
     display: flex;
 
-    box-shadow: 0px 0px 4px rgba(85, 107, 130, 0.16), inset 0px -1px 0px #d9d9d9;
+    box-shadow:
+      0px 0px 4px rgba(85, 107, 130, 0.16),
+      inset 0px -1px 0px #d9d9d9;
 
     .title {
       font-size: 1rem;

--- a/feature-libs/asm/styles/components/_asm-main-ui.component.scss
+++ b/feature-libs/asm/styles/components/_asm-main-ui.component.scss
@@ -136,7 +136,8 @@
 
     color: inherit;
     background-color: #ffffff;
-    box-shadow: 2px 2px rgba(85, 107, 130, 0.1),
+    box-shadow:
+      2px 2px rgba(85, 107, 130, 0.1),
       inset 0px -1px 0px rgba(85, 107, 130, 0.2);
   }
 

--- a/feature-libs/asm/styles/components/_asm-save-cart-dialog.component.scss
+++ b/feature-libs/asm/styles/components/_asm-save-cart-dialog.component.scss
@@ -101,7 +101,9 @@ $sapFiori_Button_Emphasized_Active_BorderColor: #0070f2;
     border-width: 0;
     display: flex;
 
-    box-shadow: 0px 0px 4px rgba(85, 107, 130, 0.16), inset 0px -1px 0px #d9d9d9;
+    box-shadow:
+      0px 0px 4px rgba(85, 107, 130, 0.16),
+      inset 0px -1px 0px #d9d9d9;
 
     .title {
       font-size: 1rem;

--- a/feature-libs/asm/styles/components/_asm-switch-customer-dialog.component.scss
+++ b/feature-libs/asm/styles/components/_asm-switch-customer-dialog.component.scss
@@ -38,7 +38,9 @@ $sapFiori_Button_Emphasized_Active_BorderColor: #0070f2;
     border-width: 0;
     display: flex;
 
-    box-shadow: 0px 0px 4px rgba(85, 107, 130, 0.16), inset 0px -1px 0px #d9d9d9;
+    box-shadow:
+      0px 0px 4px rgba(85, 107, 130, 0.16),
+      inset 0px -1px 0px #d9d9d9;
 
     .title {
       font-family: '72';

--- a/feature-libs/asm/styles/components/_customer-selection.component.scss
+++ b/feature-libs/asm/styles/components/_customer-selection.component.scss
@@ -84,7 +84,9 @@
     line-height: 1.5rem;
     left: 2rem;
     z-index: 11;
-    box-shadow: 0 5px 20px 0 #d9d9d9, 0 2px 8px 0 #ededed;
+    box-shadow:
+      0 5px 20px 0 #d9d9d9,
+      0 2px 8px 0 #ededed;
     background-color: #fff;
     border-radius: 4px;
     max-width: 50vw;

--- a/feature-libs/cart/base/components/abstract-order-context/abstract-order-context.directive.spec.ts
+++ b/feature-libs/cart/base/components/abstract-order-context/abstract-order-context.directive.spec.ts
@@ -12,9 +12,9 @@ let emissionCounterKey = 0;
 
 @Component({
   selector: 'cx-test-cmp',
-  template: `
-<span [cxAbstractOrderContext]="abstractOrderKey"><cx-test-cmp-inner/>        
-</span>`,
+  template: ` <span [cxAbstractOrderContext]="abstractOrderKey"
+    ><cx-test-cmp-inner />
+  </span>`,
 })
 class TestComponent {
   abstractOrderKey: AbstractOrderKeyInput = {
@@ -43,19 +43,17 @@ describe('AbstractOrderContextDirective', () => {
   let fixture: ComponentFixture<TestComponent>;
   let testOuterComponent: TestComponent;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [TestComponent, TestInnerComponent],
-        imports: [AbstractOrderContextModule],
-        providers: [],
-      }).compileComponents();
-      emissionCounterKey = 0;
-      fixture = TestBed.createComponent(TestComponent);
-      testOuterComponent = fixture.componentInstance;
-      fixture.detectChanges();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent, TestInnerComponent],
+      imports: [AbstractOrderContextModule],
+      providers: [],
+    }).compileComponents();
+    emissionCounterKey = 0;
+    fixture = TestBed.createComponent(TestComponent);
+    testOuterComponent = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
 
   it('should propagate abstract order ID to inner component', () => {
     expect(fixture.nativeElement.innerHTML).toContain(abstractOrderId);

--- a/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.html
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.html
@@ -46,11 +46,7 @@
           </div>
           <!-- Separator -->
           <div
-            class="
-              cx-dialog-separator
-              col-sm-12
-              d-xs-block d-sm-block d-md-none
-            "
+            class="cx-dialog-separator col-sm-12 d-xs-block d-sm-block d-md-none"
           ></div>
           <!-- Total container -->
           <div

--- a/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.spec.ts
@@ -41,27 +41,25 @@ describe('AppliedCouponsComponent', () => {
     'removeVoucher',
   ]);
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          AppliedCouponsComponent,
-          MockCxIconComponent,
-          MockedCartCouponComponent,
-        ],
-        providers: [
-          { provide: CartVoucherFacade, useValue: mockCartVoucherService },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '5.1' },
-            },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        AppliedCouponsComponent,
+        MockCxIconComponent,
+        MockedCartCouponComponent,
+      ],
+      providers: [
+        { provide: CartVoucherFacade, useValue: mockCartVoucherService },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '5.1' },
           },
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MockedCartCouponComponent);

--- a/feature-libs/cart/base/components/cart-coupon/cart-coupon.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-coupon/cart-coupon.component.spec.ts
@@ -70,26 +70,24 @@ describe('CartCouponComponent', () => {
 
   const appliedVouchers: Voucher[] = [{ code: 'CustomerCoupon1' }];
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, FormErrorsModule],
-        declarations: [
-          CartCouponComponent,
-          MockAppliedCouponsComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          { provide: ActiveCartFacade, useValue: mockActiveCartService },
-          { provide: CartVoucherFacade, useValue: mockCartVoucherService },
-          {
-            provide: CustomerCouponService,
-            useValue: mockCustomerCouponService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, FormErrorsModule],
+      declarations: [
+        CartCouponComponent,
+        MockAppliedCouponsComponent,
+        MockFeatureDirective,
+      ],
+      providers: [
+        { provide: ActiveCartFacade, useValue: mockActiveCartService },
+        { provide: CartVoucherFacade, useValue: mockCartVoucherService },
+        {
+          provide: CustomerCouponService,
+          useValue: mockCustomerCouponService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CartCouponComponent);

--- a/feature-libs/cart/base/components/cart-coupon/cart-coupon.component.ts
+++ b/feature-libs/cart/base/components/cart-coupon/cart-coupon.component.ts
@@ -71,7 +71,7 @@ export class CartCouponComponent implements OnInit, OnDestroy {
         ([cart, activeCardId, customerCoupons]: [
           Cart,
           string,
-          CustomerCouponSearchResult
+          CustomerCouponSearchResult,
         ]) => {
           this.cartId = activeCardId;
           this.getApplicableCustomerCoupons(

--- a/feature-libs/cart/base/components/cart-details/cart-details.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-details/cart-details.component.spec.ts
@@ -94,35 +94,33 @@ describe('CartDetailsComponent', () => {
 
   const mockRoutingService = jasmine.createSpyObj('RoutingService', ['go']);
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, PromotionsModule, I18nTestingModule],
-        declarations: [
-          CartDetailsComponent,
-          MockCartItemListComponent,
-          MockCartCouponComponent,
-          MockCartValidationWarningsComponent,
-        ],
-        providers: [
-          { provide: SelectiveCartFacade, useValue: mockSelectiveCartFacade },
-          { provide: AuthService, useValue: mockAuthService },
-          { provide: RoutingService, useValue: mockRoutingService },
-          {
-            provide: ActiveCartFacade,
-            useClass: MockActiveCartService,
-          },
-          {
-            provide: CartConfigService,
-            useValue: mockCartConfig,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, PromotionsModule, I18nTestingModule],
+      declarations: [
+        CartDetailsComponent,
+        MockCartItemListComponent,
+        MockCartCouponComponent,
+        MockCartValidationWarningsComponent,
+      ],
+      providers: [
+        { provide: SelectiveCartFacade, useValue: mockSelectiveCartFacade },
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: RoutingService, useValue: mockRoutingService },
+        {
+          provide: ActiveCartFacade,
+          useClass: MockActiveCartService,
+        },
+        {
+          provide: CartConfigService,
+          useValue: mockCartConfig,
+        },
+      ],
+    }).compileComponents();
 
-      mockCartConfig.isSelectiveCartEnabled.and.returnValue(true);
-      mockSelectiveCartFacade.isStable.and.returnValue(of(true));
-    })
-  );
+    mockCartConfig.isSelectiveCartEnabled.and.returnValue(true);
+    mockSelectiveCartFacade.isStable.and.returnValue(of(true));
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CartDetailsComponent);

--- a/feature-libs/cart/base/components/cart-page-layout-handler.ts
+++ b/feature-libs/cart/base/components/cart-page-layout-handler.ts
@@ -47,13 +47,13 @@ export class CartPageLayoutHandler implements PageLayoutHandler {
                 'EmptyCartMiddleContent',
               ])
             : cart.totalItems
-            ? exclude(slots, ['EmptyCartMiddleContent'])
-            : selectiveCart?.totalItems
-            ? exclude(slots, [
-                'EmptyCartMiddleContent',
-                'CenterRightContentSlot',
-              ])
-            : exclude(slots, ['TopContent', 'CenterRightContentSlot']);
+              ? exclude(slots, ['EmptyCartMiddleContent'])
+              : selectiveCart?.totalItems
+                ? exclude(slots, [
+                    'EmptyCartMiddleContent',
+                    'CenterRightContentSlot',
+                  ])
+                : exclude(slots, ['TopContent', 'CenterRightContentSlot']);
         })
       );
     }

--- a/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.component.spec.ts
@@ -25,24 +25,22 @@ describe('CartProceedToCheckoutComponent', () => {
   let component: CartProceedToCheckoutComponent;
   let fixture: ComponentFixture<CartProceedToCheckoutComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule, ProgressButtonModule],
-        declarations: [CartProceedToCheckoutComponent, MockUrlPipe],
-        providers: [
-          {
-            provide: Router,
-            useClass: MockRouter,
-          },
-          {
-            provide: ChangeDetectorRef,
-            useValue: { markForCheck: createSpy('markForCheck') },
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule, ProgressButtonModule],
+      declarations: [CartProceedToCheckoutComponent, MockUrlPipe],
+      providers: [
+        {
+          provide: Router,
+          useClass: MockRouter,
+        },
+        {
+          provide: ChangeDetectorRef,
+          useValue: { markForCheck: createSpy('markForCheck') },
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CartProceedToCheckoutComponent);

--- a/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.component.ts
+++ b/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.component.ts
@@ -38,7 +38,10 @@ export class CartProceedToCheckoutComponent implements OnInit, OnDestroy {
    * @deprecated since 5.2
    */
   constructor(router: Router);
-  constructor(protected router: Router, protected cd?: ChangeDetectorRef) {}
+  constructor(
+    protected router: Router,
+    protected cd?: ChangeDetectorRef
+  ) {}
 
   ngOnInit(): void {
     this.subscription.add(

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.html
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.html
@@ -51,7 +51,7 @@
       <ng-template
         *ngIf="!readonly"
         [cxOutlet]="CartOutlets.ITEM_DELIVERY_DETAILS"
-        [cxOutletContext]="{item, cartType: options.cartType}"
+        [cxOutletContext]="{ item, cartType: options.cartType }"
       ></ng-template>
     </div>
 

--- a/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.spec.ts
@@ -113,34 +113,32 @@ describe('CartItemComponent', () => {
     'isLevel',
   ]);
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          RouterTestingModule,
-          ReactiveFormsModule,
-          I18nTestingModule,
-          OutletModule,
-        ],
-        declarations: [
-          CartItemComponent,
-          MockMediaComponent,
-          MockItemCounterComponent,
-          MockPromotionsComponent,
-          MockUrlPipe,
-          MockFeatureLevelDirective,
-          MockOutletDirective,
-          MockCartItemValidationWarningComponent,
-          MockAtMessageDirective,
-        ],
-        providers: [
-          {
-            provide: ControlContainer,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        ReactiveFormsModule,
+        I18nTestingModule,
+        OutletModule,
+      ],
+      declarations: [
+        CartItemComponent,
+        MockMediaComponent,
+        MockItemCounterComponent,
+        MockPromotionsComponent,
+        MockUrlPipe,
+        MockFeatureLevelDirective,
+        MockOutletDirective,
+        MockCartItemValidationWarningComponent,
+        MockAtMessageDirective,
+      ],
+      providers: [
+        {
+          provide: ControlContainer,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CartItemComponent);

--- a/feature-libs/cart/base/components/cart-shared/order-summary/order-summary.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-shared/order-summary/order-summary.component.spec.ts
@@ -30,21 +30,19 @@ describe('OrderSummary', () => {
   let component: OrderSummaryComponent;
   let fixture: ComponentFixture<OrderSummaryComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [CommonModule, PromotionsModule, I18nTestingModule],
-        declarations: [OrderSummaryComponent, MockAppliedCouponsComponent],
-        providers: [
-          { provide: CartVoucherFacade, useValue: {} },
-          {
-            provide: OutletContextData,
-            useValue: { context$ },
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [CommonModule, PromotionsModule, I18nTestingModule],
+      declarations: [OrderSummaryComponent, MockAppliedCouponsComponent],
+      providers: [
+        { provide: CartVoucherFacade, useValue: {} },
+        {
+          provide: OutletContextData,
+          useValue: { context$ },
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderSummaryComponent);

--- a/feature-libs/cart/base/components/cart-totals/cart-totals.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-totals/cart-totals.component.spec.ts
@@ -26,19 +26,17 @@ describe('CartTotalsComponent', () => {
   let component: CartTotalsComponent;
   let fixture: ComponentFixture<CartTotalsComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [CartTotalsComponent, MockOrderSummaryComponent],
-        providers: [
-          {
-            provide: ActiveCartFacade,
-            useClass: MockActiveCartService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [CartTotalsComponent, MockOrderSummaryComponent],
+      providers: [
+        {
+          provide: ActiveCartFacade,
+          useClass: MockActiveCartService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CartTotalsComponent);

--- a/feature-libs/cart/base/components/mini-cart/mini-cart.component.spec.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.component.spec.ts
@@ -37,20 +37,18 @@ describe('MiniCartComponent', () => {
   let miniCartComponent: MiniCartComponent;
   let fixture: ComponentFixture<MiniCartComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [MiniCartComponent, MockUrlPipe, MockCxIconComponent],
-        providers: [
-          {
-            provide: MiniCartComponentService,
-            useValue: mockMiniCartComponentService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [MiniCartComponent, MockUrlPipe, MockCxIconComponent],
+      providers: [
+        {
+          provide: MiniCartComponentService,
+          useValue: mockMiniCartComponentService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MiniCartComponent);

--- a/feature-libs/cart/base/components/save-for-later/save-for-later.component.spec.ts
+++ b/feature-libs/cart/base/components/save-for-later/save-for-later.component.spec.ts
@@ -46,19 +46,17 @@ describe('SaveForLaterComponent', () => {
     'getComponentData',
   ]);
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [SaveForLaterComponent, MockCartItemListComponent],
-        imports: [I18nTestingModule],
-        providers: [
-          { provide: CmsService, useValue: mockCmsService },
-          { provide: ActiveCartFacade, useValue: mockActiveCartService },
-          { provide: SelectiveCartFacade, useValue: mockSelectiveCartService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [SaveForLaterComponent, MockCartItemListComponent],
+      imports: [I18nTestingModule],
+      providers: [
+        { provide: CmsService, useValue: mockCmsService },
+        { provide: ActiveCartFacade, useValue: mockActiveCartService },
+        { provide: SelectiveCartFacade, useValue: mockSelectiveCartService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SaveForLaterComponent);

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details-items/saved-cart-details-items.component.spec.ts
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details-items/saved-cart-details-items.component.spec.ts
@@ -79,46 +79,44 @@ describe('SavedCartDetailsItemsComponent', () => {
   let globalMessageService: GlobalMessageService;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [StoreModule.forRoot({}), I18nTestingModule, OutletModule],
-        declarations: [SavedCartDetailsItemsComponent],
-        providers: [
-          {
-            provide: SavedCartFacade,
-            useClass: MockSavedCartFacade,
-          },
-          {
-            provide: EventService,
-            useClass: MockEventService,
-          },
-          {
-            provide: SavedCartDetailsService,
-            useClass: MockSavedCartDetailsService,
-          },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [StoreModule.forRoot({}), I18nTestingModule, OutletModule],
+      declarations: [SavedCartDetailsItemsComponent],
+      providers: [
+        {
+          provide: SavedCartFacade,
+          useClass: MockSavedCartFacade,
+        },
+        {
+          provide: EventService,
+          useClass: MockEventService,
+        },
+        {
+          provide: SavedCartDetailsService,
+          useClass: MockSavedCartDetailsService,
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(SavedCartDetailsItemsComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(SavedCartDetailsItemsComponent);
+    component = fixture.componentInstance;
 
-      savedCartFacade = TestBed.inject(SavedCartFacade);
-      eventService = TestBed.inject(EventService);
-      globalMessageService = TestBed.inject(GlobalMessageService);
-      routingService = TestBed.inject(RoutingService);
+    savedCartFacade = TestBed.inject(SavedCartFacade);
+    eventService = TestBed.inject(EventService);
+    globalMessageService = TestBed.inject(GlobalMessageService);
+    routingService = TestBed.inject(RoutingService);
 
-      spyOn(routingService, 'go').and.callThrough();
-      spyOn(globalMessageService, 'add').and.callThrough();
-      spyOn(savedCartFacade, 'deleteSavedCart').and.callThrough();
+    spyOn(routingService, 'go').and.callThrough();
+    spyOn(globalMessageService, 'add').and.callThrough();
+    spyOn(savedCartFacade, 'deleteSavedCart').and.callThrough();
 
-      cart$.next(mockSavedCart);
+    cart$.next(mockSavedCart);
 
-      fixture.detectChanges();
-    })
-  );
+    fixture.detectChanges();
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.spec.ts
+++ b/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.spec.ts
@@ -105,31 +105,29 @@ describe('AddToWishListComponent', () => {
   let wishListFacade: WishListFacade;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule],
-        declarations: [
-          AddToWishListComponent,
-          MockIconComponent,
-          MockUrlPipe,
-          MockAtMessageDirective,
-        ],
-        providers: [
-          { provide: AuthService, useClass: MockAuthService },
-          { provide: WishListFacade, useClass: MockWishListService },
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-        ],
-      })
-        .overrideComponent(AddToWishListComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule],
+      declarations: [
+        AddToWishListComponent,
+        MockIconComponent,
+        MockUrlPipe,
+        MockAtMessageDirective,
+      ],
+      providers: [
+        { provide: AuthService, useClass: MockAuthService },
+        { provide: WishListFacade, useClass: MockWishListService },
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+      ],
     })
-  );
+      .overrideComponent(AddToWishListComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AddToWishListComponent);

--- a/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.spec.ts
+++ b/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.spec.ts
@@ -85,24 +85,22 @@ describe('WishListItemComponent', () => {
   let el: DebugElement;
   let componentInjector: Injector;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule],
-        declarations: [
-          WishListItemComponent,
-          MockPictureComponent,
-          MockAddToCartComponent,
-          MockUrlPipe,
-          MockAtMessageDirective,
-        ],
-      })
-        .overrideComponent(WishListItemComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule],
+      declarations: [
+        WishListItemComponent,
+        MockPictureComponent,
+        MockAddToCartComponent,
+        MockUrlPipe,
+        MockAtMessageDirective,
+      ],
     })
-  );
+      .overrideComponent(WishListItemComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WishListItemComponent);

--- a/feature-libs/cart/wish-list/components/wish-list/wish-list.component.spec.ts
+++ b/feature-libs/cart/wish-list/components/wish-list/wish-list.component.spec.ts
@@ -36,20 +36,18 @@ describe('WishListComponent', () => {
 
   let wishListService: WishListFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [WishListComponent, MockWishListItemComponent],
-        providers: [
-          {
-            provide: WishListFacade,
-            useClass: MockWishListService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [WishListComponent, MockWishListItemComponent],
+      providers: [
+        {
+          provide: WishListFacade,
+          useClass: MockWishListService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WishListComponent);

--- a/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
+++ b/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
@@ -158,62 +158,60 @@ describe('B2BCheckoutDeliveryAddressComponent', () => {
   let globalMessageService: GlobalMessageService;
   let checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          B2BCheckoutDeliveryAddressComponent,
-          MockAddressFormComponent,
-          MockCardComponent,
-          MockSpinnerComponent,
-        ],
-        providers: [
-          { provide: UserAddressService, useClass: MockUserAddressService },
-          { provide: ActiveCartFacade, useClass: MockActiveCartService },
-          {
-            provide: CheckoutDeliveryAddressFacade,
-            useClass: MockCheckoutDeliveryAddressFacade,
-          },
-          { provide: CheckoutStepService, useClass: MockCheckoutStepService },
-          { provide: ActivatedRoute, useValue: mockActivatedRoute },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          {
-            provide: CheckoutPaymentTypeFacade,
-            useClass: MockPaymentTypeService,
-          },
-          {
-            provide: UserCostCenterService,
-            useClass: MockUserCostCenterService,
-          },
-          {
-            provide: CheckoutCostCenterFacade,
-            useClass: MockCheckoutCostCenterService,
-          },
-          {
-            provide: CheckoutDeliveryModesFacade,
-            useClass: MockCheckoutDeliveryModesFacade,
-          },
-        ],
-      })
-        .overrideComponent(B2BCheckoutDeliveryAddressComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
-
-      checkoutDeliveryAddressFacade = TestBed.inject(
-        CheckoutDeliveryAddressFacade
-      );
-      activeCartFacade = TestBed.inject(ActiveCartFacade);
-      checkoutStepService = TestBed.inject(
-        CheckoutStepService as Type<CheckoutStepService>
-      );
-      userAddressService = TestBed.inject(UserAddressService);
-      userCostCenterService = TestBed.inject(UserCostCenterService);
-      globalMessageService = TestBed.inject(GlobalMessageService);
-      checkoutDeliveryModesFacade = TestBed.inject(CheckoutDeliveryModesFacade);
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        B2BCheckoutDeliveryAddressComponent,
+        MockAddressFormComponent,
+        MockCardComponent,
+        MockSpinnerComponent,
+      ],
+      providers: [
+        { provide: UserAddressService, useClass: MockUserAddressService },
+        { provide: ActiveCartFacade, useClass: MockActiveCartService },
+        {
+          provide: CheckoutDeliveryAddressFacade,
+          useClass: MockCheckoutDeliveryAddressFacade,
+        },
+        { provide: CheckoutStepService, useClass: MockCheckoutStepService },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        {
+          provide: CheckoutPaymentTypeFacade,
+          useClass: MockPaymentTypeService,
+        },
+        {
+          provide: UserCostCenterService,
+          useClass: MockUserCostCenterService,
+        },
+        {
+          provide: CheckoutCostCenterFacade,
+          useClass: MockCheckoutCostCenterService,
+        },
+        {
+          provide: CheckoutDeliveryModesFacade,
+          useClass: MockCheckoutDeliveryModesFacade,
+        },
+      ],
     })
-  );
+      .overrideComponent(B2BCheckoutDeliveryAddressComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+
+    checkoutDeliveryAddressFacade = TestBed.inject(
+      CheckoutDeliveryAddressFacade
+    );
+    activeCartFacade = TestBed.inject(ActiveCartFacade);
+    checkoutStepService = TestBed.inject(
+      CheckoutStepService as Type<CheckoutStepService>
+    );
+    userAddressService = TestBed.inject(UserAddressService);
+    userCostCenterService = TestBed.inject(UserCostCenterService);
+    globalMessageService = TestBed.inject(GlobalMessageService);
+    checkoutDeliveryModesFacade = TestBed.inject(CheckoutDeliveryModesFacade);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(B2BCheckoutDeliveryAddressComponent);

--- a/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.component.spec.ts
+++ b/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.component.spec.ts
@@ -84,33 +84,31 @@ describe('CheckoutOnePaymentTypeComponent', () => {
 
   let checkoutStepService: CheckoutStepService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [CheckoutPaymentTypeComponent, MockSpinnerComponent],
-        providers: [
-          {
-            provide: CheckoutPaymentTypeFacade,
-            useClass: MockCheckoutOnePaymentTypeService,
-          },
-          {
-            provide: CheckoutStepService,
-            useClass: MockCheckoutStepService,
-          },
-          { provide: ActivatedRoute, useValue: mockActivatedRoute },
-          {
-            provide: GlobalMessageService,
-            useClass: MockGlobalMessageService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [CheckoutPaymentTypeComponent, MockSpinnerComponent],
+      providers: [
+        {
+          provide: CheckoutPaymentTypeFacade,
+          useClass: MockCheckoutOnePaymentTypeService,
+        },
+        {
+          provide: CheckoutStepService,
+          useClass: MockCheckoutStepService,
+        },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        {
+          provide: GlobalMessageService,
+          useClass: MockGlobalMessageService,
+        },
+      ],
+    }).compileComponents();
 
-      checkoutStepService = TestBed.inject(
-        CheckoutStepService as Type<CheckoutStepService>
-      );
-    })
-  );
+    checkoutStepService = TestBed.inject(
+      CheckoutStepService as Type<CheckoutStepService>
+    );
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutPaymentTypeComponent);
@@ -141,36 +139,34 @@ describe('CheckoutPaymentTypeComponent', () => {
   let checkoutStepService: CheckoutStepService;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [CheckoutPaymentTypeComponent, MockSpinnerComponent],
-        providers: [
-          {
-            provide: CheckoutPaymentTypeFacade,
-            useClass: MockCheckoutPaymentTypeService,
-          },
-          {
-            provide: CheckoutStepService,
-            useClass: MockCheckoutStepService,
-          },
-          { provide: ActivatedRoute, useValue: mockActivatedRoute },
-          {
-            provide: GlobalMessageService,
-            useClass: MockGlobalMessageService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [CheckoutPaymentTypeComponent, MockSpinnerComponent],
+      providers: [
+        {
+          provide: CheckoutPaymentTypeFacade,
+          useClass: MockCheckoutPaymentTypeService,
+        },
+        {
+          provide: CheckoutStepService,
+          useClass: MockCheckoutStepService,
+        },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        {
+          provide: GlobalMessageService,
+          useClass: MockGlobalMessageService,
+        },
+      ],
+    }).compileComponents();
 
-      checkoutPaymentTypeFacade = TestBed.inject(
-        CheckoutPaymentTypeFacade as Type<CheckoutPaymentTypeFacade>
-      );
-      checkoutStepService = TestBed.inject(
-        CheckoutStepService as Type<CheckoutStepService>
-      );
-    })
-  );
+    checkoutPaymentTypeFacade = TestBed.inject(
+      CheckoutPaymentTypeFacade as Type<CheckoutPaymentTypeFacade>
+    );
+    checkoutStepService = TestBed.inject(
+      CheckoutStepService as Type<CheckoutStepService>
+    );
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutPaymentTypeComponent);

--- a/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.component.ts
@@ -87,7 +87,7 @@ export class CheckoutPaymentTypeComponent {
     map(
       ([selectedPaymentType, availablePaymentTypes]: [
         PaymentType | undefined,
-        PaymentType[]
+        PaymentType[],
       ]) => {
         if (
           selectedPaymentType &&

--- a/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.spec.ts
+++ b/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.spec.ts
@@ -213,55 +213,53 @@ describe('B2BCheckoutReviewSubmitComponent', () => {
   let component: B2BCheckoutReviewSubmitComponent;
   let fixture: ComponentFixture<B2BCheckoutReviewSubmitComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          PromotionsModule,
-          RouterTestingModule,
-          IconTestingModule,
-          OutletModule,
-        ],
-        declarations: [
-          B2BCheckoutReviewSubmitComponent,
-          MockCardComponent,
-          MockUrlPipe,
-        ],
-        providers: [
-          {
-            provide: CheckoutDeliveryAddressFacade,
-            useClass: MockCheckoutDeliveryAddressService,
-          },
-          {
-            provide: CheckoutDeliveryModesFacade,
-            useClass: MockCheckoutDeliveryModesService,
-          },
-          {
-            provide: CheckoutPaymentFacade,
-            useClass: MockCheckoutPaymentService,
-          },
-          { provide: ActiveCartFacade, useClass: MockActiveCartService },
-          {
-            provide: CheckoutStepService,
-            useClass: MockCheckoutStepService,
-          },
-          {
-            provide: CheckoutPaymentTypeFacade,
-            useClass: MockCheckoutPaymentTypeFacade,
-          },
-          {
-            provide: CheckoutCostCenterFacade,
-            useClass: MockCheckoutCostCenterService,
-          },
-          {
-            provide: UserCostCenterService,
-            useClass: MockUserCostCenterService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        PromotionsModule,
+        RouterTestingModule,
+        IconTestingModule,
+        OutletModule,
+      ],
+      declarations: [
+        B2BCheckoutReviewSubmitComponent,
+        MockCardComponent,
+        MockUrlPipe,
+      ],
+      providers: [
+        {
+          provide: CheckoutDeliveryAddressFacade,
+          useClass: MockCheckoutDeliveryAddressService,
+        },
+        {
+          provide: CheckoutDeliveryModesFacade,
+          useClass: MockCheckoutDeliveryModesService,
+        },
+        {
+          provide: CheckoutPaymentFacade,
+          useClass: MockCheckoutPaymentService,
+        },
+        { provide: ActiveCartFacade, useClass: MockActiveCartService },
+        {
+          provide: CheckoutStepService,
+          useClass: MockCheckoutStepService,
+        },
+        {
+          provide: CheckoutPaymentTypeFacade,
+          useClass: MockCheckoutPaymentTypeFacade,
+        },
+        {
+          provide: CheckoutCostCenterFacade,
+          useClass: MockCheckoutCostCenterService,
+        },
+        {
+          provide: UserCostCenterService,
+          useClass: MockUserCostCenterService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(B2BCheckoutReviewSubmitComponent);

--- a/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.component.spec.ts
@@ -92,39 +92,37 @@ describe('CheckoutBillingAddressFormComponent', () => {
   let mockGlobalMessageService: MockGlobalMessageService;
   let userAddressService: UserAddressService;
 
-  beforeEach(
-    waitForAsync(() => {
-      mockCheckoutDeliveryService = new MockCheckoutDeliveryService();
-      mockUserPaymentService = new MockUserPaymentService();
-      mockGlobalMessageService = new MockGlobalMessageService();
+  beforeEach(waitForAsync(() => {
+    mockCheckoutDeliveryService = new MockCheckoutDeliveryService();
+    mockUserPaymentService = new MockUserPaymentService();
+    mockGlobalMessageService = new MockGlobalMessageService();
 
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          NgSelectModule,
-          NgSelectA11yModule,
-          I18nTestingModule,
-          FormErrorsModule,
-        ],
-        declarations: [CheckoutBillingAddressFormComponent, MockCardComponent],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: CheckoutDeliveryAddressFacade,
-            useValue: mockCheckoutDeliveryService,
-          },
-          { provide: UserPaymentService, useValue: mockUserPaymentService },
-          { provide: GlobalMessageService, useValue: mockGlobalMessageService },
-          { provide: UserAddressService, useClass: MockUserAddressService },
-          CheckoutBillingAddressFormService,
-        ],
-      })
-        .overrideComponent(CheckoutBillingAddressFormComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        NgSelectModule,
+        NgSelectA11yModule,
+        I18nTestingModule,
+        FormErrorsModule,
+      ],
+      declarations: [CheckoutBillingAddressFormComponent, MockCardComponent],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: CheckoutDeliveryAddressFacade,
+          useValue: mockCheckoutDeliveryService,
+        },
+        { provide: UserPaymentService, useValue: mockUserPaymentService },
+        { provide: GlobalMessageService, useValue: mockGlobalMessageService },
+        { provide: UserAddressService, useClass: MockUserAddressService },
+        CheckoutBillingAddressFormService,
+      ],
     })
-  );
+      .overrideComponent(CheckoutBillingAddressFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     userAddressService = TestBed.inject(UserAddressService);

--- a/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
@@ -139,60 +139,58 @@ describe('CheckoutDeliveryAddressComponent', () => {
   let globalMessageService: GlobalMessageService;
   let featureConfig: FeatureConfigService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          CheckoutDeliveryAddressComponent,
-          MockAddressFormComponent,
-          MockCardComponent,
-          MockSpinnerComponent,
-        ],
-        providers: [
-          { provide: UserAddressService, useClass: MockUserAddressService },
-          { provide: ActiveCartFacade, useClass: MockActiveCartService },
-          {
-            provide: CheckoutDeliveryAddressFacade,
-            useClass: MockCheckoutDeliveryAddressFacade,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        CheckoutDeliveryAddressComponent,
+        MockAddressFormComponent,
+        MockCardComponent,
+        MockSpinnerComponent,
+      ],
+      providers: [
+        { provide: UserAddressService, useClass: MockUserAddressService },
+        { provide: ActiveCartFacade, useClass: MockActiveCartService },
+        {
+          provide: CheckoutDeliveryAddressFacade,
+          useClass: MockCheckoutDeliveryAddressFacade,
+        },
+        { provide: CheckoutStepService, useClass: MockCheckoutStepService },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        {
+          provide: CheckoutDeliveryModesFacade,
+          useClass: MockCheckoutDeliveryModesFacade,
+        },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '6.3' },
           },
-          { provide: CheckoutStepService, useClass: MockCheckoutStepService },
-          { provide: ActivatedRoute, useValue: mockActivatedRoute },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          {
-            provide: CheckoutDeliveryModesFacade,
-            useClass: MockCheckoutDeliveryModesFacade,
-          },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '6.3' },
-            },
-          },
-          {
-            provide: FeatureConfigService,
-            useClass: MockFeatureConfigService,
-          },
-        ],
-      })
-        .overrideComponent(CheckoutDeliveryAddressComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
-
-      checkoutDeliveryAddressFacade = TestBed.inject(
-        CheckoutDeliveryAddressFacade
-      );
-      activeCartFacade = TestBed.inject(ActiveCartFacade);
-      checkoutStepService = TestBed.inject(
-        CheckoutStepService as Type<CheckoutStepService>
-      );
-      userAddressService = TestBed.inject(UserAddressService);
-      checkoutDeliveryModesFacade = TestBed.inject(CheckoutDeliveryModesFacade);
-      globalMessageService = TestBed.inject(GlobalMessageService);
-      featureConfig = TestBed.inject(FeatureConfigService);
+        },
+        {
+          provide: FeatureConfigService,
+          useClass: MockFeatureConfigService,
+        },
+      ],
     })
-  );
+      .overrideComponent(CheckoutDeliveryAddressComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+
+    checkoutDeliveryAddressFacade = TestBed.inject(
+      CheckoutDeliveryAddressFacade
+    );
+    activeCartFacade = TestBed.inject(ActiveCartFacade);
+    checkoutStepService = TestBed.inject(
+      CheckoutStepService as Type<CheckoutStepService>
+    );
+    userAddressService = TestBed.inject(UserAddressService);
+    checkoutDeliveryModesFacade = TestBed.inject(CheckoutDeliveryModesFacade);
+    globalMessageService = TestBed.inject(GlobalMessageService);
+    featureConfig = TestBed.inject(FeatureConfigService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutDeliveryAddressComponent);

--- a/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.spec.ts
@@ -128,36 +128,34 @@ describe('CheckoutDeliveryModeComponent', () => {
   let checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade;
   let globalMessageService: GlobalMessageService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [ReactiveFormsModule, I18nTestingModule, OutletModule],
-        declarations: [CheckoutDeliveryModeComponent, MockSpinnerComponent],
-        providers: [
-          {
-            provide: CheckoutDeliveryModesFacade,
-            useClass: MockCheckoutDeliveryModeService,
-          },
-          { provide: CheckoutStepService, useClass: MockCheckoutStepService },
-          {
-            provide: CheckoutConfigService,
-            useClass: MockCheckoutConfigService,
-          },
-          { provide: ActivatedRoute, useValue: mockActivatedRoute },
-          { provide: ActiveCartFacade, useClass: MockCartService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          { provide: FeatureConfigService, useClass: MockFeatureConfigService },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, I18nTestingModule, OutletModule],
+      declarations: [CheckoutDeliveryModeComponent, MockSpinnerComponent],
+      providers: [
+        {
+          provide: CheckoutDeliveryModesFacade,
+          useClass: MockCheckoutDeliveryModeService,
+        },
+        { provide: CheckoutStepService, useClass: MockCheckoutStepService },
+        {
+          provide: CheckoutConfigService,
+          useClass: MockCheckoutConfigService,
+        },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: ActiveCartFacade, useClass: MockCartService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
+      ],
+    }).compileComponents();
 
-      checkoutConfigService = TestBed.inject(CheckoutConfigService);
-      checkoutDeliveryModesFacade = TestBed.inject(CheckoutDeliveryModesFacade);
-      globalMessageService = TestBed.inject(GlobalMessageService);
-      checkoutStepService = TestBed.inject(
-        CheckoutStepService as Type<CheckoutStepService>
-      );
-    })
-  );
+    checkoutConfigService = TestBed.inject(CheckoutConfigService);
+    checkoutDeliveryModesFacade = TestBed.inject(CheckoutDeliveryModesFacade);
+    globalMessageService = TestBed.inject(GlobalMessageService);
+    checkoutStepService = TestBed.inject(
+      CheckoutStepService as Type<CheckoutStepService>
+    );
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutDeliveryModeComponent);

--- a/feature-libs/checkout/base/components/checkout-login/checkout-login.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-login/checkout-login.component.spec.ts
@@ -28,21 +28,19 @@ describe('CheckoutLoginComponent', () => {
   let email: AbstractControl;
   let emailConfirmation: AbstractControl;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [ReactiveFormsModule, I18nTestingModule, FormErrorsModule],
-        declarations: [CheckoutLoginComponent, MockFeatureDirective],
-        providers: [
-          { provide: ActiveCartFacade, useClass: MockActiveCartService },
-          {
-            provide: AuthRedirectService,
-            useClass: MockRedirectAfterAuthService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, I18nTestingModule, FormErrorsModule],
+      declarations: [CheckoutLoginComponent, MockFeatureDirective],
+      providers: [
+        { provide: ActiveCartFacade, useClass: MockActiveCartService },
+        {
+          provide: AuthRedirectService,
+          useClass: MockRedirectAfterAuthService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutLoginComponent);

--- a/feature-libs/checkout/base/components/checkout-orchestrator/checkout-orchestrator.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-orchestrator/checkout-orchestrator.component.spec.ts
@@ -5,13 +5,11 @@ describe('MultiStepCheckoutOrchestratorComponent', () => {
   let component: CheckoutOrchestratorComponent;
   let fixture: ComponentFixture<CheckoutOrchestratorComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [CheckoutOrchestratorComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [CheckoutOrchestratorComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutOrchestratorComponent);

--- a/feature-libs/checkout/base/components/checkout-order-summary/checkout-order-summary.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-order-summary/checkout-order-summary.component.spec.ts
@@ -24,23 +24,21 @@ describe('CheckoutOrderSummaryComponent', () => {
   let component: CheckoutOrderSummaryComponent;
   let fixture: ComponentFixture<CheckoutOrderSummaryComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          CheckoutOrderSummaryComponent,
-          OrderSummaryComponent,
-          PromotionsComponent,
-          AppliedCouponsComponent,
-          MockFeatureLevelDirective,
-        ],
-        providers: [
-          { provide: ActiveCartFacade, useClass: MockActiveCartService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        CheckoutOrderSummaryComponent,
+        OrderSummaryComponent,
+        PromotionsComponent,
+        AppliedCouponsComponent,
+        MockFeatureLevelDirective,
+      ],
+      providers: [
+        { provide: ActiveCartFacade, useClass: MockActiveCartService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutOrderSummaryComponent);

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
@@ -192,55 +192,53 @@ describe('CheckoutPaymentFormComponent', () => {
     billingAddress: UntypedFormGroup['controls'];
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      mockCheckoutDeliveryService = new MockCheckoutDeliveryService();
-      mockCheckoutPaymentService = new MockCheckoutPaymentService();
-      mockUserPaymentService = new MockUserPaymentService();
-      mockGlobalMessageService = new MockGlobalMessageService();
+  beforeEach(waitForAsync(() => {
+    mockCheckoutDeliveryService = new MockCheckoutDeliveryService();
+    mockCheckoutPaymentService = new MockCheckoutPaymentService();
+    mockUserPaymentService = new MockUserPaymentService();
+    mockGlobalMessageService = new MockGlobalMessageService();
 
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          NgSelectModule,
-          NgSelectA11yModule,
-          I18nTestingModule,
-          FormErrorsModule,
-        ],
-        declarations: [
-          CheckoutPaymentFormComponent,
-          MockCardComponent,
-          MockBillingAddressFormComponent,
-          MockCxIconComponent,
-          MockSpinnerComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: CheckoutPaymentFacade,
-            useValue: mockCheckoutPaymentService,
-          },
-          {
-            provide: CheckoutDeliveryAddressFacade,
-            useValue: mockCheckoutDeliveryService,
-          },
-          { provide: UserPaymentService, useValue: mockUserPaymentService },
-          { provide: GlobalMessageService, useValue: mockGlobalMessageService },
-          { provide: UserAddressService, useClass: MockUserAddressService },
-          {
-            provide: CheckoutBillingAddressFormService,
-            useClass: MockCheckoutBillingAddressFormService,
-          },
-          { provide: FeatureConfigService, useClass: MockFeatureConfigService },
-        ],
-      })
-        .overrideComponent(CheckoutPaymentFormComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        NgSelectModule,
+        NgSelectA11yModule,
+        I18nTestingModule,
+        FormErrorsModule,
+      ],
+      declarations: [
+        CheckoutPaymentFormComponent,
+        MockCardComponent,
+        MockBillingAddressFormComponent,
+        MockCxIconComponent,
+        MockSpinnerComponent,
+        MockFeatureDirective,
+      ],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: CheckoutPaymentFacade,
+          useValue: mockCheckoutPaymentService,
+        },
+        {
+          provide: CheckoutDeliveryAddressFacade,
+          useValue: mockCheckoutDeliveryService,
+        },
+        { provide: UserPaymentService, useValue: mockUserPaymentService },
+        { provide: GlobalMessageService, useValue: mockGlobalMessageService },
+        { provide: UserAddressService, useClass: MockUserAddressService },
+        {
+          provide: CheckoutBillingAddressFormService,
+          useClass: MockCheckoutBillingAddressFormService,
+        },
+        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
+      ],
     })
-  );
+      .overrideComponent(CheckoutPaymentFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutPaymentFormComponent);

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.spec.ts
@@ -179,57 +179,55 @@ describe('CheckoutPaymentMethodComponent', () => {
   let globalMessageService: GlobalMessageService;
   let featureConfig: FeatureConfigService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          CheckoutPaymentMethodComponent,
-          MockPaymentFormComponent,
-          CardComponent,
-          MockSpinnerComponent,
-          MockCxIconComponent,
-        ],
-        providers: [
-          { provide: UserPaymentService, useClass: MockUserPaymentService },
-          {
-            provide: CheckoutDeliveryAddressFacade,
-            useClass: MockCheckoutDeliveryFacade,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        CheckoutPaymentMethodComponent,
+        MockPaymentFormComponent,
+        CardComponent,
+        MockSpinnerComponent,
+        MockCxIconComponent,
+      ],
+      providers: [
+        { provide: UserPaymentService, useClass: MockUserPaymentService },
+        {
+          provide: CheckoutDeliveryAddressFacade,
+          useClass: MockCheckoutDeliveryFacade,
+        },
+        {
+          provide: ActiveCartFacade,
+          useClass: MockActiveCartService,
+        },
+        {
+          provide: CheckoutPaymentFacade,
+          useClass: MockCheckoutPaymentService,
+        },
+        { provide: CheckoutStepService, useClass: MockCheckoutStepService },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '6.3' },
           },
-          {
-            provide: ActiveCartFacade,
-            useClass: MockActiveCartService,
-          },
-          {
-            provide: CheckoutPaymentFacade,
-            useClass: MockCheckoutPaymentService,
-          },
-          { provide: CheckoutStepService, useClass: MockCheckoutStepService },
-          { provide: ActivatedRoute, useValue: mockActivatedRoute },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '6.3' },
-            },
-          },
-          {
-            provide: FeatureConfigService,
-            useClass: MockFeatureConfigService,
-          },
-        ],
-      }).compileComponents();
+        },
+        {
+          provide: FeatureConfigService,
+          useClass: MockFeatureConfigService,
+        },
+      ],
+    }).compileComponents();
 
-      mockUserPaymentService = TestBed.inject(UserPaymentService);
-      mockCheckoutPaymentService = TestBed.inject(CheckoutPaymentFacade);
-      mockActiveCartService = TestBed.inject(ActiveCartFacade);
-      checkoutStepService = TestBed.inject(
-        CheckoutStepService as Type<CheckoutStepService>
-      );
-      globalMessageService = TestBed.inject(GlobalMessageService);
-      featureConfig = TestBed.inject(FeatureConfigService);
-    })
-  );
+    mockUserPaymentService = TestBed.inject(UserPaymentService);
+    mockCheckoutPaymentService = TestBed.inject(CheckoutPaymentFacade);
+    mockActiveCartService = TestBed.inject(ActiveCartFacade);
+    checkoutStepService = TestBed.inject(
+      CheckoutStepService as Type<CheckoutStepService>
+    );
+    globalMessageService = TestBed.inject(GlobalMessageService);
+    featureConfig = TestBed.inject(FeatureConfigService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutPaymentMethodComponent);

--- a/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.spec.ts
@@ -47,25 +47,23 @@ describe('CheckoutPlaceOrderComponent', () => {
   let routingService: RoutingService;
   let launchDialogService: LaunchDialogService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          AtMessageModule,
-        ],
-        declarations: [MockUrlPipe, CheckoutPlaceOrderComponent],
-        providers: [
-          { provide: OrderFacade, useClass: MockOrderFacade },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          { provide: GlobalMessageService, useValue: {} },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        AtMessageModule,
+      ],
+      declarations: [MockUrlPipe, CheckoutPlaceOrderComponent],
+      providers: [
+        { provide: OrderFacade, useClass: MockOrderFacade },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        { provide: GlobalMessageService, useValue: {} },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutPlaceOrderComponent);

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-bottom/checkout-progress-mobile-bottom.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-bottom/checkout-progress-mobile-bottom.component.spec.ts
@@ -47,20 +47,18 @@ describe('CheckoutProgressMobileBottomComponent', () => {
   let component: CheckoutProgressMobileBottomComponent;
   let fixture: ComponentFixture<CheckoutProgressMobileBottomComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          CheckoutProgressMobileBottomComponent,
-          MockTranslateUrlPipe,
-        ],
-        providers: [
-          { provide: CheckoutStepService, useClass: MockCheckoutStepService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        CheckoutProgressMobileBottomComponent,
+        MockTranslateUrlPipe,
+      ],
+      providers: [
+        { provide: CheckoutStepService, useClass: MockCheckoutStepService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutProgressMobileBottomComponent);

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.component.spec.ts
@@ -60,21 +60,16 @@ describe('CheckoutProgressMobileTopComponent', () => {
   let component: CheckoutProgressMobileTopComponent;
   let fixture: ComponentFixture<CheckoutProgressMobileTopComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          CheckoutProgressMobileTopComponent,
-          MockTranslateUrlPipe,
-        ],
-        providers: [
-          { provide: CheckoutStepService, useClass: MockCheckoutStepService },
-          { provide: ActiveCartFacade, useClass: MockActiveCartService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [CheckoutProgressMobileTopComponent, MockTranslateUrlPipe],
+      providers: [
+        { provide: CheckoutStepService, useClass: MockCheckoutStepService },
+        { provide: ActiveCartFacade, useClass: MockActiveCartService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutProgressMobileTopComponent);

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress.component.spec.ts
@@ -56,21 +56,19 @@ describe('CheckoutProgressComponent', () => {
   let component: CheckoutProgressComponent;
   let fixture: ComponentFixture<CheckoutProgressComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          CheckoutProgressComponent,
-          MockTranslateUrlPipe,
-          MockMultiLinePipe,
-        ],
-        providers: [
-          { provide: CheckoutStepService, useClass: MockCheckoutStepService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        CheckoutProgressComponent,
+        MockTranslateUrlPipe,
+        MockMultiLinePipe,
+      ],
+      providers: [
+        { provide: CheckoutStepService, useClass: MockCheckoutStepService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutProgressComponent);

--- a/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.spec.ts
@@ -145,43 +145,41 @@ describe('CheckoutReviewSubmitComponent', () => {
   let component: CheckoutReviewSubmitComponent;
   let fixture: ComponentFixture<CheckoutReviewSubmitComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          PromotionsModule,
-          RouterTestingModule,
-          IconTestingModule,
-          OutletModule,
-        ],
-        declarations: [
-          CheckoutReviewSubmitComponent,
-          MockCardComponent,
-          MockUrlPipe,
-        ],
-        providers: [
-          {
-            provide: CheckoutDeliveryAddressFacade,
-            useClass: MockCheckoutDeliveryAddressService,
-          },
-          {
-            provide: CheckoutDeliveryModesFacade,
-            useClass: MockCheckoutDeliveryModesService,
-          },
-          {
-            provide: CheckoutPaymentFacade,
-            useClass: MockCheckoutPaymentService,
-          },
-          { provide: ActiveCartFacade, useClass: MockActiveCartService },
-          {
-            provide: CheckoutStepService,
-            useClass: MockCheckoutStepService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        PromotionsModule,
+        RouterTestingModule,
+        IconTestingModule,
+        OutletModule,
+      ],
+      declarations: [
+        CheckoutReviewSubmitComponent,
+        MockCardComponent,
+        MockUrlPipe,
+      ],
+      providers: [
+        {
+          provide: CheckoutDeliveryAddressFacade,
+          useClass: MockCheckoutDeliveryAddressService,
+        },
+        {
+          provide: CheckoutDeliveryModesFacade,
+          useClass: MockCheckoutDeliveryModesService,
+        },
+        {
+          provide: CheckoutPaymentFacade,
+          useClass: MockCheckoutPaymentService,
+        },
+        { provide: ActiveCartFacade, useClass: MockActiveCartService },
+        {
+          provide: CheckoutStepService,
+          useClass: MockCheckoutStepService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CheckoutReviewSubmitComponent);

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
@@ -319,7 +319,6 @@ export class OccCheckoutPaymentAdapter implements CheckoutPaymentAdapter {
       const key = item.key;
       result[key] = item.value;
       return result;
-    },
-    {});
+    }, {});
   }
 }

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.spec.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.spec.ts
@@ -90,39 +90,37 @@ describe('CheckoutScheduledReplenishmentPlaceOrderComponent', () => {
   let launchDialogService: LaunchDialogService;
   let scheduledReplenishmentOrderFacade: ScheduledReplenishmentOrderFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          AtMessageModule,
-        ],
-        declarations: [
-          MockUrlPipe,
-          CheckoutScheduledReplenishmentPlaceOrderComponent,
-        ],
-        providers: [
-          { provide: OrderFacade, useClass: MockOrderFacade },
-          {
-            provide: CheckoutReplenishmentFormService,
-            useClass: MockCheckoutReplenishmentFormService,
-          },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: ScheduledReplenishmentOrderFacade,
-            useClass: MockScheduledReplenishmentOrderFacade,
-          },
-          {
-            provide: GlobalMessageService,
-            useValue: {},
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        AtMessageModule,
+      ],
+      declarations: [
+        MockUrlPipe,
+        CheckoutScheduledReplenishmentPlaceOrderComponent,
+      ],
+      providers: [
+        { provide: OrderFacade, useClass: MockOrderFacade },
+        {
+          provide: CheckoutReplenishmentFormService,
+          useClass: MockCheckoutReplenishmentFormService,
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: ScheduledReplenishmentOrderFacade,
+          useClass: MockScheduledReplenishmentOrderFacade,
+        },
+        {
+          provide: GlobalMessageService,
+          useValue: {},
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.spec.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.spec.ts
@@ -37,20 +37,18 @@ describe('CheckoutScheduleReplenishmentOrderComponent', () => {
 
   let checkoutReplenishmentFormService: CheckoutReplenishmentFormService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule, IconTestingModule],
-        declarations: [CheckoutScheduleReplenishmentOrderComponent],
-        providers: [
-          {
-            provide: CheckoutReplenishmentFormService,
-            useClass: MockCheckoutReplenishmentFormService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule, IconTestingModule],
+      declarations: [CheckoutScheduleReplenishmentOrderComponent],
+      providers: [
+        {
+          provide: CheckoutReplenishmentFormService,
+          useClass: MockCheckoutReplenishmentFormService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/checkout/scheduled-replenishment/components/services/checkout-replenishment-form.service.spec.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/services/checkout-replenishment-form.service.spec.ts
@@ -11,13 +11,11 @@ const newReplenishmentFormData: ScheduleReplenishmentForm = {
 describe('Checkout Replenishment Form Service', () => {
   let service: CheckoutReplenishmentFormService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [CheckoutReplenishmentFormService],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [CheckoutReplenishmentFormService],
+    });
+  }));
 
   beforeEach(() => {
     service = TestBed.inject(CheckoutReplenishmentFormService);

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.spec.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.spec.ts
@@ -206,47 +206,45 @@ describe('CustomerTicketingListComponent', () => {
   let routingService: RoutingService;
   let customerTicketingFacade: CustomerTicketingFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          CustomerTicketingListComponent,
-          MockPaginationComponent,
-          MockSortingComponent,
-          MockUrlPipe,
-          MockCustomerTicketingCreateComponent,
-        ],
-        providers: [
-          {
-            provide: CustomerTicketingFacade,
-            useClass: MockCustomerTicketingFacade,
-          },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: TranslationService, useClass: MockTranslationService },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        CustomerTicketingListComponent,
+        MockPaginationComponent,
+        MockSortingComponent,
+        MockUrlPipe,
+        MockCustomerTicketingCreateComponent,
+      ],
+      providers: [
+        {
+          provide: CustomerTicketingFacade,
+          useClass: MockCustomerTicketingFacade,
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: TranslationService, useClass: MockTranslationService },
+      ],
+    }).compileComponents();
 
-      const translationService = TestBed.inject(TranslationService);
-      spyOn(translationService, 'translate').and.callFake((input) => {
-        switch (input) {
-          case 'customerTicketing.ticketId':
-            return of('ticket-id');
-          case 'customerTicketing.changedOn':
-            return of(new Date(0).toISOString());
-          default:
-            return EMPTY;
-        }
-      });
+    const translationService = TestBed.inject(TranslationService);
+    spyOn(translationService, 'translate').and.callFake((input) => {
+      switch (input) {
+        case 'customerTicketing.ticketId':
+          return of('ticket-id');
+        case 'customerTicketing.changedOn':
+          return of(new Date(0).toISOString());
+        default:
+          return EMPTY;
+      }
+    });
 
-      customerTicketingFacade = TestBed.inject(CustomerTicketingFacade);
+    customerTicketingFacade = TestBed.inject(CustomerTicketingFacade);
 
-      fixture = TestBed.createComponent(CustomerTicketingListComponent);
-      component = fixture.componentInstance;
-      routingService = TestBed.inject(RoutingService);
-      fixture.detectChanges();
-    })
-  );
+    fixture = TestBed.createComponent(CustomerTicketingListComponent);
+    component = fixture.componentInstance;
+    routingService = TestBed.inject(RoutingService);
+    fixture.detectChanges();
+  }));
 
   it('should be created', () => {
     expect(component).toBeTruthy();

--- a/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.component.spec.ts
+++ b/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.component.spec.ts
@@ -67,31 +67,29 @@ describe('MyAccountV2CustomerTicketingComponent', () => {
   let component: MyAccountV2CustomerTicketingComponent;
   let fixture: ComponentFixture<MyAccountV2CustomerTicketingComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          MyAccountV2CustomerTicketingComponent,
-          MockTranslatePipe,
-          MockUrlPipe,
-        ],
-        providers: [
-          {
-            provide: 'CustomerTicketingFacade',
-            useClass: MockcustomerTicketingFacade,
-          },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: TranslationService, useClass: MockTranslationService },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        MyAccountV2CustomerTicketingComponent,
+        MockTranslatePipe,
+        MockUrlPipe,
+      ],
+      providers: [
+        {
+          provide: 'CustomerTicketingFacade',
+          useClass: MockcustomerTicketingFacade,
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: TranslationService, useClass: MockTranslationService },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MyAccountV2CustomerTicketingComponent);
-      component = fixture.componentInstance;
-      component.tickets$ = of(mockTicketList);
-      fixture.detectChanges();
-    })
-  );
+    fixture = TestBed.createComponent(MyAccountV2CustomerTicketingComponent);
+    component = fixture.componentInstance;
+    component.tickets$ = of(mockTicketList);
+    fixture.detectChanges();
+  }));
 
   it('should be created', () => {
     expect(component).toBeTruthy();

--- a/feature-libs/estimated-delivery-date/show-estimated-delivery-date/components/estimated-delivery-date.component.spec.ts
+++ b/feature-libs/estimated-delivery-date/show-estimated-delivery-date/components/estimated-delivery-date.component.spec.ts
@@ -53,26 +53,24 @@ describe('EstimatedDeliveryDateCartEntryComponent', () => {
   let mockCartItemContext: MockCartItemContext;
   let mockOrderHistoryFacade: MockOrderHistoryFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
-        declarations: [
-          EstimatedDeliveryDateComponent,
-          MockConfigureEstimatedDeliveryDateComponent,
-        ],
-        providers: [
-          { provide: CartItemContext, useClass: MockCartItemContext },
-          { provide: OrderHistoryFacade, useClass: MockOrderHistoryFacade },
-          {
-            provide: TranslationService,
-            useClass: MockTranslationService,
-          },
-          { provide: LanguageService, useClass: MockLanguageService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      declarations: [
+        EstimatedDeliveryDateComponent,
+        MockConfigureEstimatedDeliveryDateComponent,
+      ],
+      providers: [
+        { provide: CartItemContext, useClass: MockCartItemContext },
+        { provide: OrderHistoryFacade, useClass: MockOrderHistoryFacade },
+        {
+          provide: TranslationService,
+          useClass: MockTranslationService,
+        },
+        { provide: LanguageService, useClass: MockLanguageService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(EstimatedDeliveryDateComponent);

--- a/feature-libs/order/components/amend-order/amend-order-actions/amend-order-actions.component.spec.ts
+++ b/feature-libs/order/components/amend-order/amend-order-actions/amend-order-actions.component.spec.ts
@@ -30,27 +30,25 @@ describe('AmendOrderActionsComponent', () => {
   let fixture: ComponentFixture<AmendOrderActionsComponent>;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          RouterTestingModule,
-          I18nTestingModule,
-          StoreModule.forRoot({}),
-        ],
-        declarations: [MockUrlPipe, AmendOrderActionsComponent],
-        providers: [
-          {
-            provide: RoutingConfigService,
-            useClass: MockRoutingConfigService,
-          },
-          { provide: RoutingService, useClass: MockRoutingService },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        I18nTestingModule,
+        StoreModule.forRoot({}),
+      ],
+      declarations: [MockUrlPipe, AmendOrderActionsComponent],
+      providers: [
+        {
+          provide: RoutingConfigService,
+          useClass: MockRoutingConfigService,
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+      ],
+    }).compileComponents();
 
-      routingService = TestBed.inject(RoutingService);
-    })
-  );
+    routingService = TestBed.inject(RoutingService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AmendOrderActionsComponent);

--- a/feature-libs/order/components/amend-order/amend-order-items/amend-order-items.component.spec.ts
+++ b/feature-libs/order/components/amend-order/amend-order-items/amend-order-items.component.spec.ts
@@ -65,25 +65,23 @@ describe('CancelOrReturnItemsComponent', () => {
   let fixture: ComponentFixture<CancelOrReturnItemsComponent>;
   let orderAmendService: OrderAmendService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [ReactiveFormsModule, I18nTestingModule],
-        providers: [
-          {
-            provide: OrderAmendService,
-            useClass: MockOrderAmendService,
-          },
-        ],
-        declarations: [
-          CancelOrReturnItemsComponent,
-          MockMediaComponent,
-          MockItemCounterComponent,
-          MockFeatureLevelDirective,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, I18nTestingModule],
+      providers: [
+        {
+          provide: OrderAmendService,
+          useClass: MockOrderAmendService,
+        },
+      ],
+      declarations: [
+        CancelOrReturnItemsComponent,
+        MockMediaComponent,
+        MockItemCounterComponent,
+        MockFeatureLevelDirective,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CancelOrReturnItemsComponent);

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.component.spec.ts
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.component.spec.ts
@@ -66,26 +66,24 @@ describe('CancelOrderConfirmationComponent', () => {
   let fixture: ComponentFixture<CancelOrderConfirmationComponent>;
   let service: OrderAmendService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          CommonModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          ReactiveFormsModule,
-        ],
-        providers: [
-          { provide: OrderAmendService, useClass: MockOrderAmendService },
-        ],
-        declarations: [
-          CancelOrderConfirmationComponent,
-          MockAmendOrderActionComponent,
-          MockCancelOrReturnItemsComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        ReactiveFormsModule,
+      ],
+      providers: [
+        { provide: OrderAmendService, useClass: MockOrderAmendService },
+      ],
+      declarations: [
+        CancelOrderConfirmationComponent,
+        MockAmendOrderActionComponent,
+        MockCancelOrReturnItemsComponent,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CancelOrderConfirmationComponent);

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.component.spec.ts
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.component.spec.ts
@@ -44,21 +44,19 @@ describe('CancelOrderComponent', () => {
   let component: CancelOrderComponent;
   let fixture: ComponentFixture<CancelOrderComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, FormErrorsModule],
-        providers: [
-          { provide: OrderAmendService, useClass: MockOrderAmendService },
-        ],
-        declarations: [
-          CancelOrderComponent,
-          MockAmendOrderActionComponent,
-          MockCancelOrReturnItemsComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, FormErrorsModule],
+      providers: [
+        { provide: OrderAmendService, useClass: MockOrderAmendService },
+      ],
+      declarations: [
+        CancelOrderComponent,
+        MockAmendOrderActionComponent,
+        MockCancelOrReturnItemsComponent,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CancelOrderComponent);

--- a/feature-libs/order/components/amend-order/cancellations/order-cancellation.service.ts
+++ b/feature-libs/order/components/amend-order/cancellations/order-cancellation.service.ts
@@ -63,7 +63,7 @@ export class OrderCancellationService extends OrderAmendService {
           ({
             orderEntryNumber: Number(entryNumber),
             quantity: <number>entries[entryNumber],
-          } as CancelOrReturnRequestEntryInput)
+          }) as CancelOrReturnRequestEntryInput
       );
 
     this.form.reset();

--- a/feature-libs/order/components/amend-order/returns/order-return.service.ts
+++ b/feature-libs/order/components/amend-order/returns/order-return.service.ts
@@ -61,7 +61,7 @@ export class OrderReturnService extends OrderAmendService {
           ({
             orderEntryNumber: Number(entryNumber),
             quantity: <number>entries[entryNumber],
-          } as CancelOrReturnRequestEntryInput)
+          }) as CancelOrReturnRequestEntryInput
       );
 
     this.form.reset();

--- a/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.component.spec.ts
+++ b/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.component.spec.ts
@@ -65,21 +65,19 @@ describe('ReturnOrderConfirmationComponent', () => {
   let fixture: ComponentFixture<ReturnOrderConfirmationComponent>;
   let service: OrderAmendService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule, ReactiveFormsModule],
-        providers: [
-          { provide: OrderAmendService, useClass: MockOrderAmendService },
-        ],
-        declarations: [
-          ReturnOrderConfirmationComponent,
-          MockAmendOrderActionComponent,
-          MockCancelOrReturnItemsComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule, ReactiveFormsModule],
+      providers: [
+        { provide: OrderAmendService, useClass: MockOrderAmendService },
+      ],
+      declarations: [
+        ReturnOrderConfirmationComponent,
+        MockAmendOrderActionComponent,
+        MockCancelOrReturnItemsComponent,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ReturnOrderConfirmationComponent);

--- a/feature-libs/order/components/amend-order/returns/return-order/return-order.component.spec.ts
+++ b/feature-libs/order/components/amend-order/returns/return-order/return-order.component.spec.ts
@@ -44,21 +44,19 @@ describe('ReturnOrderComponent', () => {
   let component: ReturnOrderComponent;
   let fixture: ComponentFixture<ReturnOrderComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, FormErrorsModule],
-        providers: [
-          { provide: OrderAmendService, useClass: MockOrderAmendService },
-        ],
-        declarations: [
-          ReturnOrderComponent,
-          MockAmendOrderActionComponent,
-          MockCancelOrReturnItemsComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, FormErrorsModule],
+      providers: [
+        { provide: OrderAmendService, useClass: MockOrderAmendService },
+      ],
+      declarations: [
+        ReturnOrderComponent,
+        MockAmendOrderActionComponent,
+        MockCancelOrReturnItemsComponent,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ReturnOrderComponent);

--- a/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.spec.ts
+++ b/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.spec.ts
@@ -94,25 +94,23 @@ describe(' MyAccountV2OrdersComponent', () => {
   let fixture: ComponentFixture<MyAccountV2OrdersComponent>;
   let service: MyAccountV2OrderHistoryService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          MyAccountV2OrdersComponent,
-          MockUrlPipe,
-          MockMediaComponent,
-          MockSpinnerComponent,
-        ],
-        providers: [
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: MyAccountV2OrderHistoryService, useClass: MockService },
-          { provide: TranslationService, useClass: MockTranslationService },
-        ],
-      }).compileComponents();
-      service = TestBed.inject(MyAccountV2OrderHistoryService);
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        MyAccountV2OrdersComponent,
+        MockUrlPipe,
+        MockMediaComponent,
+        MockSpinnerComponent,
+      ],
+      providers: [
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: MyAccountV2OrderHistoryService, useClass: MockService },
+        { provide: TranslationService, useClass: MockTranslationService },
+      ],
+    }).compileComponents();
+    service = TestBed.inject(MyAccountV2OrderHistoryService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyAccountV2OrdersComponent);

--- a/feature-libs/order/components/order-confirmation/order-confirmation-items/order-confirmation-items.component.spec.ts
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-items/order-confirmation-items.component.spec.ts
@@ -24,23 +24,21 @@ describe('OrderConfirmationItemsComponent', () => {
   let component: OrderConfirmationItemsComponent;
   let fixture: ComponentFixture<OrderConfirmationItemsComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, PromotionsModule],
-        declarations: [OrderConfirmationItemsComponent],
-        providers: [
-          { provide: OrderFacade, useClass: MockOrderFacade },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '1.3' },
-            },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, PromotionsModule],
+      declarations: [OrderConfirmationItemsComponent],
+      providers: [
+        { provide: OrderFacade, useClass: MockOrderFacade },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '1.3' },
           },
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderConfirmationItemsComponent);

--- a/feature-libs/order/components/order-confirmation/order-confirmation-thank-you-message/order-confirmation-thank-you-message.component.spec.ts
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-thank-you-message/order-confirmation-thank-you-message.component.spec.ts
@@ -50,24 +50,22 @@ describe('OrderConfirmationThankYouMessageComponent', () => {
   let orderFacade: OrderFacade;
   let globalMessageService: GlobalMessageService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          OrderConfirmationThankYouMessageComponent,
-          MockAddtoHomeScreenBannerComponent,
-          MockGuestRegisterFormComponent,
-          MockFeatureLevelDirective,
-        ],
-        providers: [
-          { provide: OrderFacade, useClass: MockOrderFacade },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          { provide: TranslationService, useClass: MockTranslationService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        OrderConfirmationThankYouMessageComponent,
+        MockAddtoHomeScreenBannerComponent,
+        MockGuestRegisterFormComponent,
+        MockFeatureLevelDirective,
+      ],
+      providers: [
+        { provide: OrderFacade, useClass: MockOrderFacade },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        { provide: TranslationService, useClass: MockTranslationService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/order/components/order-confirmation/order-confirmation-totals/order-confirmation-totals.component.spec.ts
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-totals/order-confirmation-totals.component.spec.ts
@@ -18,15 +18,13 @@ describe('OrderConfirmationTotalsComponent', () => {
   let component: OrderConfirmationTotalsComponent;
   let fixture: ComponentFixture<OrderConfirmationTotalsComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [OrderConfirmationTotalsComponent],
-        providers: [{ provide: OrderFacade, useClass: MockOrderFacade }],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [OrderConfirmationTotalsComponent],
+      providers: [{ provide: OrderFacade, useClass: MockOrderFacade }],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderConfirmationTotalsComponent);

--- a/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.spec.ts
+++ b/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.spec.ts
@@ -34,24 +34,22 @@ describe('OrderGuestRegisterFormComponent', () => {
   let userRegisterFacade: UserRegisterFacade;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          ReactiveFormsModule,
-          FormErrorsModule,
-          PasswordVisibilityToggleModule,
-        ],
-        declarations: [OrderGuestRegisterFormComponent, MockFeatureDirective],
-        providers: [
-          { provide: AuthService, useClass: MockAuthService },
-          { provide: UserRegisterFacade, useClass: MockUserRegisterFacade },
-          { provide: RoutingService, useClass: MockRoutingService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        ReactiveFormsModule,
+        FormErrorsModule,
+        PasswordVisibilityToggleModule,
+      ],
+      declarations: [OrderGuestRegisterFormComponent, MockFeatureDirective],
+      providers: [
+        { provide: AuthService, useClass: MockAuthService },
+        { provide: UserRegisterFacade, useClass: MockUserRegisterFacade },
+        { provide: RoutingService, useClass: MockRoutingService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderGuestRegisterFormComponent);

--- a/feature-libs/order/components/order-details/my-account-v2-order-consignments.service.ts
+++ b/feature-libs/order/components/order-details/my-account-v2-order-consignments.service.ts
@@ -50,12 +50,15 @@ export class MyAccountV2OrderConsignmentsService {
   protected groupConsignments(
     consignments: Consignment[] | undefined
   ): Consignment[] | undefined {
-    const grouped = consignments?.reduce((result, current) => {
-      const key = this.getStatusGroupKey(current.status || '');
-      result[key] = result[key] || [];
-      result[key].push(current);
-      return result;
-    }, {} as { [key: string]: Consignment[] });
+    const grouped = consignments?.reduce(
+      (result, current) => {
+        const key = this.getStatusGroupKey(current.status || '');
+        result[key] = result[key] || [];
+        result[key].push(current);
+        return result;
+      },
+      {} as { [key: string]: Consignment[] }
+    );
 
     return grouped
       ? [...(grouped[1] || []), ...(grouped[0] || []), ...(grouped[-1] || [])]

--- a/feature-libs/order/components/order-details/my-account-v2/order-details-actions/my-account-v2-order-details-actions.component.spec.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/order-details-actions/my-account-v2-order-details-actions.component.spec.ts
@@ -51,24 +51,22 @@ describe('MyAccountV2OrderDetailsActionsComponent', () => {
   let el: DebugElement;
   let event: EventService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nModule, RouterTestingModule],
-        providers: [
-          { provide: TranslationService, useClass: MockTranslationService },
-          { provide: OrderDetailsService, useClass: MockOrderDetailsService },
-          { provide: RoutingService, useClass: MockRoutingService },
-        ],
-        declarations: [
-          MyAccountV2OrderDetailsActionsComponent,
-          MockUrlPipe,
-          MockOrderDetailActionsComponent,
-        ],
-      }).compileComponents();
-      event = TestBed.inject(EventService);
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nModule, RouterTestingModule],
+      providers: [
+        { provide: TranslationService, useClass: MockTranslationService },
+        { provide: OrderDetailsService, useClass: MockOrderDetailsService },
+        { provide: RoutingService, useClass: MockRoutingService },
+      ],
+      declarations: [
+        MyAccountV2OrderDetailsActionsComponent,
+        MockUrlPipe,
+        MockOrderDetailActionsComponent,
+      ],
+    }).compileComponents();
+    event = TestBed.inject(EventService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyAccountV2OrderDetailsActionsComponent);

--- a/feature-libs/order/components/order-details/order-detail-actions/order-detail-actions.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-actions/order-detail-actions.component.spec.ts
@@ -28,29 +28,27 @@ describe('OrderDetailActionsComponent', () => {
   let mockOrderDetailsService: OrderDetailsService;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      mockOrderDetailsService = <OrderDetailsService>{
-        getOrderDetails() {
-          return of(mockOrder);
-        },
-      };
+  beforeEach(waitForAsync(() => {
+    mockOrderDetailsService = <OrderDetailsService>{
+      getOrderDetails() {
+        return of(mockOrder);
+      },
+    };
 
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule],
-        providers: [
-          { provide: OrderDetailsService, useValue: mockOrderDetailsService },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { cancellationAndReturn: true },
-            },
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule],
+      providers: [
+        { provide: OrderDetailsService, useValue: mockOrderDetailsService },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { cancellationAndReturn: true },
           },
-        ],
-        declarations: [OrderDetailActionsComponent, MockUrlPipe],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+      declarations: [OrderDetailActionsComponent, MockUrlPipe],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderDetailActionsComponent);

--- a/feature-libs/order/components/order-details/order-detail-billing/order-detail-billing.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-billing/order-detail-billing.component.spec.ts
@@ -42,20 +42,18 @@ describe('OrderDetailBillingComponent', () => {
   let component: OrderDetailBillingComponent;
   let fixture: ComponentFixture<OrderDetailBillingComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [OrderDetailBillingComponent],
-        providers: [
-          {
-            provide: OrderDetailsService,
-            useClass: MockOrderDetailsService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [OrderDetailBillingComponent],
+      providers: [
+        {
+          provide: OrderDetailsService,
+          useClass: MockOrderDetailsService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderDetailBillingComponent);

--- a/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/tracking-events/tracking-events.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/tracking-events/tracking-events.component.spec.ts
@@ -37,25 +37,23 @@ describe('TrackingEventsComponent', () => {
   ]);
   let launchDialogService: LaunchDialogService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          SpinnerModule,
-          I18nTestingModule,
-          KeyboardFocusTestingModule,
-          IconTestingModule,
-        ],
-        declarations: [TrackingEventsComponent, MockTranslateUrlPipe],
-        providers: [
-          { provide: OrderHistoryFacade, useValue: userOrderService },
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        SpinnerModule,
+        I18nTestingModule,
+        KeyboardFocusTestingModule,
+        IconTestingModule,
+      ],
+      declarations: [TrackingEventsComponent, MockTranslateUrlPipe],
+      providers: [
+        { provide: OrderHistoryFacade, useValue: userOrderService },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+      ],
+    }).compileComponents();
 
-      launchDialogService = TestBed.inject(LaunchDialogService);
-    })
-  );
+    launchDialogService = TestBed.inject(LaunchDialogService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TrackingEventsComponent);

--- a/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.component.spec.ts
@@ -81,30 +81,28 @@ describe('OrderConsignedEntriesComponent', () => {
   let fixture: ComponentFixture<OrderConsignedEntriesComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          CardModule,
-          I18nTestingModule,
-          RouterTestingModule,
-          OutletModule,
-        ],
-        providers: [
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '1.4', consignmentTracking: true },
-            },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CardModule,
+        I18nTestingModule,
+        RouterTestingModule,
+        OutletModule,
+      ],
+      providers: [
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '1.4', consignmentTracking: true },
           },
-        ],
-        declarations: [
-          OrderConsignedEntriesComponent,
-          MockConsignmentTrackingComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+      declarations: [
+        OrderConsignedEntriesComponent,
+        MockConsignmentTrackingComponent,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderConsignedEntriesComponent);

--- a/feature-libs/order/components/order-details/order-detail-items/order-detail-items.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/order-detail-items.component.spec.ts
@@ -149,37 +149,35 @@ describe('OrderDetailItemsComponent', () => {
   let mockOrderDetailsService: OrderDetailsService;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      mockOrderDetailsService = <OrderDetailsService>{
-        isOrderDetailsLoading(): Observable<boolean> {
-          return of(false);
-        },
-        getOrderDetails() {
-          return of(mockOrder);
-        },
-      };
+  beforeEach(waitForAsync(() => {
+    mockOrderDetailsService = <OrderDetailsService>{
+      isOrderDetailsLoading(): Observable<boolean> {
+        return of(false);
+      },
+      getOrderDetails() {
+        return of(mockOrder);
+      },
+    };
 
-      TestBed.configureTestingModule({
-        imports: [
-          CardModule,
-          I18nTestingModule,
-          PromotionsModule,
-          RouterTestingModule,
-          OutletModule,
-        ],
-        providers: [
-          { provide: OrderDetailsService, useValue: mockOrderDetailsService },
-          { provide: CmsComponentData, useValue: MockCmsComponentData },
-        ],
-        declarations: [
-          OrderDetailItemsComponent,
-          MockConsignmentTrackingComponent,
-          OrderConsignedEntriesComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+    TestBed.configureTestingModule({
+      imports: [
+        CardModule,
+        I18nTestingModule,
+        PromotionsModule,
+        RouterTestingModule,
+        OutletModule,
+      ],
+      providers: [
+        { provide: OrderDetailsService, useValue: mockOrderDetailsService },
+        { provide: CmsComponentData, useValue: MockCmsComponentData },
+      ],
+      declarations: [
+        OrderDetailItemsComponent,
+        MockConsignmentTrackingComponent,
+        OrderConsignedEntriesComponent,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderDetailItemsComponent);

--- a/feature-libs/order/components/order-details/order-detail-reorder/order-detail-reorder.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-reorder/order-detail-reorder.component.spec.ts
@@ -35,25 +35,23 @@ describe('Order detail reorder component', () => {
   let fixture: ComponentFixture<OrderDetailReorderComponent>;
   let launchDialogService: LaunchDialogService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [OrderDetailReorderComponent],
-        providers: [
-          RouterTestingModule,
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-          {
-            provide: OrderDetailsService,
-            useClass: MockOrderDetailsService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [OrderDetailReorderComponent],
+      providers: [
+        RouterTestingModule,
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+        {
+          provide: OrderDetailsService,
+          useClass: MockOrderDetailsService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderDetailReorderComponent);

--- a/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.spec.ts
@@ -119,41 +119,39 @@ describe('ReorderDialogComponent', () => {
   let el: DebugElement;
   let reorderOrderFacade: ReorderOrderFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          FormsModule,
-          ReactiveFormsModule,
-          RouterTestingModule,
-          SpinnerModule,
-          I18nTestingModule,
-          PromotionsModule,
-        ],
-        declarations: [
-          ReorderDialogComponent,
-          MockCxIconComponent,
-          MockSpinnerComponent,
-          MockFocusDirective,
-        ],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: ReorderOrderFacade,
-            useClass: MockReorderOrderFacade,
-          },
-          {
-            provide: MultiCartFacade,
-            useClass: MockMultiCartService,
-          },
-          {
-            provide: FeatureConfigService,
-            useClass: MockFeatureConfigService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        SpinnerModule,
+        I18nTestingModule,
+        PromotionsModule,
+      ],
+      declarations: [
+        ReorderDialogComponent,
+        MockCxIconComponent,
+        MockSpinnerComponent,
+        MockFocusDirective,
+      ],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: ReorderOrderFacade,
+          useClass: MockReorderOrderFacade,
+        },
+        {
+          provide: MultiCartFacade,
+          useClass: MockMultiCartService,
+        },
+        {
+          provide: FeatureConfigService,
+          useClass: MockFeatureConfigService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ReorderDialogComponent);

--- a/feature-libs/order/components/order-details/order-detail-totals/order-detail-totals.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-totals/order-detail-totals.component.spec.ts
@@ -53,23 +53,21 @@ describe('OrderDetailTotalsComponent', () => {
   let fixture: ComponentFixture<OrderDetailTotalsComponent>;
   let mockOrderDetailsService: OrderDetailsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      mockOrderDetailsService = <OrderDetailsService>{
-        getOrderDetails() {
-          return of(mockOrder);
-        },
-      };
+  beforeEach(waitForAsync(() => {
+    mockOrderDetailsService = <OrderDetailsService>{
+      getOrderDetails() {
+        return of(mockOrder);
+      },
+    };
 
-      TestBed.configureTestingModule({
-        imports: [OutletModule],
-        providers: [
-          { provide: OrderDetailsService, useValue: mockOrderDetailsService },
-        ],
-        declarations: [OrderDetailTotalsComponent],
-      }).compileComponents();
-    })
-  );
+    TestBed.configureTestingModule({
+      imports: [OutletModule],
+      providers: [
+        { provide: OrderDetailsService, useValue: mockOrderDetailsService },
+      ],
+      declarations: [OrderDetailTotalsComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderDetailTotalsComponent);

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
@@ -205,7 +205,7 @@ export class OrderOverviewComponent {
                 ? deliveryMode.deliveryCost?.formattedValue
                 : '',
             ],
-          } as Card)
+          }) as Card
       )
     );
   }
@@ -243,7 +243,7 @@ export class OrderOverviewComponent {
               billingAddress.formattedAddress,
               billingAddress.country?.name,
             ],
-          } as Card)
+          }) as Card
       )
     );
   }

--- a/feature-libs/order/components/order-history/my-account-v2/consignment-entries/my-account-v2-consignment-entries.component.spec.ts
+++ b/feature-libs/order/components/order-history/my-account-v2/consignment-entries/my-account-v2-consignment-entries.component.spec.ts
@@ -66,22 +66,20 @@ describe('MyAccountV2ConsignmentEntriesComponent', () => {
   let fixture: ComponentFixture<MyAccountV2ConsignmentEntriesComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nModule],
-        providers: [
-          { provide: TranslationService, useClass: MockTranslationService },
-          { provide: LanguageService, useClass: MockLanguageService },
-        ],
-        declarations: [
-          MyAccountV2ConsignmentEntriesComponent,
-          MockUrlPipe,
-          MockDatePipe,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nModule],
+      providers: [
+        { provide: TranslationService, useClass: MockTranslationService },
+        { provide: LanguageService, useClass: MockLanguageService },
+      ],
+      declarations: [
+        MyAccountV2ConsignmentEntriesComponent,
+        MockUrlPipe,
+        MockDatePipe,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyAccountV2ConsignmentEntriesComponent);

--- a/feature-libs/order/components/order-history/my-account-v2/consolidated-information/my-account-v2-order-consolidated-information.component.spec.ts
+++ b/feature-libs/order/components/order-history/my-account-v2/consolidated-information/my-account-v2-order-consolidated-information.component.spec.ts
@@ -66,26 +66,24 @@ describe('MyAccountV2OrderConsolidatedInformationComponent', () => {
   let fixture: ComponentFixture<MyAccountV2OrderConsolidatedInformationComponent>;
   let service: MyAccountV2OrderConsignmentsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          MyAccountV2OrderConsolidatedInformationComponent,
-          MockUrlPipe,
-          MockMediaComponent,
-        ],
-        providers: [
-          {
-            provide: MyAccountV2OrderConsignmentsService,
-            useClass: MockMyAccountV2OrderConsignmentsService,
-          },
-          { provide: TranslationService, useClass: MockTranslationService },
-        ],
-      }).compileComponents();
-      service = TestBed.inject(MyAccountV2OrderConsignmentsService);
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        MyAccountV2OrderConsolidatedInformationComponent,
+        MockUrlPipe,
+        MockMediaComponent,
+      ],
+      providers: [
+        {
+          provide: MyAccountV2OrderConsignmentsService,
+          useClass: MockMyAccountV2OrderConsignmentsService,
+        },
+        { provide: TranslationService, useClass: MockTranslationService },
+      ],
+    }).compileComponents();
+    service = TestBed.inject(MyAccountV2OrderConsignmentsService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.component.spec.ts
+++ b/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.component.spec.ts
@@ -107,33 +107,31 @@ describe('MyAccountV2OrderHistoryComponent', () => {
   let fixture: ComponentFixture<MyAccountV2OrderHistoryComponent>;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          MyAccountV2OrderHistoryComponent,
-          MockUrlPipe,
-          MockPaginationComponent,
-          MockMyAccountV2OrderConsolidatedInformationComponent,
-          MockSpinnerComponent,
-        ],
-        providers: [
-          { provide: RoutingService, useClass: MockRoutingService },
-          {
-            provide: MyAccountV2OrderHistoryService,
-            useClass: MockMyAccountV2OrderHistoryService,
-          },
-          { provide: TranslationService, useClass: MockTranslationService },
-          {
-            provide: ReplenishmentOrderHistoryFacade,
-            useClass: MockReplenishmentOrderHistoryFacade,
-          },
-        ],
-      }).compileComponents();
-      routingService = TestBed.inject(RoutingService);
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        MyAccountV2OrderHistoryComponent,
+        MockUrlPipe,
+        MockPaginationComponent,
+        MockMyAccountV2OrderConsolidatedInformationComponent,
+        MockSpinnerComponent,
+      ],
+      providers: [
+        { provide: RoutingService, useClass: MockRoutingService },
+        {
+          provide: MyAccountV2OrderHistoryService,
+          useClass: MockMyAccountV2OrderHistoryService,
+        },
+        { provide: TranslationService, useClass: MockTranslationService },
+        {
+          provide: ReplenishmentOrderHistoryFacade,
+          useClass: MockReplenishmentOrderHistoryFacade,
+        },
+      ],
+    }).compileComponents();
+    routingService = TestBed.inject(RoutingService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyAccountV2OrderHistoryComponent);

--- a/feature-libs/order/components/order-history/order-history.component.spec.ts
+++ b/feature-libs/order/components/order-history/order-history.component.spec.ts
@@ -151,31 +151,29 @@ describe('OrderHistoryComponent', () => {
   let orderHistoryFacade: OrderHistoryFacade;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          OrderHistoryComponent,
-          MockUrlPipe,
-          MockPaginationComponent,
-          MockSortingComponent,
-        ],
-        providers: [
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: OrderHistoryFacade, useClass: MockOrderHistoryFacade },
-          { provide: TranslationService, useClass: MockTranslationService },
-          {
-            provide: ReplenishmentOrderHistoryFacade,
-            useClass: MockReplenishmentOrderHistoryFacade,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        OrderHistoryComponent,
+        MockUrlPipe,
+        MockPaginationComponent,
+        MockSortingComponent,
+      ],
+      providers: [
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: OrderHistoryFacade, useClass: MockOrderHistoryFacade },
+        { provide: TranslationService, useClass: MockTranslationService },
+        {
+          provide: ReplenishmentOrderHistoryFacade,
+          useClass: MockReplenishmentOrderHistoryFacade,
+        },
+      ],
+    }).compileComponents();
 
-      orderHistoryFacade = TestBed.inject(OrderHistoryFacade);
-      routingService = TestBed.inject(RoutingService);
-    })
-  );
+    orderHistoryFacade = TestBed.inject(OrderHistoryFacade);
+    routingService = TestBed.inject(RoutingService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderHistoryComponent);

--- a/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.spec.ts
+++ b/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.spec.ts
@@ -72,26 +72,24 @@ describe('ReplenishmentOrderCancellationDialogComponent', () => {
   let fixture: ComponentFixture<ReplenishmentOrderCancellationDialogComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, KeyboardFocusTestingModule],
-        declarations: [
-          ReplenishmentOrderCancellationDialogComponent,
-          MockCxIconComponent,
-          MockFeatureLevelDirective,
-        ],
-        providers: [
-          {
-            provide: ReplenishmentOrderHistoryFacade,
-            useClass: MockReplenishmentOrderHistoryFacade,
-          },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, KeyboardFocusTestingModule],
+      declarations: [
+        ReplenishmentOrderCancellationDialogComponent,
+        MockCxIconComponent,
+        MockFeatureLevelDirective,
+      ],
+      providers: [
+        {
+          provide: ReplenishmentOrderHistoryFacade,
+          useClass: MockReplenishmentOrderHistoryFacade,
+        },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/order/components/replenishment-order-details/replenishment-order-cancellation/replenishment-order-cancellation.component.spec.ts
+++ b/feature-libs/order/components/replenishment-order-details/replenishment-order-cancellation/replenishment-order-cancellation.component.spec.ts
@@ -61,24 +61,22 @@ describe('ReplenishmentOrderCancellationComponent', () => {
   let fixture: ComponentFixture<ReplenishmentOrderCancellationComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule],
-        declarations: [ReplenishmentOrderCancellationComponent, MockUrlPipe],
-        providers: [
-          {
-            provide: ReplenishmentOrderHistoryFacade,
-            useClass: MockReplenishmentOrderHistoryFacade,
-          },
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule],
+      declarations: [ReplenishmentOrderCancellationComponent, MockUrlPipe],
+      providers: [
+        {
+          provide: ReplenishmentOrderHistoryFacade,
+          useClass: MockReplenishmentOrderHistoryFacade,
+        },
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ReplenishmentOrderCancellationComponent);

--- a/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.html
+++ b/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.html
@@ -15,11 +15,7 @@
         <!-- Select Form and Pagination Top -->
         <div class="cx-replenishment-order-history-sort top row">
           <label
-            class="
-              cx-replenishment-order-history-form-group
-              form-group
-              col-sm-12 col-md-4 col-lg-4
-            "
+            class="cx-replenishment-order-history-form-group form-group col-sm-12 col-md-4 col-lg-4"
           >
             <span>{{ 'orderHistory.sortBy' | cxTranslate }}</span>
             <cx-sorting
@@ -123,10 +119,7 @@
                       params: order
                     } | cxUrl
                   "
-                  class="
-                    cx-replenishment-order-history-value
-                    cx-purchase-order-number
-                  "
+                  class="cx-replenishment-order-history-value cx-purchase-order-number"
                 >
                   {{
                     order?.purchaseOrderNumber?.length > 0
@@ -164,7 +157,7 @@
                   "
                   class="cx-replenishment-order-history-value"
                 >
-                  {{ order?.trigger.displayTimeTable | slice: 0:-12 }}
+                  {{ order?.trigger.displayTimeTable | slice: 0 : -12 }}
                 </a>
               </td>
               <td role="cell">
@@ -179,9 +172,7 @@
                       params: order
                     } | cxUrl
                   "
-                  class="
-                    cx-replenishment-order-history-value cx-next-order-date
-                  "
+                  class="cx-replenishment-order-history-value cx-next-order-date"
                 >
                   {{
                     order?.active

--- a/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.spec.ts
+++ b/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.spec.ts
@@ -122,36 +122,34 @@ describe('ReplenishmentOrderHistoryComponent', () => {
   let launchDialogService: LaunchDialogService;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          ReplenishmentOrderHistoryComponent,
-          MockUrlPipe,
-          MockPaginationComponent,
-          MockSortingComponent,
-        ],
-        providers: [
-          { provide: RoutingService, useClass: MockRoutingService },
-          {
-            provide: ReplenishmentOrderHistoryFacade,
-            useClass: MockReplenishmentOrderHistoryFacade,
-          },
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        ReplenishmentOrderHistoryComponent,
+        MockUrlPipe,
+        MockPaginationComponent,
+        MockSortingComponent,
+      ],
+      providers: [
+        { provide: RoutingService, useClass: MockRoutingService },
+        {
+          provide: ReplenishmentOrderHistoryFacade,
+          useClass: MockReplenishmentOrderHistoryFacade,
+        },
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+      ],
+    }).compileComponents();
 
-      replenishmentOrderHistoryFacade = TestBed.inject(
-        ReplenishmentOrderHistoryFacade
-      );
-      routingService = TestBed.inject(RoutingService);
-      launchDialogService = TestBed.inject(LaunchDialogService);
-    })
-  );
+    replenishmentOrderHistoryFacade = TestBed.inject(
+      ReplenishmentOrderHistoryFacade
+    );
+    routingService = TestBed.inject(RoutingService);
+    launchDialogService = TestBed.inject(LaunchDialogService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ReplenishmentOrderHistoryComponent);

--- a/feature-libs/order/components/return-request-detail/return-request-items/return-request-items.component.spec.ts
+++ b/feature-libs/order/components/return-request-detail/return-request-items/return-request-items.component.spec.ts
@@ -30,21 +30,19 @@ describe('ReturnRequestItemsComponent', () => {
   let component: ReturnRequestItemsComponent;
   let fixture: ComponentFixture<ReturnRequestItemsComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          ReturnRequestItemsComponent,
-          MockMediaComponent,
-          MockFeatureLevelDirective,
-        ],
-        providers: [
-          { provide: ReturnRequestService, useClass: MockCheckoutService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        ReturnRequestItemsComponent,
+        MockMediaComponent,
+        MockFeatureLevelDirective,
+      ],
+      providers: [
+        { provide: ReturnRequestService, useClass: MockCheckoutService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ReturnRequestItemsComponent);

--- a/feature-libs/order/components/return-request-detail/return-request-overview/return-request-overview.component.spec.ts
+++ b/feature-libs/order/components/return-request-detail/return-request-overview/return-request-overview.component.spec.ts
@@ -27,17 +27,15 @@ describe('ReturnRequestOverviewComponent', () => {
   let fixture: ComponentFixture<ReturnRequestOverviewComponent>;
   let returnRequestService: ReturnRequestService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [ReturnRequestOverviewComponent],
-        providers: [
-          { provide: ReturnRequestService, useClass: MockReturnRequestService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [ReturnRequestOverviewComponent],
+      providers: [
+        { provide: ReturnRequestService, useClass: MockReturnRequestService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ReturnRequestOverviewComponent);

--- a/feature-libs/order/components/return-request-detail/return-request-totals/return-request-totals.component.spec.ts
+++ b/feature-libs/order/components/return-request-detail/return-request-totals/return-request-totals.component.spec.ts
@@ -21,17 +21,15 @@ describe('ReturnRequestTotalsComponent', () => {
   let component: ReturnRequestTotalsComponent;
   let fixture: ComponentFixture<ReturnRequestTotalsComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [ReturnRequestTotalsComponent],
-        providers: [
-          { provide: ReturnRequestService, useClass: MockReturnRequestService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [ReturnRequestTotalsComponent],
+      providers: [
+        { provide: ReturnRequestService, useClass: MockReturnRequestService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ReturnRequestTotalsComponent);

--- a/feature-libs/order/components/return-request-list/order-return-request-list.component.spec.ts
+++ b/feature-libs/order/components/return-request-list/order-return-request-list.component.spec.ts
@@ -61,26 +61,24 @@ describe('OrderReturnRequestListComponent', () => {
   let fixture: ComponentFixture<OrderReturnRequestListComponent>;
   let returnService: OrderReturnRequestFacade;
   let el: DebugElement;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, ListNavigationModule, I18nTestingModule],
-        declarations: [OrderReturnRequestListComponent, MockUrlPipe],
-        providers: [
-          {
-            provide: OrderReturnRequestFacade,
-            useClass: MockOrderReturnRequestService,
-          },
-          {
-            provide: TranslationService,
-            useClass: MockTranslationService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, ListNavigationModule, I18nTestingModule],
+      declarations: [OrderReturnRequestListComponent, MockUrlPipe],
+      providers: [
+        {
+          provide: OrderReturnRequestFacade,
+          useClass: MockOrderReturnRequestService,
+        },
+        {
+          provide: TranslationService,
+          useClass: MockTranslationService,
+        },
+      ],
+    }).compileComponents();
 
-      returnService = TestBed.inject(OrderReturnRequestFacade);
-    })
-  );
+    returnService = TestBed.inject(OrderReturnRequestFacade);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderReturnRequestListComponent);

--- a/feature-libs/order/core/connectors/reorder-order.connector.spec.ts
+++ b/feature-libs/order/core/connectors/reorder-order.connector.spec.ts
@@ -21,19 +21,17 @@ describe('ReorderOrderConnector', () => {
   let adapter: ReorderOrderAdapter;
   let connector: ReorderOrderConnector;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          ReorderOrderConnector,
-          {
-            provide: ReorderOrderAdapter,
-            useClass: MockReorderOrderAdapter,
-          },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ReorderOrderConnector,
+        {
+          provide: ReorderOrderAdapter,
+          useClass: MockReorderOrderAdapter,
+        },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     adapter = TestBed.inject(ReorderOrderAdapter);

--- a/feature-libs/order/core/connectors/scheduled-replenishment-order.connector.spec.ts
+++ b/feature-libs/order/core/connectors/scheduled-replenishment-order.connector.spec.ts
@@ -30,19 +30,17 @@ describe('Scheduled Replenishment Order Connector', () => {
   let adapter: ScheduledReplenishmentOrderAdapter;
   let connector: ScheduledReplenishmentOrderConnector;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          ScheduledReplenishmentOrderConnector,
-          {
-            provide: ScheduledReplenishmentOrderAdapter,
-            useClass: MockScheduledReplenishmentOrderAdapter,
-          },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ScheduledReplenishmentOrderConnector,
+        {
+          provide: ScheduledReplenishmentOrderAdapter,
+          useClass: MockScheduledReplenishmentOrderAdapter,
+        },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     adapter = TestBed.inject(ScheduledReplenishmentOrderAdapter);

--- a/feature-libs/order/core/facade/my-account-v2-order-history.service.ts
+++ b/feature-libs/order/core/facade/my-account-v2-order-history.service.ts
@@ -147,7 +147,7 @@ export class MyAccountV2OrderHistoryService {
         (
           responses: [
             OrderHistoryListView | undefined,
-            ReturnRequestList | undefined
+            ReturnRequestList | undefined,
           ]
         ) => {
           const returnRequests = responses?.[1]?.returnRequests;

--- a/feature-libs/order/occ/adapters/converters/occ-reorder-order-normalizer.spec.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-reorder-order-normalizer.spec.ts
@@ -15,19 +15,17 @@ describe('OccReorderOrderNormalizer', () => {
   let normalizer: OccReorderOrderNormalizer;
   let converter: ConverterService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          OccReorderOrderNormalizer,
-          {
-            provide: ConverterService,
-            useClass: MockConverterService,
-          },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccReorderOrderNormalizer,
+        {
+          provide: ConverterService,
+          useClass: MockConverterService,
+        },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     normalizer = TestBed.inject(OccReorderOrderNormalizer);

--- a/feature-libs/order/occ/adapters/converters/occ-replenishment-order-normalizer.spec.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-replenishment-order-normalizer.spec.ts
@@ -22,19 +22,17 @@ describe('OccReplenishmentOrderNormalizer', () => {
   let normalizer: OccReplenishmentOrderNormalizer;
   let converter: ConverterService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          OccReplenishmentOrderNormalizer,
-          {
-            provide: ConverterService,
-            useClass: MockConverterService,
-          },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OccReplenishmentOrderNormalizer,
+        {
+          provide: ConverterService,
+          useClass: MockConverterService,
+        },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     normalizer = TestBed.inject(OccReplenishmentOrderNormalizer);

--- a/feature-libs/order/occ/adapters/converters/occ-return-request-normalizer.spec.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-return-request-normalizer.spec.ts
@@ -17,7 +17,7 @@ describe('OccReturnRequestNormalizer', () => {
         ({
           ...product,
           code: (product as Product).code + 'converted',
-        } as any)
+        }) as any
     );
   });
 

--- a/feature-libs/order/occ/adapters/converters/occ-scheduled-replenishment-order-form-serializer.spec.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-scheduled-replenishment-order-form-serializer.spec.ts
@@ -8,13 +8,11 @@ const mockDate = '2021-06-01';
 describe('OccScheduledReplenishmentOrderFormSerializer', () => {
   let serializer: OccScheduledReplenishmentOrderFormSerializer;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [OccScheduledReplenishmentOrderFormSerializer],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [OccScheduledReplenishmentOrderFormSerializer],
+    });
+  }));
 
   beforeEach(() => {
     serializer = TestBed.inject(OccScheduledReplenishmentOrderFormSerializer);

--- a/feature-libs/order/occ/adapters/occ-order-history.adapter.spec.ts
+++ b/feature-libs/order/occ/adapters/occ-order-history.adapter.spec.ts
@@ -72,50 +72,38 @@ describe('OccOrderHistoryAdapter', () => {
   });
 
   describe('getUserOrders', () => {
-    it(
-      'should fetch user Orders with default options',
-      waitForAsync(() => {
-        const PAGE_SIZE = 5;
-        occOrderHistoryAdapter.loadHistory(userId, PAGE_SIZE).subscribe();
-        httpMock.expectOne((req: HttpRequest<any>) => {
-          return req.method === 'GET';
-        }, `GET method and url`);
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'orderHistory',
-          {
-            urlParams: { userId },
-            queryParams: { pageSize: PAGE_SIZE.toString() },
-          }
-        );
-      })
-    );
+    it('should fetch user Orders with default options', waitForAsync(() => {
+      const PAGE_SIZE = 5;
+      occOrderHistoryAdapter.loadHistory(userId, PAGE_SIZE).subscribe();
+      httpMock.expectOne((req: HttpRequest<any>) => {
+        return req.method === 'GET';
+      }, `GET method and url`);
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith('orderHistory', {
+        urlParams: { userId },
+        queryParams: { pageSize: PAGE_SIZE.toString() },
+      });
+    }));
 
-    it(
-      'should fetch user Orders with defined options',
-      waitForAsync(() => {
-        const PAGE_SIZE = 5;
-        const currentPage = 1;
-        const sort = 'byDate';
+    it('should fetch user Orders with defined options', waitForAsync(() => {
+      const PAGE_SIZE = 5;
+      const currentPage = 1;
+      const sort = 'byDate';
 
-        occOrderHistoryAdapter
-          .loadHistory(userId, PAGE_SIZE, currentPage, sort)
-          .subscribe();
-        httpMock.expectOne((req: HttpRequest<any>) => {
-          return req.method === 'GET';
-        }, `GET method`);
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'orderHistory',
-          {
-            urlParams: { userId },
-            queryParams: {
-              pageSize: PAGE_SIZE.toString(),
-              currentPage: currentPage.toString(),
-              sort,
-            },
-          }
-        );
-      })
-    );
+      occOrderHistoryAdapter
+        .loadHistory(userId, PAGE_SIZE, currentPage, sort)
+        .subscribe();
+      httpMock.expectOne((req: HttpRequest<any>) => {
+        return req.method === 'GET';
+      }, `GET method`);
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith('orderHistory', {
+        urlParams: { userId },
+        queryParams: {
+          pageSize: PAGE_SIZE.toString(),
+          currentPage: currentPage.toString(),
+          sort,
+        },
+      });
+    }));
 
     it('should use converter', () => {
       occOrderHistoryAdapter.loadHistory(userId).subscribe();
@@ -129,21 +117,15 @@ describe('OccOrderHistoryAdapter', () => {
   });
 
   describe('getOrder', () => {
-    it(
-      'should fetch a single order',
-      waitForAsync(() => {
-        occOrderHistoryAdapter.load(userId, orderData.code).subscribe();
-        httpMock.expectOne((req: HttpRequest<any>) => {
-          return req.method === 'GET';
-        }, `GET a single order`);
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'orderDetail',
-          {
-            urlParams: { userId, orderId: orderData.code },
-          }
-        );
-      })
-    );
+    it('should fetch a single order', waitForAsync(() => {
+      occOrderHistoryAdapter.load(userId, orderData.code).subscribe();
+      httpMock.expectOne((req: HttpRequest<any>) => {
+        return req.method === 'GET';
+      }, `GET a single order`);
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith('orderDetail', {
+        urlParams: { userId, orderId: orderData.code },
+      });
+    }));
 
     it('should use converter', () => {
       occOrderHistoryAdapter.load(userId, orderData.code).subscribe();
@@ -153,30 +135,27 @@ describe('OccOrderHistoryAdapter', () => {
   });
 
   describe('getConsignmentTracking', () => {
-    it(
-      'should fetch a consignment tracking',
-      waitForAsync(() => {
-        const tracking: ConsignmentTracking = {
-          trackingID: '1234567890',
-          trackingEvents: [],
-        };
-        occOrderHistoryAdapter
-          .getConsignmentTracking(orderData.code, consignmentCode, userId)
-          .subscribe((result) => expect(result).toEqual(tracking));
-        const mockReq = httpMock.expectOne((req) => {
-          return req.method === 'GET';
-        }, `GET a consignment tracking`);
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'consignmentTracking',
-          {
-            urlParams: { userId, orderCode: orderData.code, consignmentCode },
-          }
-        );
-        expect(mockReq.cancelled).toBeFalsy();
-        expect(mockReq.request.responseType).toEqual('json');
-        mockReq.flush(tracking);
-      })
-    );
+    it('should fetch a consignment tracking', waitForAsync(() => {
+      const tracking: ConsignmentTracking = {
+        trackingID: '1234567890',
+        trackingEvents: [],
+      };
+      occOrderHistoryAdapter
+        .getConsignmentTracking(orderData.code, consignmentCode, userId)
+        .subscribe((result) => expect(result).toEqual(tracking));
+      const mockReq = httpMock.expectOne((req) => {
+        return req.method === 'GET';
+      }, `GET a consignment tracking`);
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
+        'consignmentTracking',
+        {
+          urlParams: { userId, orderCode: orderData.code, consignmentCode },
+        }
+      );
+      expect(mockReq.cancelled).toBeFalsy();
+      expect(mockReq.request.responseType).toEqual('json');
+      mockReq.flush(tracking);
+    }));
 
     it('should use converter', () => {
       occOrderHistoryAdapter
@@ -194,70 +173,56 @@ describe('OccOrderHistoryAdapter', () => {
   });
 
   describe('cancel', () => {
-    it(
-      'should be able to cancel an order',
-      waitForAsync(() => {
-        const cancelRequestInput: CancellationRequestEntryInputList = {
-          cancellationRequestEntryInputs: [
-            { orderEntryNumber: 0, quantity: 1 },
-          ],
-        };
+    it('should be able to cancel an order', waitForAsync(() => {
+      const cancelRequestInput: CancellationRequestEntryInputList = {
+        cancellationRequestEntryInputs: [{ orderEntryNumber: 0, quantity: 1 }],
+      };
 
-        let result;
-        occOrderHistoryAdapter
-          .cancel(userId, orderData.code, cancelRequestInput)
-          .subscribe((res) => (result = res));
+      let result;
+      occOrderHistoryAdapter
+        .cancel(userId, orderData.code, cancelRequestInput)
+        .subscribe((res) => (result = res));
 
-        const mockReq = httpMock.expectOne((req) => {
-          return req.method === 'POST';
-        });
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'cancelOrder',
-          {
-            urlParams: { userId, orderId: orderData.code },
-          }
-        );
-        expect(mockReq.cancelled).toBeFalsy();
-        expect(mockReq.request.responseType).toEqual('json');
-        mockReq.flush({});
-        expect(result).toEqual({});
-      })
-    );
+      const mockReq = httpMock.expectOne((req) => {
+        return req.method === 'POST';
+      });
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith('cancelOrder', {
+        urlParams: { userId, orderId: orderData.code },
+      });
+      expect(mockReq.cancelled).toBeFalsy();
+      expect(mockReq.request.responseType).toEqual('json');
+      mockReq.flush({});
+      expect(result).toEqual({});
+    }));
   });
 
   describe('createReturnRequest', () => {
-    it(
-      'should be able to create an order return request',
-      waitForAsync(() => {
-        const returnRequestInput: ReturnRequestEntryInputList = {
-          orderCode: orderData.code,
-          returnRequestEntryInputs: [{ orderEntryNumber: 0, quantity: 1 }],
-        };
+    it('should be able to create an order return request', waitForAsync(() => {
+      const returnRequestInput: ReturnRequestEntryInputList = {
+        orderCode: orderData.code,
+        returnRequestEntryInputs: [{ orderEntryNumber: 0, quantity: 1 }],
+      };
 
-        let result;
-        occOrderHistoryAdapter
-          .createReturnRequest(userId, returnRequestInput)
-          .subscribe((res) => (result = res));
+      let result;
+      occOrderHistoryAdapter
+        .createReturnRequest(userId, returnRequestInput)
+        .subscribe((res) => (result = res));
 
-        const mockReq = httpMock.expectOne((req) => {
-          return req.method === 'POST';
-        });
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'returnOrder',
-          {
-            urlParams: { userId },
-          }
-        );
-        expect(mockReq.cancelled).toBeFalsy();
-        expect(mockReq.request.responseType).toEqual('json');
-        mockReq.flush(returnRequest);
-        expect(result).toEqual(returnRequest);
-        expect(converter.convert).toHaveBeenCalledWith(
-          returnRequestInput,
-          ORDER_RETURN_REQUEST_INPUT_SERIALIZER
-        );
-      })
-    );
+      const mockReq = httpMock.expectOne((req) => {
+        return req.method === 'POST';
+      });
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith('returnOrder', {
+        urlParams: { userId },
+      });
+      expect(mockReq.cancelled).toBeFalsy();
+      expect(mockReq.request.responseType).toEqual('json');
+      mockReq.flush(returnRequest);
+      expect(result).toEqual(returnRequest);
+      expect(converter.convert).toHaveBeenCalledWith(
+        returnRequestInput,
+        ORDER_RETURN_REQUEST_INPUT_SERIALIZER
+      );
+    }));
 
     it('should use converter', () => {
       const returnRequestInput: ReturnRequestEntryInputList = {};
@@ -276,46 +241,37 @@ describe('OccOrderHistoryAdapter', () => {
   });
 
   describe('loadReturnRequestList', () => {
-    it(
-      'should fetch order return request list with default options',
-      waitForAsync(() => {
-        occOrderHistoryAdapter.loadReturnRequestList(userId).subscribe();
-        httpMock.expectOne((req: HttpRequest<any>) => {
-          return req.method === 'GET';
-        });
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'orderReturns',
-          { urlParams: { userId }, queryParams: {} }
-        );
-      })
-    );
+    it('should fetch order return request list with default options', waitForAsync(() => {
+      occOrderHistoryAdapter.loadReturnRequestList(userId).subscribe();
+      httpMock.expectOne((req: HttpRequest<any>) => {
+        return req.method === 'GET';
+      });
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith('orderReturns', {
+        urlParams: { userId },
+        queryParams: {},
+      });
+    }));
 
-    it(
-      'should fetch user order return request list with defined options',
-      waitForAsync(() => {
-        const PAGE_SIZE = 5;
-        const currentPage = 1;
-        const sort = 'byDate';
+    it('should fetch user order return request list with defined options', waitForAsync(() => {
+      const PAGE_SIZE = 5;
+      const currentPage = 1;
+      const sort = 'byDate';
 
-        occOrderHistoryAdapter
-          .loadReturnRequestList(userId, PAGE_SIZE, currentPage, sort)
-          .subscribe();
-        httpMock.expectOne((req: HttpRequest<any>) => {
-          return req.method === 'GET';
-        });
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'orderReturns',
-          {
-            urlParams: { userId },
-            queryParams: {
-              pageSize: PAGE_SIZE.toString(),
-              currentPage: currentPage.toString(),
-              sort,
-            },
-          }
-        );
-      })
-    );
+      occOrderHistoryAdapter
+        .loadReturnRequestList(userId, PAGE_SIZE, currentPage, sort)
+        .subscribe();
+      httpMock.expectOne((req: HttpRequest<any>) => {
+        return req.method === 'GET';
+      });
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith('orderReturns', {
+        urlParams: { userId },
+        queryParams: {
+          pageSize: PAGE_SIZE.toString(),
+          currentPage: currentPage.toString(),
+          sort,
+        },
+      });
+    }));
 
     it('should use converter', () => {
       occOrderHistoryAdapter.loadReturnRequestList(userId).subscribe();
@@ -329,28 +285,25 @@ describe('OccOrderHistoryAdapter', () => {
   });
 
   describe('loadReturnRequestDetail', () => {
-    it(
-      'should be able to load an order return request data',
-      waitForAsync(() => {
-        let result;
-        occOrderHistoryAdapter
-          .loadReturnRequestDetail(userId, 'test')
-          .subscribe((res) => (result = res));
+    it('should be able to load an order return request data', waitForAsync(() => {
+      let result;
+      occOrderHistoryAdapter
+        .loadReturnRequestDetail(userId, 'test')
+        .subscribe((res) => (result = res));
 
-        const mockReq = httpMock.expectOne((req) => {
-          return req.method === 'GET';
-        });
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'orderReturnDetail',
-          {
-            urlParams: { userId, returnRequestCode: 'test' },
-          }
-        );
-        expect(mockReq.cancelled).toBeFalsy();
-        mockReq.flush({});
-        expect(result).toEqual({});
-      })
-    );
+      const mockReq = httpMock.expectOne((req) => {
+        return req.method === 'GET';
+      });
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
+        'orderReturnDetail',
+        {
+          urlParams: { userId, returnRequestCode: 'test' },
+        }
+      );
+      expect(mockReq.cancelled).toBeFalsy();
+      mockReq.flush({});
+      expect(result).toEqual({});
+    }));
 
     it('should use converter', () => {
       occOrderHistoryAdapter
@@ -368,28 +321,22 @@ describe('OccOrderHistoryAdapter', () => {
   });
 
   describe('cancelReturnRequest', () => {
-    it(
-      'should be able to cancel one return request',
-      waitForAsync(() => {
-        let result;
-        occOrderHistoryAdapter
-          .cancelReturnRequest(userId, 'returnCode', { status: 'CANCELLING' })
-          .subscribe((res) => (result = res));
+    it('should be able to cancel one return request', waitForAsync(() => {
+      let result;
+      occOrderHistoryAdapter
+        .cancelReturnRequest(userId, 'returnCode', { status: 'CANCELLING' })
+        .subscribe((res) => (result = res));
 
-        const mockReq = httpMock.expectOne((req) => {
-          return req.method === 'PATCH';
-        });
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'cancelReturn',
-          {
-            urlParams: { userId, returnRequestCode: 'returnCode' },
-          }
-        );
-        expect(mockReq.cancelled).toBeFalsy();
-        expect(mockReq.request.responseType).toEqual('json');
-        mockReq.flush({});
-        expect(result).toEqual({});
-      })
-    );
+      const mockReq = httpMock.expectOne((req) => {
+        return req.method === 'PATCH';
+      });
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith('cancelReturn', {
+        urlParams: { userId, returnRequestCode: 'returnCode' },
+      });
+      expect(mockReq.cancelled).toBeFalsy();
+      expect(mockReq.request.responseType).toEqual('json');
+      mockReq.flush({});
+      expect(result).toEqual({});
+    }));
   });
 });

--- a/feature-libs/order/occ/adapters/occ-reorder-order.adapter.spec.ts
+++ b/feature-libs/order/occ/adapters/occ-reorder-order.adapter.spec.ts
@@ -26,17 +26,15 @@ describe(`OccReorderOrderAdapter`, () => {
   let converter: ConverterService;
   let occEndpointService: OccEndpointsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
-        providers: [
-          OccReorderOrderAdapter,
-          { provide: OccEndpointsService, useClass: MockOccEndpointsService },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        OccReorderOrderAdapter,
+        { provide: OccEndpointsService, useClass: MockOccEndpointsService },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     occAdapter = TestBed.inject(OccReorderOrderAdapter);

--- a/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.spec.ts
+++ b/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.spec.ts
@@ -82,18 +82,16 @@ describe(`OccScheduledReplenishmentOrderAdapter`, () => {
   let httpMock: HttpTestingController;
   let converter: ConverterService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
-        providers: [
-          OccScheduledReplenishmentOrderAdapter,
-          { provide: OccConfig, useValue: MockOccModuleConfig },
-          { provide: LoggerService, useClass: MockLoggerService },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        OccScheduledReplenishmentOrderAdapter,
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+        { provide: LoggerService, useClass: MockLoggerService },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     occAdapter = TestBed.inject(OccScheduledReplenishmentOrderAdapter);

--- a/feature-libs/organization/account-summary/components/details/header/account-summary-header.component.html
+++ b/feature-libs/organization/account-summary/components/details/header/account-summary-header.component.html
@@ -1,9 +1,7 @@
 <div class="cx-account-summary" *ngIf="headerDetails$ | async as headerDetails">
   <div class="cx-account-summary-header-cards">
     <div
-      class="
-        cx-summary-card-responsive-group cx-summary-card-group-unit-address
-      "
+      class="cx-summary-card-responsive-group cx-summary-card-group-unit-address"
     >
       <!-- Card: Unit ID & Unit Name -->
       <div class="cx-summary-card">
@@ -30,9 +28,7 @@
     </div>
 
     <div
-      class="
-        cx-summary-card-responsive-group cx-summary-card-group-credit-balance
-      "
+      class="cx-summary-card-responsive-group cx-summary-card-group-credit-balance"
     >
       <!-- Card: Credit Rep & Credit Line -->
       <div class="cx-summary-card">

--- a/feature-libs/organization/administration/components/shared/message/message.model.ts
+++ b/feature-libs/organization/administration/components/shared/message/message.model.ts
@@ -12,7 +12,7 @@ import { BaseMessageComponent } from './base-message.component';
 
 export class MessageData<
   O extends MessageEventData = MessageEventData,
-  T extends BaseMessageComponent = BaseMessageComponent
+  T extends BaseMessageComponent = BaseMessageComponent,
 > {
   /**
    * The message contains the `translatable` message that is rendered

--- a/feature-libs/organization/administration/components/shared/message/services/message.service.ts
+++ b/feature-libs/organization/administration/components/shared/message/services/message.service.ts
@@ -14,7 +14,7 @@ const DEFAULT_INFO_TIMEOUT = 3000;
 @Injectable()
 export class MessageService<
   O extends MessageEventData = MessageEventData,
-  T extends MessageData<O> = MessageData<O>
+  T extends MessageData<O> = MessageData<O>,
 > {
   protected data$: ReplaySubject<T | undefined> = new ReplaySubject();
 

--- a/feature-libs/organization/administration/components/shared/sub-list/sub-list.service.ts
+++ b/feature-libs/organization/administration/components/shared/sub-list/sub-list.service.ts
@@ -17,7 +17,7 @@ import { BaseItem } from '../organization.model';
 
 @Injectable()
 export abstract class SubListService<
-  T extends BaseItem
+  T extends BaseItem,
 > extends ListService<T> {
   /**
    * The default table structure for sub lists is only showing tables with vertical layout.

--- a/feature-libs/organization/administration/core/services/budget.service.ts
+++ b/feature-libs/organization/administration/core/services/budget.service.ts
@@ -109,7 +109,7 @@ export class BudgetService {
         (budget) =>
           ({
             values: budget.costCenters ?? [],
-          } as EntitiesModel<CostCenter>)
+          }) as EntitiesModel<CostCenter>
       )
     );
   }

--- a/feature-libs/organization/administration/core/services/org-unit.service.ts
+++ b/feature-libs/organization/administration/core/services/org-unit.service.ts
@@ -275,8 +275,8 @@ export class OrgUnitService {
     return (a.id ?? '').toLowerCase() < (b.id ?? '').toLowerCase()
       ? -1
       : (a.id ?? '').toLowerCase() > (b.id ?? '').toLowerCase()
-      ? 1
-      : 0;
+        ? 1
+        : 0;
   }
 
   getUsers(

--- a/feature-libs/organization/administration/core/utils/get-item-status.ts
+++ b/feature-libs/organization/administration/core/utils/get-item-status.ts
@@ -23,8 +23,8 @@ export function getItemStatus<T>(
       status: currentState.success
         ? LoadStatus.SUCCESS
         : currentState.error
-        ? LoadStatus.ERROR
-        : null,
+          ? LoadStatus.ERROR
+          : null,
       item: currentState.value,
     }))
   );

--- a/feature-libs/organization/order-approval/components/list/order-approval-list.component.html
+++ b/feature-libs/organization/order-approval/components/list/order-approval-list.component.html
@@ -10,11 +10,7 @@
     <!-- Select Form and Pagination Top -->
     <div class="cx-order-approval-sort top row">
       <div
-        class="
-          cx-order-approval-form-group
-          form-group
-          col-sm-12 col-md-4 col-lg-4
-        "
+        class="cx-order-approval-form-group form-group col-sm-12 col-md-4 col-lg-4"
       >
         <label>
           <span class="cx-visually-hidden">{{
@@ -172,11 +168,7 @@
     <!-- Select Form and Pagination Bottom -->
     <div class="cx-order-approval-sort bottom row">
       <div
-        class="
-          cx-order-approval-form-group
-          form-group
-          col-sm-12 col-md-4 col-lg-4
-        "
+        class="cx-order-approval-form-group form-group col-sm-12 col-md-4 col-lg-4"
       >
         <label>
           <span class="cx-visually-hidden">{{

--- a/feature-libs/organization/order-approval/occ/converters/occ-order-approval-normalizer.spec.ts
+++ b/feature-libs/organization/order-approval/occ/converters/occ-order-approval-normalizer.spec.ts
@@ -57,7 +57,7 @@ describe('OrderApprovalNormalizer', () => {
         ({
           ...order,
           code: (order as Occ.Order).code + '-converted',
-        } as any)
+        }) as any
     );
   });
 

--- a/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/unit-level-order-overview.component.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/unit-level-order-overview.component.ts
@@ -44,7 +44,7 @@ export class UnitLevelOrderOverviewComponent implements OnInit {
           ({
             title: textTitle,
             text: [orderCode],
-          } as Card)
+          }) as Card
       )
     );
   }
@@ -74,7 +74,7 @@ export class UnitLevelOrderOverviewComponent implements OnInit {
           ({
             title: textTitle,
             text: [textStatus],
-          } as Card)
+          }) as Card
       )
     );
   }
@@ -156,7 +156,7 @@ export class UnitLevelOrderOverviewComponent implements OnInit {
                 ? deliveryMode.deliveryCost?.formattedValue
                 : '',
             ],
-          } as Card)
+          }) as Card
       )
     );
   }
@@ -178,7 +178,7 @@ export class UnitLevelOrderOverviewComponent implements OnInit {
             title: textTitle,
             textBold: payment?.accountHolderName,
             text: [payment?.cardNumber, textExpires],
-          } as Card)
+          }) as Card
       )
     );
   }
@@ -197,7 +197,7 @@ export class UnitLevelOrderOverviewComponent implements OnInit {
               billingAddress?.formattedAddress,
               billingAddress?.country?.name,
             ],
-          } as Card)
+          }) as Card
       )
     );
   }
@@ -210,7 +210,7 @@ export class UnitLevelOrderOverviewComponent implements OnInit {
           ({
             title: textTitle,
             text: [customer?.name, `(${customer?.email})`],
-          } as Card)
+          }) as Card
       )
     );
   }
@@ -223,7 +223,7 @@ export class UnitLevelOrderOverviewComponent implements OnInit {
           ({
             title: textTitle,
             text: [orgUnit],
-          } as Card)
+          }) as Card
       )
     );
   }

--- a/feature-libs/organization/unit-order/occ/adapters/occ-unit-order.adapter.spec.ts
+++ b/feature-libs/organization/unit-order/occ/adapters/occ-unit-order.adapter.spec.ts
@@ -101,23 +101,20 @@ describe('OccUnitOrderAdapter', () => {
   });
 
   describe('loadUnitOrderDetail', () => {
-    it(
-      'should fetch a single unit-level order',
-      waitForAsync(() => {
-        occOrderHistoryAdapter
-          .loadUnitOrderDetail(userId, orderDetailCode)
-          .subscribe();
-        httpMock.expectOne((req: HttpRequest<any>) => {
-          return req.method === 'GET';
-        }, `GET a single order`);
-        expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
-          'unitLevelOrderDetail',
-          {
-            urlParams: { userId, orderId: orderDetailCode },
-          }
-        );
-      })
-    );
+    it('should fetch a single unit-level order', waitForAsync(() => {
+      occOrderHistoryAdapter
+        .loadUnitOrderDetail(userId, orderDetailCode)
+        .subscribe();
+      httpMock.expectOne((req: HttpRequest<any>) => {
+        return req.method === 'GET';
+      }, `GET a single order`);
+      expect(occEnpointsService.buildUrl).toHaveBeenCalledWith(
+        'unitLevelOrderDetail',
+        {
+          urlParams: { userId, orderId: orderDetailCode },
+        }
+      );
+    }));
 
     it('should use converter', () => {
       occOrderHistoryAdapter

--- a/feature-libs/organization/user-registration/components/form/user-registration-form.component.spec.ts
+++ b/feature-libs/organization/user-registration/components/form/user-registration-form.component.spec.ts
@@ -116,34 +116,32 @@ describe('UserRegistrationFormComponent', () => {
 
   let userRegistrationFormService: UserRegistrationFormService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          NgSelectModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          RouterTestingModule,
-        ],
-        declarations: [
-          UserRegistrationFormComponent,
-          MockUrlPipe,
-          NgSelectA11yDirective,
-          SpinnerComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          {
-            provide: UserRegistrationFormService,
-            useClass: MockUserRegistrationFormService,
-          },
-        ],
-      });
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        NgSelectModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        RouterTestingModule,
+      ],
+      declarations: [
+        UserRegistrationFormComponent,
+        MockUrlPipe,
+        NgSelectA11yDirective,
+        SpinnerComponent,
+        MockFeatureDirective,
+      ],
+      providers: [
+        {
+          provide: UserRegistrationFormService,
+          useClass: MockUserRegistrationFormService,
+        },
+      ],
+    });
 
-      userRegistrationFormService = TestBed.inject(UserRegistrationFormService);
-    })
-  );
+    userRegistrationFormService = TestBed.inject(UserRegistrationFormService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UserRegistrationFormComponent);

--- a/feature-libs/pickup-in-store/components/presentational/store/store.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store.component.ts
@@ -22,7 +22,8 @@ export class StoreComponent implements OnInit {
   @Input() storeDetails: PointOfServiceStock = {};
   /** An event emitter triggered when this store is selected for pickup */
   @Output()
-  storeSelected: EventEmitter<PointOfServiceStock> = new EventEmitter<PointOfServiceStock>();
+  storeSelected: EventEmitter<PointOfServiceStock> =
+    new EventEmitter<PointOfServiceStock>();
 
   isInStock: boolean;
   openHoursOpen = false;

--- a/feature-libs/pickup-in-store/core/store/selectors/stock.selectors.spec.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/stock.selectors.spec.ts
@@ -123,9 +123,8 @@ describe('StockSelectors', () => {
     ];
 
     it('should return an empty list for a product without store data', () => {
-      const result = getStoresWithStockForProductCode('productCode')(
-        stateFactory()
-      );
+      const result =
+        getStoresWithStockForProductCode('productCode')(stateFactory());
       const expectedResult: PointOfServiceStock[] = [];
       expect(result).toEqual(expectedResult);
     });

--- a/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.spec.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.spec.ts
@@ -58,18 +58,16 @@ describe(`OccPickupLocationAdapter`, () => {
   let httpMock: HttpTestingController;
   let occEndpointService: OccEndpointsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
-        providers: [
-          OccPickupLocationAdapter,
-          { provide: OccEndpointsService, useClass: MockOccEndpointsService },
-          { provide: LoggerService, useClass: MockLoggerService },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        OccPickupLocationAdapter,
+        { provide: OccEndpointsService, useClass: MockOccEndpointsService },
+        { provide: LoggerService, useClass: MockLoggerService },
+      ],
+    });
+  }));
   beforeEach(() => {
     occAdapter = TestBed.inject(OccPickupLocationAdapter);
     httpMock = TestBed.inject(HttpTestingController);

--- a/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.spec.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.spec.ts
@@ -59,18 +59,16 @@ describe(`OccStockAdapter`, () => {
   let httpMock: HttpTestingController;
   let occEndpointService: OccEndpointsService;
   let httpClient: HttpClient;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
-        providers: [
-          OccStockAdapter,
-          { provide: OccEndpointsService, useClass: MockOccEndpointsService },
-          { provide: LoggerService, useClass: MockLoggerService },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        OccStockAdapter,
+        { provide: OccEndpointsService, useClass: MockOccEndpointsService },
+        { provide: LoggerService, useClass: MockLoggerService },
+      ],
+    });
+  }));
   beforeEach(() => {
     occAdapter = TestBed.inject(OccStockAdapter);
     httpMock = TestBed.inject(HttpTestingController);

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
@@ -927,14 +927,12 @@ describe('ConfiguratorCartEntryBundleInfoComponent without cart item context', (
   let component: ConfiguratorCartEntryBundleInfoComponent;
   let fixture: ComponentFixture<ConfiguratorCartEntryBundleInfoComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [ConfiguratorCartEntryBundleInfoComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [ConfiguratorCartEntryBundleInfoComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorCartEntryBundleInfoComponent);

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.spec.ts
@@ -44,23 +44,21 @@ describe('ConfiguratorCartEntryInfoComponent', () => {
   let htmlElem: HTMLElement;
   let mockCartItemContext: MockCartItemContext;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
-        declarations: [
-          ConfiguratorCartEntryInfoComponent,
-          MockConfigureCartEntryComponent,
-        ],
-        providers: [
-          { provide: CartItemContext, useClass: MockCartItemContext },
-          {
-            provide: ControlContainer,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      declarations: [
+        ConfiguratorCartEntryInfoComponent,
+        MockConfigureCartEntryComponent,
+      ],
+      providers: [
+        { provide: CartItemContext, useClass: MockCartItemContext },
+        {
+          provide: ControlContainer,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorCartEntryInfoComponent);
@@ -383,13 +381,11 @@ describe('ConfiguratorCartEntryInfoComponent without cart item context', () => {
   let component: ConfiguratorCartEntryInfoComponent;
   let fixture: ComponentFixture<ConfiguratorCartEntryInfoComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ConfiguratorCartEntryInfoComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ConfiguratorCartEntryInfoComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorCartEntryInfoComponent);

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.spec.ts
@@ -74,21 +74,19 @@ describe('ConfigureIssuesNotificationComponent', () => {
     mockCartItemContext.quantityControl$?.next(new UntypedFormControl());
   }
   describe('with cart item context', () => {
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          declarations: [
-            ConfiguratorIssuesNotificationComponent,
-            MockTranslatePipe,
-            MockCxIconComponent,
-            MockConfigureCartEntryComponent,
-          ],
-          providers: [
-            { provide: CartItemContext, useClass: MockCartItemContext },
-          ],
-        }).compileComponents();
-      })
-    );
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          ConfiguratorIssuesNotificationComponent,
+          MockTranslatePipe,
+          MockCxIconComponent,
+          MockConfigureCartEntryComponent,
+        ],
+        providers: [
+          { provide: CartItemContext, useClass: MockCartItemContext },
+        ],
+      }).compileComponents();
+    }));
 
     beforeEach(() => {
       fixture = TestBed.createComponent(
@@ -295,19 +293,17 @@ describe('ConfigureIssuesNotificationComponent', () => {
     });
   });
   describe('without cart item context', () => {
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          declarations: [
-            ConfiguratorIssuesNotificationComponent,
-            MockTranslatePipe,
-            MockCxIconComponent,
-            MockConfigureCartEntryComponent,
-          ],
-          providers: [{ provide: CartItemContext, useValue: null }],
-        }).compileComponents();
-      })
-    );
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          ConfiguratorIssuesNotificationComponent,
+          MockTranslatePipe,
+          MockCxIconComponent,
+          MockConfigureCartEntryComponent,
+        ],
+        providers: [{ provide: CartItemContext, useValue: null }],
+      }).compileComponents();
+    }));
 
     beforeEach(() => {
       fixture = TestBed.createComponent(

--- a/feature-libs/product-configurator/common/components/configure-product/configure-product.component.ts
+++ b/feature-libs/product-configurator/common/components/configure-product/configure-product.component.ts
@@ -33,10 +33,10 @@ export class ConfigureProductComponent {
   product$: Observable<Product> = (this.productListItemContext
     ? this.productListItemContext.product$
     : this.currentProductService
-    ? this.currentProductService.getProduct(
-        ConfiguratorProductScope.CONFIGURATOR
-      )
-    : of(null)
+      ? this.currentProductService.getProduct(
+          ConfiguratorProductScope.CONFIGURATOR
+        )
+      : of(null)
   ).pipe(
     //needed because also currentProductService might return null
     map((product) => (product ? product : this.nonConfigurable))

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
@@ -30,19 +30,17 @@ class MockRoutingService {
 describe('ConfigRouterExtractorService', () => {
   let serviceUnderTest: ConfiguratorRouterExtractorService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     serviceUnderTest = TestBed.inject(
       ConfiguratorRouterExtractorService as Type<ConfiguratorRouterExtractorService>

--- a/feature-libs/product-configurator/common/shared/utils/common-configurator-utils.service.spec.ts
+++ b/feature-libs/product-configurator/common/shared/utils/common-configurator-utils.service.spec.ts
@@ -76,19 +76,17 @@ describe('CommonConfiguratorUtilsService', () => {
   let classUnderTest: CommonConfiguratorUtilsService;
   let mockCartItemContext: CartItemContextSource;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: UserIdService,
-            useClass: MockUserIdService,
-          },
-          { provide: CartItemContext, useClass: MockCartItemContext },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: UserIdService,
+          useClass: MockUserIdService,
+        },
+        { provide: CartItemContext, useClass: MockCartItemContext },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     classUnderTest = TestBed.inject(
       CommonConfiguratorUtilsService as Type<CommonConfiguratorUtilsService>

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.spec.ts
@@ -410,77 +410,75 @@ describe('ConfiguratorAddToCartButtonComponent', () => {
   let configuratorQuantityService: ConfiguratorQuantityService;
   let keyboardFocusService: KeyboardFocusService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          ConfiguratorAddToCartButtonComponent,
-          MockItemCounterComponent,
-          MockCxIconComponent,
-          MockFeatureLevelDirective,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ConfiguratorQuantityService,
-            useClass: MockConfiguratorQuantityService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorCartService,
-            useClass: MockConfiguratorCartService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockConfiguratorGroupsService,
-          },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          {
-            provide: OrderHistoryFacade,
-            useClass: MockOrderHistoryFacade,
-          },
-          {
-            provide: CommonConfiguratorUtilsService,
-            useClass: MockCommonConfiguratorUtilsService,
-          },
-          {
-            provide: ConfiguratorRouterExtractorService,
-            useClass: MockConfiguratorRouterExtractorService,
-          },
-          {
-            provide: ConfiguratorAddToCartButtonComponent,
-            useClass: MockConfiguratorAddToCartButtonComponent,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-          {
-            provide: IntersectionService,
-            useClass: MockIntersectionService,
-          },
-          {
-            provide: MultiCartFacade,
-            useClass: MockMultiCartFacade,
-          },
-          { provide: ActiveCartFacade, useClass: MockActiveCartFacade },
-        ],
-      })
-        .overrideComponent(ConfiguratorAddToCartButtonComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        ConfiguratorAddToCartButtonComponent,
+        MockItemCounterComponent,
+        MockCxIconComponent,
+        MockFeatureLevelDirective,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ConfiguratorQuantityService,
+          useClass: MockConfiguratorQuantityService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorCartService,
+          useClass: MockConfiguratorCartService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockConfiguratorGroupsService,
+        },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        {
+          provide: OrderHistoryFacade,
+          useClass: MockOrderHistoryFacade,
+        },
+        {
+          provide: CommonConfiguratorUtilsService,
+          useClass: MockCommonConfiguratorUtilsService,
+        },
+        {
+          provide: ConfiguratorRouterExtractorService,
+          useClass: MockConfiguratorRouterExtractorService,
+        },
+        {
+          provide: ConfiguratorAddToCartButtonComponent,
+          useClass: MockConfiguratorAddToCartButtonComponent,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+        {
+          provide: IntersectionService,
+          useClass: MockIntersectionService,
+        },
+        {
+          provide: MultiCartFacade,
+          useClass: MockMultiCartFacade,
+        },
+        { provide: ActiveCartFacade, useClass: MockActiveCartFacade },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAddToCartButtonComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     elementMock = {

--- a/feature-libs/product-configurator/rulebased/components/attribute/footer/configurator-attribute-footer.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/footer/configurator-attribute-footer.component.spec.ts
@@ -79,35 +79,33 @@ const owner = ConfiguratorModelUtils.createOwner(
 );
 
 describe('ConfigAttributeFooterComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, IconModule],
-        declarations: [
-          ConfiguratorAttributeFooterComponent,
-          MockFeatureLevelDirective,
-        ],
-        providers: [
-          { provide: IconLoaderService, useClass: MockIconFontLoaderService },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, IconModule],
+      declarations: [
+        ConfiguratorAttributeFooterComponent,
+        MockFeatureLevelDirective,
+      ],
+      providers: [
+        { provide: IconLoaderService, useClass: MockIconFontLoaderService },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
 
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeFooterComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeFooterComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   it('should render an empty component because showRequiredMessageForUserInput$ is `false`', () => {
     createComponentWithData(false).ngOnInit();

--- a/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.spec.ts
@@ -125,53 +125,51 @@ describe('ConfigAttributeHeaderComponent', () => {
     },
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, IconModule],
-        declarations: [
-          ConfiguratorAttributeHeaderComponent,
-          MockConfiguratorShowMoreComponent,
-        ],
-        providers: [
-          { provide: IconLoaderService, useClass: MockIconFontLoaderService },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockConfiguratorGroupsService,
-          },
-          {
-            provide: ConfiguratorUISettingsConfig,
-            useValue: TestConfiguratorUISettings,
-          },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, IconModule],
+      declarations: [
+        ConfiguratorAttributeHeaderComponent,
+        MockConfiguratorShowMoreComponent,
+      ],
+      providers: [
+        { provide: IconLoaderService, useClass: MockIconFontLoaderService },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockConfiguratorGroupsService,
+        },
+        {
+          provide: ConfiguratorUISettingsConfig,
+          useValue: TestConfiguratorUISettings,
+        },
 
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '*' },
           },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '*' },
-            },
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeHeaderComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeHeaderComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     config = configWithoutConflicts;

--- a/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.ts
@@ -171,8 +171,8 @@ export class ConfiguratorAttributeHeaderComponent
     return this.groupType === Configurator.GroupType.CONFLICT_GROUP
       ? 'configurator.conflict.viewConfigurationDetails'
       : this.isNavigationToConflictEnabled()
-      ? 'configurator.conflict.viewConflictDetails'
-      : 'configurator.conflict.conflictDetected';
+        ? 'configurator.conflict.viewConflictDetails'
+        : 'configurator.conflict.conflictDetected';
   }
 
   /**

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.spec.ts
@@ -151,39 +151,37 @@ describe('ConfiguratorAttributeProductCardComponent', () => {
     return configValue;
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          ReactiveFormsModule,
-          RouterTestingModule,
-          UrlTestingModule,
-          MediaModule,
-        ],
-        declarations: [
-          ConfiguratorAttributeProductCardComponent,
-          ConfiguratorShowMoreComponent,
-          ItemCounterComponent,
-          MockConfiguratorPriceComponent,
-          MockFocusDirective,
-          MockConfiguratorAttributeQuantityComponent,
-        ],
-        providers: [
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeProductCardComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        UrlTestingModule,
+        MediaModule,
+      ],
+      declarations: [
+        ConfiguratorAttributeProductCardComponent,
+        ConfiguratorShowMoreComponent,
+        ItemCounterComponent,
+        MockConfiguratorPriceComponent,
+        MockFocusDirective,
+        MockConfiguratorAttributeQuantityComponent,
+      ],
+      providers: [
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeProductCardComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.component.spec.ts
@@ -57,29 +57,27 @@ class MockItemCounterComponent {
 }
 
 describe(' ConfiguratorAttributeQuantityComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeQuantityComponent,
-          MockItemCounterComponent,
-        ],
-        imports: [I18nTestingModule],
-        providers: [
-          {
-            provide: ConfiguratorUISettingsConfig,
-            useValue: TestConfiguratorUISettings,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeQuantityComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeQuantityComponent,
+        MockItemCounterComponent,
+      ],
+      imports: [I18nTestingModule],
+      providers: [
+        {
+          provide: ConfiguratorUISettingsConfig,
+          useValue: TestConfiguratorUISettings,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeQuantityComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   it('should create', () => {
     initialize(false);

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-multi-selection-base.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-multi-selection-base.component.spec.ts
@@ -51,24 +51,22 @@ describe('ConfiguratorAttributeMultiSelectionBaseComponent', () => {
   let component: ConfiguratorAttributeMultiSelectionBaseComponent;
   let fixture: ComponentFixture<ExampleConfiguratorAttributeMultiSelectionComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ExampleConfiguratorAttributeMultiSelectionComponent],
-        providers: [
-          ConfiguratorAttributeQuantityService,
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ExampleConfiguratorAttributeMultiSelectionComponent],
+      providers: [
+        ConfiguratorAttributeQuantityService,
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   function createValue(code: string, name: string, isSelected: boolean) {
     const value: Configurator.Value = {

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.spec.ts
@@ -80,29 +80,27 @@ describe('ConfiguratorAttributeSingleSelectionBaseComponent', () => {
   const attributeQuantity = 4;
   const selectedValue = 'a';
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ExampleConfiguratorAttributeSingleSelectionComponent],
-        imports: [
-          I18nTestingModule,
-          StoreModule.forRoot({}),
-          StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
-        ],
-        providers: [
-          ConfiguratorAttributeQuantityService,
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ExampleConfiguratorAttributeSingleSelectionComponent],
+      imports: [
+        I18nTestingModule,
+        StoreModule.forRoot({}),
+        StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
+      ],
+      providers: [
+        ConfiguratorAttributeQuantityService,
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.spec.ts
@@ -76,45 +76,43 @@ describe('ConfiguratorAttributeCheckBoxListComponent', () => {
   let htmlElem: HTMLElement;
   let configuratorStorefrontUtilsService: ConfiguratorStorefrontUtilsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeCheckBoxListComponent,
-          MockFocusDirective,
-          MockConfiguratorAttributeQuantityComponent,
-          MockConfiguratorPriceComponent,
-          MockConfiguratorShowMoreComponent,
-        ],
-        imports: [ReactiveFormsModule, NgSelectModule, I18nTestingModule],
-        providers: [
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockGroupService,
-          },
-          ConfiguratorAttributeQuantityService,
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeCheckBoxListComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeCheckBoxListComponent,
+        MockFocusDirective,
+        MockConfiguratorAttributeQuantityComponent,
+        MockConfiguratorPriceComponent,
+        MockConfiguratorShowMoreComponent,
+      ],
+      imports: [ReactiveFormsModule, NgSelectModule, I18nTestingModule],
+      providers: [
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockGroupService,
+        },
+        ConfiguratorAttributeQuantityService,
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeCheckBoxListComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   function createValue(code: string, name: string, isSelected: boolean) {
     const value: Configurator.Value = {

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.spec.ts
@@ -51,35 +51,33 @@ describe('ConfigAttributeCheckBoxComponent', () => {
   let fixture: ComponentFixture<ConfiguratorAttributeCheckBoxComponent>;
   let htmlElem: HTMLElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeCheckBoxComponent,
-          MockFocusDirective,
-          MockConfiguratorPriceComponent,
-          MockConfiguratorShowMoreComponent,
-        ],
-        imports: [ReactiveFormsModule, NgSelectModule, I18nTestingModule],
-        providers: [
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeCheckBoxComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeCheckBoxComponent,
+        MockFocusDirective,
+        MockConfiguratorPriceComponent,
+        MockConfiguratorShowMoreComponent,
+      ],
+      imports: [ReactiveFormsModule, NgSelectModule, I18nTestingModule],
+      providers: [
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeCheckBoxComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   function createValue(code: string, name: string, isSelected: boolean) {
     const value: Configurator.Value = {

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.spec.ts
@@ -135,50 +135,48 @@ describe('ConfiguratorAttributeDropDownComponent', () => {
     return component;
   }
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeDropDownComponent,
-          ConfiguratorAttributeInputFieldComponent,
-          ConfiguratorAttributeNumericInputFieldComponent,
-          MockFocusDirective,
-          MockConfiguratorAttributeQuantityComponent,
-          MockConfiguratorPriceComponent,
-          MockFeatureLevelDirective,
-          MockConfiguratorShowMoreComponent,
-        ],
-        imports: [
-          ReactiveFormsModule,
-          NgSelectModule,
-          I18nTestingModule,
-          StoreModule.forRoot({}),
-          StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
-        ],
-        providers: [
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
-          { provide: Config, useClass: MockConfig },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeDropDownComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeDropDownComponent,
+        ConfiguratorAttributeInputFieldComponent,
+        ConfiguratorAttributeNumericInputFieldComponent,
+        MockFocusDirective,
+        MockConfiguratorAttributeQuantityComponent,
+        MockConfiguratorPriceComponent,
+        MockFeatureLevelDirective,
+        MockConfiguratorShowMoreComponent,
+      ],
+      imports: [
+        ReactiveFormsModule,
+        NgSelectModule,
+        I18nTestingModule,
+        StoreModule.forRoot({}),
+        StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
+      ],
+      providers: [
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
+        { provide: Config, useClass: MockConfig },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeDropDownComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   afterEach(() => {
     document.body.removeChild(htmlElem);

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.spec.ts
@@ -48,47 +48,45 @@ describe('ConfiguratorAttributeInputFieldComponent', () => {
   const groupId = 'theGroupId';
   const userInput = 'theUserInput';
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeInputFieldComponent,
-          MockFocusDirective,
-        ],
-        imports: [ReactiveFormsModule, I18nTestingModule],
-        providers: [
-          {
-            provide: ConfiguratorUISettingsConfig,
-            useValue: defaultConfiguratorUISettingsConfig,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeInputFieldComponent,
+        MockFocusDirective,
+      ],
+      imports: [ReactiveFormsModule, I18nTestingModule],
+      providers: [
+        {
+          provide: ConfiguratorUISettingsConfig,
+          useValue: defaultConfiguratorUISettingsConfig,
+        },
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '*' },
           },
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '*' },
-            },
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeInputFieldComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeInputFieldComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorAttributeInputFieldComponent);

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.spec.ts
@@ -97,49 +97,47 @@ describe('ConfiguratorAttributeMultiSelectionBundleComponent', () => {
     return value;
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          RouterTestingModule,
-          UrlTestingModule,
-          ReactiveFormsModule,
-          MediaModule,
-        ],
-        declarations: [
-          ConfiguratorAttributeMultiSelectionBundleComponent,
-          ConfiguratorShowMoreComponent,
-          ItemCounterComponent,
-          MockProductCardComponent,
-          MockConfiguratorAttributeQuantityComponent,
-          MockConfiguratorPriceComponent,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeMultiSelectionBundleComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-            providers: [
-              {
-                provide: ConfiguratorAttributeProductCardComponent,
-                useClass: MockProductCardComponent,
-              },
-            ],
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        RouterTestingModule,
+        UrlTestingModule,
+        ReactiveFormsModule,
+        MediaModule,
+      ],
+      declarations: [
+        ConfiguratorAttributeMultiSelectionBundleComponent,
+        ConfiguratorShowMoreComponent,
+        ItemCounterComponent,
+        MockProductCardComponent,
+        MockConfiguratorAttributeQuantityComponent,
+        MockConfiguratorPriceComponent,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeMultiSelectionBundleComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+          providers: [
+            {
+              provide: ConfiguratorAttributeProductCardComponent,
+              useClass: MockProductCardComponent,
+            },
+          ],
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     const values: Configurator.Value[] = [

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.html
@@ -133,7 +133,7 @@
                 placement: 'auto',
                 class: 'cx-value-description',
                 appendToBody: true,
-                displayCloseButton: true,
+                displayCloseButton: true
               }"
               [attr.aria-label]="'configurator.a11y.description' | cxTranslate"
             >

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.spec.ts
@@ -57,49 +57,47 @@ describe('ConfiguratorAttributeMultiSelectionImageComponent', () => {
   let htmlElem: HTMLElement;
   let config: Config;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeMultiSelectionImageComponent,
-          MockFocusDirective,
-          MockConfiguratorPriceComponent,
-        ],
-        imports: [
-          ReactiveFormsModule,
-          NgSelectModule,
-          I18nTestingModule,
-          IconTestingModule,
-          PopoverModule,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockGroupService,
-          },
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          { provide: Config, useClass: MockConfig },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeMultiSelectionImageComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeMultiSelectionImageComponent,
+        MockFocusDirective,
+        MockConfiguratorPriceComponent,
+      ],
+      imports: [
+        ReactiveFormsModule,
+        NgSelectModule,
+        I18nTestingModule,
+        IconTestingModule,
+        PopoverModule,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockGroupService,
+        },
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        { provide: Config, useClass: MockConfig },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeMultiSelectionImageComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   function createImage(url: string, altText: string): Configurator.Image {
     const image: Configurator.Image = {

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.spec.ts
@@ -125,57 +125,55 @@ describe('ConfigAttributeNumericInputFieldComponent', () => {
     },
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      configuratorUISettingsConfig.productConfigurator =
-        defaultConfiguratorUISettingsConfig.productConfigurator;
-      mockLanguageService = {
-        getAll: () => of([]),
-        getActive: jasmine.createSpy().and.returnValue(of(locale)),
-        setActive: jasmine.createSpy(),
-      };
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeNumericInputFieldComponent,
-          MockFocusDirective,
-          MockCxIconComponent,
-        ],
-        imports: [ReactiveFormsModule, I18nTestingModule],
-        providers: [
-          { provide: LanguageService, useValue: mockLanguageService },
-          {
-            provide: ConfiguratorUISettingsConfig,
-            useValue: configuratorUISettingsConfig,
-          },
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
+  beforeEach(waitForAsync(() => {
+    configuratorUISettingsConfig.productConfigurator =
+      defaultConfiguratorUISettingsConfig.productConfigurator;
+    mockLanguageService = {
+      getAll: () => of([]),
+      getActive: jasmine.createSpy().and.returnValue(of(locale)),
+      setActive: jasmine.createSpy(),
+    };
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeNumericInputFieldComponent,
+        MockFocusDirective,
+        MockCxIconComponent,
+      ],
+      imports: [ReactiveFormsModule, I18nTestingModule],
+      providers: [
+        { provide: LanguageService, useValue: mockLanguageService },
+        {
+          provide: ConfiguratorUISettingsConfig,
+          useValue: configuratorUISettingsConfig,
+        },
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
 
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '*' },
-            },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '*' },
           },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeNumericInputFieldComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeNumericInputFieldComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.spec.ts
@@ -94,49 +94,47 @@ describe('ConfigAttributeRadioButtonComponent', () => {
 
   const values: Configurator.Value[] = [value1, value2, value3];
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeRadioButtonComponent,
-          ConfiguratorAttributeInputFieldComponent,
-          ConfiguratorAttributeNumericInputFieldComponent,
-          ItemCounterComponent,
-          MockFocusDirective,
-          MockConfiguratorAttributeQuantityComponent,
-          MockConfiguratorPriceComponent,
-          MockConfiguratorShowMoreComponent,
-        ],
-        imports: [
-          I18nTestingModule,
-          ReactiveFormsModule,
-          StoreModule.forRoot({}),
-          StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
-        ],
-        providers: [
-          ConfiguratorStorefrontUtilsService,
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockGroupService,
-          },
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeRadioButtonComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeRadioButtonComponent,
+        ConfiguratorAttributeInputFieldComponent,
+        ConfiguratorAttributeNumericInputFieldComponent,
+        ItemCounterComponent,
+        MockFocusDirective,
+        MockConfiguratorAttributeQuantityComponent,
+        MockConfiguratorPriceComponent,
+        MockConfiguratorShowMoreComponent,
+      ],
+      imports: [
+        I18nTestingModule,
+        ReactiveFormsModule,
+        StoreModule.forRoot({}),
+        StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
+      ],
+      providers: [
+        ConfiguratorStorefrontUtilsService,
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockGroupService,
+        },
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeRadioButtonComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.spec.ts
@@ -68,30 +68,28 @@ describe('ConfigAttributeReadOnlyComponent', () => {
     isLightedUp: myValues[0].selected,
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeReadOnlyComponent,
-          MockConfiguratorPriceComponent,
-          MockConfiguratorShowMoreComponent,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-        ],
-        imports: [ReactiveFormsModule, I18nTestingModule],
-      })
-        .overrideComponent(ConfiguratorAttributeReadOnlyComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeReadOnlyComponent,
+        MockConfiguratorPriceComponent,
+        MockConfiguratorShowMoreComponent,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+      ],
+      imports: [ReactiveFormsModule, I18nTestingModule],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeReadOnlyComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorAttributeReadOnlyComponent);

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.html
@@ -34,16 +34,16 @@
             | cxTranslate
               : { value: item.valueDisplay, attribute: attribute.label })
           : item.valuePrice && item.valuePrice?.value !== 0
-          ? ('configurator.a11y.selectedValueOfAttributeFullWithPrice'
-            | cxTranslate
-              : {
-                  value: item.valueDisplay,
-                  attribute: attribute.label,
-                  price: item.valuePriceTotal?.formattedValue ?? 0
-                })
-          : ('configurator.a11y.selectedValueOfAttributeFull'
-            | cxTranslate
-              : { value: item.valueDisplay, attribute: attribute.label })
+            ? ('configurator.a11y.selectedValueOfAttributeFullWithPrice'
+              | cxTranslate
+                : {
+                    value: item.valueDisplay,
+                    attribute: attribute.label,
+                    price: item.valuePriceTotal?.formattedValue ?? 0
+                  })
+            : ('configurator.a11y.selectedValueOfAttributeFull'
+              | cxTranslate
+                : { value: item.valueDisplay, attribute: attribute.label })
       "
       [value]="item.valueCode"
     >

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.spec.ts
@@ -188,60 +188,58 @@ describe('ConfiguratorAttributeSingleSelectionBundleDropdownComponent', () => {
     return component;
   }
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeSingleSelectionBundleDropdownComponent,
-          ConfiguratorShowMoreComponent,
-          MockProductCardComponent,
-          MockConfiguratorAttributeQuantityComponent,
-          MockConfiguratorPriceComponent,
-          MockFocusDirective,
-          MockFeatureLevelDirective,
-        ],
-        imports: [
-          ReactiveFormsModule,
-          NgSelectModule,
-          I18nTestingModule,
-          RouterTestingModule,
-          UrlTestingModule,
-          StoreModule.forRoot({}),
-          StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
-        ],
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeSingleSelectionBundleDropdownComponent,
+        ConfiguratorShowMoreComponent,
+        MockProductCardComponent,
+        MockConfiguratorAttributeQuantityComponent,
+        MockConfiguratorPriceComponent,
+        MockFocusDirective,
+        MockFeatureLevelDirective,
+      ],
+      imports: [
+        ReactiveFormsModule,
+        NgSelectModule,
+        I18nTestingModule,
+        RouterTestingModule,
+        UrlTestingModule,
+        StoreModule.forRoot({}),
+        StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
+      ],
 
-        providers: [
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
-        ],
-      })
-        .overrideComponent(
-          ConfiguratorAttributeSingleSelectionBundleDropdownComponent,
-          {
-            set: {
-              changeDetection: ChangeDetectionStrategy.Default,
-              providers: [
-                {
-                  provide: ConfiguratorAttributeProductCardComponent,
-                  useClass: MockProductCardComponent,
-                },
-                {
-                  provide: ConfiguratorAttributeQuantityService,
-                  useClass: ConfiguratorAttributeQuantityService,
-                },
-              ],
-            },
-          }
-        )
-        .compileComponents();
+      providers: [
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
+      ],
     })
-  );
+      .overrideComponent(
+        ConfiguratorAttributeSingleSelectionBundleDropdownComponent,
+        {
+          set: {
+            changeDetection: ChangeDetectionStrategy.Default,
+            providers: [
+              {
+                provide: ConfiguratorAttributeProductCardComponent,
+                useClass: MockProductCardComponent,
+              },
+              {
+                provide: ConfiguratorAttributeQuantityService,
+                useClass: ConfiguratorAttributeQuantityService,
+              },
+            ],
+          },
+        }
+      )
+      .compileComponents();
+  }));
 
   afterEach(() => {
     document.body.removeChild(htmlElem);

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.spec.ts
@@ -93,48 +93,43 @@ describe('ConfiguratorAttributeSingleSelectionBundleComponent', () => {
     return value;
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          RouterTestingModule,
-          ReactiveFormsModule,
-          StoreModule.forRoot({}),
-          StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
-        ],
-        declarations: [
-          ConfiguratorAttributeSingleSelectionBundleComponent,
-          ConfiguratorShowMoreComponent,
-          ItemCounterComponent,
-          MockProductCardComponent,
-          MockConfiguratorPriceComponent,
-          MockConfiguratorAttributeQuantityComponent,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-        ],
-      })
-        .overrideComponent(
-          ConfiguratorAttributeSingleSelectionBundleComponent,
-          {
-            set: {
-              changeDetection: ChangeDetectionStrategy.Default,
-              providers: [
-                {
-                  provide: ConfiguratorAttributeProductCardComponent,
-                  useClass: MockProductCardComponent,
-                },
-              ],
-            },
-          }
-        )
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        RouterTestingModule,
+        ReactiveFormsModule,
+        StoreModule.forRoot({}),
+        StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
+      ],
+      declarations: [
+        ConfiguratorAttributeSingleSelectionBundleComponent,
+        ConfiguratorShowMoreComponent,
+        ItemCounterComponent,
+        MockProductCardComponent,
+        MockConfiguratorPriceComponent,
+        MockConfiguratorAttributeQuantityComponent,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeSingleSelectionBundleComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+          providers: [
+            {
+              provide: ConfiguratorAttributeProductCardComponent,
+              useClass: MockProductCardComponent,
+            },
+          ],
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     values = [

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.html
@@ -161,7 +161,7 @@
                 placement: 'auto',
                 class: 'cx-value-description',
                 appendToBody: true,
-                displayCloseButton: true,
+                displayCloseButton: true
               }"
               [attr.aria-label]="'configurator.a11y.description' | cxTranslate"
             >

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.spec.ts
@@ -56,46 +56,44 @@ describe('ConfiguratorAttributeSingleSelectionImageComponent', () => {
   const attributeName = 'attributeName';
   let config: Config;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorAttributeSingleSelectionImageComponent,
-          MockFocusDirective,
-          MockConfiguratorPriceComponent,
-        ],
-        imports: [
-          ReactiveFormsModule,
-          NgSelectModule,
-          I18nTestingModule,
-          IconTestingModule,
-          PopoverModule,
-        ],
-        providers: [
-          ConfiguratorStorefrontUtilsService,
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockGroupService,
-          },
-          {
-            provide: ConfiguratorAttributeCompositionContext,
-            useValue: ConfiguratorTestUtils.getAttributeContext(),
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          { provide: Config, useClass: MockConfig },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeSingleSelectionImageComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorAttributeSingleSelectionImageComponent,
+        MockFocusDirective,
+        MockConfiguratorPriceComponent,
+      ],
+      imports: [
+        ReactiveFormsModule,
+        NgSelectModule,
+        I18nTestingModule,
+        IconTestingModule,
+        PopoverModule,
+      ],
+      providers: [
+        ConfiguratorStorefrontUtilsService,
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockGroupService,
+        },
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        { provide: Config, useClass: MockConfig },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeSingleSelectionImageComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   function createImage(url: string, altText: string): Configurator.Image {
     const configImage: Configurator.Image = {

--- a/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/configurator-conflict-and-error-messages.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/configurator-conflict-and-error-messages.component.spec.ts
@@ -110,29 +110,27 @@ describe('ConfiguratorConflictAndErrorMessagesComponent', () => {
   let configuratorUtils: CommonConfiguratorUtilsService;
   let htmlElem: HTMLElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [
-          ConfiguratorConflictAndErrorMessagesComponent,
-          MockCxIconComponent,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorRouterExtractorService,
-            useClass: MockConfiguratorRouterExtractorService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [
+        ConfiguratorConflictAndErrorMessagesComponent,
+        MockCxIconComponent,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorRouterExtractorService,
+          useClass: MockConfiguratorRouterExtractorService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
 
-          { provide: IconLoaderService, useClass: MockIconFontLoaderService },
-        ],
-      });
-    })
-  );
+        { provide: IconLoaderService, useClass: MockIconFontLoaderService },
+      ],
+    });
+  }));
   beforeEach(() => {
     fixture = TestBed.createComponent(
       ConfiguratorConflictAndErrorMessagesComponent

--- a/feature-libs/product-configurator/rulebased/components/conflict-description/configurator-conflict-description.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-description/configurator-conflict-description.component.spec.ts
@@ -19,24 +19,22 @@ describe('ConfigurationConflictDescriptionComponent', () => {
   let fixture: ComponentFixture<ConfiguratorConflictDescriptionComponent>;
   let htmlElem: HTMLElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorConflictDescriptionComponent,
-          MockCxIconComponent,
-        ],
-        imports: [],
-        providers: [],
-      })
-        .overrideComponent(ConfiguratorConflictDescriptionComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorConflictDescriptionComponent,
+        MockCxIconComponent,
+      ],
+      imports: [],
+      providers: [],
     })
-  );
+      .overrideComponent(ConfiguratorConflictDescriptionComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorConflictDescriptionComponent);

--- a/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.component.spec.ts
@@ -91,30 +91,28 @@ describe('ConfiguratorConflictSolverDialogComponent', () => {
   let configuratorStorefrontUtilsService: ConfiguratorStorefrontUtilsService;
   let focusService: KeyboardFocusService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, IconModule],
-        declarations: [
-          MockConfiguratorDefaultFormComponent,
-          ConfiguratorConflictSolverDialogComponent,
-          MockKeyboardFocusDirective,
-        ],
-        providers: [
-          { provide: IconLoaderService, useClass: MockIconFontLoaderService },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, IconModule],
+      declarations: [
+        MockConfiguratorDefaultFormComponent,
+        ConfiguratorConflictSolverDialogComponent,
+        MockKeyboardFocusDirective,
+      ],
+      providers: [
+        { provide: IconLoaderService, useClass: MockIconFontLoaderService },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/product-configurator/rulebased/components/conflict-suggestion/configurator-conflict-suggestion.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-suggestion/configurator-conflict-suggestion.component.spec.ts
@@ -11,21 +11,19 @@ describe('ConfigurationConflictSuggestionComponent', () => {
   let fixture: ComponentFixture<ConfiguratorConflictSuggestionComponent>;
   let htmlElem: HTMLElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ConfiguratorConflictSuggestionComponent],
-        imports: [I18nTestingModule],
-        providers: [],
-      })
-        .overrideComponent(ConfiguratorConflictSuggestionComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ConfiguratorConflictSuggestionComponent],
+      imports: [I18nTestingModule],
+      providers: [],
     })
-  );
+      .overrideComponent(ConfiguratorConflictSuggestionComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorConflictSuggestionComponent);

--- a/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.spec.ts
@@ -108,36 +108,34 @@ describe('ConfiguratorExitButton', () => {
   let routingService: RoutingService;
   let breakpointService: BreakpointService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [ConfiguratorExitButtonComponent],
-        providers: [
-          {
-            provide: ConfiguratorRouterExtractorService,
-            useClass: MockConfiguratorRouterExtractorService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: BreakpointService,
-            useClass: MockBreakpointService,
-          },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [ConfiguratorExitButtonComponent],
+      providers: [
+        {
+          provide: ConfiguratorRouterExtractorService,
+          useClass: MockConfiguratorRouterExtractorService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: BreakpointService,
+          useClass: MockBreakpointService,
+        },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorExitButtonComponent);

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.spec.ts
@@ -259,46 +259,44 @@ let configExpertModeService: ConfiguratorExpertModeService;
 let hasConfigurationConflictsObservable: Observable<boolean> = EMPTY;
 
 describe('ConfigurationFormComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [
-          MockConfiguratorDefaultFormComponent,
-          ConfiguratorFormComponent,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockConfiguratorGroupsService,
-          },
-          {
-            provide: ConfiguratorExpertModeService,
-            useClass: MockConfiguratorExpertModeService,
-          },
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeHeaderComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [
+        MockConfiguratorDefaultFormComponent,
+        ConfiguratorFormComponent,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockConfiguratorGroupsService,
+        },
+        {
+          provide: ConfiguratorExpertModeService,
+          useClass: MockConfiguratorExpertModeService,
+        },
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeHeaderComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     configuratorGroupsService = TestBed.inject(

--- a/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.component.spec.ts
@@ -235,49 +235,47 @@ function initialize() {
 }
 
 describe('ConfiguratorGroupMenuComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [
-          ConfiguratorGroupMenuComponent,
-          MockCxIconComponent,
-          MockFocusDirective,
-        ],
-        providers: [
-          HamburgerMenuService,
-          {
-            provide: Router,
-            useClass: MockRouter,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockConfiguratorGroupService,
-          },
-          {
-            provide: DirectionService,
-            useClass: MockDirectionService,
-          },
-          {
-            provide: BreakpointService,
-            useClass: MockBreakpointService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [
+        ConfiguratorGroupMenuComponent,
+        MockCxIconComponent,
+        MockFocusDirective,
+      ],
+      providers: [
+        HamburgerMenuService,
+        {
+          provide: Router,
+          useClass: MockRouter,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockConfiguratorGroupService,
+        },
+        {
+          provide: DirectionService,
+          useClass: MockDirectionService,
+        },
+        {
+          provide: BreakpointService,
+          useClass: MockBreakpointService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     groupVisitedObservable = of(false);

--- a/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.spec.ts
@@ -92,47 +92,45 @@ describe('ConfiguratorGroupTitleComponent', () => {
   let configuratorStorefrontUtilsService: ConfiguratorStorefrontUtilsService;
   let hamburgerMenuService: HamburgerMenuService;
 
-  beforeEach(
-    waitForAsync(() => {
-      routerStateObservable = of(ConfigurationTestData.mockRouterState);
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [
-          ConfiguratorGroupTitleComponent,
-          MockHamburgerMenuComponent,
-        ],
-        providers: [
-          HamburgerMenuService,
-          {
-            provide: Router,
-            useClass: MockRouter,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
+  beforeEach(waitForAsync(() => {
+    routerStateObservable = of(ConfigurationTestData.mockRouterState);
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [
+        ConfiguratorGroupTitleComponent,
+        MockHamburgerMenuComponent,
+      ],
+      providers: [
+        HamburgerMenuService,
+        {
+          provide: Router,
+          useClass: MockRouter,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
 
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockConfiguratorGroupService,
-          },
-          { provide: IconLoaderService, useClass: MockIconFontLoaderService },
-          {
-            provide: BreakpointService,
-            useClass: MockBreakpointService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockConfiguratorGroupService,
+        },
+        { provide: IconLoaderService, useClass: MockIconFontLoaderService },
+        {
+          provide: BreakpointService,
+          useClass: MockBreakpointService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorGroupTitleComponent);
     component = fixture.componentInstance;

--- a/feature-libs/product-configurator/rulebased/components/group/configurator-group.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/group/configurator-group.component.spec.ts
@@ -279,77 +279,75 @@ describe('ConfiguratorGroupComponent', () => {
   let fixture: ComponentFixture<ConfiguratorGroupComponent>;
   let component: ConfiguratorGroupComponent;
 
-  beforeEach(
-    waitForAsync(() => {
-      mockLanguageService = {
-        getAll: () => of([]),
-        getActive: jasmine.createSpy().and.returnValue(of('en')),
-      };
+  beforeEach(waitForAsync(() => {
+    mockLanguageService = {
+      getAll: () => of([]),
+      getActive: jasmine.createSpy().and.returnValue(of('en')),
+    };
 
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [
-          MockCxIconComponent,
-          MockConfiguratorPriceComponent,
-          MockFocusDirective,
-          MockFeatureLevelDirective,
-          MockProductCardComponent,
-          ConfiguratorAttributeCompositionDirective,
-          ConfiguratorGroupComponent,
-          MockConfiguratorConflictDescriptionComponent,
-          ConfiguratorConflictSuggestionComponent,
-          ConfiguratorAttributeHeaderComponent,
-          ConfiguratorAttributeFooterComponent,
-          ConfiguratorAttributeNotSupportedComponent,
-          ConfiguratorAttributeRadioButtonComponent,
-          ConfiguratorAttributeDropDownComponent,
-          ConfiguratorAttributeReadOnlyComponent,
-          ConfiguratorAttributeCheckBoxComponent,
-          ConfiguratorAttributeCheckBoxListComponent,
-          ConfiguratorAttributeMultiSelectionImageComponent,
-          ConfiguratorAttributeSingleSelectionImageComponent,
-          MockConfiguratorAttributeInputFieldComponent,
-          MockConfiguratorAttributeNumericInputFieldComponent,
-          ConfiguratorAttributeSingleSelectionBundleDropdownComponent,
-          ConfiguratorAttributeSingleSelectionBundleComponent,
-          ConfiguratorAttributeMultiSelectionBundleComponent,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockConfiguratorGroupsService,
-          },
-          { provide: LanguageService, useValue: mockLanguageService },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-          {
-            provide: ConfiguratorExpertModeService,
-            useClass: MockConfiguratorExpertModeService,
-          },
-          {
-            provide: ConfiguratorAttributeCompositionConfig,
-            useValue: mockConfiguratorAttributeCompositionConfig,
-          },
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorAttributeHeaderComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [
+        MockCxIconComponent,
+        MockConfiguratorPriceComponent,
+        MockFocusDirective,
+        MockFeatureLevelDirective,
+        MockProductCardComponent,
+        ConfiguratorAttributeCompositionDirective,
+        ConfiguratorGroupComponent,
+        MockConfiguratorConflictDescriptionComponent,
+        ConfiguratorConflictSuggestionComponent,
+        ConfiguratorAttributeHeaderComponent,
+        ConfiguratorAttributeFooterComponent,
+        ConfiguratorAttributeNotSupportedComponent,
+        ConfiguratorAttributeRadioButtonComponent,
+        ConfiguratorAttributeDropDownComponent,
+        ConfiguratorAttributeReadOnlyComponent,
+        ConfiguratorAttributeCheckBoxComponent,
+        ConfiguratorAttributeCheckBoxListComponent,
+        ConfiguratorAttributeMultiSelectionImageComponent,
+        ConfiguratorAttributeSingleSelectionImageComponent,
+        MockConfiguratorAttributeInputFieldComponent,
+        MockConfiguratorAttributeNumericInputFieldComponent,
+        ConfiguratorAttributeSingleSelectionBundleDropdownComponent,
+        ConfiguratorAttributeSingleSelectionBundleComponent,
+        ConfiguratorAttributeMultiSelectionBundleComponent,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockConfiguratorGroupsService,
+        },
+        { provide: LanguageService, useValue: mockLanguageService },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+        {
+          provide: ConfiguratorExpertModeService,
+          useClass: MockConfiguratorExpertModeService,
+        },
+        {
+          provide: ConfiguratorAttributeCompositionConfig,
+          useValue: mockConfiguratorAttributeCompositionConfig,
+        },
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorAttributeHeaderComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     configuratorUtils = TestBed.inject(

--- a/feature-libs/product-configurator/rulebased/components/overview-attribute/configurator-overview-attribute.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-attribute/configurator-overview-attribute.component.spec.ts
@@ -23,18 +23,16 @@ describe('ConfigurationOverviewAttributeComponent', () => {
   let htmlElem: HTMLElement;
   let breakpointService: BreakpointService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [ReactiveFormsModule, NgSelectModule, I18nTestingModule],
-        declarations: [
-          ConfiguratorOverviewAttributeComponent,
-          MockConfiguratorPriceComponent,
-        ],
-        providers: [],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, NgSelectModule, I18nTestingModule],
+      declarations: [
+        ConfiguratorOverviewAttributeComponent,
+        MockConfiguratorPriceComponent,
+      ],
+      providers: [],
+    });
+  }));
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorOverviewAttributeComponent);
     component = fixture.componentInstance;

--- a/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/configurator-overview-bundle-attribute.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/configurator-overview-bundle-attribute.component.spec.ts
@@ -65,19 +65,17 @@ describe('ConfiguratorOverviewBundleAttributeComponent', () => {
   let fixture: ComponentFixture<ConfiguratorOverviewBundleAttributeComponent>;
   let htmlElem: HTMLElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MediaModule, I18nTestingModule],
-        declarations: [
-          ConfiguratorOverviewBundleAttributeComponent,
-          MockConfiguratorPriceComponent,
-          MockNumericPipe,
-        ],
-        providers: [{ provide: ProductService, useClass: MockProductService }],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [MediaModule, I18nTestingModule],
+      declarations: [
+        ConfiguratorOverviewBundleAttributeComponent,
+        MockConfiguratorPriceComponent,
+        MockNumericPipe,
+      ],
+      providers: [{ provide: ProductService, useClass: MockProductService }],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-bar/configurator-overview-filter-bar.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-bar/configurator-overview-filter-bar.component.spec.ts
@@ -70,25 +70,23 @@ class MockCxIconComponent {
 
 describe('ConfiguratorOverviewFilterBarComponent', () => {
   describe('in a component test environment', () => {
-    beforeEach(
-      waitForAsync(() => {
-        initTestData();
-        initMocks();
-        TestBed.configureTestingModule({
-          imports: [I18nTestingModule],
-          declarations: [
-            ConfiguratorOverviewFilterBarComponent,
-            MockCxIconComponent,
-          ],
-          providers: [
-            {
-              provide: ConfiguratorCommonsService,
-              useValue: mockConfigCommonsService,
-            },
-          ],
-        }).compileComponents();
-      })
-    );
+    beforeEach(waitForAsync(() => {
+      initTestData();
+      initMocks();
+      TestBed.configureTestingModule({
+        imports: [I18nTestingModule],
+        declarations: [
+          ConfiguratorOverviewFilterBarComponent,
+          MockCxIconComponent,
+        ],
+        providers: [
+          {
+            provide: ConfiguratorCommonsService,
+            useValue: mockConfigCommonsService,
+          },
+        ],
+      }).compileComponents();
+    }));
 
     it('should create component', () => {
       initTestComponent();

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.spec.ts
@@ -85,35 +85,33 @@ class MockConfiguratorStorefrontUtilsService {
 }
 
 describe('ConfigurationOverviewFilterButtonComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      initTestData();
-      initMocks();
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          ConfiguratorOverviewFilterButtonComponent,
-          MockConfiguratorOverviewFilterBarComponent,
-        ],
-        providers: [
-          { provide: LaunchDialogService, useValue: mockLaunchDialogService },
-          {
-            provide: ConfiguratorRouterExtractorService,
-            useValue: mockConfigRouterService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useValue: mockConfigCommonsService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-        ],
-      }).compileComponents();
-      initComponent();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    initTestData();
+    initMocks();
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        ConfiguratorOverviewFilterButtonComponent,
+        MockConfiguratorOverviewFilterBarComponent,
+      ],
+      providers: [
+        { provide: LaunchDialogService, useValue: mockLaunchDialogService },
+        {
+          provide: ConfiguratorRouterExtractorService,
+          useValue: mockConfigRouterService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useValue: mockConfigCommonsService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+      ],
+    }).compileComponents();
+    initComponent();
+  }));
 
   beforeEach(() => {
     fixture.detectChanges(); //due to the additional delay(0)

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.component.spec.ts
@@ -59,23 +59,21 @@ export class MockKeyboadFocusDirective {
 }
 
 describe('ConfiguratorOverviewFilterDialogComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      initializeMocks();
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorOverviewFilterDialogComponent,
-          MockCxIconComponent,
-          MockConfiguratorOverviewFilterComponent,
-          MockKeyboadFocusDirective,
-        ],
-        imports: [I18nTestingModule],
-        providers: [
-          { provide: LaunchDialogService, useValue: mockLaunchDialogService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    initializeMocks();
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorOverviewFilterDialogComponent,
+        MockCxIconComponent,
+        MockConfiguratorOverviewFilterComponent,
+        MockKeyboadFocusDirective,
+      ],
+      imports: [I18nTestingModule],
+      providers: [
+        { provide: LaunchDialogService, useValue: mockLaunchDialogService },
+      ],
+    }).compileComponents();
+  }));
 
   it('should create component', () => {
     initialize();

--- a/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.component.spec.ts
@@ -98,14 +98,12 @@ describe('ConfiguratorOverviewFilterComponent', () => {
     });
   }
 
-  beforeEach(
-    waitForAsync(() => {
-      initTestData();
-      initMocks();
-      configureTestingModule().compileComponents();
-      initTestComponent();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    initTestData();
+    initMocks();
+    configureTestingModule().compileComponents();
+    initTestComponent();
+  }));
 
   describe('in a component test environment', () => {
     it('should create component', () => {

--- a/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.spec.ts
@@ -135,33 +135,31 @@ class MockConfiguratorPriceComponent {
 }
 
 describe('ConfigurationOverviewFormComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [
-          ConfiguratorOverviewFormComponent,
-          ConfiguratorOverviewAttributeComponent,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [
+        ConfiguratorOverviewFormComponent,
+        ConfiguratorOverviewAttributeComponent,
 
-          MockConfiguratorPriceComponent,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+        MockConfiguratorPriceComponent,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     routerStateObservable = null;
     configurationObservable = null;

--- a/feature-libs/product-configurator/rulebased/components/overview-menu/configurator-overview-menu.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-menu/configurator-overview-menu.component.spec.ts
@@ -107,24 +107,22 @@ function initialize() {
 }
 
 describe('ConfigurationOverviewMenuComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [MockCxIconComponent, ConfiguratorOverviewMenuComponent],
-        providers: [
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockConfiguratorGroupsService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [MockCxIconComponent, ConfiguratorOverviewMenuComponent],
+      providers: [
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockConfiguratorGroupsService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   afterEach(() => {
     document.body.removeChild(htmlElem);

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
@@ -123,29 +123,27 @@ class MockCxIconComponent {
 }
 
 describe('ConfigOverviewNotificationBannerComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterModule, RouterTestingModule],
-        declarations: [
-          ConfiguratorOverviewNotificationBannerComponent,
-          MockTranslatePipe,
-          MockUrlPipe,
-          MockCxIconComponent,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorRouterExtractorService,
-            useClass: MockConfigRouterExtractorService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterModule, RouterTestingModule],
+      declarations: [
+        ConfiguratorOverviewNotificationBannerComponent,
+        MockTranslatePipe,
+        MockUrlPipe,
+        MockCxIconComponent,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorRouterExtractorService,
+          useClass: MockConfigRouterExtractorService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   it('should create', () => {
     configurationObs = of(productConfiguration);

--- a/feature-libs/product-configurator/rulebased/components/overview-sidebar/configurator-overview-sidebar.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-sidebar/configurator-overview-sidebar.component.spec.ts
@@ -111,39 +111,37 @@ class MockConfiguratorOverviewMenuComponent {
 }
 
 describe('ConfiguratorOverviewSidebarComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          MockConfiguratorOverviewFilterComponent,
-          MockConfiguratorOverviewMenuComponent,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorRouterExtractorService,
-            useClass: MockConfiguratorRouterExtractorService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfiguratorStorefrontUtilsService,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        MockConfiguratorOverviewFilterComponent,
+        MockConfiguratorOverviewMenuComponent,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorRouterExtractorService,
+          useClass: MockConfiguratorRouterExtractorService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfiguratorStorefrontUtilsService,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   it('should create component', () => {
     initTestComponent();

--- a/feature-libs/product-configurator/rulebased/components/previous-next-buttons/configurator-previous-next-buttons.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/previous-next-buttons/configurator-previous-next-buttons.component.spec.ts
@@ -103,42 +103,40 @@ describe('ConfigPreviousNextButtonsComponent', () => {
   let configuratorUtils: CommonConfiguratorUtilsService;
   let configuratorStorefrontUtilsService: ConfiguratorStorefrontUtilsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      routerStateObservable = of(ConfigurationTestData.mockRouterState);
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          ConfiguratorPreviousNextButtonsComponent,
-          MockFocusDirective,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockConfiguratorGroupsService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorPreviousNextButtonsComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    routerStateObservable = of(ConfigurationTestData.mockRouterState);
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        ConfiguratorPreviousNextButtonsComponent,
+        MockFocusDirective,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockConfiguratorGroupsService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorPreviousNextButtonsComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorPreviousNextButtonsComponent);

--- a/feature-libs/product-configurator/rulebased/components/price-summary/configurator-price-summary.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/price-summary/configurator-price-summary.component.spec.ts
@@ -77,35 +77,33 @@ describe('ConfigPriceSummaryComponent', () => {
   let fixture: ComponentFixture<ConfiguratorPriceSummaryComponent>;
   let htmlElem: HTMLElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      routerStateObservable = of(mockRouterState);
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          ConfiguratorPriceSummaryComponent,
-          MockFeatureLevelDirective,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
+  beforeEach(waitForAsync(() => {
+    routerStateObservable = of(mockRouterState);
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        ConfiguratorPriceSummaryComponent,
+        MockFeatureLevelDirective,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
 
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorPriceSummaryComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorPriceSummaryComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
   beforeEach(() => {
     config = { ...defaultConfig };
     fixture = TestBed.createComponent(ConfiguratorPriceSummaryComponent);

--- a/feature-libs/product-configurator/rulebased/components/price/configurator-price.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/price/configurator-price.component.spec.ts
@@ -39,20 +39,18 @@ describe('ConfiguratorPriceComponent', () => {
   let htmlElem: HTMLElement;
   let directionService: DirectionService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ConfiguratorPriceComponent, MockNumericPipe],
-        imports: [I18nTestingModule],
-        providers: [
-          {
-            provide: DirectionService,
-            useClass: MockDirectionService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ConfiguratorPriceComponent, MockNumericPipe],
+      imports: [I18nTestingModule],
+      providers: [
+        {
+          provide: DirectionService,
+          useClass: MockDirectionService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorPriceComponent);

--- a/feature-libs/product-configurator/rulebased/components/product-title/configurator-product-title.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/product-title/configurator-product-title.component.spec.ts
@@ -320,45 +320,43 @@ function setDataForQuoteEntry() {
 }
 
 describe('ConfigProductTitleComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [
-          ConfiguratorProductTitleComponent,
-          MockCxIconComponent,
-          MockMediaComponent,
-        ],
-        providers: [
-          {
-            provide: Router,
-            useClass: MockRouter,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ConfiguratorRouterExtractorService,
-            useClass: MockConfiguratorRouterExtractorService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-          { provide: IconLoaderService, useClass: MockIconFontLoaderService },
-          {
-            provide: ConfiguratorExpertModeService,
-            useClass: MockConfiguratorExpertModeService,
-          },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [
+        ConfiguratorProductTitleComponent,
+        MockCxIconComponent,
+        MockMediaComponent,
+      ],
+      providers: [
+        {
+          provide: Router,
+          useClass: MockRouter,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ConfiguratorRouterExtractorService,
+          useClass: MockConfiguratorRouterExtractorService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+        { provide: IconLoaderService, useClass: MockIconFontLoaderService },
+        {
+          provide: ConfiguratorExpertModeService,
+          useClass: MockConfiguratorExpertModeService,
+        },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     initialize();

--- a/feature-libs/product-configurator/rulebased/components/restart-dialog/configurator-restart-dialog.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/restart-dialog/configurator-restart-dialog.component.spec.ts
@@ -81,34 +81,32 @@ describe('ConfiguratorRestartDialogComponent', () => {
     return <jasmine.Spy>f;
   }
 
-  beforeEach(
-    waitForAsync(() => {
-      initializeMocks();
-      TestBed.configureTestingModule({
-        declarations: [
-          ConfiguratorRestartDialogComponent,
-          MockCxIconComponent,
-          MockKeyboadFocusDirective,
-        ],
-        imports: [I18nTestingModule],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: ConfiguratorCommonsService,
-            useValue: mockConfigCommonsService,
-          },
-          {
-            provide: RoutingService,
-            useValue: mockRoutingService,
-          },
-          {
-            provide: ProductService,
-            useValue: mockProductService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    initializeMocks();
+    TestBed.configureTestingModule({
+      declarations: [
+        ConfiguratorRestartDialogComponent,
+        MockCxIconComponent,
+        MockKeyboadFocusDirective,
+      ],
+      imports: [I18nTestingModule],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: ConfiguratorCommonsService,
+          useValue: mockConfigCommonsService,
+        },
+        {
+          provide: RoutingService,
+          useValue: mockRoutingService,
+        },
+        {
+          provide: ProductService,
+          useValue: mockProductService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     initialize();

--- a/feature-libs/product-configurator/rulebased/components/show-more/configurator-show-more.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/show-more/configurator-show-more.component.spec.ts
@@ -14,21 +14,19 @@ describe('ConfiguratorShowMoreComponent', () => {
   let htmlElem: HTMLElement;
   let config: Config;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [ConfiguratorShowMoreComponent],
-        providers: [{ provide: Config, useClass: MockConfig }],
-      })
-        .overrideComponent(ConfiguratorShowMoreComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [ConfiguratorShowMoreComponent],
+      providers: [{ provide: Config, useClass: MockConfig }],
     })
-  );
+      .overrideComponent(ConfiguratorShowMoreComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorShowMoreComponent);

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.spec.ts
@@ -103,41 +103,39 @@ describe('ConfigTabBarComponent', () => {
   let routingService: RoutingService;
   let keyboardFocusService: KeyboardFocusService;
 
-  beforeEach(
-    waitForAsync(() => {
-      mockRouterState.state.params.displayOnly = false;
+  beforeEach(waitForAsync(() => {
+    mockRouterState.state.params.displayOnly = false;
 
-      routerStateObservable = of(mockRouterState);
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterModule, RouterTestingModule],
-        declarations: [ConfiguratorTabBarComponent, MockUrlPipe],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-          {
-            provide: ConfiguratorStorefrontUtilsService,
-            useClass: MockConfigUtilsService,
-          },
-          {
-            provide: ConfiguratorGroupsService,
-            useClass: MockConfiguratorGroupsService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorTabBarComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+    routerStateObservable = of(mockRouterState);
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterModule, RouterTestingModule],
+      declarations: [ConfiguratorTabBarComponent, MockUrlPipe],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useClass: MockConfigUtilsService,
+        },
+        {
+          provide: ConfiguratorGroupsService,
+          useClass: MockConfiguratorGroupsService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorTabBarComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorTabBarComponent);
     component = fixture.componentInstance;

--- a/feature-libs/product-configurator/rulebased/components/update-message/configurator-update-message.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/update-message/configurator-update-message.component.spec.ts
@@ -57,33 +57,31 @@ describe('ConfigurationUpdateMessageComponent', () => {
   let fixture: ComponentFixture<ConfiguratorUpdateMessageComponent>;
   let htmlElem: HTMLElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      routerStateObservable = of(ConfigurationTestData.mockRouterState);
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
-        declarations: [
-          ConfiguratorUpdateMessageComponent,
-          MockCxSpinnerComponent,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
+  beforeEach(waitForAsync(() => {
+    routerStateObservable = of(ConfigurationTestData.mockRouterState);
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule, NgSelectModule],
+      declarations: [
+        ConfiguratorUpdateMessageComponent,
+        MockCxSpinnerComponent,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
 
-          {
-            provide: ConfiguratorMessageConfig,
-            useClass: MockMessageConfig,
-          },
-          {
-            provide: ConfiguratorCommonsService,
-            useClass: MockConfiguratorCommonsService,
-          },
-        ],
-      });
-    })
-  );
+        {
+          provide: ConfiguratorMessageConfig,
+          useClass: MockMessageConfig,
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+      ],
+    });
+  }));
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorUpdateMessageComponent);
     htmlElem = fixture.nativeElement;

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-cart.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-cart.service.spec.ts
@@ -101,35 +101,33 @@ describe('ConfiguratorCartService', () => {
   let store: Store<StateWithConfigurator>;
   let configuratorUtils: CommonConfiguratorUtilsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      cartObs = of(cart);
-      isStableObs = of(true);
-      checkoutLoadingObs = of({ loading: true, error: false, data: undefined });
-      TestBed.configureTestingModule({
-        imports: [
-          StoreModule.forRoot({}),
-          StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
-        ],
-        providers: [
-          ConfiguratorCartService,
+  beforeEach(waitForAsync(() => {
+    cartObs = of(cart);
+    isStableObs = of(true);
+    checkoutLoadingObs = of({ loading: true, error: false, data: undefined });
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({}),
+        StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
+      ],
+      providers: [
+        ConfiguratorCartService,
 
-          {
-            provide: ActiveCartFacade,
-            useClass: MockActiveCartService,
-          },
-          {
-            provide: CheckoutQueryFacade,
-            useClass: MockCheckoutQueryFacade,
-          },
-          {
-            provide: UserIdService,
-            useClass: MockUserIdService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+        {
+          provide: ActiveCartFacade,
+          useClass: MockActiveCartService,
+        },
+        {
+          provide: CheckoutQueryFacade,
+          useClass: MockCheckoutQueryFacade,
+        },
+        {
+          provide: UserIdService,
+          useClass: MockUserIdService,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     serviceUnderTest = TestBed.inject(ConfiguratorCartService);
     store = TestBed.inject(Store);

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-commons.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-commons.service.spec.ts
@@ -161,31 +161,29 @@ describe('ConfiguratorCommonsService', () => {
   const cart: Cart = {};
   cartObs = of(cart);
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          StoreModule.forRoot({}),
-          StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
-        ],
-        providers: [
-          ConfiguratorCommonsService,
-          {
-            provide: ConfiguratorCartService,
-            useClass: MockConfiguratorCartService,
-          },
-          {
-            provide: ActiveCartFacade,
-            useClass: MockActiveCartService,
-          },
-          {
-            provide: ConfiguratorUtilsService,
-            useClass: MockconfiguratorUtilsService,
-          },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({}),
+        StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
+      ],
+      providers: [
+        ConfiguratorCommonsService,
+        {
+          provide: ConfiguratorCartService,
+          useClass: MockConfiguratorCartService,
+        },
+        {
+          provide: ActiveCartFacade,
+          useClass: MockActiveCartService,
+        },
+        {
+          provide: ConfiguratorUtilsService,
+          useClass: MockconfiguratorUtilsService,
+        },
+      ],
+    });
+  }));
   beforeEach(() => {
     configOrderObservable = of(productConfiguration);
     configCartObservable = of(productConfiguration);

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-group-status.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-group-status.service.spec.ts
@@ -22,14 +22,12 @@ describe('ConfiguratorGroupStatusService', () => {
   let classUnderTest: ConfiguratorGroupStatusService;
   let store: Store<StateWithConfigurator>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [StoreModule.forRoot({})],
-        providers: [ConfiguratorUtilsService, ConfiguratorGroupStatusService],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [StoreModule.forRoot({})],
+      providers: [ConfiguratorUtilsService, ConfiguratorGroupStatusService],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     classUnderTest = TestBed.inject(

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-groups.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-groups.service.spec.ts
@@ -47,27 +47,25 @@ describe('ConfiguratorGroupsService', () => {
   let configGroupStatusService: ConfiguratorGroupStatusService;
   let configFacadeUtilsService: ConfiguratorUtilsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [StoreModule.forRoot({})],
-        providers: [
-          ConfiguratorGroupsService,
-          ConfiguratorCommonsService,
-          ConfiguratorGroupStatusService,
-          ConfiguratorUtilsService,
-          {
-            provide: ActiveCartFacade,
-            useClass: MockActiveCartService,
-          },
-          {
-            provide: ConfiguratorCartService,
-            useClass: MockConfiguratorCartService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [StoreModule.forRoot({})],
+      providers: [
+        ConfiguratorGroupsService,
+        ConfiguratorCommonsService,
+        ConfiguratorGroupStatusService,
+        ConfiguratorUtilsService,
+        {
+          provide: ActiveCartFacade,
+          useClass: MockActiveCartService,
+        },
+        {
+          provide: ConfiguratorCartService,
+          useClass: MockConfiguratorCartService,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     classUnderTest = TestBed.inject(
       ConfiguratorGroupsService as Type<ConfiguratorGroupsService>

--- a/feature-libs/product-configurator/rulebased/core/facade/routing/configurator-router.listener.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/routing/configurator-router.listener.spec.ts
@@ -64,26 +64,24 @@ describe('ConfiguratorRouterListener', () => {
   let configuratorCartService: ConfiguratorCartService;
   let configuratorQuantityService: ConfiguratorQuantityService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: ConfiguratorCartService,
-            useValue: mockConfiguratorCartService,
-          },
-          {
-            provide: RoutingService,
-            useValue: mockRoutingService,
-          },
-          {
-            provide: ConfiguratorQuantityService,
-            useClass: MockConfiguratorQuantityService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfiguratorCartService,
+          useValue: mockConfiguratorCartService,
+        },
+        {
+          provide: RoutingService,
+          useValue: mockRoutingService,
+        },
+        {
+          provide: ConfiguratorQuantityService,
+          useClass: MockConfiguratorQuantityService,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     configuratorCartService = TestBed.inject(
       ConfiguratorCartService as Type<ConfiguratorCartService>

--- a/feature-libs/product-configurator/rulebased/core/facade/utils/configurator-utils.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/utils/configurator-utils.service.spec.ts
@@ -117,13 +117,11 @@ function mergeChangesAndGetFirstGroup(
 describe('ConfiguratorUtilsService', () => {
   let classUnderTest: ConfiguratorUtilsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [ConfiguratorUtilsService],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [ConfiguratorUtilsService],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     classUnderTest = TestBed.inject(

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-basic-effect.service.spec.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-basic-effect.service.spec.ts
@@ -131,13 +131,11 @@ const groupListWithConflictsAndAttributesOnRootLevel: Configurator.Group[] = [
 describe('ConfiguratorBasicEffectService', () => {
   let classUnderTest: ConfiguratorBasicEffectService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [ConfiguratorBasicEffectService],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [ConfiguratorBasicEffectService],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     classUnderTest = TestBed.inject(
       ConfiguratorBasicEffectService as Type<ConfiguratorBasicEffectService>

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-normalizer-utils.service.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-normalizer-utils.service.ts
@@ -258,8 +258,8 @@ export class CpqConfiguratorNormalizerUtilsService {
     return attribute.label
       ? attribute.label
       : attribute.name
-      ? attribute.name
-      : '';
+        ? attribute.name
+        : '';
   }
 
   /**

--- a/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-page-layout-handler.spec.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-page-layout-handler.spec.ts
@@ -92,26 +92,24 @@ const sectionContent = 'content';
 describe('CpqConfiguratorPageLayoutHandler', () => {
   let classUnderTest: CpqConfiguratorPageLayoutHandler;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: ConfiguratorRouterExtractorService,
-            useClass: MockRouterExtractorService,
-          },
-          {
-            provide: BreakpointService,
-            useClass: MockBreakpointService,
-          },
-          {
-            provide: LayoutConfig,
-            useValue: mockLayoutConfig,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfiguratorRouterExtractorService,
+          useClass: MockRouterExtractorService,
+        },
+        {
+          provide: BreakpointService,
+          useClass: MockBreakpointService,
+        },
+        {
+          provide: LayoutConfig,
+          useValue: mockLayoutConfig,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     classUnderTest = TestBed.inject(
       CpqConfiguratorPageLayoutHandler as Type<CpqConfiguratorPageLayoutHandler>

--- a/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-page-layout-handler.spec.ts
+++ b/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-page-layout-handler.spec.ts
@@ -66,26 +66,24 @@ const sectionContent = 'content';
 describe('VariantConfiguratorPageLayoutHandler', () => {
   let classUnderTest: VariantConfiguratorPageLayoutHandler;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: ConfiguratorRouterExtractorService,
-            useClass: MockRouterExtractorService,
-          },
-          {
-            provide: BreakpointService,
-            useClass: MockBreakpointService,
-          },
-          {
-            provide: LayoutConfig,
-            useValue: mockLayoutConfig,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfiguratorRouterExtractorService,
+          useClass: MockRouterExtractorService,
+        },
+        {
+          provide: BreakpointService,
+          useClass: MockBreakpointService,
+        },
+        {
+          provide: LayoutConfig,
+          useValue: mockLayoutConfig,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     classUnderTest = TestBed.inject(
       VariantConfiguratorPageLayoutHandler as Type<VariantConfiguratorPageLayoutHandler>

--- a/feature-libs/product-configurator/textfield/components/add-to-cart-button/configurator-textfield-add-to-cart-button.component.spec.ts
+++ b/feature-libs/product-configurator/textfield/components/add-to-cart-button/configurator-textfield-add-to-cart-button.component.spec.ts
@@ -81,33 +81,31 @@ describe('ConfigTextfieldAddToCartButtonComponent', () => {
     expect(seenText).toBe(buttonText);
   }
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule],
-        declarations: [
-          ConfiguratorTextfieldAddToCartButtonComponent,
-          MockUrlPipe,
-        ],
-        providers: [
-          {
-            provide: ConfiguratorTextfieldService,
-            useClass: MockConfiguratorTextfieldService,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-        ],
-      })
-        .overrideComponent(ConfiguratorTextfieldAddToCartButtonComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule],
+      declarations: [
+        ConfiguratorTextfieldAddToCartButtonComponent,
+        MockUrlPipe,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorTextfieldService,
+          useClass: MockConfiguratorTextfieldService,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ConfiguratorTextfieldAddToCartButtonComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/product-configurator/textfield/components/form/configurator-textfield-form.component.spec.ts
+++ b/feature-libs/product-configurator/textfield/components/form/configurator-textfield-form.component.spec.ts
@@ -77,33 +77,31 @@ describe('TextfieldFormComponent', () => {
   let fixture: ComponentFixture<ConfiguratorTextfieldFormComponent>;
   let textfieldService: ConfiguratorTextfieldService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          ReactiveFormsModule,
-          NgSelectModule,
-          PageLayoutModule,
-        ],
-        declarations: [
-          ConfiguratorTextfieldFormComponent,
-          ConfiguratorTextfieldInputFieldComponent,
-          ConfiguratorTextfieldAddToCartButtonComponent,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ConfiguratorTextfieldService,
-            useClass: MockConfiguratorTextfieldService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        ReactiveFormsModule,
+        NgSelectModule,
+        PageLayoutModule,
+      ],
+      declarations: [
+        ConfiguratorTextfieldFormComponent,
+        ConfiguratorTextfieldInputFieldComponent,
+        ConfiguratorTextfieldAddToCartButtonComponent,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ConfiguratorTextfieldService,
+          useClass: MockConfiguratorTextfieldService,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorTextfieldFormComponent);
     component = fixture.componentInstance;

--- a/feature-libs/product-configurator/textfield/components/input-field-readonly/configurator-textfield-input-field-readonly.component.spec.ts
+++ b/feature-libs/product-configurator/textfield/components/input-field-readonly/configurator-textfield-input-field-readonly.component.spec.ts
@@ -10,14 +10,12 @@ describe('TextfieldInputFieldReadonlyComponent', () => {
   let htmlElem: HTMLElement;
   let fixture: ComponentFixture<ConfiguratorTextfieldInputFieldReadonlyComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [ConfiguratorTextfieldInputFieldReadonlyComponent],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [ConfiguratorTextfieldInputFieldReadonlyComponent],
+    });
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/feature-libs/product-configurator/textfield/components/input-field/configurator-textfield-input-field.component.spec.ts
+++ b/feature-libs/product-configurator/textfield/components/input-field/configurator-textfield-input-field.component.spec.ts
@@ -9,14 +9,12 @@ describe('TextfieldInputFieldComponent', () => {
   let fixture: ComponentFixture<ConfiguratorTextfieldInputFieldComponent>;
   let htmlElem: HTMLElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, ReactiveFormsModule],
-        declarations: [ConfiguratorTextfieldInputFieldComponent],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, ReactiveFormsModule],
+      declarations: [ConfiguratorTextfieldInputFieldComponent],
+    });
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfiguratorTextfieldInputFieldComponent);

--- a/feature-libs/product-configurator/textfield/core/facade/configurator-textfield.service.spec.ts
+++ b/feature-libs/product-configurator/textfield/core/facade/configurator-textfield.service.spec.ts
@@ -139,24 +139,22 @@ describe('ConfiguratorTextfieldService', () => {
     of(productConfiguration)
   );
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [StoreModule.forRoot({})],
-        providers: [
-          ConfiguratorTextfieldService,
-          {
-            provide: ActiveCartFacade,
-            useClass: MockActiveCartService,
-          },
-          {
-            provide: UserIdService,
-            useClass: MockUserIdService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [StoreModule.forRoot({})],
+      providers: [
+        ConfiguratorTextfieldService,
+        {
+          provide: ActiveCartFacade,
+          useClass: MockActiveCartService,
+        },
+        {
+          provide: UserIdService,
+          useClass: MockUserIdService,
+        },
+      ],
+    }).compileComponents();
+  }));
   beforeEach(() => {
     serviceUnderTest = TestBed.inject(
       ConfiguratorTextfieldService as Type<ConfiguratorTextfieldService>

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.spec.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.spec.ts
@@ -103,27 +103,25 @@ describe('ProductImagesComponent', () => {
   let fixture: ComponentFixture<ProductImageZoomProductImagesComponent>;
   let currentProductService: CurrentProductService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          ProductImageZoomProductImagesComponent,
-          MockMediaComponent,
-          MockCarouselComponent,
-          MockProductImageZoomTriggerComponent,
-        ],
-        providers: [
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        ProductImageZoomProductImagesComponent,
+        MockMediaComponent,
+        MockCarouselComponent,
+        MockProductImageZoomTriggerComponent,
+      ],
+      providers: [
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+      ],
+    }).compileComponents();
 
-      currentProductService = TestBed.inject(CurrentProductService);
-    })
-  );
+    currentProductService = TestBed.inject(CurrentProductService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductImageZoomProductImagesComponent);
@@ -152,25 +150,19 @@ describe('ProductImagesComponent', () => {
       expect(result.zoom.url).toEqual('zoom-1.jpg');
     });
 
-    it(
-      'should have 2 thumbnails',
-      waitForAsync(() => {
-        let items: Observable<Product>[];
-        component.thumbs$.subscribe((i) => (items = i));
-        expect(items.length).toBe(2);
-      })
-    );
+    it('should have 2 thumbnails', waitForAsync(() => {
+      let items: Observable<Product>[];
+      component.thumbs$.subscribe((i) => (items = i));
+      expect(items.length).toBe(2);
+    }));
 
-    it(
-      'should have thumb with url in first product',
-      waitForAsync(() => {
-        let thumbs: Observable<Product>[];
-        component.thumbs$.subscribe((i) => (thumbs = i));
-        let thumb: any;
-        thumbs[0].subscribe((p) => (thumb = p));
-        expect(thumb.container.thumbnail.url).toEqual('thumb-1.jpg');
-      })
-    );
+    it('should have thumb with url in first product', waitForAsync(() => {
+      let thumbs: Observable<Product>[];
+      component.thumbs$.subscribe((i) => (thumbs = i));
+      let thumb: any;
+      thumbs[0].subscribe((p) => (thumb = p));
+      expect(thumb.container.thumbnail.url).toEqual('thumb-1.jpg');
+    }));
 
     describe('UI test', () => {
       it('should have cx-carousel element', () => {
@@ -178,15 +170,12 @@ describe('ProductImagesComponent', () => {
         expect(carousel).toBeTruthy();
       });
 
-      it(
-        'should have 2 rendered templates',
-        waitForAsync(() => {
-          const el = fixture.debugElement.queryAll(
-            By.css('cx-carousel cx-media')
-          );
-          expect(el.length).toEqual(2);
-        })
-      );
+      it('should have 2 rendered templates', waitForAsync(() => {
+        const el = fixture.debugElement.queryAll(
+          By.css('cx-carousel cx-media')
+        );
+        expect(el.length).toEqual(2);
+      }));
     });
   });
 
@@ -211,14 +200,11 @@ describe('ProductImagesComponent', () => {
       expect(result.zoom.url).toEqual('zoom-1.jpg');
     });
 
-    it(
-      'should not have thumbnails in case there is only one GALLERY image',
-      waitForAsync(() => {
-        let items: Observable<Product>[];
-        component.thumbs$.subscribe((i) => (items = i));
-        expect(items.length).toBe(0);
-      })
-    );
+    it('should not have thumbnails in case there is only one GALLERY image', waitForAsync(() => {
+      let items: Observable<Product>[];
+      component.thumbs$.subscribe((i) => (items = i));
+      expect(items.length).toBe(0);
+    }));
 
     describe('(UI test)', () => {
       it('should not render cx-carousel for one GALLERY image', () => {

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.spec.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.spec.ts
@@ -44,16 +44,14 @@ describe('ProductImageZoomThumbnailsComponent', () => {
   let productImageZoomThumbnailsComponent: ProductImageZoomThumbnailsComponent;
   let fixture: ComponentFixture<ProductImageZoomThumbnailsComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ProductImageZoomThumbnailsComponent,
-          MockCarouselComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ProductImageZoomThumbnailsComponent,
+        MockCarouselComponent,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductImageZoomThumbnailsComponent);

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.spec.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.spec.ts
@@ -157,27 +157,19 @@ describe('ProductImageZoomViewComponent', () => {
       expect(result.zoom.url).toEqual('zoom-1.jpg');
     });
 
-    it(
-      'should have 2 thumbnails',
-      waitForAsync(() => {
-        let items: Observable<ThumbnailsGroup>[];
-        productImageZoomViewComponent.thumbnails$.subscribe((i) => (items = i));
-        expect(items.length).toBe(2);
-      })
-    );
+    it('should have 2 thumbnails', waitForAsync(() => {
+      let items: Observable<ThumbnailsGroup>[];
+      productImageZoomViewComponent.thumbnails$.subscribe((i) => (items = i));
+      expect(items.length).toBe(2);
+    }));
 
-    it(
-      'should have thumb with url in first product',
-      waitForAsync(() => {
-        let thumbs: Observable<ThumbnailsGroup>[];
-        productImageZoomViewComponent.thumbnails$.subscribe(
-          (i) => (thumbs = i)
-        );
-        let thumb: any;
-        thumbs[0].subscribe((p) => (thumb = p));
-        expect(thumb.container.thumbnail.url).toEqual('thumb-1.jpg');
-      })
-    );
+    it('should have thumb with url in first product', waitForAsync(() => {
+      let thumbs: Observable<ThumbnailsGroup>[];
+      productImageZoomViewComponent.thumbnails$.subscribe((i) => (thumbs = i));
+      let thumb: any;
+      thumbs[0].subscribe((p) => (thumb = p));
+      expect(thumb.container.thumbnail.url).toEqual('thumb-1.jpg');
+    }));
 
     it('should zoom on click', () => {
       const defaultImageElement = fixture.debugElement.query(
@@ -222,14 +214,11 @@ describe('ProductImageZoomViewComponent', () => {
       expect(result.zoom.url).toEqual('zoom-1.jpg');
     });
 
-    it(
-      'should not have thumbnails in case there is only one GALLERY image',
-      waitForAsync(() => {
-        let items: Observable<ThumbnailsGroup>[];
-        productImageZoomViewComponent.thumbnails$.subscribe((i) => (items = i));
-        expect(items.length).toBe(0);
-      })
-    );
+    it('should not have thumbnails in case there is only one GALLERY image', waitForAsync(() => {
+      let items: Observable<ThumbnailsGroup>[];
+      productImageZoomViewComponent.thumbnails$.subscribe((i) => (items = i));
+      expect(items.length).toBe(0);
+    }));
   });
 
   describe('without pictures', () => {

--- a/feature-libs/product/variants/components/product-variants-container/product-variants-container.component.spec.ts
+++ b/feature-libs/product/variants/components/product-variants-container/product-variants-container.component.spec.ts
@@ -88,30 +88,28 @@ describe('ProductVariantsContainerComponent', () => {
   let component: ProductVariantsContainerComponent;
   let fixture: ComponentFixture<ProductVariantsContainerComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ProductVariantsContainerComponent,
-          MockUrlPipe,
-          MockCxProductStyleSelectorComponent,
-          MockCxProductSizeSelectorComponent,
-          MockCxProductColorSelectorComponent,
-        ],
-        imports: [RouterTestingModule, I18nTestingModule],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ProductVariantsContainerComponent,
+        MockUrlPipe,
+        MockCxProductStyleSelectorComponent,
+        MockCxProductSizeSelectorComponent,
+        MockCxProductColorSelectorComponent,
+      ],
+      imports: [RouterTestingModule, I18nTestingModule],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductVariantsContainerComponent);

--- a/feature-libs/product/variants/components/variant-color-selector/product-variant-color-selector.component.spec.ts
+++ b/feature-libs/product/variants/components/variant-color-selector/product-variant-color-selector.component.spec.ts
@@ -48,17 +48,15 @@ describe('ProductVariantColorSelectorComponent', () => {
   let fixture: ComponentFixture<ProductVariantColorSelectorComponent>;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProductVariantColorSelectorComponent],
-        imports: [RouterTestingModule, I18nTestingModule],
-        providers: [{ provide: RoutingService, useClass: MockRoutingService }],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProductVariantColorSelectorComponent],
+      imports: [RouterTestingModule, I18nTestingModule],
+      providers: [{ provide: RoutingService, useClass: MockRoutingService }],
+    }).compileComponents();
 
-      routingService = TestBed.inject(RoutingService);
-    })
-  );
+    routingService = TestBed.inject(RoutingService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductVariantColorSelectorComponent);

--- a/feature-libs/product/variants/components/variant-size-selector/product-variant-size-selector.component.spec.ts
+++ b/feature-libs/product/variants/components/variant-size-selector/product-variant-size-selector.component.spec.ts
@@ -51,22 +51,20 @@ describe('ProductVariantSizeSelectorComponent', () => {
   let fixture: ComponentFixture<ProductVariantSizeSelectorComponent>;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProductVariantSizeSelectorComponent],
-        imports: [RouterTestingModule, I18nTestingModule],
-        providers: [
-          { provide: RoutingService, useClass: MockRoutingService },
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-        ],
-      }).compileComponents();
-      routingService = TestBed.inject(RoutingService);
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProductVariantSizeSelectorComponent],
+      imports: [RouterTestingModule, I18nTestingModule],
+      providers: [
+        { provide: RoutingService, useClass: MockRoutingService },
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+      ],
+    }).compileComponents();
+    routingService = TestBed.inject(RoutingService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductVariantSizeSelectorComponent);

--- a/feature-libs/product/variants/components/variant-style-selector/product-variant-style-selector.component.spec.ts
+++ b/feature-libs/product/variants/components/variant-style-selector/product-variant-style-selector.component.spec.ts
@@ -89,25 +89,23 @@ describe('ProductVariantStyleSelectorComponent', () => {
   let fixture: ComponentFixture<ProductVariantStyleSelectorComponent>;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProductVariantStyleSelectorComponent, MockUrlPipe],
-        imports: [RouterTestingModule, I18nTestingModule],
-        providers: [
-          {
-            provide: OccConfig,
-            useValue: { backend: { occ: { baseUrl: mockOccBackendUrl } } },
-          },
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-          { provide: RoutingService, useClass: MockRoutingService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProductVariantStyleSelectorComponent, MockUrlPipe],
+      imports: [RouterTestingModule, I18nTestingModule],
+      providers: [
+        {
+          provide: OccConfig,
+          useValue: { backend: { occ: { baseUrl: mockOccBackendUrl } } },
+        },
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+      ],
+    }).compileComponents();
+  }));
 
   describe('Empty config scenario', () => {
     beforeEach(() => {

--- a/feature-libs/product/variants/root/components/variant-style-icons/product-variant-style-icons.component.spec.ts
+++ b/feature-libs/product/variants/root/components/variant-style-icons/product-variant-style-icons.component.spec.ts
@@ -40,19 +40,17 @@ describe('ProductVariantStyleIconsComponent', () => {
   let component: ProductVariantStyleIconsComponent;
   let fixture: ComponentFixture<ProductVariantStyleIconsComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProductVariantStyleIconsComponent],
-        providers: [
-          {
-            provide: OccConfig,
-            useValue: { backend: { occ: { baseUrl: mockOccBackendUrl } } },
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProductVariantStyleIconsComponent],
+      providers: [
+        {
+          provide: OccConfig,
+          useValue: { backend: { occ: { baseUrl: mockOccBackendUrl } } },
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductVariantStyleIconsComponent);

--- a/feature-libs/quote/components/comments/quote-comments.component.spec.ts
+++ b/feature-libs/quote/components/comments/quote-comments.component.spec.ts
@@ -60,38 +60,36 @@ describe('QuoteCommentsComponent', () => {
 
   let quote: Quote;
 
-  beforeEach(
-    waitForAsync(() => {
-      initTestData();
-      initMocks();
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          QuoteCommentsComponent,
-          MockCxMessagingComponent,
-          MockCxIconComponent,
-        ],
-        providers: [
-          {
-            provide: QuoteFacade,
-            useValue: quoteFacade,
-          },
-          {
-            provide: EventService,
-            useValue: eventService,
-          },
-          {
-            provide: QuoteUIConfig,
-            useValue: quoteUIConfig,
-          },
-          {
-            provide: QuoteItemsComponentService,
-            useValue: mockQuoteItemsComponentService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    initTestData();
+    initMocks();
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        QuoteCommentsComponent,
+        MockCxMessagingComponent,
+        MockCxIconComponent,
+      ],
+      providers: [
+        {
+          provide: QuoteFacade,
+          useValue: quoteFacade,
+        },
+        {
+          provide: EventService,
+          useValue: eventService,
+        },
+        {
+          provide: QuoteUIConfig,
+          useValue: quoteUIConfig,
+        },
+        {
+          provide: QuoteItemsComponentService,
+          useValue: mockQuoteItemsComponentService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(QuoteCommentsComponent);

--- a/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.component.spec.ts
+++ b/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.component.spec.ts
@@ -77,26 +77,24 @@ describe('QuoteConfirmDialogComponent', () => {
     data$ = dialogDataSender;
   }
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          QuoteConfirmDialogComponent,
-          MockKeyboardFocusDirective,
-          MockCxIconComponent,
-        ],
-        providers: [
-          CxDatePipe,
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-          { provide: LanguageService, useClass: MockLanguageService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        QuoteConfirmDialogComponent,
+        MockKeyboardFocusDirective,
+        MockCxIconComponent,
+      ],
+      providers: [
+        CxDatePipe,
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+        { provide: LanguageService, useClass: MockLanguageService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     dialogDataSender = new BehaviorSubject({

--- a/feature-libs/quote/components/header/overview/quote-header-overview.component.spec.ts
+++ b/feature-libs/quote/components/header/overview/quote-header-overview.component.spec.ts
@@ -96,35 +96,33 @@ describe('QuoteHeaderOverviewComponent', () => {
   let eventService: EventService;
   let quoteUIConfig: QuoteUIConfig;
 
-  beforeEach(
-    waitForAsync(() => {
-      initMocks();
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, CardModule, RouterTestingModule],
-        declarations: [
-          QuoteHeaderOverviewComponent,
-          MockCxIconComponent,
-          MockQuoteActionsLinkComponent,
-          MockQuoteHeaderBuyerEditComponent,
-        ],
-        providers: [
-          {
-            provide: QuoteFacade,
-            useClass: MockCommerceQuotesFacade,
-          },
-          {
-            provide: EventService,
-            useValue: eventService,
-          },
-          { provide: TranslationService, useClass: MockTranslationService },
-          {
-            provide: QuoteUIConfig,
-            useValue: quoteUIConfig,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    initMocks();
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, CardModule, RouterTestingModule],
+      declarations: [
+        QuoteHeaderOverviewComponent,
+        MockCxIconComponent,
+        MockQuoteActionsLinkComponent,
+        MockQuoteHeaderBuyerEditComponent,
+      ],
+      providers: [
+        {
+          provide: QuoteFacade,
+          useClass: MockCommerceQuotesFacade,
+        },
+        {
+          provide: EventService,
+          useValue: eventService,
+        },
+        { provide: TranslationService, useClass: MockTranslationService },
+        {
+          provide: QuoteUIConfig,
+          useValue: quoteUIConfig,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(QuoteHeaderOverviewComponent);

--- a/feature-libs/quote/components/items/quote-items.component.spec.ts
+++ b/feature-libs/quote/components/items/quote-items.component.spec.ts
@@ -29,29 +29,27 @@ describe('QuoteItemsComponent', () => {
   let eventService: EventService;
   let quoteItemsComponentService: QuoteItemsComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      initMocks();
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          IconTestingModule,
-          AbstractOrderContextModule,
-        ],
-        declarations: [QuoteItemsComponent, MockOutletDirective],
-        providers: [
-          {
-            provide: EventService,
-            useValue: eventService,
-          },
-          {
-            provide: QuoteItemsComponentService,
-            useValue: quoteItemsComponentService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    initMocks();
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        IconTestingModule,
+        AbstractOrderContextModule,
+      ],
+      declarations: [QuoteItemsComponent, MockOutletDirective],
+      providers: [
+        {
+          provide: EventService,
+          useValue: eventService,
+        },
+        {
+          provide: QuoteItemsComponentService,
+          useValue: quoteItemsComponentService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(QuoteItemsComponent);

--- a/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.spec.ts
@@ -51,23 +51,21 @@ describe('StoreFinderGridComponent', () => {
   let storeFinderService: StoreFinderService;
   let route: ActivatedRoute;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, SpinnerModule],
-        declarations: [
-          StoreFinderGridComponent,
-          MockStoreFinderListItemComponent,
-        ],
-        providers: [
-          { provide: StoreFinderService, useClass: MockStoreFinderService },
-          { provide: ActivatedRoute, useValue: mockActivatedRoute },
-          { provide: RoutingService, useValue: mockRoutingService },
-          { provide: TranslationService, useClass: MockTranslationService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, SpinnerModule],
+      declarations: [
+        StoreFinderGridComponent,
+        MockStoreFinderListItemComponent,
+      ],
+      providers: [
+        { provide: StoreFinderService, useClass: MockStoreFinderService },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: RoutingService, useValue: mockRoutingService },
+        { provide: TranslationService, useClass: MockTranslationService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderGridComponent);

--- a/feature-libs/storefinder/components/store-finder-header/store-finder-header.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-header/store-finder-header.component.spec.ts
@@ -13,17 +13,15 @@ describe('StoreFinderHeaderComponent', () => {
   let component: StoreFinderHeaderComponent;
   let fixture: ComponentFixture<StoreFinderHeaderComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          StoreFinderHeaderComponent,
-          MockStoreFinderSearchComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        StoreFinderHeaderComponent,
+        MockStoreFinderSearchComponent,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderHeaderComponent);

--- a/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.spec.ts
@@ -101,23 +101,21 @@ describe('StoreFinderListItemComponent', () => {
   let component: StoreFinderListItemComponent;
   let fixture: ComponentFixture<StoreFinderListItemComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          CommonModule,
-          ReactiveFormsModule,
-          I18nTestingModule,
-          RouterTestingModule,
-          OutletModule,
-        ],
-        declarations: [StoreFinderListItemComponent],
-        providers: [
-          { provide: StoreFinderService, useClass: MockStoreFinderService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        I18nTestingModule,
+        RouterTestingModule,
+        OutletModule,
+      ],
+      declarations: [StoreFinderListItemComponent],
+      providers: [
+        { provide: StoreFinderService, useClass: MockStoreFinderService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderListItemComponent);

--- a/feature-libs/storefinder/components/store-finder-pagination-details/store-finder-pagination-details.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-pagination-details/store-finder-pagination-details.component.spec.ts
@@ -13,14 +13,12 @@ describe('StoreFinderPaginationDetailsComponent', () => {
   let component: StoreFinderPaginationDetailsComponent;
   let fixture: ComponentFixture<StoreFinderPaginationDetailsComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [StoreFinderPaginationDetailsComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [StoreFinderPaginationDetailsComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderPaginationDetailsComponent);

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
@@ -49,27 +49,25 @@ describe('StoreFinderDisplayListComponent', () => {
   let storeFinderService: StoreFinderService;
   let googleMapRendererService: GoogleMapRendererService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          RouterTestingModule,
-          HttpClientTestingModule,
-          SpinnerModule,
-          I18nTestingModule,
-        ],
-        schemas: [NO_ERRORS_SCHEMA],
-        declarations: [StoreFinderListComponent, StoreFinderMapComponent],
-        providers: [
-          {
-            provide: GoogleMapRendererService,
-            useClass: GoogleMapRendererServiceMock,
-          },
-          { provide: StoreFinderService, useClass: StoreFinderServiceMock },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        HttpClientTestingModule,
+        SpinnerModule,
+        I18nTestingModule,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+      declarations: [StoreFinderListComponent, StoreFinderMapComponent],
+      providers: [
+        {
+          provide: GoogleMapRendererService,
+          useClass: GoogleMapRendererServiceMock,
+        },
+        { provide: StoreFinderService, useClass: StoreFinderServiceMock },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderListComponent);

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-search-result.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-search-result.component.spec.ts
@@ -39,20 +39,18 @@ describe('StoreFinderListComponent', () => {
   let storeFinderService: StoreFinderService;
   let activatedRoute: ActivatedRoute | ActivatedRouteMock;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        schemas: [NO_ERRORS_SCHEMA],
-        declarations: [StoreFinderSearchResultComponent],
-        providers: [
-          { provide: StoreFinderService, useValue: mockStoreFinderService },
-          { provide: ActivatedRoute, useClass: ActivatedRouteMock },
-          { provide: StoreFinderConfig, useValue: mockStoreFinderConfig },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      schemas: [NO_ERRORS_SCHEMA],
+      declarations: [StoreFinderSearchResultComponent],
+      providers: [
+        { provide: StoreFinderService, useValue: mockStoreFinderService },
+        { provide: ActivatedRoute, useClass: ActivatedRouteMock },
+        { provide: StoreFinderConfig, useValue: mockStoreFinderConfig },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderSearchResultComponent);

--- a/feature-libs/storefinder/components/store-finder-search/store-finder-search.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-search/store-finder-search.component.spec.ts
@@ -48,25 +48,23 @@ describe('StoreFinderSearchComponent', () => {
 
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
-        declarations: [
-          StoreFinderSearchComponent,
-          MockUrlPipe,
-          MockCxIconComponent,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useValue: { go: jasmine.createSpy() },
-          },
-          { provide: ActivatedRoute, useValue: mockActivatedRoute },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      declarations: [
+        StoreFinderSearchComponent,
+        MockUrlPipe,
+        MockCxIconComponent,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useValue: { go: jasmine.createSpy() },
+        },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderSearchComponent);

--- a/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.spec.ts
@@ -24,21 +24,19 @@ describe('StoreFinderStoreDescriptionComponent', () => {
   let component: StoreFinderStoreDescriptionComponent;
   let fixture: ComponentFixture<StoreFinderStoreDescriptionComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          StoreFinderStoreDescriptionComponent,
-          MockScheduleComponent,
-          MockStoreFinderMapComponent,
-        ],
-        providers: [
-          { provide: StoreFinderService, useClass: StoreFinderServiceMock },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        StoreFinderStoreDescriptionComponent,
+        MockScheduleComponent,
+        MockStoreFinderMapComponent,
+      ],
+      providers: [
+        { provide: StoreFinderService, useClass: StoreFinderServiceMock },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderStoreDescriptionComponent);

--- a/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.spec.ts
@@ -52,29 +52,27 @@ describe('StoreFinderStoreComponent', () => {
   let fixture: ComponentFixture<StoreFinderStoreComponent>;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [SpinnerModule, RouterTestingModule, I18nTestingModule],
-        declarations: [
-          StoreFinderStoreComponent,
-          MockStoreFinderStoreDescriptionComponent,
-          MockCxIconComponent,
-        ],
-        providers: [
-          { provide: RoutingService, useValue: { go: jasmine.createSpy() } },
-          {
-            provide: StoreFinderService,
-            useClass: MockStoreFinderService,
-          },
-          {
-            provide: ActivatedRoute,
-            useValue: mockActivatedRoute,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [SpinnerModule, RouterTestingModule, I18nTestingModule],
+      declarations: [
+        StoreFinderStoreComponent,
+        MockStoreFinderStoreDescriptionComponent,
+        MockCxIconComponent,
+      ],
+      providers: [
+        { provide: RoutingService, useValue: { go: jasmine.createSpy() } },
+        {
+          provide: StoreFinderService,
+          useClass: MockStoreFinderService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: mockActivatedRoute,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     routingService = TestBed.inject(RoutingService);

--- a/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.spec.ts
@@ -32,24 +32,22 @@ describe('StoreFinderStoresCountComponent', () => {
   let el: DebugElement;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [SpinnerModule, I18nTestingModule, RouterTestingModule],
-        declarations: [StoreFinderStoresCountComponent],
-        providers: [
-          {
-            provide: StoreFinderService,
-            useClass: MockStoreFinderService,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [SpinnerModule, I18nTestingModule, RouterTestingModule],
+      declarations: [StoreFinderStoresCountComponent],
+      providers: [
+        {
+          provide: StoreFinderService,
+          useClass: MockStoreFinderService,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderStoresCountComponent);

--- a/feature-libs/storefinder/components/store-finder/store-finder.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder/store-finder.component.spec.ts
@@ -13,14 +13,12 @@ describe('StoreFinderComponent', () => {
   let component: StoreFinderComponent;
   let fixture: ComponentFixture<StoreFinderComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
-        declarations: [StoreFinderComponent, MockStoreFinderHeaderComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [StoreFinderComponent, MockStoreFinderHeaderComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StoreFinderComponent);

--- a/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
@@ -33,25 +33,23 @@ describe('LoginFormComponentService', () => {
   let authService: AuthService;
   let winRef: WindowRef;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-        ],
-        declarations: [],
-        providers: [
-          LoginFormComponentService,
-          { provide: WindowRef, useClass: MockWinRef },
-          { provide: AuthService, useClass: MockAuthService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+      ],
+      declarations: [],
+      providers: [
+        LoginFormComponentService,
+        { provide: WindowRef, useClass: MockWinRef },
+        { provide: AuthService, useClass: MockAuthService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     service = TestBed.inject(LoginFormComponentService);

--- a/feature-libs/user/account/components/login-form/login-form.component.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form.component.spec.ts
@@ -39,26 +39,24 @@ describe('LoginFormComponent', () => {
   let el: DebugElement;
   let service: LoginFormComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          SpinnerModule,
-        ],
-        declarations: [LoginFormComponent, MockUrlPipe, MockFeatureDirective],
-        providers: [
-          {
-            provide: LoginFormComponentService,
-            useClass: MockLoginFormComponentService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        SpinnerModule,
+      ],
+      declarations: [LoginFormComponent, MockUrlPipe, MockFeatureDirective],
+      providers: [
+        {
+          provide: LoginFormComponentService,
+          useClass: MockLoginFormComponentService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoginFormComponent);

--- a/feature-libs/user/account/components/login-register/login-register.component.spec.ts
+++ b/feature-libs/user/account/components/login-register/login-register.component.spec.ts
@@ -50,11 +50,9 @@ describe('LoginRegisterComponent', () => {
     fixture.detectChanges();
   }
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule(testBedDefaults).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule(testBedDefaults).compileComponents();
+  }));
 
   beforeEach(() => {
     createComponent();

--- a/feature-libs/user/account/components/login/login.component.spec.ts
+++ b/feature-libs/user/account/components/login/login.component.spec.ts
@@ -60,33 +60,31 @@ describe('LoginComponent', () => {
 
   let authService: AuthService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [LoginComponent, MockDynamicSlotComponent, MockUrlPipe],
-        providers: [
-          {
-            provide: ActivatedRoute,
-            useValue: {
-              snapshot: {
-                firstChild: {
-                  routeConfig: {
-                    canActivate: [{ GUARD_NAME: 'AuthGuard' }],
-                  },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [LoginComponent, MockDynamicSlotComponent, MockUrlPipe],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              firstChild: {
+                routeConfig: {
+                  canActivate: [{ GUARD_NAME: 'AuthGuard' }],
                 },
               },
             },
           },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: UserAccountFacade, useClass: MockUserAccountFacade },
-          { provide: AuthService, useClass: MockAuthService },
-        ],
-      }).compileComponents();
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: UserAccountFacade, useClass: MockUserAccountFacade },
+        { provide: AuthService, useClass: MockAuthService },
+      ],
+    }).compileComponents();
 
-      authService = TestBed.inject(AuthService);
-    })
-  );
+    authService = TestBed.inject(AuthService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoginComponent);

--- a/feature-libs/user/account/components/otp-login-form/otp-login-form.component.spec.ts
+++ b/feature-libs/user/account/components/otp-login-form/otp-login-form.component.spec.ts
@@ -58,28 +58,26 @@ describe('OneTimePasswordLoginFormComponent', () => {
   let service: VerificationTokenFacade;
   let winRef: WindowRef;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          SpinnerModule,
-        ],
-        declarations: [OneTimePasswordLoginFormComponent, MockUrlPipe],
-        providers: [
-          {
-            provide: VerificationTokenFacade,
-            useClass: MockVerificationTokenService,
-          },
-          { provide: WindowRef, useClass: MockWinRef },
-          { provide: RoutingService, useClass: MockRoutingService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        SpinnerModule,
+      ],
+      declarations: [OneTimePasswordLoginFormComponent, MockUrlPipe],
+      providers: [
+        {
+          provide: VerificationTokenFacade,
+          useClass: MockVerificationTokenService,
+        },
+        { provide: WindowRef, useClass: MockWinRef },
+        { provide: RoutingService, useClass: MockRoutingService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     winRef = TestBed.inject(WindowRef);

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.spec.ts
@@ -33,28 +33,26 @@ describe('VerificationTokenFormComponentService', () => {
   let authService: AuthService;
   let facade: VerificationTokenFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-        ],
-        declarations: [],
-        providers: [
-          VerificationTokenFormComponentService,
-          { provide: AuthService, useClass: MockAuthService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          {
-            provide: VerificationTokenFacade,
-            useClass: MockVerificationTokenFacade,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+      ],
+      declarations: [],
+      providers: [
+        VerificationTokenFormComponentService,
+        { provide: AuthService, useClass: MockAuthService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        {
+          provide: VerificationTokenFacade,
+          useClass: MockVerificationTokenFacade,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     service = TestBed.inject(VerificationTokenFormComponentService);

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form.component.spec.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form.component.spec.ts
@@ -63,35 +63,33 @@ describe('VerificationTokenFormComponent', () => {
   let launchDialogService: LaunchDialogService;
   let routineservice: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          SpinnerModule,
-        ],
-        declarations: [VerificationTokenFormComponent, MockUrlPipe],
-        providers: [
-          {
-            provide: VerificationTokenFormComponentService,
-            useClass: MockFormComponentService,
-          },
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          ChangeDetectorRef,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        SpinnerModule,
+      ],
+      declarations: [VerificationTokenFormComponent, MockUrlPipe],
+      providers: [
+        {
+          provide: VerificationTokenFormComponentService,
+          useClass: MockFormComponentService,
+        },
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        ChangeDetectorRef,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(VerificationTokenFormComponent);

--- a/feature-libs/user/profile/components/address-book/address-book.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-book.component.spec.ts
@@ -96,26 +96,24 @@ describe('AddressBookComponent', () => {
   let el: DebugElement;
   let addressBookComponentService: AddressBookComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          SpinnerModule,
-          I18nTestingModule,
-          CardModule,
-          RouterTestingModule,
-        ],
-        providers: [
-          {
-            provide: AddressBookComponentService,
-            useClass: MockComponentService,
-          },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-        ],
-        declarations: [AddressBookComponent, MockAddressFormComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        SpinnerModule,
+        I18nTestingModule,
+        CardModule,
+        RouterTestingModule,
+      ],
+      providers: [
+        {
+          provide: AddressBookComponentService,
+          useClass: MockComponentService,
+        },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+      ],
+      declarations: [AddressBookComponent, MockAddressFormComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AddressBookComponent);

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
@@ -134,41 +134,39 @@ describe('AddressFormComponent', () => {
   const defaultAddressCheckbox = (): DebugElement =>
     fixture.debugElement.query(By.css('[formcontrolname=defaultAddress]'));
 
-  beforeEach(
-    waitForAsync(() => {
-      mockGlobalMessageService = {
-        add: createSpy(),
-      };
+  beforeEach(waitForAsync(() => {
+    mockGlobalMessageService = {
+      add: createSpy(),
+    };
 
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          NgSelectModule,
-          I18nTestingModule,
-          FormErrorsModule,
-        ],
-        declarations: [
-          AddressFormComponent,
-          MockNgSelectA11yDirective,
-          MockFeatureDirective,
-        ],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          { provide: UserAddressService, useClass: MockUserAddressService },
-          { provide: GlobalMessageService, useValue: mockGlobalMessageService },
-          { provide: UserProfileFacade, useClass: MockUserProfileFacade },
-        ],
-      })
-        .overrideComponent(AddressFormComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
-
-      userProfileFacade = TestBed.inject(UserProfileFacade);
-      userAddressService = TestBed.inject(UserAddressService);
-      launchDialogService = TestBed.inject(LaunchDialogService);
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        NgSelectModule,
+        I18nTestingModule,
+        FormErrorsModule,
+      ],
+      declarations: [
+        AddressFormComponent,
+        MockNgSelectA11yDirective,
+        MockFeatureDirective,
+      ],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        { provide: UserAddressService, useClass: MockUserAddressService },
+        { provide: GlobalMessageService, useValue: mockGlobalMessageService },
+        { provide: UserProfileFacade, useClass: MockUserProfileFacade },
+      ],
     })
-  );
+      .overrideComponent(AddressFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+
+    userProfileFacade = TestBed.inject(UserProfileFacade);
+    userAddressService = TestBed.inject(UserAddressService);
+    launchDialogService = TestBed.inject(LaunchDialogService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AddressFormComponent);

--- a/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/suggested-addresses-dialog.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/suggested-addresses-dialog.component.spec.ts
@@ -39,21 +39,19 @@ describe('SuggestedAddressDialogComponent', () => {
 
   let launchDialogService: LaunchDialogService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [FormsModule, I18nTestingModule],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-        ],
-        declarations: [
-          SuggestedAddressDialogComponent,
-          MockCxIconComponent,
-          FocusDirective,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [FormsModule, I18nTestingModule],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+      ],
+      declarations: [
+        SuggestedAddressDialogComponent,
+        MockCxIconComponent,
+        FocusDirective,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SuggestedAddressDialogComponent);

--- a/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.spec.ts
+++ b/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.spec.ts
@@ -57,40 +57,38 @@ describe('CloseAccountModalComponent', () => {
   let globalMessageService: GlobalMessageService;
   let launchDialogService: LaunchDialogService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          CloseAccountModalComponent,
-          MockCxSpinnerComponent,
-          MockCxIconComponent,
-        ],
-        providers: [
-          {
-            provide: UserProfileFacade,
-            useClass: MockUserProfileFacade,
-          },
-          {
-            provide: GlobalMessageService,
-            useClass: MockGlobalMessageService,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: AuthService,
-            useClass: MockAuthService,
-          },
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        CloseAccountModalComponent,
+        MockCxSpinnerComponent,
+        MockCxIconComponent,
+      ],
+      providers: [
+        {
+          provide: UserProfileFacade,
+          useClass: MockUserProfileFacade,
+        },
+        {
+          provide: GlobalMessageService,
+          useClass: MockGlobalMessageService,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
+        },
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CloseAccountModalComponent);

--- a/feature-libs/user/profile/components/close-account/components/close-account/close-account.component.spec.ts
+++ b/feature-libs/user/profile/components/close-account/components/close-account/close-account.component.spec.ts
@@ -43,23 +43,21 @@ describe('CloseAccountComponent', () => {
   let launchDialogService: LaunchDialogService;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule],
-        declarations: [
-          CloseAccountComponent,
-          MockUrlPipe,
-          MockCxIconComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          { provide: RoutingService, useClass: MockRoutingService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule],
+      declarations: [
+        CloseAccountComponent,
+        MockUrlPipe,
+        MockCxIconComponent,
+        MockFeatureDirective,
+      ],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        { provide: RoutingService, useClass: MockRoutingService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CloseAccountComponent);

--- a/feature-libs/user/profile/components/forgot-password/forgot-password-component.service.spec.ts
+++ b/feature-libs/user/profile/components/forgot-password/forgot-password-component.service.spec.ts
@@ -36,26 +36,24 @@ describe('ForgotPasswordComponentService', () => {
   let routingService: RoutingService;
   let userPasswordFacade: UserPasswordFacade;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-        ],
-        declarations: [],
-        providers: [
-          ForgotPasswordComponentService,
-          { provide: UserPasswordFacade, useClass: MockUserPasswordService },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: AuthConfigService, useClass: MockAuthConfigService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+      ],
+      declarations: [],
+      providers: [
+        ForgotPasswordComponentService,
+        { provide: UserPasswordFacade, useClass: MockUserPasswordService },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: AuthConfigService, useClass: MockAuthConfigService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     service = TestBed.inject(ForgotPasswordComponentService);

--- a/feature-libs/user/profile/components/forgot-password/forgot-password.component.spec.ts
+++ b/feature-libs/user/profile/components/forgot-password/forgot-password.component.spec.ts
@@ -44,34 +44,32 @@ describe('ForgotPasswordComponent', () => {
   let service: ForgotPasswordComponentService;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          SpinnerModule,
-        ],
-        declarations: [
-          ForgotPasswordComponent,
-          MockUrlPipe,
-          MockFeatureDirective,
-        ],
-        providers: [
-          {
-            provide: ForgotPasswordComponentService,
-            useClass: MockForgotPasswordService,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        SpinnerModule,
+      ],
+      declarations: [
+        ForgotPasswordComponent,
+        MockUrlPipe,
+        MockFeatureDirective,
+      ],
+      providers: [
+        {
+          provide: ForgotPasswordComponentService,
+          useClass: MockForgotPasswordService,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ForgotPasswordComponent);

--- a/feature-libs/user/profile/components/register/register.component.spec.ts
+++ b/feature-libs/user/profile/components/register/register.component.spec.ts
@@ -127,53 +127,51 @@ describe('RegisterComponent', () => {
   let authConfigService: AuthConfigService;
   let registerComponentService: RegisterComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          NgSelectModule,
-          PasswordVisibilityToggleModule,
-          NgSelectA11yModule,
-        ],
-        declarations: [
-          RegisterComponent,
-          MockUrlPipe,
-          MockSpinnerComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          {
-            provide: RegisterComponentService,
-            useClass: MockRegisterComponentService,
-          },
-          {
-            provide: GlobalMessageService,
-            useClass: MockGlobalMessageService,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: AnonymousConsentsService,
-            useClass: MockAnonymousConsentsService,
-          },
-          {
-            provide: AnonymousConsentsConfig,
-            useValue: mockAnonymousConsentsConfig,
-          },
-          {
-            provide: AuthConfigService,
-            useClass: MockAuthConfigService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        NgSelectModule,
+        PasswordVisibilityToggleModule,
+        NgSelectA11yModule,
+      ],
+      declarations: [
+        RegisterComponent,
+        MockUrlPipe,
+        MockSpinnerComponent,
+        MockFeatureDirective,
+      ],
+      providers: [
+        {
+          provide: RegisterComponentService,
+          useClass: MockRegisterComponentService,
+        },
+        {
+          provide: GlobalMessageService,
+          useClass: MockGlobalMessageService,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: AnonymousConsentsService,
+          useClass: MockAnonymousConsentsService,
+        },
+        {
+          provide: AnonymousConsentsConfig,
+          useValue: mockAnonymousConsentsConfig,
+        },
+        {
+          provide: AuthConfigService,
+          useClass: MockAuthConfigService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RegisterComponent);

--- a/feature-libs/user/profile/components/register/register.component.ts
+++ b/feature-libs/user/profile/components/register/register.component.ts
@@ -147,7 +147,7 @@ export class RegisterComponent implements OnInit, OnDestroy {
       map(
         ([consent, template]: [
           AnonymousConsent | undefined,
-          ConsentTemplate | undefined
+          ConsentTemplate | undefined,
         ]) => {
           return {
             consent,

--- a/feature-libs/user/profile/components/reset-password/reset-password.component.spec.ts
+++ b/feature-libs/user/profile/components/reset-password/reset-password.component.spec.ts
@@ -37,26 +37,24 @@ describe('ResetPasswordComponent', () => {
   let el: DebugElement;
   let service: ResetPasswordComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          SpinnerModule,
-        ],
-        declarations: [ResetPasswordComponent, MockFeatureDirective],
-        providers: [
-          {
-            provide: ResetPasswordComponentService,
-            useClass: MockResetPasswordService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        SpinnerModule,
+      ],
+      declarations: [ResetPasswordComponent, MockFeatureDirective],
+      providers: [
+        {
+          provide: ResetPasswordComponentService,
+          useClass: MockResetPasswordService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ResetPasswordComponent);

--- a/feature-libs/user/profile/components/update-email/my-account-v2-email.component.spec.ts
+++ b/feature-libs/user/profile/components/update-email/my-account-v2-email.component.spec.ts
@@ -61,35 +61,33 @@ describe('MyAccountV2EmailComponent', () => {
 
   let service: UpdateEmailComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          RouterTestingModule,
-          UrlTestingModule,
-          PasswordVisibilityToggleModule,
-        ],
-        declarations: [MyAccountV2EmailComponent, MockCxSpinnerComponent],
-        providers: [
-          {
-            provide: UpdateEmailComponentService,
-            useClass: MockMyAccountV2EmailService,
-          },
-          {
-            provide: UserProfileFacade,
-            useClass: MockNewProfileFacade,
-          },
-        ],
-      })
-        .overrideComponent(MyAccountV2EmailComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        RouterTestingModule,
+        UrlTestingModule,
+        PasswordVisibilityToggleModule,
+      ],
+      declarations: [MyAccountV2EmailComponent, MockCxSpinnerComponent],
+      providers: [
+        {
+          provide: UpdateEmailComponentService,
+          useClass: MockMyAccountV2EmailService,
+        },
+        {
+          provide: UserProfileFacade,
+          useClass: MockNewProfileFacade,
+        },
+      ],
     })
-  );
+      .overrideComponent(MyAccountV2EmailComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyAccountV2EmailComponent);

--- a/feature-libs/user/profile/components/update-email/update-email-component.service.spec.ts
+++ b/feature-libs/user/profile/components/update-email/update-email-component.service.spec.ts
@@ -139,22 +139,19 @@ describe('UpdateEmailComponentService', () => {
         expect(authService.coreLogout).toHaveBeenCalled();
       });
 
-      it(
-        'should reroute to the login page',
-        waitForAsync(() => {
-          service.save();
-          authService.coreLogout().then(() => {
-            expect(routingService.go).toHaveBeenCalledWith(
-              { cxRoute: 'login' },
-              {
-                state: {
-                  newUid: 'tester@sap.com',
-                },
-              }
-            );
-          });
-        })
-      );
+      it('should reroute to the login page', waitForAsync(() => {
+        service.save();
+        authService.coreLogout().then(() => {
+          expect(routingService.go).toHaveBeenCalledWith(
+            { cxRoute: 'login' },
+            {
+              state: {
+                newUid: 'tester@sap.com',
+              },
+            }
+          );
+        });
+      }));
 
       it('reset form', () => {
         spyOn(service.form, 'reset').and.callThrough();
@@ -162,20 +159,17 @@ describe('UpdateEmailComponentService', () => {
         expect(service.form.reset).toHaveBeenCalled();
       });
 
-      it(
-        'should set the redirect url to the home page before navigating to the login page',
-        waitForAsync(() => {
-          service.save();
-          expect(authRedirectService.setRedirectUrl).toHaveBeenCalledWith(
-            routingService.getUrl({ cxRoute: 'home' })
+      it('should set the redirect url to the home page before navigating to the login page', waitForAsync(() => {
+        service.save();
+        expect(authRedirectService.setRedirectUrl).toHaveBeenCalledWith(
+          routingService.getUrl({ cxRoute: 'home' })
+        );
+        authService.coreLogout().then(() => {
+          expect(authRedirectService.setRedirectUrl).toHaveBeenCalledBefore(
+            routingService.go
           );
-          authService.coreLogout().then(() => {
-            expect(authRedirectService.setRedirectUrl).toHaveBeenCalledBefore(
-              routingService.go
-            );
-          });
-        })
-      );
+        });
+      }));
     });
 
     describe('error', () => {

--- a/feature-libs/user/profile/components/update-email/update-email.component.spec.ts
+++ b/feature-libs/user/profile/components/update-email/update-email.component.spec.ts
@@ -48,35 +48,33 @@ describe('UpdateEmailComponent', () => {
 
   let service: UpdateEmailComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          RouterTestingModule,
-          UrlTestingModule,
-          PasswordVisibilityToggleModule,
-        ],
-        declarations: [
-          UpdateEmailComponent,
-          MockCxSpinnerComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          {
-            provide: UpdateEmailComponentService,
-            useClass: MockUpdateEmailService,
-          },
-        ],
-      })
-        .overrideComponent(UpdateEmailComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        RouterTestingModule,
+        UrlTestingModule,
+        PasswordVisibilityToggleModule,
+      ],
+      declarations: [
+        UpdateEmailComponent,
+        MockCxSpinnerComponent,
+        MockFeatureDirective,
+      ],
+      providers: [
+        {
+          provide: UpdateEmailComponentService,
+          useClass: MockUpdateEmailService,
+        },
+      ],
     })
-  );
+      .overrideComponent(UpdateEmailComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UpdateEmailComponent);

--- a/feature-libs/user/profile/components/update-password/my-account-v2-password.component.spec.ts
+++ b/feature-libs/user/profile/components/update-password/my-account-v2-password.component.spec.ts
@@ -49,31 +49,29 @@ describe('MyAccountV2PasswordComponent', () => {
 
   let service: UpdatePasswordComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          RouterTestingModule,
-          UrlTestingModule,
-          PasswordVisibilityToggleModule,
-        ],
-        declarations: [MyAccountV2PasswordComponent, MockCxSpinnerComponent],
-        providers: [
-          {
-            provide: UpdatePasswordComponentService,
-            useClass: MockUpdatePasswordService,
-          },
-        ],
-      })
-        .overrideComponent(MyAccountV2PasswordComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        RouterTestingModule,
+        UrlTestingModule,
+        PasswordVisibilityToggleModule,
+      ],
+      declarations: [MyAccountV2PasswordComponent, MockCxSpinnerComponent],
+      providers: [
+        {
+          provide: UpdatePasswordComponentService,
+          useClass: MockUpdatePasswordService,
+        },
+      ],
     })
-  );
+      .overrideComponent(MyAccountV2PasswordComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyAccountV2PasswordComponent);

--- a/feature-libs/user/profile/components/update-password/update-password.component.spec.ts
+++ b/feature-libs/user/profile/components/update-password/update-password.component.spec.ts
@@ -54,36 +54,34 @@ describe('UpdatePasswordComponent', () => {
   let routingService: RoutingService;
   let service: UpdatePasswordComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          RouterTestingModule,
-          UrlTestingModule,
-          PasswordVisibilityToggleModule,
-        ],
-        declarations: [
-          UpdatePasswordComponent,
-          MockCxSpinnerComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          {
-            provide: UpdatePasswordComponentService,
-            useClass: MockUpdatePasswordService,
-          },
-          { provide: RoutingService, useClass: MockRoutingService },
-        ],
-      })
-        .overrideComponent(UpdatePasswordComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        RouterTestingModule,
+        UrlTestingModule,
+        PasswordVisibilityToggleModule,
+      ],
+      declarations: [
+        UpdatePasswordComponent,
+        MockCxSpinnerComponent,
+        MockFeatureDirective,
+      ],
+      providers: [
+        {
+          provide: UpdatePasswordComponentService,
+          useClass: MockUpdatePasswordService,
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+      ],
     })
-  );
+      .overrideComponent(UpdatePasswordComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UpdatePasswordComponent);

--- a/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.spec.ts
+++ b/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.spec.ts
@@ -49,33 +49,31 @@ describe('MyAccountV2ProfileComponent', () => {
 
   let service: UpdateProfileComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          CommonModule,
-          ReactiveFormsModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          RouterTestingModule,
-          UrlTestingModule,
-          NgSelectModule,
-          FeaturesConfigModule,
-        ],
-        declarations: [MyAccountV2ProfileComponent, MockCxSpinnerComponent],
-        providers: [
-          {
-            provide: UpdateProfileComponentService,
-            useClass: MockProfileService,
-          },
-        ],
-      })
-        .overrideComponent(MyAccountV2ProfileComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        RouterTestingModule,
+        UrlTestingModule,
+        NgSelectModule,
+        FeaturesConfigModule,
+      ],
+      declarations: [MyAccountV2ProfileComponent, MockCxSpinnerComponent],
+      providers: [
+        {
+          provide: UpdateProfileComponentService,
+          useClass: MockProfileService,
+        },
+      ],
     })
-  );
+      .overrideComponent(MyAccountV2ProfileComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyAccountV2ProfileComponent);

--- a/feature-libs/user/profile/components/update-profile/update-profile.component.spec.ts
+++ b/feature-libs/user/profile/components/update-profile/update-profile.component.spec.ts
@@ -63,40 +63,38 @@ describe('UpdateProfileComponent', () => {
 
   let service: UpdateProfileComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          CommonModule,
-          ReactiveFormsModule,
-          I18nTestingModule,
-          FormErrorsModule,
-          RouterTestingModule,
-          UrlTestingModule,
-          NgSelectModule,
-        ],
-        declarations: [
-          UpdateProfileComponent,
-          MockCxSpinnerComponent,
-          MockNgSelectA11yDirective,
-          MockFeatureDirective,
-        ],
-        providers: [
-          {
-            provide: UpdateProfileComponentService,
-            useClass: MockUpdateProfileService,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        I18nTestingModule,
+        FormErrorsModule,
+        RouterTestingModule,
+        UrlTestingModule,
+        NgSelectModule,
+      ],
+      declarations: [
+        UpdateProfileComponent,
+        MockCxSpinnerComponent,
+        MockNgSelectA11yDirective,
+        MockFeatureDirective,
+      ],
+      providers: [
+        {
+          provide: UpdateProfileComponentService,
+          useClass: MockUpdateProfileService,
+        },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '5.2' },
           },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '5.2' },
-            },
-          },
-          { provide: RoutingService, useClass: MockRoutingService },
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UpdateProfileComponent);

--- a/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.spec.ts
+++ b/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.spec.ts
@@ -51,31 +51,29 @@ describe('CdcLoginComponentService', () => {
   let cdcJsService: CdcJsService;
   let globalMessageService: GlobalMessageService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-        ],
-        declarations: [],
-        providers: [
-          CdcLoginFormComponentService,
-          { provide: WindowRef, useClass: MockWinRef },
-          { provide: AuthService, useClass: MockAuthService },
-          { provide: Store, useValue: { dispatch: () => {} } },
-          { provide: CdcJsService, useClass: MockCDCJsService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          {
-            provide: LoginFormComponentService,
-            useClass: MockLoginFormComponentService,
-          },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+      ],
+      declarations: [],
+      providers: [
+        CdcLoginFormComponentService,
+        { provide: WindowRef, useClass: MockWinRef },
+        { provide: AuthService, useClass: MockAuthService },
+        { provide: Store, useValue: { dispatch: () => {} } },
+        { provide: CdcJsService, useClass: MockCDCJsService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        {
+          provide: LoginFormComponentService,
+          useClass: MockLoginFormComponentService,
+        },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     cdcLoginService = TestBed.inject(CdcLoginFormComponentService);

--- a/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.spec.ts
+++ b/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.spec.ts
@@ -51,27 +51,25 @@ describe('CDCForgotPasswordComponentService', () => {
   let cdcJsService: CdcJsService;
   let globalMessageService: GlobalMessageService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          FormErrorsModule,
-        ],
-        declarations: [],
-        providers: [
-          CDCForgotPasswordComponentService,
-          { provide: UserPasswordFacade, useClass: MockUserPasswordService },
-          { provide: RoutingService, useClass: MockRoutingService },
-          { provide: CdcJsService, useClass: MockCDCJsService },
-          { provide: AuthConfigService, useClass: MockAuthConfigService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-        ],
-      });
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        FormErrorsModule,
+      ],
+      declarations: [],
+      providers: [
+        CDCForgotPasswordComponentService,
+        { provide: UserPasswordFacade, useClass: MockUserPasswordService },
+        { provide: RoutingService, useClass: MockRoutingService },
+        { provide: CdcJsService, useClass: MockCDCJsService },
+        { provide: AuthConfigService, useClass: MockAuthConfigService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+      ],
+    });
+  }));
 
   beforeEach(() => {
     service = TestBed.inject(CDCForgotPasswordComponentService);

--- a/integration-libs/cdc/user-profile/update-email/cdc-update-email-component.service.spec.ts
+++ b/integration-libs/cdc/user-profile/update-email/cdc-update-email-component.service.spec.ts
@@ -120,26 +120,21 @@ describe('UpdateEmailComponentService', () => {
         expect(authService.coreLogout).toHaveBeenCalled();
       });
 
-      it(
-        'should reroute to the login page',
-        waitForAsync(() => {
-          service.save();
-          expect(userService.update).not.toHaveBeenCalled();
-          expect(
-            cdcJsService.updateUserEmailWithoutScreenSet
-          ).toHaveBeenCalled();
-          authService.coreLogout().then(() => {
-            expect(routingService.go).toHaveBeenCalledWith(
-              { cxRoute: 'login' },
-              {
-                state: {
-                  newUid: 'tester@sap.com',
-                },
-              }
-            );
-          });
-        })
-      );
+      it('should reroute to the login page', waitForAsync(() => {
+        service.save();
+        expect(userService.update).not.toHaveBeenCalled();
+        expect(cdcJsService.updateUserEmailWithoutScreenSet).toHaveBeenCalled();
+        authService.coreLogout().then(() => {
+          expect(routingService.go).toHaveBeenCalledWith(
+            { cxRoute: 'login' },
+            {
+              state: {
+                newUid: 'tester@sap.com',
+              },
+            }
+          );
+        });
+      }));
 
       it('reset form', () => {
         spyOn(service.form, 'reset').and.callThrough();
@@ -149,24 +144,19 @@ describe('UpdateEmailComponentService', () => {
         expect(service.form.reset).toHaveBeenCalled();
       });
 
-      it(
-        'should set the redirect url to the home page before navigating to the login page',
-        waitForAsync(() => {
-          service.save();
-          expect(userService.update).not.toHaveBeenCalled();
-          expect(
-            cdcJsService.updateUserEmailWithoutScreenSet
-          ).toHaveBeenCalled();
-          expect(authRedirectService.setRedirectUrl).toHaveBeenCalledWith(
-            routingService.getUrl({ cxRoute: 'home' })
+      it('should set the redirect url to the home page before navigating to the login page', waitForAsync(() => {
+        service.save();
+        expect(userService.update).not.toHaveBeenCalled();
+        expect(cdcJsService.updateUserEmailWithoutScreenSet).toHaveBeenCalled();
+        expect(authRedirectService.setRedirectUrl).toHaveBeenCalledWith(
+          routingService.getUrl({ cxRoute: 'home' })
+        );
+        authService.coreLogout().then(() => {
+          expect(authRedirectService.setRedirectUrl).toHaveBeenCalledBefore(
+            routingService.go
           );
-          authService.coreLogout().then(() => {
-            expect(authRedirectService.setRedirectUrl).toHaveBeenCalledBefore(
-              routingService.go
-            );
-          });
-        })
-      );
+        });
+      }));
     });
 
     describe('error', () => {

--- a/integration-libs/cds/src/merchandising/cms-components/directives/attributes/attributes.directive.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/directives/attributes/attributes.directive.ts
@@ -23,7 +23,10 @@ export class AttributesDirective implements OnChanges {
     this._attributesNamePrefix = attributesNamePrefix;
   }
 
-  constructor(private renderer: Renderer2, private elementRef: ElementRef) {}
+  constructor(
+    private renderer: Renderer2,
+    private elementRef: ElementRef
+  ) {}
 
   ngOnChanges(): void {
     if (this.cxAttributes) {

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.service.spec.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.service.spec.ts
@@ -156,12 +156,9 @@ describe('MerchandisingCarouselComponentService', () => {
     profileTagEventService = TestBed.inject(ProfileTagEventService);
   });
 
-  it(
-    'should be created',
-    waitForAsync(() => {
-      expect(componentService).toBeTruthy();
-    })
-  );
+  it('should be created', waitForAsync(() => {
+    expect(componentService).toBeTruthy();
+  }));
 
   describe('getMerchandisingCaourselViewportThreshold', () => {
     it('should fallback to a hardcoded carousel viewport threshold if one is not provided in the carousel CMS component config or the CDS config', () => {

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.spec.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.spec.ts
@@ -165,134 +165,105 @@ describe('MerchandisingCarouselComponent', () => {
   let componentService: MerchandisingCarouselComponentService;
   let fixture: ComponentFixture<MerchandisingCarouselComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
-        declarations: [
-          MerchandisingCarouselComponent,
-          MockCarouselComponent,
-          MockAttributesDirective,
-          MockMediaComponent,
-          MockUrlPipe,
-        ],
-        providers: [
-          {
-            provide: CmsComponentData,
-            useValue: MockCmsMerchandisingCarouselComponent,
-          },
-          {
-            provide: MerchandisingCarouselComponentService,
-            useClass: MockMerchandisingCarouselComponentService,
-          },
-          {
-            provide: RoutingService,
-            useClass: RoutingServiceStub,
-          },
-          {
-            provide: IntersectionService,
-            useClass: IntersectionServiceStub,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [
+        MerchandisingCarouselComponent,
+        MockCarouselComponent,
+        MockAttributesDirective,
+        MockMediaComponent,
+        MockUrlPipe,
+      ],
+      providers: [
+        {
+          provide: CmsComponentData,
+          useValue: MockCmsMerchandisingCarouselComponent,
+        },
+        {
+          provide: MerchandisingCarouselComponentService,
+          useClass: MockMerchandisingCarouselComponentService,
+        },
+        {
+          provide: RoutingService,
+          useClass: RoutingServiceStub,
+        },
+        {
+          provide: IntersectionService,
+          useClass: IntersectionServiceStub,
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MerchandisingCarouselComponent);
-      component = fixture.componentInstance;
-      componentService = TestBed.inject(MerchandisingCarouselComponentService);
-      fixture.detectChanges();
-    })
-  );
+    fixture = TestBed.createComponent(MerchandisingCarouselComponent);
+    component = fixture.componentInstance;
+    componentService = TestBed.inject(MerchandisingCarouselComponentService);
+    fixture.detectChanges();
+  }));
 
-  it(
-    'should be created',
-    waitForAsync(() => {
-      expect(component).toBeTruthy();
-    })
-  );
+  it('should be created', waitForAsync(() => {
+    expect(component).toBeTruthy();
+  }));
 
-  it(
-    'should have a title',
-    waitForAsync(() => {
-      let actualTitle: string;
-      component.merchandisingCarouselModel$.subscribe(
-        (carouselModel) => (actualTitle = carouselModel.title)
-      );
-      expect(actualTitle).toBe(mockComponentData.title);
-    })
-  );
+  it('should have a title', waitForAsync(() => {
+    let actualTitle: string;
+    component.merchandisingCarouselModel$.subscribe(
+      (carouselModel) => (actualTitle = carouselModel.title)
+    );
+    expect(actualTitle).toBe(mockComponentData.title);
+  }));
 
-  it(
-    'should have a background color',
-    waitForAsync(() => {
-      let actualBackgroundColor: string;
-      component.merchandisingCarouselModel$.subscribe(
-        (carouselModel) =>
-          (actualBackgroundColor = <string>carouselModel.backgroundColor)
-      );
-      expect(actualBackgroundColor).toBe(mockComponentData.backgroundColour);
-    })
-  );
+  it('should have a background color', waitForAsync(() => {
+    let actualBackgroundColor: string;
+    component.merchandisingCarouselModel$.subscribe(
+      (carouselModel) =>
+        (actualBackgroundColor = <string>carouselModel.backgroundColor)
+    );
+    expect(actualBackgroundColor).toBe(mockComponentData.backgroundColour);
+  }));
 
-  it(
-    'should have a text color',
-    waitForAsync(() => {
-      let actualTextColor: string;
-      component.merchandisingCarouselModel$.subscribe(
-        (carouselModel) => (actualTextColor = <string>carouselModel.textColor)
-      );
-      expect(actualTextColor).toBe(mockComponentData.textColour);
-    })
-  );
+  it('should have a text color', waitForAsync(() => {
+    let actualTextColor: string;
+    component.merchandisingCarouselModel$.subscribe(
+      (carouselModel) => (actualTextColor = <string>carouselModel.textColor)
+    );
+    expect(actualTextColor).toBe(mockComponentData.textColour);
+  }));
 
-  it(
-    'should have MerchandisingProducts populated',
-    waitForAsync(() => {
-      let actualCarouselMetadata: MerchandisingMetadata;
-      const actualCarouselProducts: MerchandisingProduct[] = [];
-      component.merchandisingCarouselModel$.subscribe(
-        (merchandisingProducts) => {
-          actualCarouselMetadata = merchandisingProducts.metadata;
-          merchandisingProducts.items$.forEach((observableProduct) =>
-            observableProduct.subscribe((product) =>
-              actualCarouselProducts.push(product)
-            )
-          );
-        }
+  it('should have MerchandisingProducts populated', waitForAsync(() => {
+    let actualCarouselMetadata: MerchandisingMetadata;
+    const actualCarouselProducts: MerchandisingProduct[] = [];
+    component.merchandisingCarouselModel$.subscribe((merchandisingProducts) => {
+      actualCarouselMetadata = merchandisingProducts.metadata;
+      merchandisingProducts.items$.forEach((observableProduct) =>
+        observableProduct.subscribe((product) =>
+          actualCarouselProducts.push(product)
+        )
       );
-      expect(actualCarouselMetadata).toEqual(
-        merchandisingCarouselModel.metadata
-      );
-      expect(actualCarouselProducts).toEqual(
-        merchandisingCarouselModelProducts
-      );
-    })
-  );
+    });
+    expect(actualCarouselMetadata).toEqual(merchandisingCarouselModel.metadata);
+    expect(actualCarouselProducts).toEqual(merchandisingCarouselModelProducts);
+  }));
 
-  it(
-    'should have 2 items',
-    waitForAsync(() => {
-      let items: Observable<Product>[];
-      component.merchandisingCarouselModel$.subscribe(
-        (actualMerchandisingCarouselModel) =>
-          (items = actualMerchandisingCarouselModel.items$)
-      );
-      expect(items.length).toBe(2);
-    })
-  );
+  it('should have 2 items', waitForAsync(() => {
+    let items: Observable<Product>[];
+    component.merchandisingCarouselModel$.subscribe(
+      (actualMerchandisingCarouselModel) =>
+        (items = actualMerchandisingCarouselModel.items$)
+    );
+    expect(items.length).toBe(2);
+  }));
 
-  it(
-    'should have product code 111 in first product',
-    waitForAsync(() => {
-      let items: Observable<Product>[];
-      component.merchandisingCarouselModel$.subscribe(
-        (actualMerchandisingCarouselModel) =>
-          (items = actualMerchandisingCarouselModel.items$)
-      );
-      let product: Product;
-      items[0].subscribe((p) => (product = p));
-      expect(product).toEqual(merchandisingCarouselModelProducts[0]);
-    })
-  );
+  it('should have product code 111 in first product', waitForAsync(() => {
+    let items: Observable<Product>[];
+    component.merchandisingCarouselModel$.subscribe(
+      (actualMerchandisingCarouselModel) =>
+        (items = actualMerchandisingCarouselModel.items$)
+    );
+    let product: Product;
+    items[0].subscribe((p) => (product = p));
+    expect(product).toEqual(merchandisingCarouselModelProducts[0]);
+  }));
 
   describe('merchandisingCarouselModel$', () => {
     let intersectionService: IntersectionService;
@@ -318,66 +289,51 @@ describe('MerchandisingCarouselComponent', () => {
   });
 
   describe('UI test', () => {
-    it(
-      'should have 2 rendered templates',
-      waitForAsync(() => {
-        const el = fixture.debugElement.queryAll(
-          By.css('.data-cx-merchandising-product')
-        );
-        expect(el.length).toBe(2);
-      })
-    );
+    it('should have 2 rendered templates', waitForAsync(() => {
+      const el = fixture.debugElement.queryAll(
+        By.css('.data-cx-merchandising-product')
+      );
+      expect(el.length).toBe(2);
+    }));
 
-    it(
-      'should render product name in template',
-      waitForAsync(() => {
-        const el = fixture.debugElement.queryAll(
-          By.css('.data-cx-merchandising-product + a h4')
-        );
-        expect(el[0].nativeElement).toBeTruthy();
-        expect(el[0].nativeElement.innerText).toBe('product 1');
-        expect(el[1].nativeElement).toBeTruthy();
-        expect(el[1].nativeElement.innerText).toBe('product 2');
-      })
-    );
+    it('should render product name in template', waitForAsync(() => {
+      const el = fixture.debugElement.queryAll(
+        By.css('.data-cx-merchandising-product + a h4')
+      );
+      expect(el[0].nativeElement).toBeTruthy();
+      expect(el[0].nativeElement.innerText).toBe('product 1');
+      expect(el[1].nativeElement).toBeTruthy();
+      expect(el[1].nativeElement.innerText).toBe('product 2');
+    }));
 
-    it(
-      'should render product price in template',
-      waitForAsync(() => {
-        const el = fixture.debugElement.queryAll(
-          By.css('.data-cx-merchandising-product + a .price')
-        );
+    it('should render product price in template', waitForAsync(() => {
+      const el = fixture.debugElement.queryAll(
+        By.css('.data-cx-merchandising-product + a .price')
+      );
 
-        expect(el[0].nativeElement).toBeTruthy();
-        expect(el[0].nativeElement.innerText).toBe('100.00');
-        expect(el[2].nativeElement).toBeTruthy();
-        expect(el[2].nativeElement.innerText).toBe('200.00');
-      })
-    );
+      expect(el[0].nativeElement).toBeTruthy();
+      expect(el[0].nativeElement.innerText).toBe('100.00');
+      expect(el[2].nativeElement).toBeTruthy();
+      expect(el[2].nativeElement.innerText).toBe('200.00');
+    }));
 
-    it(
-      'should only render product primary image for the first item',
-      waitForAsync(() => {
-        const el = fixture.debugElement.queryAll(
-          By.css('.data-cx-merchandising-product + a')
-        );
-        expect(el[0].query(By.css('cx-media'))).toBeTruthy();
-        expect(el[1].query(By.css('cx-media'))).toBeFalsy();
-      })
-    );
+    it('should only render product primary image for the first item', waitForAsync(() => {
+      const el = fixture.debugElement.queryAll(
+        By.css('.data-cx-merchandising-product + a')
+      );
+      expect(el[0].query(By.css('cx-media'))).toBeTruthy();
+      expect(el[1].query(By.css('cx-media'))).toBeFalsy();
+    }));
 
-    it(
-      'should render product stock information in template',
-      waitForAsync(() => {
-        const el = fixture.debugElement.queryAll(
-          By.css('.data-cx-merchandising-product + a .price')
-        );
+    it('should render product stock information in template', waitForAsync(() => {
+      const el = fixture.debugElement.queryAll(
+        By.css('.data-cx-merchandising-product + a .price')
+      );
 
-        expect(el[1].nativeElement).toBeTruthy();
-        expect(el[1].nativeElement.innerText).toBe('inStock : 10');
-        expect(el[3].nativeElement).toBeTruthy();
-        expect(el[3].nativeElement.innerText).toBe('outOfStock');
-      })
-    );
+      expect(el[1].nativeElement).toBeTruthy();
+      expect(el[1].nativeElement.innerText).toBe('inStock : 10');
+      expect(el[3].nativeElement).toBeTruthy();
+      expect(el[3].nativeElement.innerText).toBe('outOfStock');
+    }));
   });
 });

--- a/integration-libs/cds/src/merchandising/facade/cds-merchandising-product.service.ts
+++ b/integration-libs/cds/src/merchandising/facade/cds-merchandising-product.service.ts
@@ -38,7 +38,7 @@ export class CdsMerchandisingProductService {
       map(
         ([siteContext, userContext]: [
           MerchandisingSiteContext,
-          MerchandisingUserContext
+          MerchandisingUserContext,
         ]) => {
           return {
             queryParams: {

--- a/integration-libs/cds/src/profiletag/cms-components/profile-tag.component.spec.ts
+++ b/integration-libs/cds/src/profiletag/cms-components/profile-tag.component.spec.ts
@@ -16,19 +16,17 @@ describe('ProfileTagComponent', () => {
   let component: ProfileTagComponent;
   let fixture: ComponentFixture<ProfileTagComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProfileTagComponent],
-        providers: [
-          {
-            provide: ProfileTagInjectorService,
-            useClass: MockProfileTagInjector,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProfileTagComponent],
+      providers: [
+        {
+          provide: ProfileTagInjectorService,
+          useClass: MockProfileTagInjector,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProfileTagComponent);

--- a/integration-libs/cds/src/recent-searches/recent-searches.component.html
+++ b/integration-libs/cds/src/recent-searches/recent-searches.component.html
@@ -12,7 +12,7 @@
         <a
           role="option"
           [innerHTML]="
-            recentSearch | cxHighlight: (outletContext$ | async)?.search:false
+            recentSearch | cxHighlight: (outletContext$ | async)?.search : false
           "
           [routerLink]="
             {

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.spec.ts
@@ -116,37 +116,35 @@ describe('CompactAddToCartComponent', () => {
 
   const mockCartEntry: OrderEntry = { entryNumber: 7 };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          BrowserAnimationsModule,
-          RouterTestingModule,
-          SpinnerModule,
-          I18nTestingModule,
-          ReactiveFormsModule,
-          IconModule,
-        ],
-        declarations: [CompactAddToCartComponent, MockItemCounterComponent],
-        providers: [
-          {
-            provide: LaunchDialogService,
-            useValue: MockLaunchDialogService,
-          },
-          { provide: ActiveCartFacade, useClass: MockActiveCartService },
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-          {
-            provide: CmsComponentData,
-            useValue: MockCmsComponentData,
-          },
-          { provide: EventService, useClass: MockEventService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        RouterTestingModule,
+        SpinnerModule,
+        I18nTestingModule,
+        ReactiveFormsModule,
+        IconModule,
+      ],
+      declarations: [CompactAddToCartComponent, MockItemCounterComponent],
+      providers: [
+        {
+          provide: LaunchDialogService,
+          useValue: MockLaunchDialogService,
+        },
+        { provide: ActiveCartFacade, useClass: MockActiveCartService },
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+        {
+          provide: CmsComponentData,
+          useValue: MockCmsComponentData,
+        },
+        { provide: EventService, useClass: MockEventService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CompactAddToCartComponent);

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.html
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.html
@@ -13,7 +13,7 @@
         >
           <ng-container
             *ngFor="
-              let item of items | slice: i:i + itemsPerSlide;
+              let item of items | slice: i : i + itemsPerSlide;
               let j = index
             "
           >

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.spec.ts
@@ -45,19 +45,17 @@ describe('PagedList Component', () => {
   let template: any;
   let headerTemplateFixture: ComponentFixture<MockHeaderTemplateComponent>;
   let headerTemplate: any;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
-        declarations: [
-          PagedListComponent,
-          MockCxIconComponent,
-          MockHeaderTemplateComponent,
-          MockTemplateComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [
+        PagedListComponent,
+        MockCxIconComponent,
+        MockHeaderTemplateComponent,
+        MockTemplateComponent,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PagedListComponent);

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.component.html
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.component.html
@@ -6,26 +6,17 @@
     <span
       cxVisualViewerAnimationSliderElement
       #bar
-      class="
-        cx-epd-visualization-animation-slider-span
-        cx-epd-visualization-animation-slider-bar-wrapper
-      "
+      class="cx-epd-visualization-animation-slider-span cx-epd-visualization-animation-slider-bar-wrapper"
     >
       <span
-        class="
-          cx-epd-visualization-animation-slider-span
-          cx-epd-visualization-animation-slider-bar
-        "
+        class="cx-epd-visualization-animation-slider-span cx-epd-visualization-animation-slider-bar"
       ></span>
     </span>
 
     <span
       cxVisualViewerAnimationSliderHandle
       #handle
-      class="
-        cx-epd-visualization-animation-slider-span
-        cx-epd-visualization-animation-slider-pointer
-      "
+      class="cx-epd-visualization-animation-slider-span cx-epd-visualization-animation-slider-pointer"
       [style.left]="(position | cxNumeric: '1.0-0') + 'px'"
       [attr.role]="
         'epdVisualization.visualViewer.toolbar.visualViewerAnimationSlider.role'

--- a/integration-libs/s4om/root/components/schedule-lines/schedule-lines.component.spec.ts
+++ b/integration-libs/s4om/root/components/schedule-lines/schedule-lines.component.spec.ts
@@ -40,25 +40,23 @@ describe('ScheduleLinesCartEntryComponent', () => {
   let htmlElem: HTMLElement;
   let mockCartItemContext: MockCartItemContext;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
-        declarations: [
-          ScheduleLinesComponent,
-          MockConfigureScheduleLineComponent,
-        ],
-        providers: [
-          { provide: CartItemContext, useClass: MockCartItemContext },
-          {
-            provide: TranslationService,
-            useClass: MockTranslationService,
-          },
-          { provide: LanguageService, useClass: MockLanguageService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      declarations: [
+        ScheduleLinesComponent,
+        MockConfigureScheduleLineComponent,
+      ],
+      providers: [
+        { provide: CartItemContext, useClass: MockCartItemContext },
+        {
+          provide: TranslationService,
+          useClass: MockTranslationService,
+        },
+        { provide: LanguageService, useClass: MockLanguageService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ScheduleLinesComponent);

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
         "parse5": "^7.1.2",
         "postcss": "^8.4.31",
         "postcss-scss": "^4.0.6",
-        "prettier": "~2.4.1",
+        "prettier": "~3.2.5",
         "rimraf": "^5.0.0",
         "sass-true": "^8.0.0",
         "semver": "^7.5.2",
@@ -20218,15 +20218,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {
@@ -38638,9 +38641,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "parse5": "^7.1.2",
     "postcss": "^8.4.31",
     "postcss-scss": "^4.0.6",
-    "prettier": "~2.4.1",
+    "prettier": "~3.2.5",
     "rimraf": "^5.0.0",
     "sass-true": "^8.0.0",
     "semver": "^7.5.2",

--- a/projects/core/src/cms/store/actions/components.action.ts
+++ b/projects/core/src/cms/store/actions/components.action.ts
@@ -36,7 +36,7 @@ export class LoadCmsComponentFail extends StateUtils.EntityFailAction {
 }
 
 export class LoadCmsComponentSuccess<
-  T extends CmsComponent
+  T extends CmsComponent,
 > extends StateUtils.EntitySuccessAction {
   readonly type = LOAD_CMS_COMPONENT_SUCCESS;
   constructor(
@@ -51,7 +51,7 @@ export class LoadCmsComponentSuccess<
 }
 
 export class CmsGetComponentFromPage<
-  T extends CmsComponent
+  T extends CmsComponent,
 > extends StateUtils.EntitySuccessAction {
   readonly type = CMS_GET_COMPONENT_FROM_PAGE;
   constructor(

--- a/projects/core/src/cms/store/actions/navigation-entry-item.action.ts
+++ b/projects/core/src/cms/store/actions/navigation-entry-item.action.ts
@@ -22,7 +22,10 @@ export class LoadCmsNavigationItems extends StateUtils.EntityLoadAction {
 
 export class LoadCmsNavigationItemsFail extends StateUtils.EntityFailAction {
   readonly type = LOAD_CMS_NAVIGATION_ITEMS_FAIL;
-  constructor(nodeId: string, public payload: any) {
+  constructor(
+    nodeId: string,
+    public payload: any
+  ) {
     super(NAVIGATION_DETAIL_ENTITY, nodeId, payload);
   }
 }

--- a/projects/core/src/cms/store/actions/page.action.ts
+++ b/projects/core/src/cms/store/actions/page.action.ts
@@ -44,7 +44,10 @@ export class CmsSetPageSuccessIndex extends StateUtils.EntitySuccessAction {
 
 export class CmsSetPageFailIndex extends StateUtils.EntityFailAction {
   readonly type = CMS_SET_PAGE_FAIL_INDEX;
-  constructor(pageContext: PageContext, public payload: string) {
+  constructor(
+    pageContext: PageContext,
+    public payload: string
+  ) {
     super(pageContext.type ?? '', pageContext.id);
   }
 }

--- a/projects/core/src/config/config-initializer/config-initializer.service.spec.ts
+++ b/projects/core/src/config/config-initializer/config-initializer.service.spec.ts
@@ -19,11 +19,11 @@ const MockConfig = {
 const configInitializers = [
   {
     scopes: ['scope1'],
-    configFactory: async () => ({ scope1: 'final' } as Config),
+    configFactory: async () => ({ scope1: 'final' }) as Config,
   },
   {
     scopes: ['scope2.nested'],
-    configFactory: async () => ({ scope2: { nested: true } } as Config),
+    configFactory: async () => ({ scope2: { nested: true } }) as Config,
   },
 ];
 

--- a/projects/core/src/config/config-providers.spec.ts
+++ b/projects/core/src/config/config-providers.spec.ts
@@ -14,7 +14,7 @@ describe('Config Providers', () => {
   const testConfigFactory: ConfigFactory = () =>
     ({
       test: 'test',
-    } as Config);
+    }) as Config;
 
   describe('provideConfig', () => {
     it('should return ConfigChunk provider', () => {

--- a/projects/core/src/config/config.module.spec.ts
+++ b/projects/core/src/config/config.module.spec.ts
@@ -15,7 +15,7 @@ describe('ConfigModule', () => {
       test1: 'test config',
       test2: 'a' + 'b',
       test3: 3 * 5,
-    } as Config);
+    }) as Config;
 
   it('configuration token should expose configuration', () => {
     TestBed.configureTestingModule({});

--- a/projects/core/src/config/utils/deep-merge.spec.ts
+++ b/projects/core/src/config/utils/deep-merge.spec.ts
@@ -122,23 +122,21 @@ describe('deepMerge utility', () => {
   });
 
   describe('protptype pollution gurads', () => {
-    it(
-      'should avoid property injection',
-      waitForAsync(async () => {
-        // arrange
-        class TestContainer {
-          constructor(public name: string) {}
+    it('should avoid property injection', waitForAsync(async () => {
+      // arrange
+      class TestContainer {
+        constructor(public name: string) {}
 
-          getName() {
-            return this.name;
-          }
+        getName() {
+          return this.name;
         }
+      }
 
-        const actual = new TestContainer('Merged');
-        const untouchedObject = new TestContainer('Untouched');
-        const baseObject = {};
+      const actual = new TestContainer('Merged');
+      const untouchedObject = new TestContainer('Untouched');
+      const baseObject = {};
 
-        const prototypePollutionVector = await new Response(`
+      const prototypePollutionVector = await new Response(`
           {
             "__proto__": {
               "radioactiveWaste": true
@@ -146,32 +144,29 @@ describe('deepMerge utility', () => {
           }
         `).json();
 
-        // act
-        deepMerge(actual as {}, prototypePollutionVector);
+      // act
+      deepMerge(actual as {}, prototypePollutionVector);
 
-        // assert
-        expect('radioactiveWaste' in baseObject).toBe(false);
-        expect('radioactiveWaste' in untouchedObject).toBe(false);
-        expect('radioactiveWaste' in actual).toBe(false);
-      })
-    );
+      // assert
+      expect('radioactiveWaste' in baseObject).toBe(false);
+      expect('radioactiveWaste' in untouchedObject).toBe(false);
+      expect('radioactiveWaste' in actual).toBe(false);
+    }));
 
-    it(
-      'should avoid denial of service',
-      waitForAsync(async () => {
-        class TestContainer {
-          constructor(public name: string) {}
+    it('should avoid denial of service', waitForAsync(async () => {
+      class TestContainer {
+        constructor(public name: string) {}
 
-          getName() {
-            return this.name;
-          }
+        getName() {
+          return this.name;
         }
+      }
 
-        const actual = new TestContainer('Merged');
-        const untouchedObject = new TestContainer('Untouched');
-        const baseObject = {};
+      const actual = new TestContainer('Merged');
+      const untouchedObject = new TestContainer('Untouched');
+      const baseObject = {};
 
-        const prototypePollutionVector = await new Response(`
+      const prototypePollutionVector = await new Response(`
           {
             "__proto__": {
               "toString": "attack success"
@@ -179,12 +174,11 @@ describe('deepMerge utility', () => {
           }
         `).json();
 
-        deepMerge(actual as {}, prototypePollutionVector);
+      deepMerge(actual as {}, prototypePollutionVector);
 
-        expect(typeof baseObject.toString).toBe('function');
-        expect(typeof untouchedObject.toString).toBe('function');
-        expect(typeof actual.toString).toBe('function');
-      })
-    );
+      expect(typeof baseObject.toString).toBe('function');
+      expect(typeof untouchedObject.toString).toBe('function');
+      expect(typeof actual.toString).toBe('function');
+    }));
   });
 });

--- a/projects/core/src/features-config/directives/feature-level.directive.spec.ts
+++ b/projects/core/src/features-config/directives/feature-level.directive.spec.ts
@@ -37,50 +37,38 @@ describe('cxFeatureLevel directive', () => {
   });
 
   describe('when using string parameter', () => {
-    it(
-      'should show components for enabled feature level',
-      waitForAsync(() => {
-        const template = `<span *cxFeatureLevel="'1.1'">hello</span>`;
-        fixture = createTestComponent(template);
-        fixture.detectChanges();
-        expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-        expect(fixture.nativeElement.textContent).toEqual('hello');
-      })
-    );
+    it('should show components for enabled feature level', waitForAsync(() => {
+      const template = `<span *cxFeatureLevel="'1.1'">hello</span>`;
+      fixture = createTestComponent(template);
+      fixture.detectChanges();
+      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+      expect(fixture.nativeElement.textContent).toEqual('hello');
+    }));
 
-    it(
-      'should hide components for not enabled feature level',
-      waitForAsync(() => {
-        const template = `<span *cxFeatureLevel="'1.3'">hello</span>`;
-        fixture = createTestComponent(template);
-        fixture.detectChanges();
-        expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-        expect(fixture.nativeElement.textContent).toEqual('');
-      })
-    );
+    it('should hide components for not enabled feature level', waitForAsync(() => {
+      const template = `<span *cxFeatureLevel="'1.3'">hello</span>`;
+      fixture = createTestComponent(template);
+      fixture.detectChanges();
+      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+      expect(fixture.nativeElement.textContent).toEqual('');
+    }));
   });
 
   describe('when using number parameter', () => {
-    it(
-      'should show components for enabled feature level',
-      waitForAsync(() => {
-        const template = `<span *cxFeatureLevel="1.1">hello</span>`;
-        fixture = createTestComponent(template);
-        fixture.detectChanges();
-        expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-        expect(fixture.nativeElement.textContent).toEqual('hello');
-      })
-    );
+    it('should show components for enabled feature level', waitForAsync(() => {
+      const template = `<span *cxFeatureLevel="1.1">hello</span>`;
+      fixture = createTestComponent(template);
+      fixture.detectChanges();
+      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+      expect(fixture.nativeElement.textContent).toEqual('hello');
+    }));
 
-    it(
-      'should hide components for not enabled feature level',
-      waitForAsync(() => {
-        const template = `<span *cxFeatureLevel="1.3">hello</span>`;
-        fixture = createTestComponent(template);
-        fixture.detectChanges();
-        expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-        expect(fixture.nativeElement.textContent).toEqual('');
-      })
-    );
+    it('should hide components for not enabled feature level', waitForAsync(() => {
+      const template = `<span *cxFeatureLevel="1.3">hello</span>`;
+      fixture = createTestComponent(template);
+      fixture.detectChanges();
+      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+      expect(fixture.nativeElement.textContent).toEqual('');
+    }));
   });
 });

--- a/projects/core/src/features-config/directives/feature.directive.spec.ts
+++ b/projects/core/src/features-config/directives/feature.directive.spec.ts
@@ -36,25 +36,19 @@ describe('cxFeature directive', () => {
     });
   });
 
-  it(
-    'should show components for enabled feature level',
-    waitForAsync(() => {
-      const template = `<span *cxFeature="'testFeature'">hello</span>`;
-      fixture = createTestComponent(template);
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toEqual('hello');
-    })
-  );
+  it('should show components for enabled feature level', waitForAsync(() => {
+    const template = `<span *cxFeature="'testFeature'">hello</span>`;
+    fixture = createTestComponent(template);
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toEqual('hello');
+  }));
 
-  it(
-    'should hide components for not enabled feature level',
-    waitForAsync(() => {
-      const template = `<span *cxFeature="'disabledFeature'">hello</span>`;
-      fixture = createTestComponent(template);
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toEqual('');
-    })
-  );
+  it('should hide components for not enabled feature level', waitForAsync(() => {
+    const template = `<span *cxFeature="'disabledFeature'">hello</span>`;
+    fixture = createTestComponent(template);
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toEqual('');
+  }));
 });

--- a/projects/core/src/features-config/feature-toggles/feature-toggles-providers.spec.ts
+++ b/projects/core/src/features-config/feature-toggles/feature-toggles-providers.spec.ts
@@ -43,7 +43,7 @@ describe('FeatureToggles providers', () => {
 
   describe(`provideFeatureTogglesFactory`, () => {
     it('should provide FeatureTogglesChunk with the given factory', () => {
-      const factory = () => ({ test: true } as FeatureToggles);
+      const factory = () => ({ test: true }) as FeatureToggles;
       const provider = provideFeatureTogglesFactory(factory);
       expect(provider).toEqual({
         provide: FeatureTogglesChunk,
@@ -55,7 +55,7 @@ describe('FeatureToggles providers', () => {
 
   describe(`provideDefaultFeatureTogglesFactory`, () => {
     it('should provide DefaultFeatureTogglesChunk with the given factory', () => {
-      const factory = () => ({ test: true } as FeatureToggles);
+      const factory = () => ({ test: true }) as FeatureToggles;
       const provider = provideDefaultFeatureTogglesFactory(factory);
       expect(provider).toEqual({
         provide: DefaultFeatureTogglesChunk,

--- a/projects/core/src/http/http-timeout/http-timeout.interceptor.ts
+++ b/projects/core/src/http/http-timeout/http-timeout.interceptor.ts
@@ -27,7 +27,10 @@ import { HTTP_TIMEOUT_CONFIG } from './http-timeout.config';
 export class HttpTimeoutInterceptor implements HttpInterceptor {
   protected logger = inject(LoggerService);
 
-  constructor(protected windowRef: WindowRef, protected config: OccConfig) {}
+  constructor(
+    protected windowRef: WindowRef,
+    protected config: OccConfig
+  ) {}
 
   /**
    * It throws an error when a request takes longer than the specified time.

--- a/projects/core/src/occ/adapters/product/occ-product.adapter.ts
+++ b/projects/core/src/occ/adapters/product/occ-product.adapter.ts
@@ -47,7 +47,7 @@ export class OccProductAdapter implements ProductAdapter {
             data$: scopedProduct.data$?.pipe(
               this.converter.pipeable(PRODUCT_NORMALIZER)
             ),
-          } as ScopedProductData)
+          }) as ScopedProductData
       );
   }
 

--- a/projects/core/src/occ/adapters/site-context/occ-site.adapter.ts
+++ b/projects/core/src/occ/adapters/site-context/occ-site.adapter.ts
@@ -86,7 +86,9 @@ export class OccSiteAdapter implements SiteAdapter {
     }
 
     return this.http
-      .get<{ baseSites: BaseSite[] }>(
+      .get<{
+        baseSites: BaseSite[];
+      }>(
         this.occEndpointsService.buildUrl('baseSites', {}, { baseSite: false })
       )
       .pipe(
@@ -98,7 +100,9 @@ export class OccSiteAdapter implements SiteAdapter {
 
   loadBaseSites(): Observable<BaseSite[]> {
     return this.http
-      .get<{ baseSites: BaseSite[] }>(
+      .get<{
+        baseSites: BaseSite[];
+      }>(
         this.occEndpointsService.buildUrl('baseSites', {}, { baseSite: false })
       )
       .pipe(

--- a/projects/core/src/occ/config/config-from-meta-tag-factory.spec.ts
+++ b/projects/core/src/occ/config/config-from-meta-tag-factory.spec.ts
@@ -21,20 +21,20 @@ describe('config from MetaTag Factory', () => {
     });
 
     it('should return server config with baseUrl from meta tag', () => {
-      mockMeta.getTag = () => ({ content: 'testBaseUrl' } as HTMLMetaElement);
+      mockMeta.getTag = () => ({ content: 'testBaseUrl' }) as HTMLMetaElement;
       expect(occServerConfigFromMetaTagFactory(mockMeta as Meta)).toEqual({
         backend: { occ: { baseUrl: 'testBaseUrl' } },
       });
     });
 
     it('should return empty object when meta tag contains empty string', () => {
-      mockMeta.getTag = () => ({ content: '' } as HTMLMetaElement);
+      mockMeta.getTag = () => ({ content: '' }) as HTMLMetaElement;
       expect(occServerConfigFromMetaTagFactory(mockMeta as Meta)).toEqual({});
     });
 
     it('should return empty object when meta tag contains placeholder "OCC_BACKEND_BASE_URL_VALUE"', () => {
       mockMeta.getTag = () =>
-        ({ content: 'OCC_BACKEND_BASE_URL_VALUE' } as HTMLMetaElement);
+        ({ content: 'OCC_BACKEND_BASE_URL_VALUE' }) as HTMLMetaElement;
       expect(occServerConfigFromMetaTagFactory(mockMeta as Meta)).toEqual({});
     });
 
@@ -55,20 +55,20 @@ describe('config from MetaTag Factory', () => {
 
     it('should return server config with baseUrl from meta tag', () => {
       mockMeta.getTag = () =>
-        ({ content: 'testMediaBaseUrl' } as HTMLMetaElement);
+        ({ content: 'testMediaBaseUrl' }) as HTMLMetaElement;
       expect(mediaServerConfigFromMetaTagFactory(mockMeta as Meta)).toEqual({
         backend: { media: { baseUrl: 'testMediaBaseUrl' } },
       });
     });
 
     it('should return empty object when meta tag contains empty string', () => {
-      mockMeta.getTag = () => ({ content: '' } as HTMLMetaElement);
+      mockMeta.getTag = () => ({ content: '' }) as HTMLMetaElement;
       expect(mediaServerConfigFromMetaTagFactory(mockMeta as Meta)).toEqual({});
     });
 
     it('should return empty object when meta tag contains placeholder "MEDIA_BACKEND_BASE_URL_VALUE"', () => {
       mockMeta.getTag = () =>
-        ({ content: 'MEDIA_BACKEND_BASE_URL_VALUE' } as HTMLMetaElement);
+        ({ content: 'MEDIA_BACKEND_BASE_URL_VALUE' }) as HTMLMetaElement;
       expect(mediaServerConfigFromMetaTagFactory(mockMeta as Meta)).toEqual({});
     });
 

--- a/projects/core/src/occ/services/occ-requests-optimizer.service.ts
+++ b/projects/core/src/occ/services/occ-requests-optimizer.service.ts
@@ -48,7 +48,7 @@ export class OccRequestsOptimizerService {
         string,
         {
           [scope: string]: OccFieldsModel;
-        }
+        },
       ]) => {
         const groupedModels = Object.values(groupedModelsSet);
 

--- a/projects/core/src/product/store/actions/product-search.action.ts
+++ b/projects/core/src/product/store/actions/product-search.action.ts
@@ -42,7 +42,10 @@ export class SearchProductsFail implements Action {
 
 export class SearchProductsSuccess implements Action {
   readonly type = SEARCH_PRODUCTS_SUCCESS;
-  constructor(public payload: ProductSearchPage, public auxiliary?: boolean) {}
+  constructor(
+    public payload: ProductSearchPage,
+    public auxiliary?: boolean
+  ) {}
 }
 
 export class GetProductSuggestions implements Action {

--- a/projects/core/src/product/store/actions/product.action.ts
+++ b/projects/core/src/product/store/actions/product.action.ts
@@ -27,21 +27,31 @@ export interface EntityScopedLoaderAction extends Action {
 
 export class LoadProduct extends EntityScopedLoaderActions.EntityScopedLoadAction {
   readonly type = LOAD_PRODUCT;
-  constructor(public payload: string, scope = '') {
+  constructor(
+    public payload: string,
+    scope = ''
+  ) {
     super(PRODUCT_DETAIL_ENTITY, payload, scope);
   }
 }
 
 export class LoadProductFail extends EntityScopedLoaderActions.EntityScopedFailAction {
   readonly type = LOAD_PRODUCT_FAIL;
-  constructor(productCode: string, public payload: any, scope = '') {
+  constructor(
+    productCode: string,
+    public payload: any,
+    scope = ''
+  ) {
     super(PRODUCT_DETAIL_ENTITY, productCode, scope, payload);
   }
 }
 
 export class LoadProductSuccess extends EntityScopedLoaderActions.EntityScopedSuccessAction {
   readonly type = LOAD_PRODUCT_SUCCESS;
-  constructor(public payload: Product, scope = '') {
+  constructor(
+    public payload: Product,
+    scope = ''
+  ) {
     super(PRODUCT_DETAIL_ENTITY, payload.code ?? '', scope);
   }
 }

--- a/projects/core/src/routing/store/effects/router.effect.ts
+++ b/projects/core/src/routing/store/effects/router.effect.ts
@@ -36,5 +36,8 @@ export class RouterEffects {
     { dispatch: false }
   );
 
-  constructor(private actions$: Actions, private router: Router) {}
+  constructor(
+    private actions$: Actions,
+    private router: Router
+  ) {}
 }

--- a/projects/core/src/site-context/services/site-context-url-serializer.spec.ts
+++ b/projects/core/src/site-context/services/site-context-url-serializer.spec.ts
@@ -10,8 +10,8 @@ describe('SiteContextUrlSerializer', () => {
   const mockSiteContextParamsService = {
     getUrlEncodingParameters: () => ['language', 'currency'],
     getParamValues: (param) =>
-      ({ language: ['en', 'de'], currency: ['usd', 'pln'] }[param]),
-    getValue: (param) => ({ language: 'de', currency: 'usd' }[param]),
+      ({ language: ['en', 'de'], currency: ['usd', 'pln'] })[param],
+    getValue: (param) => ({ language: 'de', currency: 'usd' })[param],
   };
 
   let mockUrlTree: UrlTreeWithSiteContext;

--- a/projects/core/src/state/utils/entity-loader/entity-loader.action.ts
+++ b/projects/core/src/state/utils/entity-loader/entity-loader.action.ts
@@ -86,7 +86,11 @@ export class EntityFailAction implements EntityLoaderAction {
 export class EntitySuccessAction implements EntityLoaderAction {
   type = ENTITY_SUCCESS_ACTION;
   readonly meta: EntityLoaderMeta;
-  constructor(entityType: string, id: EntityId, public payload?: any) {
+  constructor(
+    entityType: string,
+    id: EntityId,
+    public payload?: any
+  ) {
     this.meta = entitySuccessMeta(entityType, id);
   }
 }

--- a/projects/schematics/src/add-spartacus/spartacus-feature-toggles.ts
+++ b/projects/schematics/src/add-spartacus/spartacus-feature-toggles.ts
@@ -106,8 +106,8 @@ function createFeatureTogglesProvider(): string {
  * For more, see the script `copy-feature-toggles` in the schematics's `package.json`.
  */
 function getDefaultFeatureToggles(): Record<string, boolean> {
-  const {
-    defaultFeatureToggles,
-  } = require(FEATURE_TOGGLES_COPIED_FROM_CORE_LIB_PATH);
+  const { defaultFeatureToggles } = require(
+    FEATURE_TOGGLES_COPIED_FROM_CORE_LIB_PATH
+  );
   return defaultFeatureToggles;
 }

--- a/projects/schematics/src/migrations/3_0/component-deprecations/component-deprecations.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/component-deprecations.ts
@@ -47,9 +47,10 @@ export function migrate(): Rule {
   // - a wrapper function returning Promise<Rule>
   // - passing the resolved `angularCompiler` as an argument down to other helper functions
   return async (tree: Tree, context: SchematicContext): Promise<Rule> => {
-    const angularCompiler = await loadEsmModule<
-      typeof import('@angular/compiler')
-    >('@angular/compiler');
+    const angularCompiler =
+      await loadEsmModule<typeof import('@angular/compiler')>(
+        '@angular/compiler'
+      );
 
     return (): Tree => {
       return migrateComponentMigration(

--- a/projects/schematics/src/migrations/mechanism/rename-symbol/rename-symbol.ts
+++ b/projects/schematics/src/migrations/mechanism/rename-symbol/rename-symbol.ts
@@ -26,7 +26,8 @@ export function migrateRenamedSymbols(
       const importDeclarationStructures: ImportDeclarationStructure[] = [];
 
       sourceFile.getImportDeclarations().forEach((id) => {
-        id.getImportClause()
+        id
+          .getImportClause()
           ?.getNamedImports()
           .forEach((namedImport) => {
             const importName = namedImport.getName();

--- a/projects/schematics/src/shared/utils/import-utils.ts
+++ b/projects/schematics/src/shared/utils/import-utils.ts
@@ -197,7 +197,8 @@ export function removeImports(
   const removedImports: ImportSpecifier[] = [];
 
   sourceFile.getImportDeclarations().forEach((id) => {
-    id.getImportClause()
+    id
+      .getImportClause()
       ?.getNamedImports()
       .forEach((namedImport) => {
         const importName = namedImport.getName();

--- a/projects/schematics/src/shared/utils/lib-utils.ts
+++ b/projects/schematics/src/shared/utils/lib-utils.ts
@@ -752,7 +752,7 @@ export function addPackageJsonDependencies(
  * Adds libraries dependencies to package.json
  */
 export function addPackageJsonDependenciesForLibrary<
-  OPTIONS extends LibraryOptions
+  OPTIONS extends LibraryOptions,
 >(dependencies: Record<string, string>, _options: OPTIONS): Rule {
   return (tree: Tree, _context: SchematicContext): Rule => {
     const packageJson = readPackageJson(tree);

--- a/projects/schematics/src/shared/utils/tree-file-system.ts
+++ b/projects/schematics/src/shared/utils/tree-file-system.ts
@@ -10,7 +10,10 @@ import * as path from 'path';
 import { FileSystemHost, ts } from 'ts-morph';
 
 export class TreeFileSystem implements FileSystemHost {
-  constructor(private readonly tree: Tree, private readonly rootDir: string) {}
+  constructor(
+    private readonly tree: Tree,
+    private readonly rootDir: string
+  ) {}
 
   private resolvePath(filePath: string) {
     return normalize(resolve(normalize(this.rootDir), normalize(filePath)));

--- a/projects/schematics/src/shared/utils/workspace-utils.ts
+++ b/projects/schematics/src/shared/utils/workspace-utils.ts
@@ -82,7 +82,7 @@ export function getAngularJsonFile(
 }
 
 export function getProjectFromWorkspace<
-  TProjectType extends ProjectType.Application
+  TProjectType extends ProjectType.Application,
 >(
   tree: Tree,
   options: SpartacusOptions,
@@ -151,7 +151,7 @@ export function buildDefaultPath(project: WorkspaceProject): string {
 }
 
 export function getProject<
-  TProjectType extends ProjectType = ProjectType.Application
+  TProjectType extends ProjectType = ProjectType.Application,
 >(
   workspaceOrHost: WorkspaceSchema | Tree,
   projectName: string
@@ -186,10 +186,7 @@ export function scaffoldStructure(options: SpartacusOptions): Rule {
   const APP_PATH = 'app/spartacus';
   return (_tree: Tree, _context: SchematicContext) => {
     return chain([
-      debugLogRule(
-        `⌛️ Scaffolding Spartacus file structure...`,
-        options.debug
-      ),
+      debugLogRule(`⌛️ Scaffolding Spartacus file structure...`, options.debug),
 
       ensureModuleExists({
         name: SPARTACUS_MODULE,

--- a/projects/storefrontapp/src/index.html
+++ b/projects/storefrontapp/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.spec.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.spec.ts
@@ -38,24 +38,22 @@ describe('AnonymousConsentManagementBannerComponent', () => {
   let anonymousConsentsService: AnonymousConsentsService;
   let launchDialogService: LaunchDialogService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [AnonymousConsentManagementBannerComponent],
-        providers: [
-          {
-            provide: AnonymousConsentsService,
-            useClass: MockAnonymousConsentsService,
-          },
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [AnonymousConsentManagementBannerComponent],
+      providers: [
+        {
+          provide: AnonymousConsentsService,
+          useClass: MockAnonymousConsentsService,
+        },
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.spec.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.spec.ts
@@ -20,20 +20,18 @@ describe('AnonymousConsentOpenDialogComponent', () => {
   let fixture: ComponentFixture<AnonymousConsentOpenDialogComponent>;
   let launchDialogService: LaunchDialogService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [AnonymousConsentOpenDialogComponent],
-        providers: [
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [AnonymousConsentOpenDialogComponent],
+      providers: [
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AnonymousConsentOpenDialogComponent);

--- a/projects/storefrontlib/cms-components/content/banner-carousel/banner-carousel.spec.ts
+++ b/projects/storefrontlib/cms-components/content/banner-carousel/banner-carousel.spec.ts
@@ -34,23 +34,21 @@ describe('CreateComponent', () => {
   let bannerCarouselComponent: BannerCarouselComponent;
   let fixture: ComponentFixture<BannerCarouselComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
-        declarations: [
-          BannerCarouselComponent,
-          CarouselComponent,
-          ComponentWrapperDirective,
-          IconComponent,
-        ],
-        providers: [
-          { provide: CmsComponentData, useValue: MockCmsComponentData },
-          { provide: CmsService, useClass: MockCmsService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [
+        BannerCarouselComponent,
+        CarouselComponent,
+        ComponentWrapperDirective,
+        IconComponent,
+      ],
+      providers: [
+        { provide: CmsComponentData, useValue: MockCmsComponentData },
+        { provide: CmsService, useClass: MockCmsService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BannerCarouselComponent);

--- a/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.spec.ts
+++ b/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.spec.ts
@@ -44,21 +44,19 @@ describe('CmsParagraphComponent in CmsLib', () => {
     }
   }
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
-        declarations: [MockAnchorPipe, ParagraphComponent],
-        providers: [
-          {
-            provide: CmsComponentData,
-            useValue: MockCmsComponentData,
-          },
-          { provide: DomSanitizer, useClass: MockDomSanitizer },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [MockAnchorPipe, ParagraphComponent],
+      providers: [
+        {
+          provide: CmsComponentData,
+          useValue: MockCmsComponentData,
+        },
+        { provide: DomSanitizer, useClass: MockDomSanitizer },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ParagraphComponent);

--- a/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.spec.ts
+++ b/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.spec.ts
@@ -75,26 +75,24 @@ describe('TabParagraphContainerComponent', () => {
   let cmsService: CmsService;
   let windowRef: WindowRef;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          TestComponent,
-          TabParagraphContainerComponent,
-          ComponentWrapperDirective,
-          OutletDirective,
-        ],
-        providers: [
-          WindowRef,
-          { provide: CmsComponentData, useValue: MockCmsComponentData },
-          { provide: CmsService, useValue: MockCmsService },
-          { provide: CmsConfig, useValue: MockCmsModuleConfig },
-          { provide: LayoutConfig, useValue: MockLayoutConfig },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        TestComponent,
+        TabParagraphContainerComponent,
+        ComponentWrapperDirective,
+        OutletDirective,
+      ],
+      providers: [
+        WindowRef,
+        { provide: CmsComponentData, useValue: MockCmsComponentData },
+        { provide: CmsService, useValue: MockCmsService },
+        { provide: CmsConfig, useValue: MockCmsModuleConfig },
+        { provide: LayoutConfig, useValue: MockLayoutConfig },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TabParagraphContainerComponent);

--- a/projects/storefrontlib/cms-components/misc/global-message/global-message.component.spec.ts
+++ b/projects/storefrontlib/cms-components/misc/global-message/global-message.component.spec.ts
@@ -36,17 +36,15 @@ describe('GlobalMessageComponent', () => {
   let messageService: GlobalMessageService;
   let fixture: ComponentFixture<GlobalMessageComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [GlobalMessageComponent, MockCxIconComponent],
-        providers: [
-          { provide: GlobalMessageService, useClass: MockMessageService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [GlobalMessageComponent, MockCxIconComponent],
+      providers: [
+        { provide: GlobalMessageService, useClass: MockMessageService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(GlobalMessageComponent);

--- a/projects/storefrontlib/cms-components/misc/icon/icon.component.spec.ts
+++ b/projects/storefrontlib/cms-components/misc/icon/icon.component.spec.ts
@@ -37,17 +37,15 @@ describe('IconComponent', () => {
   let fixture: ComponentFixture<IconComponent>;
   let service: IconLoaderService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [],
-        declarations: [IconComponent],
-        providers: [
-          { provide: IconLoaderService, useClass: MockIconLoaderService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [IconComponent],
+      providers: [
+        { provide: IconLoaderService, useClass: MockIconLoaderService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IconComponent);
@@ -184,17 +182,15 @@ describe('host icon components', () => {
   let fixture: ComponentFixture<MockIconTestComponent>;
   let debugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [IconModule],
-        declarations: [MockIconTestComponent],
-        providers: [
-          { provide: IconLoaderService, useClass: MockIconLoaderService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [IconModule],
+      declarations: [MockIconTestComponent],
+      providers: [
+        { provide: IconLoaderService, useClass: MockIconLoaderService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IconComponent);

--- a/projects/storefrontlib/cms-components/misc/message/message.component.spec.ts
+++ b/projects/storefrontlib/cms-components/misc/message/message.component.spec.ts
@@ -37,18 +37,16 @@ describe('MessageComponent', () => {
   let fixture: ComponentFixture<MessageComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          MessageComponent,
-          MockCxIconComponent,
-          MockAtMessageDirective,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        MessageComponent,
+        MockCxIconComponent,
+        MockAtMessageDirective,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MessageComponent);

--- a/projects/storefrontlib/cms-components/misc/promotions/promotions.component.spec.ts
+++ b/projects/storefrontlib/cms-components/misc/promotions/promotions.component.spec.ts
@@ -13,15 +13,13 @@ describe('PromotionsComponent', () => {
 
   const mockPromotions: Promotion[] = [mockPromotion];
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [],
-        declarations: [PromotionsComponent],
-        providers: [],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [PromotionsComponent],
+      providers: [],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PromotionsComponent);

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/language-currency.component.spec.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/language-currency.component.spec.ts
@@ -82,45 +82,43 @@ describe('LanguageCurrencyComponent in CmsLib', () => {
     data$: of(mockComponentData),
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [BrowserAnimationsModule],
-        declarations: [
-          LanguageCurrencyComponent,
-          SiteContextSelectorComponent,
-          MockCxIconComponent,
-        ],
-        providers: [
-          { provide: CmsService, useValue: MockCmsService },
-          {
-            provide: LanguageService,
-            useValue: MockLanguageService,
-          },
-          {
-            provide: CurrencyService,
-            useValue: MockCurrencyService,
-          },
-          {
-            provide: CmsComponentData,
-            useValue: MockCmsComponentData,
-          },
-          contextServiceMapProvider,
-        ],
-      })
-        .overrideComponent(SiteContextSelectorComponent, {
-          set: {
-            providers: [
-              {
-                provide: SiteContextComponentService,
-                useClass: SiteContextComponentService,
-              },
-            ],
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserAnimationsModule],
+      declarations: [
+        LanguageCurrencyComponent,
+        SiteContextSelectorComponent,
+        MockCxIconComponent,
+      ],
+      providers: [
+        { provide: CmsService, useValue: MockCmsService },
+        {
+          provide: LanguageService,
+          useValue: MockLanguageService,
+        },
+        {
+          provide: CurrencyService,
+          useValue: MockCurrencyService,
+        },
+        {
+          provide: CmsComponentData,
+          useValue: MockCmsComponentData,
+        },
+        contextServiceMapProvider,
+      ],
     })
-  );
+      .overrideComponent(SiteContextSelectorComponent, {
+        set: {
+          providers: [
+            {
+              provide: SiteContextComponentService,
+              useClass: SiteContextComponentService,
+            },
+          ],
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LanguageCurrencyComponent);

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.component.spec.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.component.spec.ts
@@ -78,45 +78,43 @@ describe('SiteContextSelectorComponent in CmsLib', () => {
     data$: of(mockComponentData),
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [BrowserAnimationsModule],
-        declarations: [
-          SiteContextSelectorComponent,
-          MockUrlPipe,
-          MockCxIconComponent,
-        ],
-        providers: [
-          { provide: CmsService, useValue: MockCmsService },
-          {
-            provide: LanguageService,
-            useValue: MockLanguageService,
-          },
-          {
-            provide: CurrencyService,
-            useValue: {},
-          },
-          {
-            provide: CmsComponentData,
-            useValue: MockCmsComponentData,
-          },
-          contextServiceMapProvider,
-        ],
-      })
-        .overrideComponent(SiteContextSelectorComponent, {
-          set: {
-            providers: [
-              {
-                provide: SiteContextComponentService,
-                useClass: SiteContextComponentService,
-              },
-            ],
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserAnimationsModule],
+      declarations: [
+        SiteContextSelectorComponent,
+        MockUrlPipe,
+        MockCxIconComponent,
+      ],
+      providers: [
+        { provide: CmsService, useValue: MockCmsService },
+        {
+          provide: LanguageService,
+          useValue: MockLanguageService,
+        },
+        {
+          provide: CurrencyService,
+          useValue: {},
+        },
+        {
+          provide: CmsComponentData,
+          useValue: MockCmsComponentData,
+        },
+        contextServiceMapProvider,
+      ],
     })
-  );
+      .overrideComponent(SiteContextSelectorComponent, {
+        set: {
+          providers: [
+            {
+              provide: SiteContextComponentService,
+              useClass: SiteContextComponentService,
+            },
+          ],
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SiteContextSelectorComponent);

--- a/projects/storefrontlib/cms-components/myaccount/consent-management/components/consent-form/consent-management-form.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/consent-management/components/consent-form/consent-management-form.component.spec.ts
@@ -13,14 +13,12 @@ describe('ConsentManagementFormComponent', () => {
   let fixture: ComponentFixture<ConsentManagementFormComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [ConsentManagementFormComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [ConsentManagementFormComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConsentManagementFormComponent);

--- a/projects/storefrontlib/cms-components/myaccount/consent-management/components/consent-management.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/consent-management/components/consent-management.component.spec.ts
@@ -120,39 +120,37 @@ describe('ConsentManagementComponent', () => {
   let anonymousConsentsConfig: AnonymousConsentsConfig;
   let anonymousConsentsService: AnonymousConsentsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      const mockAnonymousConsentsConfig = {
-        anonymousConsents: {},
-      };
+  beforeEach(waitForAsync(() => {
+    const mockAnonymousConsentsConfig = {
+      anonymousConsents: {},
+    };
 
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          MockCxSpinnerComponent,
-          MockConsentManagementFormComponent,
-          ConsentManagementComponent,
-        ],
-        providers: [
-          ConsentManagementComponentService,
-          { provide: UserConsentService, useClass: UserConsentServiceMock },
-          { provide: GlobalMessageService, useClass: GlobalMessageServiceMock },
-          {
-            provide: AnonymousConsentsService,
-            useClass: AnonymousConsentsServiceMock,
-          },
-          {
-            provide: AuthService,
-            useClass: AuthServiceMock,
-          },
-          {
-            provide: AnonymousConsentsConfig,
-            useValue: mockAnonymousConsentsConfig,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        MockCxSpinnerComponent,
+        MockConsentManagementFormComponent,
+        ConsentManagementComponent,
+      ],
+      providers: [
+        ConsentManagementComponentService,
+        { provide: UserConsentService, useClass: UserConsentServiceMock },
+        { provide: GlobalMessageService, useClass: GlobalMessageServiceMock },
+        {
+          provide: AnonymousConsentsService,
+          useClass: AnonymousConsentsServiceMock,
+        },
+        {
+          provide: AuthService,
+          useClass: AuthServiceMock,
+        },
+        {
+          provide: AnonymousConsentsConfig,
+          useValue: mockAnonymousConsentsConfig,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConsentManagementComponent);

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/consent-form/my-account-v2-consent-management-form.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/consent-form/my-account-v2-consent-management-form.component.spec.ts
@@ -13,14 +13,12 @@ describe('MyAccountV2ConsentManagementFormComponent', () => {
   let fixture: ComponentFixture<MyAccountV2ConsentManagementFormComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [MyAccountV2ConsentManagementFormComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [MyAccountV2ConsentManagementFormComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/my-account-v2-consent-management.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/my-account-v2-consent-management.component.spec.ts
@@ -120,39 +120,37 @@ describe('MyAccountV2ConsentManagementComponent', () => {
   let anonymousConsentsConfig: AnonymousConsentsConfig;
   let anonymousConsentsService: AnonymousConsentsService;
 
-  beforeEach(
-    waitForAsync(() => {
-      const mockAnonymousConsentsConfig = {
-        anonymousConsents: {},
-      };
+  beforeEach(waitForAsync(() => {
+    const mockAnonymousConsentsConfig = {
+      anonymousConsents: {},
+    };
 
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          MockCxSpinnerComponent,
-          MockConsentManagementFormComponent,
-          MyAccountV2ConsentManagementComponent,
-        ],
-        providers: [
-          ConsentManagementComponentService,
-          { provide: UserConsentService, useClass: UserConsentServiceMock },
-          { provide: GlobalMessageService, useClass: GlobalMessageServiceMock },
-          {
-            provide: AnonymousConsentsService,
-            useClass: AnonymousConsentsServiceMock,
-          },
-          {
-            provide: AuthService,
-            useClass: AuthServiceMock,
-          },
-          {
-            provide: AnonymousConsentsConfig,
-            useValue: mockAnonymousConsentsConfig,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        MockCxSpinnerComponent,
+        MockConsentManagementFormComponent,
+        MyAccountV2ConsentManagementComponent,
+      ],
+      providers: [
+        ConsentManagementComponentService,
+        { provide: UserConsentService, useClass: UserConsentServiceMock },
+        { provide: GlobalMessageService, useClass: GlobalMessageServiceMock },
+        {
+          provide: AnonymousConsentsService,
+          useClass: AnonymousConsentsServiceMock,
+        },
+        {
+          provide: AuthService,
+          useClass: AuthServiceMock,
+        },
+        {
+          provide: AnonymousConsentsConfig,
+          useValue: mockAnonymousConsentsConfig,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyAccountV2ConsentManagementComponent);

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-navigation/my-account-v2-navigation.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-navigation/my-account-v2-navigation.component.spec.ts
@@ -36,26 +36,21 @@ describe('MyAccountV2NavigationComponent', () => {
     createNavigation: createSpy().and.returnValue(of(null)),
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: NavigationService,
-            useValue: mockNavigationService,
-          },
-          {
-            provide: CmsComponentData,
-            useValue: MockCmsNavigationComponent,
-          },
-        ],
-        declarations: [
-          MyAccountV2NavigationComponent,
-          MockNavigationUIComponent,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: NavigationService,
+          useValue: mockNavigationService,
+        },
+        {
+          provide: CmsComponentData,
+          useValue: MockCmsNavigationComponent,
+        },
+      ],
+      declarations: [MyAccountV2NavigationComponent, MockNavigationUIComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyAccountV2NavigationComponent);

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/my-account-v2-notification-preference.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/my-account-v2-notification-preference.spec.ts
@@ -48,23 +48,21 @@ describe('MyAccountV2NotificationPreferenceComponent', () => {
     },
   ];
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          MyAccountV2NotificationPreferenceComponent,
-          MockCxSpinnerComponent,
-        ],
-        providers: [
-          {
-            provide: UserNotificationPreferenceService,
-            useValue: notificationPreferenceService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        MyAccountV2NotificationPreferenceComponent,
+        MockCxSpinnerComponent,
+      ],
+      providers: [
+        {
+          provide: UserNotificationPreferenceService,
+          useValue: notificationPreferenceService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-card.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-card.component.spec.ts
@@ -88,27 +88,25 @@ describe('CouponCardComponent', () => {
     'MyCouponsComponentService',
     ['launchSearchPage']
   );
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [CouponCardComponent, MyCouponsComponent, MockUrlPipe],
-        imports: [I18nTestingModule, RouterTestingModule],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: MyCouponsComponentService,
-            useValue: couponComponentService,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [CouponCardComponent, MyCouponsComponent, MockUrlPipe],
+      imports: [I18nTestingModule, RouterTestingModule],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: MyCouponsComponentService,
+          useValue: couponComponentService,
+        },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '5.1' },
           },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '5.1' },
-            },
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyCouponsComponent);

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-dialog/coupon-dialog.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-dialog/coupon-dialog.component.spec.ts
@@ -39,21 +39,19 @@ describe('CouponDialogComponent', () => {
   let fixture: ComponentFixture<CouponDialogComponent>;
   let el: DebugElement;
   let launchDialogService: LaunchDialogService;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          CouponDialogComponent,
-          MockCxIconComponent,
-          FocusDirective,
-        ],
-        imports: [I18nTestingModule],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        CouponDialogComponent,
+        MockCxIconComponent,
+        FocusDirective,
+      ],
+      imports: [I18nTestingModule],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CouponDialogComponent);

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-claim/coupon-claim.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-claim/coupon-claim.component.spec.ts
@@ -42,18 +42,16 @@ describe('CouponClaimComponent', () => {
   const globalMessageService = jasmine.createSpyObj('GlobalMessageService', [
     'add',
   ]);
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [CouponClaimComponent],
-        providers: [
-          { provide: CustomerCouponService, useValue: couponService },
-          { provide: RoutingService, useValue: routingService },
-          { provide: GlobalMessageService, useValue: globalMessageService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [CouponClaimComponent],
+      providers: [
+        { provide: CustomerCouponService, useValue: couponService },
+        { provide: RoutingService, useValue: routingService },
+        { provide: GlobalMessageService, useValue: globalMessageService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     couponService.claimCustomerCoupon.and.stub();

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.html
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.html
@@ -17,11 +17,7 @@
       >
         <div class="cx-my-coupons-sort top row">
           <label
-            class="
-              cx-my-coupons-form-group
-              form-group
-              col-sm-12 col-md-4 col-lg-4
-            "
+            class="cx-my-coupons-form-group form-group col-sm-12 col-md-4 col-lg-4"
           >
             <span>{{ 'myCoupons.sortBy' | cxTranslate }}</span>
             <cx-sorting
@@ -57,12 +53,7 @@
 
         <div class="cx-my-coupons-sort bottom row">
           <label
-            class="
-              cx-my-coupons-form-group
-              form-group
-              cx-mycoupon-thead-mobile
-              col-sm-12 col-md-4 col-lg-4
-            "
+            class="cx-my-coupons-form-group form-group cx-mycoupon-thead-mobile col-sm-12 col-md-4 col-lg-4"
           >
             <span>{{ 'myCoupons.sortBy' | cxTranslate }}</span>
             <cx-sorting

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.spec.ts
@@ -165,33 +165,31 @@ describe('MyCouponsComponent', () => {
   );
   const subscriptionFail = new BehaviorSubject<boolean>(false);
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule, SpinnerModule],
-        declarations: [
-          MyCouponsComponent,
-          MockedCouponCardComponent,
-          MockCxIconComponent,
-          MockPaginationComponent,
-          MockSortingComponent,
-        ],
-        providers: [
-          { provide: CustomerCouponService, useValue: customerCouponService },
-          {
-            provide: MyCouponsComponentService,
-            useValue: myCouponsComponentService,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule, SpinnerModule],
+      declarations: [
+        MyCouponsComponent,
+        MockedCouponCardComponent,
+        MockCxIconComponent,
+        MockPaginationComponent,
+        MockSortingComponent,
+      ],
+      providers: [
+        { provide: CustomerCouponService, useValue: customerCouponService },
+        {
+          provide: MyCouponsComponentService,
+          useValue: myCouponsComponentService,
+        },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '5.1' },
           },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '5.1' },
-            },
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyCouponsComponent);

--- a/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.component.html
+++ b/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.component.html
@@ -17,11 +17,7 @@
     >
       <div class="cx-product-interests-sort top row">
         <label
-          class="
-            cx-product-interests-form-group
-            form-group
-            col-sm-12 col-md-4 col-lg-4
-          "
+          class="cx-product-interests-form-group form-group col-sm-12 col-md-4 col-lg-4"
           ><span>{{ 'myInterests.sortBy' | cxTranslate }}</span>
           <cx-sorting
             [sortOptions]="sortOptions"
@@ -35,9 +31,7 @@
           </cx-sorting>
         </label>
         <div
-          class="
-            cx-product-interests-pagination cx-product-interests-thead-mobile
-          "
+          class="cx-product-interests-pagination cx-product-interests-thead-mobile"
         >
           <cx-pagination
             [pagination]="pagination"
@@ -100,9 +94,7 @@
                       <div>
                         <div *ngIf="product.name" class="cx-name">
                           <a
-                            class="
-                              cx-link cx-product-interests-product-code-link
-                            "
+                            class="cx-link cx-product-interests-product-code-link"
                             [routerLink]="
                               { cxRoute: 'product', params: product } | cxUrl
                             "
@@ -133,9 +125,7 @@
                               {{ variant.name }}
                             </div>
                             <div
-                              class="
-                                cx-value cx-product-interests-variant-value
-                              "
+                              class="cx-value cx-product-interests-variant-value"
                             >
                               {{ variant.value }}
                             </div>
@@ -198,11 +188,7 @@
                 <div class="cx-actions cx-product-interests-remove-button">
                   <button
                     type="button"
-                    class="
-                      cx-product-interests-remove-btn
-                      link
-                      cx-action-link cx-remove-btn
-                    "
+                    class="cx-product-interests-remove-btn link cx-action-link cx-remove-btn"
                     [cxAtMessage]="'myInterests.itemRemoved' | cxTranslate"
                     [disabled]="isRemoveDisabled$ | async"
                     (click)="removeInterest(interest)"
@@ -218,11 +204,7 @@
 
       <div class="cx-product-interests-sort bottom row">
         <label
-          class="
-            cx-product-interests-form-group cx-product-interests-thead-mobile
-            form-group
-            col-sm-12 col-md-4 col-lg-4
-          "
+          class="cx-product-interests-form-group cx-product-interests-thead-mobile form-group col-sm-12 col-md-4 col-lg-4"
           ><span>{{ 'myInterests.sortBy' | cxTranslate }}</span>
           <cx-sorting
             [sortOptions]="sortOptions"

--- a/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.component.spec.ts
@@ -210,30 +210,28 @@ describe('MyInterestsComponent', () => {
   ]);
   const productService = jasmine.createSpyObj('ProductService', ['get']);
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        providers: [
-          { provide: OccConfig, useValue: MockOccModuleConfig },
-          { provide: LayoutConfig, useValue: MockLayoutConfig },
-          { provide: UserInterestsService, useValue: productInterestService },
-          { provide: ProductService, useValue: productService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-        ],
-        declarations: [
-          MyInterestsComponent,
-          MockUrlPipe,
-          MockMediaComponent,
-          MockSpinnerComponent,
-          MockPaginationComponent,
-          MockSortingComponent,
-          MockFeatureLevelDirective,
-          MockAtMessageDirective,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      providers: [
+        { provide: OccConfig, useValue: MockOccModuleConfig },
+        { provide: LayoutConfig, useValue: MockLayoutConfig },
+        { provide: UserInterestsService, useValue: productInterestService },
+        { provide: ProductService, useValue: productService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+      ],
+      declarations: [
+        MyInterestsComponent,
+        MockUrlPipe,
+        MockMediaComponent,
+        MockSpinnerComponent,
+        MockPaginationComponent,
+        MockSortingComponent,
+        MockFeatureLevelDirective,
+        MockAtMessageDirective,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyInterestsComponent);

--- a/projects/storefrontlib/cms-components/myaccount/notification-preference/notification-preference.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/notification-preference/notification-preference.component.spec.ts
@@ -49,24 +49,22 @@ describe('NotificationPreferenceComponent', () => {
     },
   ];
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          NotificationPreferenceComponent,
-          MockCxSpinnerComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          {
-            provide: UserNotificationPreferenceService,
-            useValue: notificationPreferenceService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        NotificationPreferenceComponent,
+        MockCxSpinnerComponent,
+        MockFeatureDirective,
+      ],
+      providers: [
+        {
+          provide: UserNotificationPreferenceService,
+          useValue: notificationPreferenceService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NotificationPreferenceComponent);

--- a/projects/storefrontlib/cms-components/myaccount/payment-methods/payment-methods.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/payment-methods/payment-methods.component.spec.ts
@@ -69,31 +69,29 @@ describe('PaymentMethodsComponent', () => {
   let userService: UserPaymentService;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          PaymentMethodsComponent,
-          MockCxSpinnerComponent,
-          CardComponent,
-          MockCxIconComponent,
-          MockAtMessageDirective,
-          FocusDirective,
-        ],
-        providers: [
-          { provide: UserPaymentService, useClass: MockUserPaymentService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '5.1' },
-            },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        PaymentMethodsComponent,
+        MockCxSpinnerComponent,
+        CardComponent,
+        MockCxIconComponent,
+        MockAtMessageDirective,
+        FocusDirective,
+      ],
+      providers: [
+        { provide: UserPaymentService, useClass: MockUserPaymentService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '5.1' },
           },
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PaymentMethodsComponent);

--- a/projects/storefrontlib/cms-components/navigation/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/breadcrumb/breadcrumb.component.spec.ts
@@ -19,23 +19,21 @@ describe('BreadcrumbComponent', () => {
   let component: BreadcrumbComponent;
   let fixture: ComponentFixture<BreadcrumbComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [BreadcrumbComponent, MockFeatureDirective],
-        providers: [
-          { provide: PageMetaService, useClass: MockPageMetaService },
-          {
-            provide: CmsComponentData,
-            useValue: {
-              data$: of({}),
-            },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [BreadcrumbComponent, MockFeatureDirective],
+      providers: [
+        { provide: PageMetaService, useClass: MockPageMetaService },
+        {
+          provide: CmsComponentData,
+          useValue: {
+            data$: of({}),
           },
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BreadcrumbComponent);

--- a/projects/storefrontlib/cms-components/navigation/category-navigation/category-navigation.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/category-navigation/category-navigation.component.spec.ts
@@ -57,24 +57,22 @@ describe('CategoryNavigationComponent', () => {
     },
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [CategoryNavigationComponent, MockNavigationComponent],
-        providers: [
-          {
-            provide: NavigationService,
-            useValue: mockNavigationService,
-          },
-          {
-            provide: CmsComponentData,
-            useValue: MockCmsNavigationComponent,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [CategoryNavigationComponent, MockNavigationComponent],
+      providers: [
+        {
+          provide: NavigationService,
+          useValue: mockNavigationService,
+        },
+        {
+          provide: CmsComponentData,
+          useValue: MockCmsNavigationComponent,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CategoryNavigationComponent);

--- a/projects/storefrontlib/cms-components/navigation/footer-navigation/footer-navigation.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/footer-navigation/footer-navigation.component.spec.ts
@@ -70,33 +70,31 @@ describe('FooterNavigationComponent', () => {
     getNavigationNode: createSpy().and.returnValue(of(null)),
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          FooterNavigationComponent,
-          NavigationComponent,
-          MockNavigationUIComponent,
-          MockGenericLinkComponent,
-        ],
-        providers: [
-          {
-            provide: NavigationService,
-            useValue: mockNavigationService,
-          },
-          {
-            provide: CmsComponentData,
-            useValue: MockCmsNavigationComponent,
-          },
-          {
-            provide: AnonymousConsentsConfig,
-            useValue: mockAnonymousConsentsConfig,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        FooterNavigationComponent,
+        NavigationComponent,
+        MockNavigationUIComponent,
+        MockGenericLinkComponent,
+      ],
+      providers: [
+        {
+          provide: NavigationService,
+          useValue: mockNavigationService,
+        },
+        {
+          provide: CmsComponentData,
+          useValue: MockCmsNavigationComponent,
+        },
+        {
+          provide: AnonymousConsentsConfig,
+          useValue: mockAnonymousConsentsConfig,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FooterNavigationComponent);

--- a/projects/storefrontlib/cms-components/navigation/navigation/navigation.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/navigation/navigation.component.spec.ts
@@ -40,23 +40,21 @@ describe('CmsNavigationComponent', () => {
     createNavigation: createSpy().and.returnValue(of(null)),
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: NavigationService,
-            useValue: mockNavigationService,
-          },
-          {
-            provide: CmsComponentData,
-            useValue: MockCmsNavigationComponent,
-          },
-        ],
-        declarations: [NavigationComponent, MockNavigationUIComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: NavigationService,
+          useValue: mockNavigationService,
+        },
+        {
+          provide: CmsComponentData,
+          useValue: MockCmsNavigationComponent,
+        },
+      ],
+      declarations: [NavigationComponent, MockNavigationUIComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NavigationComponent);

--- a/projects/storefrontlib/cms-components/navigation/page-header/page-title.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/page-header/page-title.component.spec.ts
@@ -21,23 +21,21 @@ describe('PageTitleComponent', () => {
   let fixture: ComponentFixture<PageTitleComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [PageTitleComponent],
-        providers: [
-          { provide: PageMetaService, useClass: MockPageMetaService },
-          {
-            provide: CmsComponentData,
-            useValue: {
-              data$: of({}),
-            },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [PageTitleComponent],
+      providers: [
+        { provide: PageMetaService, useClass: MockPageMetaService },
+        {
+          provide: CmsComponentData,
+          useValue: {
+            data$: of({}),
           },
-        ],
-      }).compileComponents();
-    })
-  );
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PageTitleComponent);

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.spec.ts
@@ -138,42 +138,40 @@ describe('SearchBoxComponent', () => {
     clearResults() {}
   }
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          BrowserAnimationsModule,
-          RouterModule.forRoot([]),
-          I18nTestingModule,
-        ],
-        declarations: [
-          SearchBoxComponent,
-          MockUrlPipe,
-          MockHighlightPipe,
-          MockCxIconComponent,
-          MockMediaComponent,
-        ],
-        providers: [
-          {
-            provide: ProductSearchService,
-            useValue: {},
-          },
-          {
-            provide: CmsComponentData,
-            useClass: MockCmsComponentData,
-          },
-          {
-            provide: SearchBoxComponentService,
-            useClass: SearchBoxComponentServiceSpy,
-          },
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        RouterModule.forRoot([]),
+        I18nTestingModule,
+      ],
+      declarations: [
+        SearchBoxComponent,
+        MockUrlPipe,
+        MockHighlightPipe,
+        MockCxIconComponent,
+        MockMediaComponent,
+      ],
+      providers: [
+        {
+          provide: ProductSearchService,
+          useValue: {},
+        },
+        {
+          provide: CmsComponentData,
+          useClass: MockCmsComponentData,
+        },
+        {
+          provide: SearchBoxComponentService,
+          useClass: SearchBoxComponentServiceSpy,
+        },
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   describe('Default config', () => {
     beforeEach(() => {
@@ -242,15 +240,12 @@ describe('SearchBoxComponent', () => {
         expect(fixture.debugElement.query(By.css('.results'))).toBeFalsy();
       });
 
-      it(
-        'should contain search results panel after search input',
-        waitForAsync(() => {
-          searchBoxComponent.queryText = 'test input';
-          fixture.detectChanges();
+      it('should contain search results panel after search input', waitForAsync(() => {
+        searchBoxComponent.queryText = 'test input';
+        fixture.detectChanges();
 
-          expect(fixture.debugElement.query(By.css('.results'))).toBeTruthy();
-        })
-      );
+        expect(fixture.debugElement.query(By.css('.results'))).toBeTruthy();
+      }));
 
       it('should contain 2 suggestion after search', () => {
         searchBoxComponent.queryText = 'te';

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel-item/product-carousel-item.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel-item/product-carousel-item.component.spec.ts
@@ -72,29 +72,27 @@ describe('ProductCarouselItemComponent in product-carousel', () => {
     },
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule, OutletModule],
-        declarations: [
-          ProductCarouselItemComponent,
-          MockUrlPipe,
-          MockOutletDirective,
-          MockMediaComponent,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule, OutletModule],
+      declarations: [
+        ProductCarouselItemComponent,
+        MockUrlPipe,
+        MockOutletDirective,
+        MockMediaComponent,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductCarouselItemComponent);
@@ -157,38 +155,26 @@ describe('ProductCarouselItemComponent in product-carousel', () => {
   });
 
   describe('UI test', () => {
-    it(
-      'should render product name in template',
-      waitForAsync(() => {
-        const el = fixture.debugElement.query(By.css('h3'));
-        expect(el.nativeElement).toBeTruthy();
-        expect(el.nativeElement.innerText).toEqual('Test product');
-      })
-    );
+    it('should render product name in template', waitForAsync(() => {
+      const el = fixture.debugElement.query(By.css('h3'));
+      expect(el.nativeElement).toBeTruthy();
+      expect(el.nativeElement.innerText).toEqual('Test product');
+    }));
 
-    it(
-      'should render product price in template',
-      waitForAsync(() => {
-        const el = fixture.debugElement.query(By.css('.price'));
-        expect(el.nativeElement).toBeTruthy();
-        expect(el.nativeElement.innerText).toEqual('$100,00');
-      })
-    );
+    it('should render product price in template', waitForAsync(() => {
+      const el = fixture.debugElement.query(By.css('.price'));
+      expect(el.nativeElement).toBeTruthy();
+      expect(el.nativeElement.innerText).toEqual('$100,00');
+    }));
 
-    it(
-      'should render product primary image for the first item',
-      waitForAsync(() => {
-        const el = fixture.debugElement.query(By.css('cx-media'));
-        expect(el.nativeElement).toBeTruthy();
-      })
-    );
+    it('should render product primary image for the first item', waitForAsync(() => {
+      const el = fixture.debugElement.query(By.css('cx-media'));
+      expect(el.nativeElement).toBeTruthy();
+    }));
 
-    it(
-      'should render missing product image for the 2nd item as well',
-      waitForAsync(() => {
-        const el = fixture.debugElement.query(By.css('cx-media'));
-        expect(el.nativeElement).toBeTruthy();
-      })
-    );
+    it('should render missing product image for the 2nd item as well', waitForAsync(() => {
+      const el = fixture.debugElement.query(By.css('cx-media'));
+      expect(el.nativeElement).toBeTruthy();
+    }));
   });
 });

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
@@ -135,11 +135,9 @@ describe('ProductCarouselComponent', () => {
     ],
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule(testBedDefaults).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule(testBedDefaults).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductCarouselComponent);
@@ -147,12 +145,9 @@ describe('ProductCarouselComponent', () => {
     fixture.detectChanges();
   });
 
-  it(
-    'should be created',
-    waitForAsync(() => {
-      expect(component).toBeTruthy();
-    })
-  );
+  it('should be created', waitForAsync(() => {
+    expect(component).toBeTruthy();
+  }));
 
   it('should have 2 items', (done) => {
     const productService = TestBed.inject(ProductService);
@@ -170,28 +165,22 @@ describe('ProductCarouselComponent', () => {
     });
   });
 
-  it(
-    'should have product code 111 in first product',
-    waitForAsync(() => {
-      let items: Observable<Product | undefined>[] = [];
-      component.items$.subscribe((i) => (items = i));
-      let product: Product | undefined;
-      items[0].subscribe((p) => (product = p));
+  it('should have product code 111 in first product', waitForAsync(() => {
+    let items: Observable<Product | undefined>[] = [];
+    component.items$.subscribe((i) => (items = i));
+    let product: Product | undefined;
+    items[0].subscribe((p) => (product = p));
 
-      expect(product).toBe(mockProducts[1]);
-    })
-  );
+    expect(product).toBe(mockProducts[1]);
+  }));
 
   describe('UI test', () => {
-    it(
-      'should have 2 rendered templates',
-      waitForAsync(() => {
-        const el = fixture.debugElement.queryAll(
-          By.css('cx-product-carousel-item')
-        );
-        expect(el.length).toEqual(2);
-      })
-    );
+    it('should have 2 rendered templates', waitForAsync(() => {
+      const el = fixture.debugElement.queryAll(
+        By.css('cx-product-carousel-item')
+      );
+      expect(el.length).toEqual(2);
+    }));
   });
 
   describe('Carousel with inner component mapping', () => {

--- a/projects/storefrontlib/cms-components/product/product-images/product-images.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-images/product-images.component.spec.ts
@@ -82,25 +82,23 @@ describe('ProductImagesComponent', () => {
   let fixture: ComponentFixture<ProductImagesComponent>;
   let currentProductService: CurrentProductService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ProductImagesComponent,
-          MockMediaComponent,
-          MockCarouselComponent,
-        ],
-        providers: [
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ProductImagesComponent,
+        MockMediaComponent,
+        MockCarouselComponent,
+      ],
+      providers: [
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+      ],
+    }).compileComponents();
 
-      currentProductService = TestBed.inject(CurrentProductService);
-    })
-  );
+    currentProductService = TestBed.inject(CurrentProductService);
+  }));
 
   describe('with multiple pictures', () => {
     beforeEach(() => {
@@ -123,25 +121,19 @@ describe('ProductImagesComponent', () => {
       expect(result.zoom.url).toEqual('zoom-1.jpg');
     });
 
-    it(
-      'should have 2 thumbnails',
-      waitForAsync(() => {
-        let items: Observable<Product>[];
-        component.thumbs$.subscribe((i) => (items = i));
-        expect(items.length).toBe(2);
-      })
-    );
+    it('should have 2 thumbnails', waitForAsync(() => {
+      let items: Observable<Product>[];
+      component.thumbs$.subscribe((i) => (items = i));
+      expect(items.length).toBe(2);
+    }));
 
-    it(
-      'should have thumb with url in first product',
-      waitForAsync(() => {
-        let thumbs: Observable<Product>[];
-        component.thumbs$.subscribe((i) => (thumbs = i));
-        let thumb: any;
-        thumbs[0].subscribe((p) => (thumb = p));
-        expect(thumb.container.thumbnail.url).toEqual('thumb-1.jpg');
-      })
-    );
+    it('should have thumb with url in first product', waitForAsync(() => {
+      let thumbs: Observable<Product>[];
+      component.thumbs$.subscribe((i) => (thumbs = i));
+      let thumb: any;
+      thumbs[0].subscribe((p) => (thumb = p));
+      expect(thumb.container.thumbnail.url).toEqual('thumb-1.jpg');
+    }));
 
     describe('UI test', () => {
       it('should have cx-carousel element', () => {
@@ -149,15 +141,12 @@ describe('ProductImagesComponent', () => {
         expect(carousel).toBeTruthy();
       });
 
-      it(
-        'should have 2 rendered templates',
-        waitForAsync(() => {
-          const el = fixture.debugElement.queryAll(
-            By.css('cx-carousel cx-media')
-          );
-          expect(el.length).toEqual(2);
-        })
-      );
+      it('should have 2 rendered templates', waitForAsync(() => {
+        const el = fixture.debugElement.queryAll(
+          By.css('cx-carousel cx-media')
+        );
+        expect(el.length).toEqual(2);
+      }));
     });
   });
 
@@ -182,14 +171,11 @@ describe('ProductImagesComponent', () => {
       expect(result.zoom.url).toEqual('zoom-1.jpg');
     });
 
-    it(
-      'should not have thumbnails in case there is only one GALLERY image',
-      waitForAsync(() => {
-        let items: Observable<Product>[];
-        component.thumbs$.subscribe((i) => (items = i));
-        expect(items.length).toBe(0);
-      })
-    );
+    it('should not have thumbnails in case there is only one GALLERY image', waitForAsync(() => {
+      let items: Observable<Product>[];
+      component.thumbs$.subscribe((i) => (items = i));
+      expect(items.length).toBe(0);
+    }));
 
     describe('(UI test)', () => {
       it('should not render cx-carousel for one GALLERY image', () => {

--- a/projects/storefrontlib/cms-components/product/product-intro/product-intro.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-intro/product-intro.component.spec.ts
@@ -47,28 +47,26 @@ describe('ProductIntroComponent in product', () => {
   let translationService: TranslationService;
   let eventService: EventService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [ProductIntroComponent, MockStarRatingComponent],
-        providers: [
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-          {
-            provide: TranslationService,
-            useClass: MockTranslationService,
-          },
-          {
-            provide: EventService,
-            useClass: MockEventService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [ProductIntroComponent, MockStarRatingComponent],
+      providers: [
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+        {
+          provide: TranslationService,
+          useClass: MockTranslationService,
+        },
+        {
+          provide: EventService,
+          useClass: MockEventService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     translationService = TestBed.inject(TranslationService);
@@ -213,7 +211,7 @@ describe('ProductIntroComponent in product', () => {
       productIntroComponent.product$ = of({
         averageRating: 5,
       } as Product);
-      productIntroComponent['getReviewsComponent'] = () => ({} as HTMLElement);
+      productIntroComponent['getReviewsComponent'] = () => ({}) as HTMLElement;
 
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.innerText).toContain(
@@ -253,7 +251,7 @@ describe('ProductIntroComponent in product', () => {
       productIntroComponent.product$ = of({
         averageRating: 4,
       } as Product);
-      productIntroComponent['getReviewsComponent'] = () => ({} as HTMLElement);
+      productIntroComponent['getReviewsComponent'] = () => ({}) as HTMLElement;
 
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.innerText).not.toContain(

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-list.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-list.component.spec.ts
@@ -101,52 +101,50 @@ describe('ProductListComponent', () => {
   let fixture: ComponentFixture<ProductListComponent>;
   let componentService: ProductListComponentService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ListNavigationModule,
-          FormsModule,
-          RouterTestingModule,
-          I18nTestingModule,
-          InfiniteScrollModule,
-          SpinnerModule,
-        ],
-        providers: [
-          {
-            provide: PageLayoutService,
-            useClass: MockPageLayoutService,
-          },
-          {
-            provide: ProductListComponentService,
-            useClass: MockProductListComponentService,
-          },
-          {
-            provide: ViewConfig,
-            useClass: MockViewConfig,
-          },
-          {
-            provide: GlobalMessageService,
-            useClass: MockGlobalMessageService,
-          },
-        ],
-        declarations: [
-          ProductListComponent,
-          ProductFacetNavigationComponent,
-          ProductGridItemComponent,
-          MockStarRatingComponent,
-          MockAddToCartComponent,
-          MediaComponent,
-          ProductViewComponent,
-          MockProductListItemComponent,
-          MockUrlPipe,
-          MockCxIconComponent,
-          ProductScrollComponent,
-          MockFeatureLevelDirective,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ListNavigationModule,
+        FormsModule,
+        RouterTestingModule,
+        I18nTestingModule,
+        InfiniteScrollModule,
+        SpinnerModule,
+      ],
+      providers: [
+        {
+          provide: PageLayoutService,
+          useClass: MockPageLayoutService,
+        },
+        {
+          provide: ProductListComponentService,
+          useClass: MockProductListComponentService,
+        },
+        {
+          provide: ViewConfig,
+          useClass: MockViewConfig,
+        },
+        {
+          provide: GlobalMessageService,
+          useClass: MockGlobalMessageService,
+        },
+      ],
+      declarations: [
+        ProductListComponent,
+        ProductFacetNavigationComponent,
+        ProductGridItemComponent,
+        MockStarRatingComponent,
+        MockAddToCartComponent,
+        MediaComponent,
+        ProductViewComponent,
+        MockProductListItemComponent,
+        MockUrlPipe,
+        MockCxIconComponent,
+        ProductScrollComponent,
+        MockFeatureLevelDirective,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductListComponent);

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-scroll/product-scroll.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-scroll/product-scroll.component.spec.ts
@@ -159,35 +159,33 @@ describe('ProductScrollComponent', () => {
   let fixture: ComponentFixture<ProductScrollComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ProductScrollComponent,
-          ProductGridItemComponent,
-          MockProductListItemComponent,
-          MockUrlPipe,
-          MediaComponent,
-          MockStarRatingComponent,
-          MockAddToCartComponent,
-          MockStyleIconsComponent,
-          MockFeatureLevelDirective,
-        ],
-        imports: [
-          InfiniteScrollModule,
-          I18nTestingModule,
-          SpinnerModule,
-          RouterTestingModule,
-        ],
-        providers: [
-          {
-            provide: ProductListComponentService,
-            useClass: MockProductListComponentService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ProductScrollComponent,
+        ProductGridItemComponent,
+        MockProductListItemComponent,
+        MockUrlPipe,
+        MediaComponent,
+        MockStarRatingComponent,
+        MockAddToCartComponent,
+        MockStyleIconsComponent,
+        MockFeatureLevelDirective,
+      ],
+      imports: [
+        InfiniteScrollModule,
+        I18nTestingModule,
+        SpinnerModule,
+        RouterTestingModule,
+      ],
+      providers: [
+        {
+          provide: ProductListComponentService,
+          useClass: MockProductListComponentService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductScrollComponent);

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.spec.ts
@@ -36,19 +36,17 @@ describe('ActiveFacetsComponent', () => {
   let fixture: ComponentFixture<ActiveFacetsComponent>;
   let element: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule, KeyboardFocusModule],
-        declarations: [ActiveFacetsComponent, MockCxIconComponent],
-        providers: [{ provide: FacetService, useClass: MockFacetService }],
-      })
-        .overrideComponent(ActiveFacetsComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule, KeyboardFocusModule],
+      declarations: [ActiveFacetsComponent, MockCxIconComponent],
+      providers: [{ provide: FacetService, useClass: MockFacetService }],
     })
-  );
+      .overrideComponent(ActiveFacetsComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ActiveFacetsComponent);

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.spec.ts
@@ -72,33 +72,31 @@ describe('FacetListComponent', () => {
   let focusService: KeyboardFocusService;
   let featureConfigService: FeatureConfigService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule],
-        declarations: [
-          FacetListComponent,
-          MockIconComponent,
-          MockFacetComponent,
-          MockKeyboadFocusDirective,
-          MockFeatureDirective,
-        ],
-        providers: [
-          { provide: FacetService, useClass: MockFacetService },
-          {
-            provide: FeaturesConfig,
-            useValue: {
-              features: { level: '5.1' },
-            },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule],
+      declarations: [
+        FacetListComponent,
+        MockIconComponent,
+        MockFacetComponent,
+        MockKeyboadFocusDirective,
+        MockFeatureDirective,
+      ],
+      providers: [
+        { provide: FacetService, useClass: MockFacetService },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '5.1' },
           },
-        ],
-      })
-        .overrideComponent(FacetListComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+        },
+      ],
     })
-  );
+      .overrideComponent(FacetListComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FacetListComponent);

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.html
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.html
@@ -18,7 +18,7 @@
   <div>
     <!-- TODO: (CXSPA-6892) - Remove feature flag next major release. -->
     <a
-      *ngFor="let value of facet.values | slice: 0:state.topVisible"
+      *ngFor="let value of facet.values | slice: 0 : state.topVisible"
       #facetValue
       routerLink="./"
       [queryParams]="getLinkParams(value)"
@@ -45,7 +45,7 @@
       <a
         *ngFor="
           let value of facet.values
-            | slice: state.topVisible ?? 0:state.maxVisible
+            | slice: state.topVisible ?? 0 : state.maxVisible
         "
         #facetValue
         routerLink="./"

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.spec.ts
@@ -66,26 +66,24 @@ describe('FacetComponent', () => {
   let element: DebugElement;
   let facetService: FacetService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule],
-        declarations: [
-          FacetComponent,
-          MockCxIconComponent,
-          MockKeyboadFocusDirective,
-        ],
-        providers: [
-          { provide: FacetService, useClass: MockFacetService },
-          { provide: FeatureConfigService, useClass: MockFeatureConfigService },
-        ],
-      })
-        .overrideComponent(FacetComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule],
+      declarations: [
+        FacetComponent,
+        MockCxIconComponent,
+        MockKeyboadFocusDirective,
+      ],
+      providers: [
+        { provide: FacetService, useClass: MockFacetService },
+        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
+      ],
     })
-  );
+      .overrideComponent(FacetComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FacetComponent);

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.spec.ts
@@ -47,25 +47,23 @@ describe('ProductFacetNavigationComponent', () => {
   let fixture: ComponentFixture<ProductFacetNavigationComponent>;
   let element: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          ProductFacetNavigationComponent,
-          MockActiveFacetsComponent,
-          MockFacetListComponent,
-          MockCxIconComponent,
-        ],
-        providers: [
-          {
-            provide: BreakpointService,
-            useClass: MockBreakpointService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        ProductFacetNavigationComponent,
+        MockActiveFacetsComponent,
+        MockFacetListComponent,
+        MockCxIconComponent,
+      ],
+      providers: [
+        {
+          provide: BreakpointService,
+          useClass: MockBreakpointService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductFacetNavigationComponent);
@@ -78,16 +76,13 @@ describe('ProductFacetNavigationComponent', () => {
   });
 
   describe('mobile', () => {
-    it(
-      'should not have facet list when trigger button is visible',
-      waitForAsync(async () => {
-        await fixture.whenStable();
-        fixture.detectChanges();
+    it('should not have facet list when trigger button is visible', waitForAsync(async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
 
-        const facetList = element.query(By.css('cx-facet-list'));
-        expect(facetList).toBeNull();
-      })
-    );
+      const facetList = element.query(By.css('cx-facet-list'));
+      expect(facetList).toBeNull();
+    }));
 
     it('should invoke launch when trigger button is clicked', () => {
       spyOn(component, 'launch');
@@ -97,61 +92,46 @@ describe('ProductFacetNavigationComponent', () => {
       expect(component.launch).toHaveBeenCalled();
     });
 
-    it(
-      'should have facet list after trigger button is clicked',
-      waitForAsync(async () => {
-        fixture.detectChanges();
-        const button: HTMLElement = element.query(
-          By.css('button')
-        ).nativeElement;
-        button.click();
+    it('should have facet list after trigger button is clicked', waitForAsync(async () => {
+      fixture.detectChanges();
+      const button: HTMLElement = element.query(By.css('button')).nativeElement;
+      button.click();
 
-        await fixture.whenStable();
-        fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
 
-        const facetList = element.query(By.css('cx-facet-list')).nativeElement;
-        expect(facetList).toBeTruthy();
-      })
-    );
+      const facetList = element.query(By.css('cx-facet-list')).nativeElement;
+      expect(facetList).toBeTruthy();
+    }));
 
-    it(
-      'should invoke close when closeList is emitted',
-      waitForAsync(async () => {
-        spyOn(component, 'close');
-        fixture.detectChanges();
-        const button: HTMLElement = element.query(
-          By.css('button')
-        ).nativeElement;
-        button.click();
+    it('should invoke close when closeList is emitted', waitForAsync(async () => {
+      spyOn(component, 'close');
+      fixture.detectChanges();
+      const button: HTMLElement = element.query(By.css('button')).nativeElement;
+      button.click();
 
-        await fixture.whenStable();
-        fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
 
-        const facetList = element.query(By.css('cx-facet-list')).nativeElement;
-        facetList.dispatchEvent(new Event('closeList'));
+      const facetList = element.query(By.css('cx-facet-list')).nativeElement;
+      facetList.dispatchEvent(new Event('closeList'));
 
-        expect(component.close).toHaveBeenCalled();
-      })
-    );
+      expect(component.close).toHaveBeenCalled();
+    }));
   });
 
   describe('desktop', () => {
-    it(
-      'should have facet list when trigger button is hidden',
-      waitForAsync(async () => {
-        fixture.detectChanges();
+    it('should have facet list when trigger button is hidden', waitForAsync(async () => {
+      fixture.detectChanges();
 
-        const button: HTMLElement = element.query(
-          By.css('button')
-        ).nativeElement;
-        button.style.display = 'none';
+      const button: HTMLElement = element.query(By.css('button')).nativeElement;
+      button.style.display = 'none';
 
-        await fixture.whenStable();
-        fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
 
-        const facetList = element.query(By.css('cx-facet-list')).nativeElement;
-        expect(facetList).toBeTruthy();
-      })
-    );
+      const facetList = element.query(By.css('cx-facet-list')).nativeElement;
+      expect(facetList).toBeTruthy();
+    }));
   });
 });

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/services/product-facet.service.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/services/product-facet.service.ts
@@ -63,7 +63,7 @@ export class ProductFacetService {
         ({
           facets: result.facets,
           activeFacets: result.breadcrumbs,
-        } as FacetList)
+        }) as FacetList
     )
   );
 

--- a/projects/storefrontlib/cms-components/product/product-list/product-grid-item/product-grid-item.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-grid-item/product-grid-item.component.spec.ts
@@ -94,37 +94,35 @@ describe('ProductGridItemComponent in product-list', () => {
     },
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule, OutletModule],
-        declarations: [
-          ProductGridItemComponent,
-          MockMediaComponent,
-          MockAddToCartComponent,
-          MockStarRatingComponent,
-          MockUrlPipe,
-          MockCxIconComponent,
-          MockFeatureLevelDirective,
-          MockOutletDirective,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-        ],
-      })
-        .overrideComponent(ProductGridItemComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule, OutletModule],
+      declarations: [
+        ProductGridItemComponent,
+        MockMediaComponent,
+        MockAddToCartComponent,
+        MockStarRatingComponent,
+        MockUrlPipe,
+        MockCxIconComponent,
+        MockFeatureLevelDirective,
+        MockOutletDirective,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ProductGridItemComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductGridItemComponent);

--- a/projects/storefrontlib/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
@@ -94,37 +94,35 @@ describe('ProductListItemComponent in product-list', () => {
     },
   };
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule, OutletModule],
-        declarations: [
-          ProductListItemComponent,
-          MockPictureComponent,
-          MockAddToCartComponent,
-          MockStarRatingComponent,
-          MockUrlPipe,
-          MockCxIconComponent,
-          MockFeatureDirective,
-          MockOutletDirective,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: ProductService,
-            useClass: MockProductService,
-          },
-        ],
-      })
-        .overrideComponent(ProductListItemComponent, {
-          set: { changeDetection: ChangeDetectionStrategy.Default },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule, OutletModule],
+      declarations: [
+        ProductListItemComponent,
+        MockPictureComponent,
+        MockAddToCartComponent,
+        MockStarRatingComponent,
+        MockUrlPipe,
+        MockCxIconComponent,
+        MockFeatureDirective,
+        MockOutletDirective,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: ProductService,
+          useClass: MockProductService,
+        },
+      ],
     })
-  );
+      .overrideComponent(ProductListItemComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductListItemComponent);

--- a/projects/storefrontlib/cms-components/product/product-list/product-view/product-view.component.html
+++ b/projects/storefrontlib/cms-components/product/product-list/product-view/product-view.component.html
@@ -7,8 +7,8 @@
     viewMode === iconTypes.GRID
       ? ('productView.gridView' | cxTranslate)
       : viewMode === iconTypes.LIST
-      ? ('productView.listView' | cxTranslate)
-      : null
+        ? ('productView.listView' | cxTranslate)
+        : null
   }}"
 >
   <cx-icon

--- a/projects/storefrontlib/cms-components/product/product-list/product-view/product-view.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-view/product-view.component.spec.ts
@@ -17,14 +17,12 @@ describe('ProductViewComponent in product-list', () => {
   let component: ProductViewComponent;
   let fixture: ComponentFixture<ProductViewComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [NgSelectModule, FormsModule, I18nTestingModule],
-        declarations: [ProductViewComponent, MockCxIconComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [NgSelectModule, FormsModule, I18nTestingModule],
+      declarations: [ProductViewComponent, MockCxIconComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductViewComponent);

--- a/projects/storefrontlib/cms-components/product/product-summary/product-summary.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-summary/product-summary.component.spec.ts
@@ -23,20 +23,18 @@ describe('ProductSummaryComponent in product', () => {
   let currentProductService: CurrentProductService;
   let featureConfigService: FeatureConfigService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [ItemCounterModule, I18nTestingModule, RouterTestingModule],
-        declarations: [ProductSummaryComponent, OutletDirective],
-        providers: [
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ItemCounterModule, I18nTestingModule, RouterTestingModule],
+      declarations: [ProductSummaryComponent, OutletDirective],
+      providers: [
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductSummaryComponent);

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-attributes/product-attributes.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-attributes/product-attributes.component.spec.ts
@@ -57,20 +57,18 @@ describe('ProductAttributesComponent in product', () => {
   let productAttributesComponent: ProductAttributesComponent;
   let fixture: ComponentFixture<ProductAttributesComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [ProductAttributesComponent],
-        providers: [
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [ProductAttributesComponent],
+      providers: [
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductAttributesComponent);

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.spec.ts
@@ -66,27 +66,25 @@ describe('ProductDetailsTabComponent', () => {
   let productDetailsTabComponent: ProductDetailsTabComponent;
   let fixture: ComponentFixture<ProductDetailsTabComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ProductDetailsTabComponent],
-        providers: [
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-          {
-            provide: CmsComponentData,
-            useClass: MockCmsComponentData,
-          },
-          {
-            provide: CmsService,
-            useClass: MockCmsService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProductDetailsTabComponent],
+      providers: [
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+        {
+          provide: CmsComponentData,
+          useClass: MockCmsComponentData,
+        },
+        {
+          provide: CmsService,
+          useClass: MockCmsService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductDetailsTabComponent);

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.component.html
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.component.html
@@ -27,7 +27,7 @@
         <div
           class="review"
           tabindex="0"
-          *ngFor="let review of reviews | slice: 0:maxListItems"
+          *ngFor="let review of reviews | slice: 0 : maxListItems"
         >
           <div class="title">{{ review.headline }}</div>
           <cx-star-rating [rating]="review.rating ?? 0"></cx-star-rating>

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.component.spec.ts
@@ -47,33 +47,31 @@ describe('ProductReviewsComponent in product', () => {
   let productReviewsComponent: ProductReviewsComponent;
   let fixture: ComponentFixture<ProductReviewsComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          ItemCounterModule,
-          I18nTestingModule,
-          FormErrorsModule,
-        ],
-        providers: [
-          {
-            provide: ProductReviewService,
-            useClass: MockProductReviewService,
-          },
-          {
-            provide: CurrentProductService,
-            useClass: MockCurrentProductService,
-          },
-        ],
-        declarations: [
-          MockStarRatingComponent,
-          ProductReviewsComponent,
-          MockFeatureDirective,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        ItemCounterModule,
+        I18nTestingModule,
+        FormErrorsModule,
+      ],
+      providers: [
+        {
+          provide: ProductReviewService,
+          useClass: MockProductReviewService,
+        },
+        {
+          provide: CurrentProductService,
+          useClass: MockCurrentProductService,
+        },
+      ],
+      declarations: [
+        MockStarRatingComponent,
+        ProductReviewsComponent,
+        MockFeatureDirective,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProductReviewsComponent);

--- a/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.html
+++ b/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.html
@@ -89,13 +89,7 @@
       <div class="cx-modal-footer">
         <div class="row">
           <div
-            class="
-              cx-dialog-actions
-              col-sm-12 col-md-4
-              offset-md-8
-              col-lg-3
-              offset-lg-9
-            "
+            class="cx-dialog-actions col-sm-12 col-md-4 offset-md-8 col-lg-3 offset-lg-9"
           >
             <button
               class="btn btn-primary btn-block btn-ok"

--- a/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.spec.ts
@@ -42,25 +42,23 @@ describe('StockNotificationDialogComponent', () => {
     },
   ];
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [StockNotificationDialogComponent, FocusDirective],
-        imports: [
-          I18nTestingModule,
-          RouterTestingModule,
-          SpinnerModule,
-          UrlTestingModule,
-        ],
-        providers: [
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          { provide: UserInterestsService, useValue: interestsService },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [StockNotificationDialogComponent, FocusDirective],
+      imports: [
+        I18nTestingModule,
+        RouterTestingModule,
+        SpinnerModule,
+        UrlTestingModule,
+      ],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        { provide: UserInterestsService, useValue: interestsService },
+      ],
+    }).compileComponents();
 
-      launchDialogService = TestBed.inject(LaunchDialogService);
-    })
-  );
+    launchDialogService = TestBed.inject(LaunchDialogService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StockNotificationDialogComponent);

--- a/projects/storefrontlib/cms-components/product/stock-notification/stock-notification.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/stock-notification/stock-notification.component.spec.ts
@@ -118,35 +118,33 @@ describe('StockNotificationComponent', () => {
 
   let launchDialogService: LaunchDialogService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, RouterTestingModule, SpinnerModule],
-        declarations: [
-          StockNotificationComponent,
-          StockNotificationDialogComponent,
-          MockUrlPipe,
-          FocusDirective,
-        ],
-        providers: [
-          { provide: UserIdService, useValue: userIdService },
-          { provide: CurrentProductService, useValue: currentProductService },
-          { provide: GlobalMessageService, useValue: globalMessageService },
-          { provide: TranslationService, useValue: translationService },
-          { provide: LaunchDialogService, useClass: MockLaunchDialogService },
-          {
-            provide: UserNotificationPreferenceService,
-            useValue: notificationPrefService,
-          },
-          {
-            provide: StockNotificationDialogComponent,
-            useValue: dialogComponent,
-          },
-          { provide: UserInterestsService, useValue: interestsService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, RouterTestingModule, SpinnerModule],
+      declarations: [
+        StockNotificationComponent,
+        StockNotificationDialogComponent,
+        MockUrlPipe,
+        FocusDirective,
+      ],
+      providers: [
+        { provide: UserIdService, useValue: userIdService },
+        { provide: CurrentProductService, useValue: currentProductService },
+        { provide: GlobalMessageService, useValue: globalMessageService },
+        { provide: TranslationService, useValue: translationService },
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: UserNotificationPreferenceService,
+          useValue: notificationPrefService,
+        },
+        {
+          provide: StockNotificationDialogComponent,
+          useValue: dialogComponent,
+        },
+        { provide: UserInterestsService, useValue: interestsService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     userIdService.getUserId.and.returnValue(of(OCC_USER_ID_CURRENT));

--- a/projects/storefrontlib/cms-structure/outlet/outlet-ref/outlet-ref.directive.spec.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet-ref/outlet-ref.directive.spec.ts
@@ -55,22 +55,20 @@ function refreshOutlet(fixture: ComponentFixture<TestContainerComponent>) {
 describe('OutletRefDirective', () => {
   let service: OutletService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [],
-        declarations: [
-          TestContainerComponent,
-          OutletDirective,
-          OutletRefDirective,
-        ],
-        providers: [
-          OutletService,
-          { provide: DeferLoaderService, useClass: MockDeferLoaderService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [
+        TestContainerComponent,
+        OutletDirective,
+        OutletRefDirective,
+      ],
+      providers: [
+        OutletService,
+        { provide: DeferLoaderService, useClass: MockDeferLoaderService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     service = TestBed.inject(OutletService);

--- a/projects/storefrontlib/cms-structure/outlet/outlet.directive.spec.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet.directive.spec.ts
@@ -78,26 +78,24 @@ describe('OutletDirective', () => {
     })
     class MockOutletAfterComponent {}
 
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          imports: [],
-          declarations: [
-            MockTemplateComponent,
-            MockOutletBeforeComponent,
-            MockOutletAfterComponent,
-            OutletDirective,
-            OutletRefDirective,
-          ],
-          providers: [
-            {
-              provide: DeferLoaderService,
-              useClass: MockDeferLoaderService,
-            },
-          ],
-        }).compileComponents();
-      })
-    );
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [],
+        declarations: [
+          MockTemplateComponent,
+          MockOutletBeforeComponent,
+          MockOutletAfterComponent,
+          OutletDirective,
+          OutletRefDirective,
+        ],
+        providers: [
+          {
+            provide: DeferLoaderService,
+            useClass: MockDeferLoaderService,
+          },
+        ],
+      }).compileComponents();
+    }));
 
     it('should render the provided template ref', () => {
       const fixture = TestBed.createComponent(MockTemplateComponent);
@@ -178,25 +176,23 @@ describe('OutletDirective', () => {
 
     let compiled: HTMLElement;
 
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          imports: [],
-          declarations: [
-            MockStackedReplaceOutletComponent,
-            MockStackedBeforeOutletComponent,
-            OutletDirective,
-            OutletRefDirective,
-          ],
-          providers: [
-            {
-              provide: DeferLoaderService,
-              useClass: MockDeferLoaderService,
-            },
-          ],
-        }).compileComponents();
-      })
-    );
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [],
+        declarations: [
+          MockStackedReplaceOutletComponent,
+          MockStackedBeforeOutletComponent,
+          OutletDirective,
+          OutletRefDirective,
+        ],
+        providers: [
+          {
+            provide: DeferLoaderService,
+            useClass: MockDeferLoaderService,
+          },
+        ],
+      }).compileComponents();
+    }));
 
     it('should add two templates in outlet', () => {
       const fixture = TestBed.createComponent(
@@ -246,26 +242,24 @@ describe('OutletDirective', () => {
 
     let deferLoaderService: DeferLoaderService;
 
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          imports: [],
-          declarations: [
-            MockInstantOutletComponent,
-            MockDeferredOutletComponent,
-            OutletDirective,
-          ],
-          providers: [
-            {
-              provide: DeferLoaderService,
-              useClass: MockDeferLoaderService,
-            },
-          ],
-        }).compileComponents();
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [],
+        declarations: [
+          MockInstantOutletComponent,
+          MockDeferredOutletComponent,
+          OutletDirective,
+        ],
+        providers: [
+          {
+            provide: DeferLoaderService,
+            useClass: MockDeferLoaderService,
+          },
+        ],
+      }).compileComponents();
 
-        deferLoaderService = TestBed.inject(DeferLoaderService);
-      })
-    );
+      deferLoaderService = TestBed.inject(DeferLoaderService);
+    }));
 
     it('should use instant loading', () => {
       spyOn(deferLoaderService, 'load').and.callThrough();
@@ -296,22 +290,20 @@ describe('OutletDirective', () => {
 
     let hostFixture: ComponentFixture<HostComponent>;
 
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          imports: [],
-          declarations: [HostComponent, OutletDirective, OutletRefDirective],
-          providers: [
-            {
-              provide: DeferLoaderService,
-              useClass: MockDeferLoaderService,
-            },
-          ],
-        }).compileComponents();
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [],
+        declarations: [HostComponent, OutletDirective, OutletRefDirective],
+        providers: [
+          {
+            provide: DeferLoaderService,
+            useClass: MockDeferLoaderService,
+          },
+        ],
+      }).compileComponents();
 
-        hostFixture = TestBed.createComponent(HostComponent);
-      })
-    );
+      hostFixture = TestBed.createComponent(HostComponent);
+    }));
 
     function getContent(fixture: ComponentFixture<any>): string {
       return fixture.debugElement.nativeElement.innerText;
@@ -357,31 +349,29 @@ describe('OutletDirective', () => {
       constructor(public outlet: OutletContextData) {}
     }
 
-    beforeEach(
-      waitForAsync(() => {
-        mockContextSubject$ = new BehaviorSubject('fakeContext');
+    beforeEach(waitForAsync(() => {
+      mockContextSubject$ = new BehaviorSubject('fakeContext');
 
-        TestBed.configureTestingModule({
-          imports: [],
-          declarations: [
-            MockTemplateComponent,
-            MockOutletComponent,
-            OutletDirective,
-            OutletRefDirective,
-          ],
-          providers: [
-            {
-              provide: DeferLoaderService,
-              useClass: MockDeferLoaderService,
-            },
-            {
-              provide: 'mockContext',
-              useValue: mockContextSubject$,
-            },
-          ],
-        }).compileComponents();
-      })
-    );
+      TestBed.configureTestingModule({
+        imports: [],
+        declarations: [
+          MockTemplateComponent,
+          MockOutletComponent,
+          OutletDirective,
+          OutletRefDirective,
+        ],
+        providers: [
+          {
+            provide: DeferLoaderService,
+            useClass: MockDeferLoaderService,
+          },
+          {
+            provide: 'mockContext',
+            useValue: mockContextSubject$,
+          },
+        ],
+      }).compileComponents();
+    }));
 
     it('should render component', () => {
       const outletService = TestBed.inject(OutletService);
@@ -498,24 +488,22 @@ describe('OutletDirective', () => {
     })
     class MockOutletComponent {}
 
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          imports: [],
-          declarations: [
-            MockTestOutletComponent,
-            OutletDirective,
-            MockOutletComponent,
-          ],
-          providers: [
-            {
-              provide: DeferLoaderService,
-              useClass: MockDeferLoaderService,
-            },
-          ],
-        }).compileComponents();
-      })
-    );
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [],
+        declarations: [
+          MockTestOutletComponent,
+          OutletDirective,
+          MockOutletComponent,
+        ],
+        providers: [
+          {
+            provide: DeferLoaderService,
+            useClass: MockDeferLoaderService,
+          },
+        ],
+      }).compileComponents();
+    }));
 
     describe('with angular component', () => {
       it('should be able to get componentRef or viewRef', () => {

--- a/projects/storefrontlib/cms-structure/page/component/component-wrapper.directive.spec.ts
+++ b/projects/storefrontlib/cms-structure/page/component/component-wrapper.directive.spec.ts
@@ -143,15 +143,13 @@ describe('ComponentWrapperDirective', () => {
   describe('in SSR', () => {
     let cmsConfig: CmsConfig;
 
-    beforeEach(
-      waitForAsync(() => {
-        testBedConfig.providers.push({
-          provide: PLATFORM_ID,
-          useValue: 'server',
-        });
-        TestBed.configureTestingModule(testBedConfig).compileComponents();
-      })
-    );
+    beforeEach(waitForAsync(() => {
+      testBedConfig.providers.push({
+        provide: PLATFORM_ID,
+        useValue: 'server',
+      });
+      TestBed.configureTestingModule(testBedConfig).compileComponents();
+    }));
 
     describe('with angular component', () => {
       beforeEach(() => {
@@ -180,11 +178,9 @@ describe('ComponentWrapperDirective', () => {
   });
 
   describe('in non-SSR', () => {
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule(testBedConfig).compileComponents();
-      })
-    );
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule(testBedConfig).compileComponents();
+    }));
 
     describe('with angular component', () => {
       beforeEach(() => {

--- a/projects/storefrontlib/cms-structure/page/component/inner-components-host.directive.spec.ts
+++ b/projects/storefrontlib/cms-structure/page/component/inner-components-host.directive.spec.ts
@@ -103,45 +103,43 @@ describe('InnerComponentsHostDirective', () => {
   describe('UI tests', () => {
     let fixture: ComponentFixture<HostComponent>;
 
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          imports: [PageComponentModule.forRoot()],
-          declarations: [
-            HostComponent,
-            InnerComponentsHostDirective,
-            ComponentWrapperDirective,
-          ],
-          providers: [
-            Renderer2,
-            { provide: CmsConfig, useValue: MockCmsModuleConfig },
-            { provide: CmsService, useClass: MockCmsService },
-            {
-              provide: DynamicAttributeService,
-              useClass: MockDynamicAttributeService,
-            },
-            {
-              provide: ComponentHandler,
-              useExisting: WebComponentHandler,
-              multi: true,
-            },
-            {
-              provide: CxApiService,
-              useValue: { cms: {}, auth: {}, routing: {} },
-            },
-            {
-              provide: ConfigInitializerService,
-              useClass: MockConfigInitializerService,
-            },
-            {
-              provide: CmsComponentData,
-              useValue: MockCmsComponentData,
-            },
-          ],
-        }).compileComponents();
-        fixture = TestBed.createComponent(HostComponent);
-      })
-    );
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [PageComponentModule.forRoot()],
+        declarations: [
+          HostComponent,
+          InnerComponentsHostDirective,
+          ComponentWrapperDirective,
+        ],
+        providers: [
+          Renderer2,
+          { provide: CmsConfig, useValue: MockCmsModuleConfig },
+          { provide: CmsService, useClass: MockCmsService },
+          {
+            provide: DynamicAttributeService,
+            useClass: MockDynamicAttributeService,
+          },
+          {
+            provide: ComponentHandler,
+            useExisting: WebComponentHandler,
+            multi: true,
+          },
+          {
+            provide: CxApiService,
+            useValue: { cms: {}, auth: {}, routing: {} },
+          },
+          {
+            provide: ConfigInitializerService,
+            useClass: MockConfigInitializerService,
+          },
+          {
+            provide: CmsComponentData,
+            useValue: MockCmsComponentData,
+          },
+        ],
+      }).compileComponents();
+      fixture = TestBed.createComponent(HostComponent);
+    }));
 
     it('should render inner components', () => {
       fixture.detectChanges();

--- a/projects/storefrontlib/cms-structure/page/page-layout/page-layout.component.spec.ts
+++ b/projects/storefrontlib/cms-structure/page/page-layout/page-layout.component.spec.ts
@@ -156,13 +156,11 @@ describe('SectionLayoutComponent', () => {
   let sectionLayoutComponent: MockHeaderComponent;
   let fixture: ComponentFixture<MockHeaderComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [TestModule],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestModule],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MockHeaderComponent);

--- a/projects/storefrontlib/cms-structure/pwa/components/add-to-home-screen.components.spec.ts
+++ b/projects/storefrontlib/cms-structure/pwa/components/add-to-home-screen.components.spec.ts
@@ -25,21 +25,19 @@ describe('AddToHomeScreenComponent', () => {
   let fixture: ComponentFixture<ExampleAddToHomeScreenComponent>;
   let mockAddToHomeScreenService: AddToHomeScreenService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ExampleAddToHomeScreenComponent],
-        providers: [
-          {
-            provide: AddToHomeScreenService,
-            useClass: MockAddToHomeScreenService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ExampleAddToHomeScreenComponent],
+      providers: [
+        {
+          provide: AddToHomeScreenService,
+          useClass: MockAddToHomeScreenService,
+        },
+      ],
+    }).compileComponents();
 
-      mockAddToHomeScreenService = TestBed.inject(AddToHomeScreenService);
-    })
-  );
+    mockAddToHomeScreenService = TestBed.inject(AddToHomeScreenService);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ExampleAddToHomeScreenComponent);

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.directive.spec.ts
@@ -51,22 +51,20 @@ class MockAutoFocusService {
 describe('AutoFocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
   let service: AutoFocusService;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent, CustomFocusDirective],
-        providers: [
-          {
-            provide: AutoFocusService,
-            useClass: MockAutoFocusService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent, CustomFocusDirective],
+      providers: [
+        {
+          provide: AutoFocusService,
+          useClass: MockAutoFocusService,
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MockComponent);
-      service = TestBed.inject(AutoFocusService);
-    })
-  );
+    fixture = TestBed.createComponent(MockComponent);
+    service = TestBed.inject(AutoFocusService);
+  }));
 
   const event = {
     preventDefault: () => {},

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.service.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.service.spec.ts
@@ -37,25 +37,23 @@ describe('AutoFocusService', () => {
 
   let fixture: ComponentFixture<MockComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent],
-        providers: [
-          AutoFocusService,
-          {
-            provide: SelectFocusUtility,
-            useClass: MockSelectFocusUtility,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent],
+      providers: [
+        AutoFocusService,
+        {
+          provide: SelectFocusUtility,
+          useClass: MockSelectFocusUtility,
+        },
+      ],
+    }).compileComponents();
 
-      service = TestBed.inject(AutoFocusService);
-      focusUtility = TestBed.inject(SelectFocusUtility);
+    service = TestBed.inject(AutoFocusService);
+    focusUtility = TestBed.inject(SelectFocusUtility);
 
-      fixture = TestBed.createComponent(MockComponent);
-    })
-  );
+    fixture = TestBed.createComponent(MockComponent);
+  }));
 
   it('should inject service', () => {
     expect(service).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/base/base-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/base/base-focus.directive.spec.ts
@@ -36,23 +36,21 @@ class MockBaseFocusService {}
 describe('BaseFocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [CustomFocusDirective, MockComponent],
-        providers: [
-          {
-            provide: BaseFocusService,
-            useClass: MockBaseFocusService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [CustomFocusDirective, MockComponent],
+      providers: [
+        {
+          provide: BaseFocusService,
+          useClass: MockBaseFocusService,
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MockComponent);
+    fixture = TestBed.createComponent(MockComponent);
 
-      fixture.detectChanges();
-    })
-  );
+    fixture.detectChanges();
+  }));
 
   it('should default tabindex to -1', () => {
     const el: HTMLElement = fixture.debugElement.query(

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/base/base-focus.service.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/base/base-focus.service.spec.ts
@@ -7,16 +7,14 @@ class MockComponent {}
 describe('BaseFocusService', () => {
   let service: BaseFocusService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent],
-        providers: [BaseFocusService],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent],
+      providers: [BaseFocusService],
+    }).compileComponents();
 
-      service = TestBed.inject(BaseFocusService);
-    })
-  );
+    service = TestBed.inject(BaseFocusService);
+  }));
 
   it('should inject service', () => {
     expect(service).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/block/block-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/block/block-focus.directive.spec.ts
@@ -26,20 +26,18 @@ class MockBaseFocusService {}
 
 describe('BlockFocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent, CustomFocusDirective],
-        providers: [
-          {
-            provide: BaseFocusService,
-            useClass: MockBaseFocusService,
-          },
-        ],
-      }).compileComponents();
-      fixture = TestBed.createComponent(MockComponent);
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent, CustomFocusDirective],
+      providers: [
+        {
+          provide: BaseFocusService,
+          useClass: MockBaseFocusService,
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(MockComponent);
+  }));
 
   beforeEach(() => {
     fixture.detectChanges();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/escape/escape-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/escape/escape-focus.directive.spec.ts
@@ -60,30 +60,28 @@ describe('EscapeFocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
   let service: EscapeFocusService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent, CustomFocusDirective],
-        providers: [
-          {
-            provide: EscapeFocusService,
-            useClass: MockEscapeFocusService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent, CustomFocusDirective],
+      providers: [
+        {
+          provide: EscapeFocusService,
+          useClass: MockEscapeFocusService,
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MockComponent);
-      component = fixture.componentInstance;
-      service = TestBed.inject(EscapeFocusService);
+    fixture = TestBed.createComponent(MockComponent);
+    component = fixture.componentInstance;
+    service = TestBed.inject(EscapeFocusService);
 
-      spyOn(service, 'shouldFocus').and.callThrough();
-      spyOn(service, 'handleEscape').and.callThrough();
+    spyOn(service, 'shouldFocus').and.callThrough();
+    spyOn(service, 'handleEscape').and.callThrough();
 
-      spyOn(component, 'handleEmit');
+    spyOn(component, 'handleEmit');
 
-      fixture.detectChanges();
-    })
-  );
+    fixture.detectChanges();
+  }));
 
   describe('config', () => {
     it('should use focusOnEscape by default', () => {

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/escape/escape-focus.service.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/escape/escape-focus.service.spec.ts
@@ -16,25 +16,23 @@ describe('EscapeFocusService', () => {
   let focusUtility: SelectFocusUtility;
   let fixture: ComponentFixture<MockComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent],
-        providers: [
-          EscapeFocusService,
-          {
-            provide: SelectFocusUtility,
-            useClass: MockSelectFocusUtility,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent],
+      providers: [
+        EscapeFocusService,
+        {
+          provide: SelectFocusUtility,
+          useClass: MockSelectFocusUtility,
+        },
+      ],
+    }).compileComponents();
 
-      service = TestBed.inject(EscapeFocusService);
-      focusUtility = TestBed.inject(SelectFocusUtility);
+    service = TestBed.inject(EscapeFocusService);
+    focusUtility = TestBed.inject(SelectFocusUtility);
 
-      fixture = TestBed.createComponent(MockComponent);
-    })
-  );
+    fixture = TestBed.createComponent(MockComponent);
+  }));
 
   it('should inject service', () => {
     expect(service).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/focus.directive.spec.ts
@@ -30,24 +30,22 @@ describe('FocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
   let keyboardFocusService: KeyboardFocusService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [FocusDirective, MockComponent],
-        providers: [
-          {
-            provide: KeyboardFocusService,
-            useClass: MockKeyboardFocusService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [FocusDirective, MockComponent],
+      providers: [
+        {
+          provide: KeyboardFocusService,
+          useClass: MockKeyboardFocusService,
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MockComponent);
+    fixture = TestBed.createComponent(MockComponent);
 
-      component = fixture.componentInstance;
-      keyboardFocusService = TestBed.inject(KeyboardFocusService);
-    })
-  );
+    component = fixture.componentInstance;
+    keyboardFocusService = TestBed.inject(KeyboardFocusService);
+  }));
 
   it('should be created', () => {
     expect(component).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/lock/lock-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/lock/lock-focus.directive.spec.ts
@@ -79,22 +79,20 @@ class MockLockFocusService {
 describe('LockFocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
   let service: LockFocusService;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent, CustomFocusDirective],
-        providers: [
-          {
-            provide: LockFocusService,
-            useClass: MockLockFocusService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent, CustomFocusDirective],
+      providers: [
+        {
+          provide: LockFocusService,
+          useClass: MockLockFocusService,
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MockComponent);
-      service = TestBed.inject(LockFocusService);
-    })
-  );
+    fixture = TestBed.createComponent(MockComponent);
+    service = TestBed.inject(LockFocusService);
+  }));
 
   beforeEach(() => {
     const children = fixture.debugElement.queryAll(

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/lock/lock-focus.service.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/lock/lock-focus.service.spec.ts
@@ -12,21 +12,19 @@ class MockSelectFocusUtility {
 describe('LockFocusService', () => {
   let service: LockFocusService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          LockFocusService,
-          {
-            provide: SelectFocusUtility,
-            useClass: MockSelectFocusUtility,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LockFocusService,
+        {
+          provide: SelectFocusUtility,
+          useClass: MockSelectFocusUtility,
+        },
+      ],
+    }).compileComponents();
 
-      service = TestBed.inject(LockFocusService);
-    })
-  );
+    service = TestBed.inject(LockFocusService);
+  }));
 
   it('should inject service', () => {
     expect(service).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/persist/persist-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/persist/persist-focus.directive.spec.ts
@@ -37,26 +37,24 @@ describe('PersistFocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
   let service: PersistFocusService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent, CustomFocusDirective],
-        providers: [
-          {
-            provide: PersistFocusService,
-            useClass: MockPersistFocusService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent, CustomFocusDirective],
+      providers: [
+        {
+          provide: PersistFocusService,
+          useClass: MockPersistFocusService,
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MockComponent);
-      component = fixture.componentInstance;
-      service = TestBed.inject(PersistFocusService);
+    fixture = TestBed.createComponent(MockComponent);
+    component = fixture.componentInstance;
+    service = TestBed.inject(PersistFocusService);
 
-      spyOn(service, 'get').and.callThrough();
-      spyOn(service, 'set').and.callThrough();
-    })
-  );
+    spyOn(service, 'get').and.callThrough();
+    spyOn(service, 'set').and.callThrough();
+  }));
 
   it('should create component', () => {
     expect(component).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/persist/persist-focus.service.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/persist/persist-focus.service.spec.ts
@@ -18,23 +18,21 @@ describe('PersistFocusService', () => {
   let service: PersistFocusService;
   let fixture: ComponentFixture<MockComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent],
-        providers: [
-          PersistFocusService,
-          {
-            provide: SelectFocusUtility,
-            useClass: MockSelectFocusUtility,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent],
+      providers: [
+        PersistFocusService,
+        {
+          provide: SelectFocusUtility,
+          useClass: MockSelectFocusUtility,
+        },
+      ],
+    }).compileComponents();
 
-      service = TestBed.inject(PersistFocusService);
-      fixture = TestBed.createComponent(MockComponent);
-    })
-  );
+    service = TestBed.inject(PersistFocusService);
+    fixture = TestBed.createComponent(MockComponent);
+  }));
 
   it('should inject service', () => {
     expect(service).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/services/keyboard-focus.service.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/services/keyboard-focus.service.spec.ts
@@ -4,15 +4,13 @@ import { KeyboardFocusService } from './keyboard-focus.service';
 describe('KeyboardFocusService', () => {
   let service: KeyboardFocusService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [KeyboardFocusService],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [KeyboardFocusService],
+    }).compileComponents();
 
-      service = TestBed.inject(KeyboardFocusService);
-    })
-  );
+    service = TestBed.inject(KeyboardFocusService);
+  }));
 
   it('should inject service', () => {
     expect(service).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/services/select-focus.util.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/services/select-focus.util.spec.ts
@@ -57,17 +57,15 @@ describe('SelectFocusUtility', () => {
   let service: SelectFocusUtility;
   let fixture: ComponentFixture<MockComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent],
-        providers: [SelectFocusUtility],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent],
+      providers: [SelectFocusUtility],
+    }).compileComponents();
 
-      service = TestBed.inject(SelectFocusUtility);
-      fixture = TestBed.createComponent(MockComponent);
-    })
-  );
+    service = TestBed.inject(SelectFocusUtility);
+    fixture = TestBed.createComponent(MockComponent);
+  }));
 
   it('should inject service', () => {
     expect(service).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/tab/tab-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/tab/tab-focus.directive.spec.ts
@@ -31,22 +31,20 @@ class MockTabFocusService {
 describe('TabFocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
   let service: TabFocusService;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent, CustomFocusDirective],
-        providers: [
-          {
-            provide: TabFocusService,
-            useClass: MockTabFocusService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent, CustomFocusDirective],
+      providers: [
+        {
+          provide: TabFocusService,
+          useClass: MockTabFocusService,
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MockComponent);
-      service = TestBed.inject(TabFocusService);
-    })
-  );
+    fixture = TestBed.createComponent(MockComponent);
+    service = TestBed.inject(TabFocusService);
+  }));
 
   const event = {
     preventDefault: () => {},

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/tab/tab-focus.service.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/tab/tab-focus.service.spec.ts
@@ -34,23 +34,21 @@ describe('TabFocusService', () => {
   let service: TabFocusService;
   let fixture: ComponentFixture<MockComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent],
-        providers: [
-          TabFocusService,
-          {
-            provide: SelectFocusUtility,
-            useClass: MockSelectFocusUtility,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent],
+      providers: [
+        TabFocusService,
+        {
+          provide: SelectFocusUtility,
+          useClass: MockSelectFocusUtility,
+        },
+      ],
+    }).compileComponents();
 
-      service = TestBed.inject(TabFocusService);
-      fixture = TestBed.createComponent(MockComponent);
-    })
-  );
+    service = TestBed.inject(TabFocusService);
+    fixture = TestBed.createComponent(MockComponent);
+  }));
 
   it('should inject service', () => {
     expect(service).toBeTruthy();

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/trap/trap-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/trap/trap-focus.directive.spec.ts
@@ -33,22 +33,20 @@ class MockTrapFocusService {
 describe('TrapFocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
   let service: TrapFocusService;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [MockComponent, CustomFocusDirective],
-        providers: [
-          {
-            provide: TrapFocusService,
-            useClass: MockTrapFocusService,
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockComponent, CustomFocusDirective],
+      providers: [
+        {
+          provide: TrapFocusService,
+          useClass: MockTrapFocusService,
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(MockComponent);
-      service = TestBed.inject(TrapFocusService);
-    })
-  );
+    fixture = TestBed.createComponent(MockComponent);
+    service = TestBed.inject(TrapFocusService);
+  }));
 
   const event = {
     preventDefault: () => {},

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/visible/visible-focus.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/visible/visible-focus.directive.spec.ts
@@ -90,24 +90,22 @@ const MockTabKeyEvent = {
 
 describe('VisibleFocusDirective', () => {
   let fixture: ComponentFixture<MockComponent>;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          MockComponent,
-          CustomFocusDirective,
-          CustomFakeFocusDirective,
-        ],
-        providers: [
-          {
-            provide: BaseFocusService,
-            useClass: MockVisibleFocusService,
-          },
-        ],
-      }).compileComponents();
-      fixture = TestBed.createComponent(MockComponent);
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        MockComponent,
+        CustomFocusDirective,
+        CustomFakeFocusDirective,
+      ],
+      providers: [
+        {
+          provide: BaseFocusService,
+          useClass: MockVisibleFocusService,
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(MockComponent);
+  }));
 
   beforeEach(() => {
     fixture.detectChanges();

--- a/projects/storefrontlib/layout/a11y/skip-link/component/skip-link.component.spec.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/component/skip-link.component.spec.ts
@@ -44,21 +44,19 @@ describe('SkipLinkComponent', () => {
   let skipLinkComponent: SkipLinkComponent;
   let fixture: ComponentFixture<SkipLinkComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [SkipLinkComponent, MockFocusDirective],
-        providers: [
-          {
-            provide: SkipLinkConfig,
-            useValue: { skipLinks: [mockSkipLinks] },
-          },
-          { provide: SkipLinkService, useClass: MockSkipLinkService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [SkipLinkComponent, MockFocusDirective],
+      providers: [
+        {
+          provide: SkipLinkConfig,
+          useValue: { skipLinks: [mockSkipLinks] },
+        },
+        { provide: SkipLinkService, useClass: MockSkipLinkService },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(async () => {
     fixture = TestBed.createComponent(SkipLinkComponent);

--- a/projects/storefrontlib/layout/a11y/skip-link/directive/skip-link.directive.spec.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/directive/skip-link.directive.spec.ts
@@ -18,21 +18,19 @@ describe('SkipLinkDirective', () => {
   let fixture: ComponentFixture<TestContainerComponent>;
   let service: SkipLinkService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [],
-        declarations: [TestContainerComponent, SkipLinkDirective],
-        providers: [
-          SkipLinkService,
-          {
-            provide: SkipLinkConfig,
-            useValue: { skipLinks: [] },
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [TestContainerComponent, SkipLinkDirective],
+      providers: [
+        SkipLinkService,
+        {
+          provide: SkipLinkConfig,
+          useValue: { skipLinks: [] },
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestContainerComponent);

--- a/projects/storefrontlib/layout/a11y/skip-link/service/skip-link.service.spec.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/service/skip-link.service.spec.ts
@@ -48,25 +48,23 @@ describe('SkipLinkService', () => {
   let keyboardFocusService: KeyboardFocusService;
   let skipLinks: SkipLink[];
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [TestContainerComponent],
-        providers: [
-          SkipLinkService,
-          {
-            provide: SkipLinkConfig,
-            useValue: MockSkipLinkConfig,
-          },
-          {
-            provide: KeyboardFocusService,
-            useClass: MockKeyboadFocusService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [TestContainerComponent],
+      providers: [
+        SkipLinkService,
+        {
+          provide: SkipLinkConfig,
+          useValue: MockSkipLinkConfig,
+        },
+        {
+          provide: KeyboardFocusService,
+          useClass: MockKeyboadFocusService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestContainerComponent);

--- a/projects/storefrontlib/layout/main/storefront.component.spec.ts
+++ b/projects/storefrontlib/layout/main/storefront.component.spec.ts
@@ -67,34 +67,32 @@ describe('StorefrontComponent', () => {
   let el: DebugElement;
   let routingService: RoutingService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
-        declarations: [
-          StorefrontComponent,
-          MockHeaderComponent,
-          MockGlobalMessageComponent,
-          MockFooterComponent,
-          DynamicSlotComponent,
-          MockPageLayoutComponent,
-          MockFeatureDirective,
-          MockSchemaComponent,
-          MockOutletDirective,
-        ],
-        providers: [
-          {
-            provide: RoutingService,
-            useClass: MockRoutingService,
-          },
-          {
-            provide: HamburgerMenuService,
-            useClass: MockHamburgerMenuService,
-          },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [
+        StorefrontComponent,
+        MockHeaderComponent,
+        MockGlobalMessageComponent,
+        MockFooterComponent,
+        DynamicSlotComponent,
+        MockPageLayoutComponent,
+        MockFeatureDirective,
+        MockSchemaComponent,
+        MockOutletDirective,
+      ],
+      providers: [
+        {
+          provide: RoutingService,
+          useClass: MockRoutingService,
+        },
+        {
+          provide: HamburgerMenuService,
+          useClass: MockHamburgerMenuService,
+        },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StorefrontComponent);

--- a/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.spec.ts
+++ b/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.spec.ts
@@ -76,38 +76,36 @@ describe('AnonymousConsentsDialogComponent', () => {
   let anonymousConsentsConfig: AnonymousConsentsConfig;
   let launchDialogService: LaunchDialogService;
 
-  beforeEach(
-    waitForAsync(() => {
-      const mockConfig: AnonymousConsentsConfig = {
-        anonymousConsents: { showLegalDescriptionInDialog: true },
-      };
+  beforeEach(waitForAsync(() => {
+    const mockConfig: AnonymousConsentsConfig = {
+      anonymousConsents: { showLegalDescriptionInDialog: true },
+    };
 
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule, KeyboardFocusTestingModule],
-        declarations: [
-          AnonymousConsentDialogComponent,
-          MockCxIconComponent,
-          MockConsentManagementFormComponent,
-          MockCxSpinnerComponent,
-        ],
-        providers: [
-          {
-            provide: AnonymousConsentsService,
-            useClass: MockAnonymousConsentsService,
-          },
-          {
-            provide: AnonymousConsentsConfig,
-            useValue: mockConfig,
-          },
-          {
-            provide: LaunchDialogService,
-            useClass: MockLaunchDialogService,
-          },
-        ],
-        schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      }).compileComponents();
-    })
-  );
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule, KeyboardFocusTestingModule],
+      declarations: [
+        AnonymousConsentDialogComponent,
+        MockCxIconComponent,
+        MockConsentManagementFormComponent,
+        MockCxSpinnerComponent,
+      ],
+      providers: [
+        {
+          provide: AnonymousConsentsService,
+          useClass: MockAnonymousConsentsService,
+        },
+        {
+          provide: AnonymousConsentsConfig,
+          useValue: mockConfig,
+        },
+        {
+          provide: LaunchDialogService,
+          useClass: MockLaunchDialogService,
+        },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AnonymousConsentDialogComponent);

--- a/projects/storefrontlib/shared/components/card/card.component.spec.ts
+++ b/projects/storefrontlib/shared/components/card/card.component.spec.ts
@@ -69,21 +69,19 @@ describe('CardComponent', () => {
   let fixture: ComponentFixture<CardComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [
-          CardComponent,
-          MockCxIconComponent,
-          MockAtMessageDirective,
-          FocusDirective,
-          MockCxTruncateTextPopoverComponent,
-          MockFeatureDirective,
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        CardComponent,
+        MockCxIconComponent,
+        MockAtMessageDirective,
+        FocusDirective,
+        MockCxTruncateTextPopoverComponent,
+        MockFeatureDirective,
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CardComponent);

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.html
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.html
@@ -21,7 +21,7 @@
           [class.active]="i === activeSlide"
         >
           <ng-container
-            *ngFor="let item of items | slice: i:i + size; let j = index"
+            *ngFor="let item of items | slice: i : i + size; let j = index"
           >
             <div
               *ngIf="item | async as data"

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
@@ -49,22 +49,18 @@ describe('Carousel Component', () => {
 
   let templateFixture: ComponentFixture<MockTemplateComponent>;
   let template;
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [
-          CarouselComponent,
-          MockCxIconComponent,
-          MockTemplateComponent,
-          MockFeatureDirective,
-        ],
-        providers: [
-          { provide: CarouselService, useClass: MockCarouselService },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [
+        CarouselComponent,
+        MockCxIconComponent,
+        MockTemplateComponent,
+        MockFeatureDirective,
+      ],
+      providers: [{ provide: CarouselService, useClass: MockCarouselService }],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CarouselComponent);

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.ts
@@ -87,7 +87,10 @@ export class CarouselComponent implements OnInit {
 
   protected logger = inject(LoggerService);
 
-  constructor(protected el: ElementRef, protected service: CarouselService) {
+  constructor(
+    protected el: ElementRef,
+    protected service: CarouselService
+  ) {
     useFeatureStyles('a11yFocusableCarouselControls');
   }
 

--- a/projects/storefrontlib/shared/components/form/form-errors/form-errors.component.spec.ts
+++ b/projects/storefrontlib/shared/components/form/form-errors/form-errors.component.spec.ts
@@ -25,21 +25,19 @@ describe('FormErrors', () => {
 
   const getContent = () => fixture.debugElement.nativeElement.innerText;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        providers: [
-          FeatureConfigService,
-          {
-            provide: FeatureConfigService,
-            useClass: MockFeatureConfigService,
-          },
-        ],
-        declarations: [FormErrorsComponent, MockFeatureDirective],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      providers: [
+        FeatureConfigService,
+        {
+          provide: FeatureConfigService,
+          useClass: MockFeatureConfigService,
+        },
+      ],
+      declarations: [FormErrorsComponent, MockFeatureDirective],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FormErrorsComponent);

--- a/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.component.spec.ts
+++ b/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.component.spec.ts
@@ -23,27 +23,25 @@ describe('PasswordVisibilityToggleComponent', () => {
   let fixture: ComponentFixture<PasswordVisibilityToggleComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          IconTestingModule,
-          FormsModule,
-          ReactiveFormsModule,
-          PasswordVisibilityToggleModule,
-        ],
-        declarations: [PasswordVisibilityToggleComponent],
-        providers: [
-          {
-            provide: FormConfig,
-            useValue: mockFormConfig,
-          },
-          { provide: WindowRef, useClass: MockWinRef },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        IconTestingModule,
+        FormsModule,
+        ReactiveFormsModule,
+        PasswordVisibilityToggleModule,
+      ],
+      declarations: [PasswordVisibilityToggleComponent],
+      providers: [
+        {
+          provide: FormConfig,
+          useValue: mockFormConfig,
+        },
+        { provide: WindowRef, useClass: MockWinRef },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PasswordVisibilityToggleComponent);

--- a/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.directive.spec.ts
+++ b/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.directive.spec.ts
@@ -51,27 +51,25 @@ describe('PasswordVisibilityToggleDirective', () => {
   let fixture: ComponentFixture<MockFormComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          IconTestingModule,
-          FormsModule,
-          ReactiveFormsModule,
-          PasswordVisibilityToggleModule,
-        ],
-        declarations: [MockFormComponent],
-        providers: [
-          {
-            provide: FormConfig,
-            useValue: mockFormConfig,
-          },
-          { provide: WindowRef, useClass: MockWinRef },
-        ],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        IconTestingModule,
+        FormsModule,
+        ReactiveFormsModule,
+        PasswordVisibilityToggleModule,
+      ],
+      declarations: [MockFormComponent],
+      providers: [
+        {
+          provide: FormConfig,
+          useValue: mockFormConfig,
+        },
+        { provide: WindowRef, useClass: MockWinRef },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MockFormComponent);

--- a/projects/storefrontlib/shared/components/item-counter/item-counter.component.spec.ts
+++ b/projects/storefrontlib/shared/components/item-counter/item-counter.component.spec.ts
@@ -18,14 +18,12 @@ describe('ItemCounterComponent', () => {
   let component: ItemCounterComponent;
   let fixture: ComponentFixture<ItemCounterComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
-        declarations: [ItemCounterComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      declarations: [ItemCounterComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ItemCounterComponent);
@@ -51,44 +49,35 @@ describe('ItemCounterComponent', () => {
     expect(input.value).toEqual('5');
   });
 
-  it(
-    'should update the form control when the input is changed',
-    waitForAsync(() => {
-      const input: HTMLInputElement = fixture.debugElement.query(
-        By.css('input')
-      ).nativeElement;
+  it('should update the form control when the input is changed', waitForAsync(() => {
+    const input: HTMLInputElement = fixture.debugElement.query(
+      By.css('input')
+    ).nativeElement;
 
-      input.focus();
-      input.value = '10';
-      input.dispatchEvent(new Event('input'));
-      fixture.detectChanges();
+    input.focus();
+    input.value = '10';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
 
-      expect(component.control.value).toEqual(10);
-    })
-  );
+    expect(component.control.value).toEqual(10);
+  }));
 
   describe('readonly', () => {
-    it(
-      'should add readonly class',
-      waitForAsync(() => {
-        component.readonly = true;
-        fixture.detectChanges();
-        expect(
-          (<HTMLElement>fixture.debugElement.nativeElement).classList
-        ).toContain('readonly');
-      })
-    );
+    it('should add readonly class', waitForAsync(() => {
+      component.readonly = true;
+      fixture.detectChanges();
+      expect(
+        (<HTMLElement>fixture.debugElement.nativeElement).classList
+      ).toContain('readonly');
+    }));
 
-    it(
-      'should not add readonly class',
-      waitForAsync(() => {
-        component.readonly = false;
-        fixture.detectChanges();
-        expect(
-          (<HTMLElement>fixture.debugElement.nativeElement).classList
-        ).not.toContain('readonly');
-      })
-    );
+    it('should not add readonly class', waitForAsync(() => {
+      component.readonly = false;
+      fixture.detectChanges();
+      expect(
+        (<HTMLElement>fixture.debugElement.nativeElement).classList
+      ).not.toContain('readonly');
+    }));
   });
 
   describe('validate value', () => {
@@ -108,21 +97,18 @@ describe('ItemCounterComponent', () => {
       expect(component.control.value).toEqual(3);
     });
 
-    it(
-      'should avoid invalid characters in the input to silently fail',
-      waitForAsync(() => {
-        component.min = 5;
-        const input: HTMLInputElement = fixture.debugElement.query(
-          By.css('input')
-        ).nativeElement;
+    it('should avoid invalid characters in the input to silently fail', waitForAsync(() => {
+      component.min = 5;
+      const input: HTMLInputElement = fixture.debugElement.query(
+        By.css('input')
+      ).nativeElement;
 
-        input.value = 'abc';
-        input.dispatchEvent(new Event('input'));
-        fixture.detectChanges();
+      input.value = 'abc';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
 
-        expect(input.value).toEqual('5');
-      })
-    );
+      expect(input.value).toEqual('5');
+    }));
 
     it('should ignore 0 value in case `allowZero` is set to true', () => {
       component.allowZero = true;

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.builder.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.builder.ts
@@ -135,8 +135,8 @@ export class PaginationBuilder {
       const type = isGap
         ? PaginationItemType.GAP
         : isSubstituted
-        ? PaginationItemType.FIRST
-        : PaginationItemType.PAGE;
+          ? PaginationItemType.FIRST
+          : PaginationItemType.PAGE;
       return [
         Object.assign(
           {
@@ -172,8 +172,8 @@ export class PaginationBuilder {
       const type = isGap
         ? PaginationItemType.GAP
         : isSubstituted
-        ? PaginationItemType.LAST
-        : PaginationItemType.PAGE;
+          ? PaginationItemType.LAST
+          : PaginationItemType.PAGE;
       return [
         Object.assign(
           {

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.component.spec.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.component.spec.ts
@@ -24,22 +24,20 @@ describe('PaginationComponent', () => {
   let fixture: ComponentFixture<PaginationComponent>;
   let debugEl: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule, I18nTestingModule],
-        declarations: [PaginationComponent, MockFeatureDirective],
-        providers: [
-          {
-            provide: PaginationConfig,
-            useValue: mockPaginationConfig,
-          },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, I18nTestingModule],
+      declarations: [PaginationComponent, MockFeatureDirective],
+      providers: [
+        {
+          provide: PaginationConfig,
+          useValue: mockPaginationConfig,
+        },
 
-          { provide: ActivatedRoute, useValue: mockActivatedRoute },
-        ],
-      }).compileComponents();
-    })
-  );
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+      ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PaginationComponent);

--- a/projects/storefrontlib/shared/components/list-navigation/sorting/sorting.component.spec.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/sorting/sorting.component.spec.ts
@@ -16,14 +16,12 @@ describe('SortingComponent', () => {
   let component: SortingComponent;
   let fixture: ComponentFixture<SortingComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [NgSelectModule, FormsModule, I18nTestingModule],
-        declarations: [SortingComponent, MockNgSelectA11yDirective],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [NgSelectModule, FormsModule, I18nTestingModule],
+      declarations: [SortingComponent, MockNgSelectA11yDirective],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SortingComponent);

--- a/projects/storefrontlib/shared/components/list-navigation/total/total.component.spec.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/total/total.component.spec.ts
@@ -6,14 +6,12 @@ describe('TotalComponent', () => {
   let component: TotalComponent;
   let fixture: ComponentFixture<TotalComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [TotalComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [TotalComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TotalComponent);

--- a/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
+++ b/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
@@ -23,7 +23,10 @@ export class NgSelectA11yDirective implements AfterViewInit {
    */
   @Input() cxNgSelectA11y: { ariaLabel?: string; ariaControls?: string };
 
-  constructor(private renderer: Renderer2, private elementRef: ElementRef) {}
+  constructor(
+    private renderer: Renderer2,
+    private elementRef: ElementRef
+  ) {}
 
   ngAfterViewInit(): void {
     const divCombobox =

--- a/projects/storefrontlib/shared/components/progress-button/progress-button.component.spec.ts
+++ b/projects/storefrontlib/shared/components/progress-button/progress-button.component.spec.ts
@@ -14,14 +14,12 @@ describe('ProgressButtonComponent', () => {
   let fixture: ComponentFixture<ProgressButtonComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [I18nTestingModule],
-        declarations: [ProgressButtonComponent, TestHostComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [ProgressButtonComponent, TestHostComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProgressButtonComponent);

--- a/projects/storefrontlib/shared/components/split-view/view/view.component.spec.ts
+++ b/projects/storefrontlib/shared/components/split-view/view/view.component.spec.ts
@@ -47,24 +47,22 @@ describe('ViewComponent', () => {
   let service: SplitViewService;
   let globalMessageService: GlobalMessageService;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ViewComponent],
-        providers: [
-          { provide: SplitViewService, useClass: MockSplitViewService },
-          { provide: GlobalMessageService, useClass: MockGlobalMessageService },
-          { provide: FeatureConfigService, useClass: MockFeatureConfigService },
-        ],
-      })
-        .overrideComponent(ViewComponent, {
-          set: {
-            changeDetection: ChangeDetectionStrategy.Default,
-          },
-        })
-        .compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ViewComponent],
+      providers: [
+        { provide: SplitViewService, useClass: MockSplitViewService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
+      ],
     })
-  );
+      .overrideComponent(ViewComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ViewComponent);

--- a/projects/storefrontlib/shared/components/truncate-text-popover/truncate-text-popover.component.spec.ts
+++ b/projects/storefrontlib/shared/components/truncate-text-popover/truncate-text-popover.component.spec.ts
@@ -17,18 +17,16 @@ describe('TruncateTextPopoverComponent', () => {
   let fixture: ComponentFixture<TruncateTextPopoverComponent>;
   let el: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          I18nTestingModule,
-          TruncateTextPopoverModule,
-          RouterTestingModule,
-        ],
-        declarations: [TruncateTextPopoverComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        TruncateTextPopoverModule,
+        RouterTestingModule,
+      ],
+      declarations: [TruncateTextPopoverComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TruncateTextPopoverComponent);

--- a/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.pipe.ts
+++ b/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.pipe.ts
@@ -20,7 +20,10 @@ import { WindowRef } from '@spartacus/core';
  */
 @Pipe({ name: 'cxSupplementHashAnchors' })
 export class SupplementHashAnchorsPipe implements PipeTransform {
-  constructor(protected renderer: Renderer2, protected winRef: WindowRef) {}
+  constructor(
+    protected renderer: Renderer2,
+    protected winRef: WindowRef
+  ) {}
 
   protected getPath(anchorId: string): string {
     const currentUrlWithoutFragment = this.winRef.location.href?.replace(

--- a/projects/storefrontstyles/scss/components/content/navigation/_scroll-to-top.scss
+++ b/projects/storefrontstyles/scss/components/content/navigation/_scroll-to-top.scss
@@ -21,8 +21,11 @@
     background-color: var(--cx-color-primary);
     border: transparent;
     border-radius: 12px;
-    box-shadow: rgba(0, 0, 0, 0.07) 0px 1px 1px, rgba(0, 0, 0, 0.07) 0px 2px 2px,
-      rgba(0, 0, 0, 0.07) 0px 4px 4px, rgba(0, 0, 0, 0.07) 0px 8px 8px,
+    box-shadow:
+      rgba(0, 0, 0, 0.07) 0px 1px 1px,
+      rgba(0, 0, 0, 0.07) 0px 2px 2px,
+      rgba(0, 0, 0, 0.07) 0px 4px 4px,
+      rgba(0, 0, 0, 0.07) 0px 8px 8px,
       rgba(0, 0, 0, 0.07) 0px 16px 16px;
 
     @media (hover: hover) {

--- a/projects/storefrontstyles/scss/components/layout/_skip-link.scss
+++ b/projects/storefrontstyles/scss/components/layout/_skip-link.scss
@@ -8,7 +8,9 @@
   height: 100%;
   // backdrop - fade out
   background-color: rgba(0, 0, 0, 0);
-  transition: top 0s 0.3s ease, background-color 0.3s ease;
+  transition:
+    top 0s 0.3s ease,
+    background-color 0.3s ease;
   > div {
     display: contents;
   }

--- a/projects/storefrontstyles/scss/components/layout/_split-view.scss
+++ b/projects/storefrontstyles/scss/components/layout/_split-view.scss
@@ -54,8 +54,9 @@
 
     flex: 1 0
       calc(
-        (100% / min(var(--cx-active-view), var(--cx-max-views))) -
-          var(--cx-split-gutter)
+        (100% / min(var(--cx-active-view), var(--cx-max-views))) - var(
+            --cx-split-gutter
+          )
       );
 
     margin-inline-end: var(--cx-split-gutter);

--- a/projects/storefrontstyles/scss/components/misc/pagination/_pagination.scss
+++ b/projects/storefrontstyles/scss/components/misc/pagination/_pagination.scss
@@ -20,7 +20,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: background-color 0.3s, color 0.3s;
+    transition:
+      background-color 0.3s,
+      color 0.3s;
 
     @include forFeature('a11yImproveContrast') {
       @include type('7');

--- a/projects/storefrontstyles/scss/components/misc/table/_table.scss
+++ b/projects/storefrontstyles/scss/components/misc/table/_table.scss
@@ -29,7 +29,9 @@
 
     th,
     td {
-      transition: opacity 0.2s ease-in-out 0.2s, width 0.2s ease-in-out 0.2s;
+      transition:
+        opacity 0.2s ease-in-out 0.2s,
+        width 0.2s ease-in-out 0.2s;
 
       padding: var(--cx-spatial-md);
 

--- a/projects/storefrontstyles/scss/layout/_page-fold.scss
+++ b/projects/storefrontstyles/scss/layout/_page-fold.scss
@@ -14,7 +14,9 @@
 
 cx-page-layout {
   cx-page-slot {
-    transition: margin-top 0s, min-height 0s;
+    transition:
+      margin-top 0s,
+      min-height 0s;
     // we delay the minimal real estate for pending slots
     transition-delay: var(--btf-delay);
 

--- a/projects/storefrontstyles/scss/theme/santorini-updated/_variables.scss
+++ b/projects/storefrontstyles/scss/theme/santorini-updated/_variables.scss
@@ -10,9 +10,18 @@
 @import '../../cxbase/functions';
 
 //fonts (see _fonts.scss to import)
-$font-family-sans-serif: 'Open Sans', -apple-system, BlinkMacSystemFont,
-  'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji',
-  'Segoe UI Emoji', 'Segoe UI Symbol';
+$font-family-sans-serif:
+  'Open Sans',
+  -apple-system,
+  BlinkMacSystemFont,
+  'Segoe UI',
+  'Roboto',
+  'Helvetica Neue',
+  Arial,
+  sans-serif,
+  'Apple Color Emoji',
+  'Segoe UI Emoji',
+  'Segoe UI Symbol';
 
 // TODO: Replace `$font-url` with swap url in 5.0 to use swap strategy by default.
 // $font-url: 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap' !default;

--- a/projects/storefrontstyles/scss/theme/santorini/_variables.scss
+++ b/projects/storefrontstyles/scss/theme/santorini/_variables.scss
@@ -10,9 +10,18 @@
 @import '../../cxbase/functions';
 
 //fonts (see _fonts.scss to import)
-$font-family-sans-serif: 'Open Sans', -apple-system, BlinkMacSystemFont,
-  'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji',
-  'Segoe UI Emoji', 'Segoe UI Symbol';
+$font-family-sans-serif:
+  'Open Sans',
+  -apple-system,
+  BlinkMacSystemFont,
+  'Segoe UI',
+  'Roboto',
+  'Helvetica Neue',
+  Arial,
+  sans-serif,
+  'Apple Color Emoji',
+  'Segoe UI Emoji',
+  'Segoe UI Symbol';
 
 // TODO: Replace `$font-url` with swap url in 5.0 to use swap strategy by default.
 // $font-url: 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap' !default;

--- a/projects/storefrontstyles/scss/theme/sparta/_variables.scss
+++ b/projects/storefrontstyles/scss/theme/sparta/_variables.scss
@@ -10,9 +10,18 @@
 @import '../../cxbase/functions';
 
 //fonts (see _fonts.scss to import)
-$font-family-sans-serif: 'Open Sans', -apple-system, BlinkMacSystemFont,
-  'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji',
-  'Segoe UI Emoji', 'Segoe UI Symbol';
+$font-family-sans-serif:
+  'Open Sans',
+  -apple-system,
+  BlinkMacSystemFont,
+  'Segoe UI',
+  'Roboto',
+  'Helvetica Neue',
+  Arial,
+  sans-serif,
+  'Apple Color Emoji',
+  'Segoe UI Emoji',
+  'Segoe UI Symbol';
 
 // change theme-colors here
 $primary: #fe5757 !default;

--- a/tools/schematics/dependency-collector.ts
+++ b/tools/schematics/dependency-collector.ts
@@ -105,7 +105,7 @@ function read(path: string): string {
 
 function format(path: string): void {
   execSync(
-    `node ./node_modules/prettier/bin-prettier.js --config ./.prettierrc ${path} --write`
+    `node ./node_modules/prettier/bin/prettier.cjs --config ./.prettierrc ${path} --write`
   );
 }
 


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-7333


Below 4 files have changed, and all other files were modified by Prettier's auto-fix.
.prettierrc
package-lock.json
packag.json
dependency-collector.ts

Migration & break changes
https://prettier.io/blog/2023/07/05/3.0.0.html
I only added trailingComma: "es5" because the default has changed to 'all,' which would result in fixing more than 3,000 files.