### PR TITLE
feat: CXSPA-7197 Create toggle for strict NgRx and HTTP error handling

### DIFF
--- a/projects/core/src/error-handling/effects-error-handler/cx-error-hadnler.effect.spec.ts
+++ b/projects/core/src/error-handling/effects-error-handler/cx-error-hadnler.effect.spec.ts
@@ -1,16 +1,18 @@
 import { TestBed } from '@angular/core/testing';
 import { Actions } from '@ngrx/effects';
 import { provideMockActions } from '@ngrx/effects/testing';
+import { Action } from '@ngrx/store';
+import { ErrorAction, FeatureConfigService, WindowRef } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
 import { CxErrorHandlerEffect } from './cx-error-handler.effect';
-import { ErrorAction } from '@spartacus/core';
 import { EffectsErrorHandlerService } from './effects-error-handler.service';
-import { Action } from '@ngrx/store';
 
 describe('CxErrorHandlerEffect', () => {
   let effect: CxErrorHandlerEffect;
   let actions$: Observable<Action>;
   let effectErrorHandler: jasmine.SpyObj<EffectsErrorHandlerService>;
+  let featureConfigService: FeatureConfigService;
+  let windowRef: WindowRef;
 
   beforeEach(() => {
     const errorHandlerSpy = jasmine.createSpyObj('EffectsErrorHandlerService', [
@@ -21,7 +23,9 @@ describe('CxErrorHandlerEffect', () => {
     TestBed.configureTestingModule({
       providers: [
         CxErrorHandlerEffect,
+        FeatureConfigService,
         provideMockActions(() => actions$),
+        { provide: WindowRef, useValue: { isBrowser: () => false } },
         { provide: EffectsErrorHandlerService, useValue: errorHandlerSpy },
       ],
     });
@@ -31,41 +35,80 @@ describe('CxErrorHandlerEffect', () => {
     effectErrorHandler = TestBed.inject(
       EffectsErrorHandlerService
     ) as jasmine.SpyObj<EffectsErrorHandlerService>;
+    featureConfigService = TestBed.inject(FeatureConfigService);
+    windowRef = TestBed.inject(WindowRef);
   });
 
   it('should be created', () => {
     expect(effect).toBeTruthy();
   });
 
-  describe('error$', () => {
-    it('should handle error action', () => {
+  describe('error$ ', () => {
+    describe('when strictHttpAndNgrxErrorHandling is enabled', () => {
+      beforeEach(() => {
+        spyOn(featureConfigService, 'isEnabled').and.returnValue(true);
+      });
+
+      it('should handle error action', () => {
+        const mockErrorAction: ErrorAction = {
+          type: 'ERROR_ACTION_TYPE',
+          error: new Error(),
+        };
+
+        effectErrorHandler.filterActions.and.returnValue(true);
+
+        actions$ = of(mockErrorAction);
+
+        effect.error$.subscribe();
+
+        expect(effectErrorHandler.handleError).toHaveBeenCalledWith(
+          mockErrorAction
+        );
+      });
+
+      it('should not handle error action when not in SSR', () => {
+        const mockErrorAction: ErrorAction = {
+          type: 'ERROR_ACTION_TYPE',
+          error: new Error(),
+        };
+
+        effectErrorHandler.filterActions.and.returnValue(true);
+        spyOn(windowRef, 'isBrowser').and.returnValue(true);
+
+        actions$ = of(mockErrorAction);
+
+        effect.error$.subscribe();
+
+        expect(effectErrorHandler.handleError).not.toHaveBeenCalled();
+      });
+
+      it('should not handle non-error action', () => {
+        const mockNonErrorAction = {
+          type: 'SOME_ACTION',
+        };
+
+        effectErrorHandler.filterActions.and.returnValue(false);
+
+        actions$ = of(mockNonErrorAction);
+
+        effect.error$.subscribe();
+
+        expect(effectErrorHandler.handleError).not.toHaveBeenCalled();
+      });
+    });
+  });
+  describe('when strictHttpAndNgrxErrorHandling is disabled', () => {
+    beforeEach(() => {
+      spyOn(featureConfigService, 'isEnabled').and.returnValue(false);
+    });
+    it('should not handle error action', () => {
       const mockErrorAction: ErrorAction = {
         type: 'ERROR_ACTION_TYPE',
         error: new Error(),
       };
-
       effectErrorHandler.filterActions.and.returnValue(true);
-
       actions$ = of(mockErrorAction);
-
       effect.error$.subscribe();
-
-      expect(effectErrorHandler.handleError).toHaveBeenCalledWith(
-        mockErrorAction
-      );
-    });
-
-    it('should not handle non-error action', () => {
-      const mockNonErrorAction = {
-        type: 'SOME_ACTION',
-      };
-
-      effectErrorHandler.filterActions.and.returnValue(false);
-
-      actions$ = of(mockNonErrorAction);
-
-      effect.error$.subscribe();
-
       expect(effectErrorHandler.handleError).not.toHaveBeenCalled();
     });
   });

--- a/projects/core/src/error-handling/effects-error-handler/cx-error-handler.effect.ts
+++ b/projects/core/src/error-handling/effects-error-handler/cx-error-handler.effect.ts
@@ -10,28 +10,25 @@ import { Observable } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 import { FeatureConfigService } from '../../features-config';
 import { ErrorAction } from '../../model/index';
-import { WindowRef } from '../../window';
 import { EffectsErrorHandlerService } from './effects-error-handler.service';
 
 @Injectable()
 export class CxErrorHandlerEffect {
   protected actions$ = inject(Actions);
-  protected effectErrorHandler = inject(EffectsErrorHandlerService);
-  protected featureConfigService = inject(FeatureConfigService);
-  protected windowRef = inject(WindowRef);
+  protected effectErrorHandlerService = inject(EffectsErrorHandlerService);
+  private featureConfigService = inject(FeatureConfigService);
 
   error$: Observable<ErrorAction> = createEffect(
     () =>
       this.actions$.pipe(
-        filter(this.effectErrorHandler.filterActions),
+        filter(this.effectErrorHandlerService.filterActions),
         tap((errorAction: ErrorAction) => {
           if (
             this.featureConfigService.isEnabled(
-              'strictHttpAndNgrxErrorHandling'
-            ) &&
-            !this.windowRef.isBrowser() // handle only in SSR
+              'ssrStrictErrorHandlingForHttpAndNgrx'
+            )
           ) {
-            this.effectErrorHandler.handleError(errorAction);
+            this.effectErrorHandlerService.handleError(errorAction);
           }
         })
       ),

--- a/projects/core/src/error-handling/effects-error-handler/cx-error-handler.effect.ts
+++ b/projects/core/src/error-handling/effects-error-handler/cx-error-handler.effect.ts
@@ -4,28 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect } from '@ngrx/effects';
 import { Observable } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
+import { FeatureConfigService } from '../../features-config';
 import { ErrorAction } from '../../model/index';
+import { WindowRef } from '../../window';
 import { EffectsErrorHandlerService } from './effects-error-handler.service';
 
 @Injectable()
 export class CxErrorHandlerEffect {
+  protected actions$ = inject(Actions);
+  protected effectErrorHandler = inject(EffectsErrorHandlerService);
+  protected featureConfigService = inject(FeatureConfigService);
+  protected windowRef = inject(WindowRef);
+
   error$: Observable<ErrorAction> = createEffect(
     () =>
       this.actions$.pipe(
         filter(this.effectErrorHandler.filterActions),
-        tap((errorAction: ErrorAction) =>
-          this.effectErrorHandler.handleError(errorAction)
-        )
+        tap((errorAction: ErrorAction) => {
+          if (
+            this.featureConfigService.isEnabled(
+              'strictHttpAndNgrxErrorHandling'
+            ) &&
+            !this.windowRef.isBrowser() // handle only in SSR
+          ) {
+            this.effectErrorHandler.handleError(errorAction);
+          }
+        })
       ),
     { dispatch: false }
   );
-
-  constructor(
-    protected actions$: Actions,
-    protected effectErrorHandler: EffectsErrorHandlerService
-  ) {}
 }

--- a/projects/core/src/error-handling/effects-error-handler/effects-error-handler.service.ts
+++ b/projects/core/src/error-handling/effects-error-handler/effects-error-handler.service.ts
@@ -5,17 +5,19 @@
  */
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { ErrorHandler, Injectable } from '@angular/core';
+import { ErrorHandler, Injectable, inject } from '@angular/core';
 import { Action } from '@ngrx/store';
 import {
   ErrorAction,
   ErrorActionType,
   HttpErrorModel,
 } from '../../model/index';
+import { WindowRef } from '../../window';
 
 @Injectable()
 export class EffectsErrorHandlerService {
-  constructor(protected errorHandler: ErrorHandler) {}
+  protected errorHandler: ErrorHandler = inject(ErrorHandler);
+  protected windowRef = inject(WindowRef);
 
   handleError(action: ErrorAction): void {
     const error: ErrorActionType = action.error;
@@ -27,7 +29,12 @@ export class EffectsErrorHandlerService {
       !(error instanceof HttpErrorModel) &&
       !(error instanceof HttpErrorResponse);
 
-    if (isNotHttpError) {
+    // We avoid sending unpredictable errors to the browser's console, to prevent
+    // possibly exposing there potentially confidential user's data.
+    // This isn't an issue in SSR, where pages are rendered anonymously.
+    // Moreover, in SSR we want to capture all app's errors, so we can potentially send
+    // a HTTP error response (e.g. 500 error page) from SSR to a client.
+    if (isNotHttpError && !this.windowRef.isBrowser()) {
       this.errorHandler.handleError(error);
     }
   }

--- a/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.spec.ts
+++ b/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.spec.ts
@@ -4,10 +4,12 @@ import {
   HttpHandler,
   HttpRequest,
 } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
-import { TestBed } from '@angular/core/testing';
-import { HttpErrorHandlerInterceptor } from './http-error-handler.interceptor';
 import { ErrorHandler, Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Observable, throwError } from 'rxjs';
+import { FeatureConfigService } from '../../features-config';
+import { WindowRef } from '../../window';
+import { HttpErrorHandlerInterceptor } from './http-error-handler.interceptor';
 
 @Injectable()
 class MockErrorHandler {
@@ -19,17 +21,23 @@ describe('HttpErrorHandlerInterceptor', () => {
   let errorHandler: ErrorHandler;
   let request: HttpRequest<any>;
   let next: HttpHandler;
+  let featureConfigService: FeatureConfigService;
+  let windowRef: WindowRef;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         HttpErrorHandlerInterceptor,
+        FeatureConfigService,
+        { provide: WindowRef, useValue: { isBrowser: () => false } },
         { provide: ErrorHandler, useClass: MockErrorHandler },
       ],
     });
 
     interceptor = TestBed.inject(HttpErrorHandlerInterceptor);
     errorHandler = TestBed.inject(ErrorHandler);
+    featureConfigService = TestBed.inject(FeatureConfigService);
+    windowRef = TestBed.inject(WindowRef);
 
     request = new HttpRequest('GET', 'test-url');
     next = {
@@ -41,35 +49,78 @@ describe('HttpErrorHandlerInterceptor', () => {
     expect(interceptor).toBeTruthy();
   });
 
-  it('should call handleError on error', (done) => {
-    const error: HttpErrorResponse = new HttpErrorResponse({
-      status: 400,
-      statusText: 'error',
+  describe('when strictHttpAndNgrxErrorHandling is enabled', () => {
+    beforeEach(() => {
+      spyOn(featureConfigService, 'isEnabled').and.returnValue(true);
     });
-    spyOn(errorHandler, 'handleError');
+    it('should call handleError on error', (done) => {
+      const error: HttpErrorResponse = new HttpErrorResponse({
+        status: 400,
+        statusText: 'error',
+      });
+      spyOn(errorHandler, 'handleError');
 
-    next.handle = () => throwError(error);
+      next.handle = () => throwError(() => error);
 
-    interceptor.intercept(request, next).subscribe({
-      error: (err) => {
-        expect(err).toEqual(error);
-        expect(errorHandler.handleError).toHaveBeenCalledWith(error);
+      interceptor.intercept(request, next).subscribe({
+        error: (err) => {
+          expect(err).toEqual(error);
+          expect(errorHandler.handleError).toHaveBeenCalledWith(error);
+          done();
+        },
+      });
+    });
+
+    it('should not call handleError when it is not SSR', (done) => {
+      spyOn(errorHandler, 'handleError');
+      spyOn(windowRef, 'isBrowser').and.returnValue(true);
+
+      next.handle = () => throwError(() => new HttpErrorResponse({}));
+
+      interceptor.intercept(request, next).subscribe({
+        error: () => {
+          expect(errorHandler.handleError).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should pass through the request when there is no error', (done) => {
+      const response: HttpEvent<any> = {
+        status: 200,
+        statusText: 'ok',
+      } as HttpEvent<any>;
+      next.handle = () =>
+        new Observable<HttpEvent<any>>((observer) => observer.next(response));
+
+      interceptor.intercept(request, next).subscribe((result) => {
+        expect(result).toBe(response);
         done();
-      },
+      });
     });
   });
 
-  it('should pass through the request when there is no error', (done) => {
-    const response: HttpEvent<any> = {
-      status: 200,
-      statusText: 'ok',
-    } as HttpEvent<any>;
-    next.handle = () =>
-      new Observable<HttpEvent<any>>((observer) => observer.next(response));
+  describe('when strictHttpAndNgrxErrorHandling is disabled', () => {
+    beforeEach(() => {
+      spyOn(featureConfigService, 'isEnabled').and.returnValue(false);
+    });
 
-    interceptor.intercept(request, next).subscribe((result) => {
-      expect(result).toBe(response);
-      done();
+    it('should pass through the request when there is an error', (done) => {
+      const error: HttpErrorResponse = new HttpErrorResponse({
+        status: 400,
+        statusText: 'error',
+      });
+      spyOn(errorHandler, 'handleError');
+
+      next.handle = () => throwError(() => error);
+
+      interceptor.intercept(request, next).subscribe({
+        error: (err) => {
+          expect(err).toEqual(error);
+          expect(errorHandler.handleError).not.toHaveBeenCalled();
+          done();
+        },
+      });
     });
   });
 });

--- a/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.spec.ts
+++ b/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.spec.ts
@@ -49,7 +49,7 @@ describe('HttpErrorHandlerInterceptor', () => {
     expect(interceptor).toBeTruthy();
   });
 
-  describe('when strictHttpAndNgrxErrorHandling is enabled', () => {
+  describe('when ssrStrictErrorHandlingForHttpAndNgrx is enabled', () => {
     beforeEach(() => {
       spyOn(featureConfigService, 'isEnabled').and.returnValue(true);
     });
@@ -100,7 +100,7 @@ describe('HttpErrorHandlerInterceptor', () => {
     });
   });
 
-  describe('when strictHttpAndNgrxErrorHandling is disabled', () => {
+  describe('when ssrStrictErrorHandlingForHttpAndNgrx is disabled', () => {
     beforeEach(() => {
       spyOn(featureConfigService, 'isEnabled').and.returnValue(false);
     });

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -44,6 +44,11 @@ export interface FeatureTogglesInterface {
   productConfiguratorAttributeTypesV2?: boolean;
 
   /**
+  * Enable strict error handling for errors occurred in HTTP calls and in NgRx failure actions.
+  */
+  strictHttpAndNgrxErrorHandling?: boolean;
+
+  /**
    * Adds asterisks to required form fields in all components existing before v2211.20
    */
   a11yRequiredAsterisks?: boolean;
@@ -160,6 +165,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   pdfInvoicesSortByInvoiceDate: false,
   storeFrontLibCardParagraphTruncated: false,
   productConfiguratorAttributeTypesV2: false,
+  strictHttpAndNgrxErrorHandling: false,
   a11yRequiredAsterisks: false,
   a11yQuantityOrderTabbing: false,
   a11yNavigationUiKeyboardControls: false,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -44,8 +44,8 @@ export interface FeatureTogglesInterface {
   productConfiguratorAttributeTypesV2?: boolean;
 
   /**
-  * Enable strict error handling for errors occurred in HTTP calls and in NgRx failure actions.
-  */
+   * Enable strict error handling in SSR for errors occurred in HTTP calls and in NgRx failure actions.
+   */
   strictHttpAndNgrxErrorHandling?: boolean;
 
   /**

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -44,9 +44,13 @@ export interface FeatureTogglesInterface {
   productConfiguratorAttributeTypesV2?: boolean;
 
   /**
-   * Enable strict error handling in SSR for errors occurred in HTTP calls and in NgRx failure actions.
+   * In SSR, the following errors will be printed to logs (and additionally can also
+   * be forwarded to ExpressJS if only the setting
+   * `SsrOptimizationOptions.ssrErrorHandling`  is enabled):
+   * 1. any outgoing HTTP request error (4xx-5xx status)
+   * 2. any NgRx action with the `error` property
    */
-  strictHttpAndNgrxErrorHandling?: boolean;
+  ssrStrictErrorHandlingForHttpAndNgrx?: boolean;
 
   /**
    * Adds asterisks to required form fields in all components existing before v2211.20
@@ -165,7 +169,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   pdfInvoicesSortByInvoiceDate: false,
   storeFrontLibCardParagraphTruncated: false,
   productConfiguratorAttributeTypesV2: false,
-  strictHttpAndNgrxErrorHandling: false,
+  ssrStrictErrorHandlingForHttpAndNgrx: false,
   a11yRequiredAsterisks: false,
   a11yQuantityOrderTabbing: false,
   a11yNavigationUiKeyboardControls: false,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -266,6 +266,7 @@ if (environment.requestedDeliveryDate) {
         pdfInvoicesSortByInvoiceDate: false,
         storeFrontLibCardParagraphTruncated: true,
         productConfiguratorAttributeTypesV2: true,
+        strictHttpAndNgrxErrorHandling: true,
         a11yRequiredAsterisks: true,
         a11yQuantityOrderTabbing: true,
         a11yNavigationUiKeyboardControls: true,
@@ -292,4 +293,4 @@ if (environment.requestedDeliveryDate) {
     }),
   ],
 })
-export class SpartacusFeaturesModule {}
+export class SpartacusFeaturesModule { }

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -293,4 +293,4 @@ if (environment.requestedDeliveryDate) {
     }),
   ],
 })
-export class SpartacusFeaturesModule { }
+export class SpartacusFeaturesModule {}

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -266,7 +266,7 @@ if (environment.requestedDeliveryDate) {
         pdfInvoicesSortByInvoiceDate: false,
         storeFrontLibCardParagraphTruncated: true,
         productConfiguratorAttributeTypesV2: true,
-        strictHttpAndNgrxErrorHandling: true,
+        ssrStrictErrorHandlingForHttpAndNgrx: true,
         a11yRequiredAsterisks: true,
         a11yQuantityOrderTabbing: true,
         a11yNavigationUiKeyboardControls: true,


### PR DESCRIPTION
This |PR contains an implementation of a toggle for strict HTTP and NgRx error handling in SSR.

QA steps (examples):
- strict HTTP error handling in storefrontapp
  - go to `default-occ-product-config.ts` and modify the default `productSearch` endpoint
  - run `npm run dev:ssr`
  - go to http://localhost:4200/electronics-spa/en/USD/Brands/all/c/brands and verify if the error log is visible in the server console and not present in the browser's console
   ![image](https://github.com/SAP/spartacus/assets/28891782/ad0eb770-ce48-46c1-baa2-d7b6979ecde1)
  - kill the SSR app and run `npm run start`
  - go to http://localhost:4200/electronics-spa/en/USD/Brands/all/c/brands and verify if the error log from `logger.service.ts` is not present in the browser's console
- strict HTTP error handling in fresh SPA app
  - build and deploy Spartacus packages locally:
  `npx ts-node ./tools/schematics/testing.ts` in the SPA root folder`
  - create new app `npx @angular/cli@17 new my-app --standalone=false --style=scss --routing=false`
  - go to the project's directory and install Spartacus from local packages:
  `npx @angular/cli@17 add @spartacus/schematics@latest --baseUrl="https://40.76.109.9:9002"`
  - adjust spartacus config in `spartacus-configuration.module.ts`
  ```ts
  providers: [
    provideConfig(<OccConfig>{
      backend: {
        occ: {
          baseUrl: 'https://40.76.109.9:9002',
          endpoints: {
            productSearch: 'products/search2',
          },
        },
      },
    }),
    / * * /
    provideFeatureToggles({
      strictHttpAndNgrxErrorHandling: true,
    }),
  ]
  ```
  - adjust `server.ts` file:
  ```
  export function app(): express.Express {
      const server = express();
      const serverDistFolder = dirname(fileURLToPath(import.meta.url));
      const browserDistFolder = resolve(serverDistFolder, '../browser');
      const indexHtml = join(browserDistFolder, 'index.html');
      const indexHtmlContent = readFileSync(indexHtml, 'utf-8');
    
      / * * /
      
      server.use(defaultServerErrorResponseHandlers(indexHtmlContent));
    
      return server;
  }
  ```
  - run `npm run build && NODE_TLS_REJECT_UNAUTHORIZED=0 run serve:ssr:my-app`
  - go to http://localhost:4200/electronics-spa/en/USD/Brands/all/c/brands and verify if the error log is visible in the server console and not present in the browser's console
  <img width="987" alt="image" src="https://github.com/SAP/spartacus/assets/28891782/55741fe0-7696-4695-b61c-290042b3ba0b">
  
- strict NgRx error handling in storefrontapp
  - go to `product-search.effect.ts` and modify `searchProducts$` effect:
  ```
  map(() => {
    // return new ProductActions.SearchProductsSuccess(
        //   data,
        //   action.auxiliary
    // );
    throw new Error('Test Error');
  }),
  ```
  - run `npm run dev:ssr`
  - go to http://localhost:4200/electronics-spa/en/USD/Brands/all/c/brands and verify if the error log is visible in the server console and not present in the browser's console
  <img width="950" alt="image" src="https://github.com/SAP/spartacus/assets/28891782/4e9b41d5-a835-428c-82ee-f41d79816b54">

  - kill the SSR app and run `npm run start`
  - go to http://localhost:4200/electronics-spa/en/USD/Brands/all/c/brands and verify if the error log with `Test Error` message from `logger.service.ts` is not present in the browser's console
- strict NgRx error handling in fresh SPA app
  - build and deploy Spartacus packages locally keeping adjustments in `product-search.effect.ts`:
  `npx ts-node ./tools/schematics/testing.ts` in the SPA root folder`
  - create new app `npx @angular/cli@17 new my-app --standalone=false --style=scss --routing=false`
  - go to the project's directory and install Spartacus from local packages:
  `npx @angular/cli@17 add @spartacus/schematics@latest --baseUrl="https://40.76.109.9:9002"`
  - adjust spartacus config in `spartacus-configuration.module.ts`
  ```ts
  providers: [
    / * * /
    provideFeatureToggles({
      strictHttpAndNgrxErrorHandling: true,
    }),
  ]
  ```
  - adjust `server.ts` file:
  ```
  export function app(): express.Express {
      const server = express();
      const serverDistFolder = dirname(fileURLToPath(import.meta.url));
      const browserDistFolder = resolve(serverDistFolder, '../browser');
      const indexHtml = join(browserDistFolder, 'index.html');
      const indexHtmlContent = readFileSync(indexHtml, 'utf-8');
    
      / *** /
      
      server.use(defaultServerErrorResponseHandlers(indexHtmlContent));
    
      return server;
  }
  ```
  - run `npm run build && NODE_TLS_REJECT_UNAUTHORIZED=0 run serve:ssr:my-app`
  - go to http://localhost:4200/electronics-spa/en/USD/Brands/all/c/brands and verify if the error log is visible in the server console and not present in the browser's console
  ![image](https://github.com/SAP/spartacus/assets/28891782/56253840-2f78-4807-aca3-76fb3d43e93f)

closes [CXSPA-7197](https://jira.tools.sap/browse/CXSPA-7197)