### PR TITLE
fix: CXSPA-7665 Remove circular dependency from organization config factories

### DIFF
--- a/feature-libs/organization/administration/components/budget/budget-components.module.ts
+++ b/feature-libs/organization/administration/components/budget/budget-components.module.ts
@@ -6,7 +6,6 @@
 
 import { NgModule } from '@angular/core';
 import {
-  FeatureConfigService,
   provideDefaultConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
@@ -25,9 +24,7 @@ import { BudgetFormModule } from './form/budget-form.module';
   ],
   providers: [
     provideDefaultConfig(budgetCmsConfig),
-    provideDefaultConfigFactory(budgetTableConfigFactory, [
-      FeatureConfigService,
-    ]),
+    provideDefaultConfigFactory(budgetTableConfigFactory),
   ],
 })
 export class BudgetComponentsModule {}

--- a/feature-libs/organization/administration/components/budget/budget.config.ts
+++ b/feature-libs/organization/administration/components/budget/budget.config.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthGuard, CmsConfig, FeatureConfigService } from '@spartacus/core';
+import { inject } from '@angular/core';
+import { AuthGuard, CmsConfig, FeatureToggles } from '@spartacus/core';
 import { AdminGuard } from '@spartacus/organization/administration/core';
 import { ROUTE_PARAMS } from '@spartacus/organization/administration/root';
 import { TableConfig } from '@spartacus/storefront';
@@ -80,11 +81,10 @@ export const budgetCmsConfig: CmsConfig = {
   },
 };
 
-// TODO: (CXSPA-7155) - Remove feature flag and legacy config next major release
-export function budgetTableConfigFactory(
-  featureConfigService?: FeatureConfigService
-): TableConfig {
-  if (featureConfigService?.isEnabled('a11yOrganizationLinkableCells')) {
+export function budgetTableConfigFactory(): TableConfig {
+  // TODO: (CXSPA-7155) - Remove feature flag and legacy config next major release
+  const featureToggles = inject(FeatureToggles);
+  if (featureToggles.a11yOrganizationLinkableCells) {
     return newBudgetTableConfig;
   }
   return budgetTableConfig;

--- a/feature-libs/organization/administration/components/cost-center/cost-center-components.module.ts
+++ b/feature-libs/organization/administration/components/cost-center/cost-center-components.module.ts
@@ -6,7 +6,6 @@
 
 import { NgModule } from '@angular/core';
 import {
-  FeatureConfigService,
   provideDefaultConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
@@ -30,9 +29,7 @@ import { CostCenterFormModule } from './form/cost-center-form.module';
   ],
   providers: [
     provideDefaultConfig(costCenterCmsConfig),
-    provideDefaultConfigFactory(costCenterTableConfigFactory, [
-      FeatureConfigService,
-    ]),
+    provideDefaultConfigFactory(costCenterTableConfigFactory),
   ],
 })
 export class CostCenterComponentsModule {}

--- a/feature-libs/organization/administration/components/cost-center/cost-center.config.ts
+++ b/feature-libs/organization/administration/components/cost-center/cost-center.config.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthGuard, CmsConfig, FeatureConfigService } from '@spartacus/core';
+import { inject } from '@angular/core';
+import { AuthGuard, CmsConfig, FeatureToggles } from '@spartacus/core';
 import { AdminGuard } from '@spartacus/organization/administration/core';
 import { ROUTE_PARAMS } from '@spartacus/organization/administration/root';
 import { TableConfig } from '@spartacus/storefront';
@@ -93,11 +94,10 @@ export const costCenterCmsConfig: CmsConfig = {
   },
 };
 
-export function costCenterTableConfigFactory(
-  featureConfigService: FeatureConfigService
-): TableConfig {
+export function costCenterTableConfigFactory(): TableConfig {
   // TODO: (CXSPA-7155) - Remove feature flag and legacy config next major release
-  if (featureConfigService?.isEnabled('a11yOrganizationLinkableCells')) {
+  const featureToggles = inject(FeatureToggles);
+  if (featureToggles.a11yOrganizationLinkableCells) {
     return newCostCenterTableConfig;
   }
   return costCenterTableConfig;

--- a/feature-libs/organization/administration/components/permission/permission-components.module.ts
+++ b/feature-libs/organization/administration/components/permission/permission-components.module.ts
@@ -6,7 +6,6 @@
 
 import { NgModule } from '@angular/core';
 import {
-  FeatureConfigService,
   provideDefaultConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
@@ -26,9 +25,7 @@ import {
   ],
   providers: [
     provideDefaultConfig(permissionCmsConfig),
-    provideDefaultConfigFactory(permissionTableConfigFactory, [
-      FeatureConfigService,
-    ]),
+    provideDefaultConfigFactory(permissionTableConfigFactory),
   ],
 })
 export class PermissionComponentsModule {}

--- a/feature-libs/organization/administration/components/permission/permission.config.ts
+++ b/feature-libs/organization/administration/components/permission/permission.config.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthGuard, CmsConfig, FeatureConfigService } from '@spartacus/core';
+import { inject } from '@angular/core';
+import { AuthGuard, CmsConfig, FeatureToggles } from '@spartacus/core';
 import { AdminGuard } from '@spartacus/organization/administration/core';
 import { ROUTE_PARAMS } from '@spartacus/organization/administration/root';
 import { TableConfig } from '@spartacus/storefront';
@@ -72,11 +73,10 @@ export const permissionCmsConfig: CmsConfig = {
   },
 };
 
-export function permissionTableConfigFactory(
-  featureConfigService?: FeatureConfigService
-): TableConfig {
+export function permissionTableConfigFactory(): TableConfig {
   // TODO: (CXSPA-7155) - Remove feature flag and legacy config next major release
-  if (featureConfigService?.isEnabled('a11yOrganizationLinkableCells')) {
+  const featureToggles = inject(FeatureToggles);
+  if (featureToggles.a11yOrganizationLinkableCells) {
     return newPermissionTableConfig;
   }
   return permisionTableConfig;

--- a/feature-libs/organization/administration/components/unit/units-components.module.ts
+++ b/feature-libs/organization/administration/components/unit/units-components.module.ts
@@ -7,7 +7,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import {
-  FeatureConfigService,
   provideDefaultConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
@@ -35,9 +34,7 @@ import { unitsCmsConfig, unitsTableConfigFactory } from './units.config';
   ],
   providers: [
     provideDefaultConfig(unitsCmsConfig),
-    provideDefaultConfigFactory(unitsTableConfigFactory, [
-      FeatureConfigService,
-    ]),
+    provideDefaultConfigFactory(unitsTableConfigFactory),
   ],
 })
 export class UnitsComponentsModule {}

--- a/feature-libs/organization/administration/components/unit/units.config.ts
+++ b/feature-libs/organization/administration/components/unit/units.config.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthGuard, CmsConfig, FeatureConfigService } from '@spartacus/core';
+import { inject } from '@angular/core';
+import { AuthGuard, CmsConfig, FeatureToggles } from '@spartacus/core';
 import {
   AdminGuard,
   OrgUnitGuard,
@@ -194,11 +195,10 @@ export const unitsCmsConfig: CmsConfig = {
   },
 };
 
-export function unitsTableConfigFactory(
-  featureConfigService?: FeatureConfigService
-): TableConfig {
-  if (featureConfigService?.isEnabled('a11yOrganizationLinkableCells')) {
-    // TODO: (CXSPA-7155) - Remove feature flag and legacy config next major release
+export function unitsTableConfigFactory(): TableConfig {
+  // TODO: (CXSPA-7155) - Remove feature flag and legacy config next major release
+  const featureToggles = inject(FeatureToggles);
+  if (featureToggles.a11yOrganizationLinkableCells) {
     return newUnitsTableConfig;
   }
   return unitsTableConfig;

--- a/feature-libs/organization/administration/components/user-group/user-group-components.module.ts
+++ b/feature-libs/organization/administration/components/user-group/user-group-components.module.ts
@@ -6,7 +6,6 @@
 
 import { NgModule } from '@angular/core';
 import {
-  FeatureConfigService,
   provideDefaultConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
@@ -30,9 +29,7 @@ import { UserGroupUserModule } from './users/user-group-user-list.module';
   ],
   providers: [
     provideDefaultConfig(userGroupCmsConfig),
-    provideDefaultConfigFactory(userGroupTableConfigFactory, [
-      FeatureConfigService,
-    ]),
+    provideDefaultConfigFactory(userGroupTableConfigFactory),
   ],
 })
 export class UserGroupComponentsModule {}

--- a/feature-libs/organization/administration/components/user-group/user-group.config.ts
+++ b/feature-libs/organization/administration/components/user-group/user-group.config.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthGuard, CmsConfig, FeatureConfigService } from '@spartacus/core';
+import { inject } from '@angular/core';
+import { AuthGuard, CmsConfig, FeatureToggles } from '@spartacus/core';
 import { AdminGuard } from '@spartacus/organization/administration/core';
 import { ROUTE_PARAMS } from '@spartacus/organization/administration/root';
 import { TableConfig } from '@spartacus/storefront';
@@ -111,11 +112,10 @@ export const userGroupCmsConfig: CmsConfig = {
   },
 };
 
-export function userGroupTableConfigFactory(
-  featureConfigService?: FeatureConfigService
-): TableConfig {
+export function userGroupTableConfigFactory(): TableConfig {
   // TODO: (CXSPA-7155) - Remove feature flag and legacy config next major release
-  if (featureConfigService?.isEnabled('a11yOrganizationLinkableCells')) {
+  const featureToggles = inject(FeatureToggles);
+  if (featureToggles.a11yOrganizationLinkableCells) {
     return newUserGroupTableConfig;
   }
   return userGroupTableConfig;

--- a/feature-libs/organization/administration/components/user/user-components.module.ts
+++ b/feature-libs/organization/administration/components/user/user-components.module.ts
@@ -6,7 +6,6 @@
 
 import { NgModule } from '@angular/core';
 import {
-  FeatureConfigService,
   provideDefaultConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
@@ -30,7 +29,7 @@ import { userCmsConfig, userTableConfigFactory } from './user.config';
   ],
   providers: [
     provideDefaultConfig(userCmsConfig),
-    provideDefaultConfigFactory(userTableConfigFactory, [FeatureConfigService]),
+    provideDefaultConfigFactory(userTableConfigFactory),
   ],
 })
 export class UserComponentsModule {}

--- a/feature-libs/organization/administration/components/user/user.config.ts
+++ b/feature-libs/organization/administration/components/user/user.config.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthGuard, CmsConfig, FeatureConfigService } from '@spartacus/core';
+import { inject } from '@angular/core';
+import { AuthGuard, CmsConfig, FeatureToggles } from '@spartacus/core';
 import {
   AdminGuard,
   UserGuard,
@@ -141,11 +142,10 @@ export const userCmsConfig: CmsConfig = {
   },
 };
 
-export function userTableConfigFactory(
-  featureConfigService?: FeatureConfigService
-): TableConfig {
+export function userTableConfigFactory(): TableConfig {
   // TODO: (CXSPA-7155) - Remove feature flag and legacy config next major release
-  if (featureConfigService?.isEnabled('a11yOrganizationLinkableCells')) {
+  const featureToggles = inject(FeatureToggles);
+  if (featureToggles.a11yOrganizationLinkableCells) {
     return newUserTableConfig;
   }
   return userTableConfig;


### PR DESCRIPTION
PR contains a fix for an issue spotted by the FSA team, related to circular DI in config factories for organisation components.
If a configuration of the `Config` subclass depends on a feature toggle, we should inject `FeatureToggles` instead of `FeatureConfigService` which depends on `Config` as well. In addition, factory `deps` have been removed in favour of the `inject` function to reduce the amount of possible breaking changes in the future.

QA steps:
- build and deploy Spartacus packages locally:
  `npx ts-node ./tools/schematics/testing.ts` in the SPA root folder`
- clone https://github.tools.sap/financial-services/financial-services-accelerator-spa and checkout branch compatibilityTesting/CXFSA-2193
- inside FSA projects, change version of all Spartacus packages to `2211.25.0-3`
- remove/rename all `.npmrc` files to ensure that Spartacus is installed from Verdaccio
- run `npm i && npm start`
- open FSA application in the browser ad verify that the circular DI error is **NOT** visible in the console:
![image](https://github.com/SAP/spartacus/assets/28891782/7718b7d8-c345-431c-8872-347460fc1ee0)

_Note:_ This change was made around `a11yOrganizationLinkableCells` toggle (for more, see: [CXSPA-1795](https://jira.tools.sap/browse/CXSPA-1795). To test whether its functionality works:
- go to Spartacus and run `npm run start:b2b`
- open Spartacus and log in as a user with an admin role (i.e. Linda Wolf)
- go to `powertools-spa/en/USD/organization/budgets/Monthly_2_5K_USD`
- with toggle `a11yOrganizationLinkableCells` enabled
![image](https://github.com/SAP/spartacus/assets/28891782/7e9ce902-96f1-42cf-ae45-a1e250fc07df)
- with toggle `a11yOrganizationLinkableCells` disabled
![image](https://github.com/SAP/spartacus/assets/28891782/4015f906-701b-4b9e-a0c6-524429e41b09)


closes [CXSPA-7665](https://jira.tools.sap/browse/CXSPA-7665)