### PR TITLE
feat: CXSPA-6941 Provide SSR Error Handling in schematics for fresh applications

### DIFF
--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -204,9 +204,11 @@ exports[`add-ssr server.ts should be configured properly 1`] = `
 "import { APP_BASE_HREF } from '@angular/common';
 import {
   NgExpressEngineDecorator,
+  defaultExpressErrorHandlers,
   ngExpressEngine as engine,
 } from '@spartacus/setup/ssr';
 import express from 'express';
+import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import AppServerModule from './src/main.server';
@@ -219,6 +221,7 @@ export function app(): express.Express {
   const serverDistFolder = dirname(fileURLToPath(import.meta.url));
   const browserDistFolder = resolve(serverDistFolder, '../browser');
   const indexHtml = join(browserDistFolder, 'index.html');
+  const indexHtmlContent = readFileSync(indexHtml, 'utf-8');
 
   server.set('trust proxy', 'loopback');
 
@@ -247,6 +250,8 @@ export function app(): express.Express {
       providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],
     });
   });
+
+  server.use(defaultExpressErrorHandlers(indexHtmlContent))
 
   return server;
 }

--- a/projects/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/projects/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -1,9 +1,11 @@
 import { APP_BASE_HREF } from '@angular/common';
 import {
   NgExpressEngineDecorator,
+  defaultExpressErrorHandlers,
   ngExpressEngine as engine,
 } from '@spartacus/setup/ssr';
 import express from 'express';
+import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import AppServerModule from './src/main.server';
@@ -16,6 +18,7 @@ export function app(): express.Express {
   const serverDistFolder = dirname(fileURLToPath(import.meta.url));
   const browserDistFolder = resolve(serverDistFolder, '../browser');
   const indexHtml = join(browserDistFolder, 'index.html');
+  const indexHtmlContent = readFileSync(indexHtml, 'utf-8');
 
   server.set('trust proxy', 'loopback');
 
@@ -44,6 +47,8 @@ export function app(): express.Express {
       providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],
     });
   });
+
+  server.use(defaultExpressErrorHandlers(indexHtmlContent))
 
   return server;
 }


### PR DESCRIPTION
This PR contains schematics adjustment to introduce SSR Error Handling in fresh applications with Spartacus.

QA steps:
- build and deploy Spartacus packages locally:
  `npx ts-node ./tools/schematics/testing.ts` in the SPA root folder`
- create new app `npx @angular/cli@17 new my-app --standalone=false --style=scss --routing=false`
- go to the new project's directory and install Spartacus from local packages:
  `npx @angular/cli@17 add @spartacus/schematics@latest --SSR --baseUrl="https://40.76.109.9:9002"`
- in a new project, verify whether `defaultExpressErrorHandlers` is used in `server.ts`:
  ```ts
  export function app(): express.Express {
    const server = express();
    const serverDistFolder = dirname(fileURLToPath(import.meta.url));
    const browserDistFolder = resolve(serverDistFolder, '../browser');
    const indexHtml = join(browserDistFolder, 'index.html');
    const indexHtmlContent = readFileSync(indexHtml, 'utf-8');
  
    / *** /
  
    server.use(defaultExpressErrorHandlers(indexHtmlContent));
  
    return server;
  }
  ```
  
  closes [CXSPA-6941](https://jira.tools.sap/browse/CXSPA-6941)
 