### PR TITLE
[WIP] feat: Extend session dialog with persist of refresh_token

### DIFF
--- a/feature-libs/user/_index.scss
+++ b/feature-libs/user/_index.scss
@@ -9,7 +9,8 @@ $selectors: cx-address-book, cx-address-form, cx-suggested-addresses-dialog,
   cx-login, cx-login-form, cx-register, cx-reset-password, cx-close-account,
   cx-close-account-modal, cx-my-account-v2-profile, cx-my-account-v2-email,
   cx-my-account-v2-password, cx-otp-login-form, cx-verification-token-form,
-  cx-verification-token-dialog !default;
+  cx-verification-token-dialog, cx-my-account-v2-password,
+  cx-extend-session-dialog !default;
 
 @each $selector in $selectors {
   #{$selector} {

--- a/feature-libs/user/account/assets/translations/en/userAccount.json
+++ b/feature-libs/user/account/assets/translations/en/userAccount.json
@@ -37,6 +37,13 @@
     "contentLine3": "3. Either the email address or the password you entered is incorrect.",
     "close": "Close"
   },
+  "extendSessionDialog": {
+    "title": "You will be logged out soon",
+    "description": "For your security, we log you out automatically after a certain period of time.",
+    "timeLeft": "Time left: {{time}}",
+    "continueSession": "Continue Session",
+    "logoutNow": "Log Out Now"
+  },
   "miniLogin": {
     "userGreeting": "Hi, {{name}}",
     "signInRegister": "Sign In / Register"

--- a/feature-libs/user/account/assets/translations/translations.ts
+++ b/feature-libs/user/account/assets/translations/translations.ts
@@ -16,6 +16,7 @@ export const userAccountTranslationChunksConfig: TranslationChunksConfig = {
     'loginForm',
     'verificationTokenForm',
     'verificationTokenDialog',
+    'extendSessionDialog',
     'miniLogin',
     'myAccountV2User',
   ],

--- a/feature-libs/user/account/components/extend-session/default-extend-session-layout.config.ts
+++ b/feature-libs/user/account/components/extend-session/default-extend-session-layout.config.ts
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DIALOG_TYPE, LayoutConfig } from '@spartacus/storefront';
+import { ExtendSessionDialogComponent } from './extend-session-dialog.component';
+
+export const defaultExtendSessionLayoutConfig: LayoutConfig = {
+  launch: {
+    EXTEND_SESSION: {
+      inlineRoot: true,
+      component: ExtendSessionDialogComponent,
+      dialogType: DIALOG_TYPE.DIALOG,
+    },
+  },
+};

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.component.html
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.component.html
@@ -1,0 +1,46 @@
+<div
+  class="cx-modal-container"
+  [cxFocus]="focusConfig"
+  (esc)="dismissModal('Escape pressed')"
+  role="dialog"
+>
+  <div class="cx-modal-content">
+    <!-- Modal Header -->
+    <div class="cx-dialog-header modal-header">
+      <h2 class="title modal-title">
+        {{ 'extendSessionDialog.title' | cxTranslate }}
+      </h2>
+      <button
+        type="button"
+        class="close"
+        [attr.aria-label]="'Extend session close modal'"
+        (click)="dismissModal('Cross click')"
+      >
+        <span aria-hidden="true">
+          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+        </span>
+      </button>
+    </div>
+
+    <!-- Modal Body -->
+    <div class="cx-dialog-body modal-body">
+      {{ 'extendSessionDialog.description' | cxTranslate }}
+      <br />
+      <b *ngIf="timeLeft$ | async as timeLeft">{{
+        'extendSessionDialog.timeLeft' | cxTranslate: { time: timeLeft }
+      }}</b>
+    </div>
+
+    <!-- Modal Footer -->
+    <div class="cx-dialog-footer modal-footer">
+      <div class="cx-dialog-buttons">
+        <button (click)="continueSession()" class="btn btn-primary" autofocus>
+          {{ 'extendSessionDialog.continueSession' | cxTranslate }}
+        </button>
+        <button (click)="logout()" class="btn btn-secondary">
+          {{ 'extendSessionDialog.logoutNow' | cxTranslate }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.component.spec.ts
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.component.spec.ts
@@ -1,0 +1,112 @@
+import {
+  ComponentFixture,
+  TestBed,
+  discardPeriodicTasks,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import { ExtendSessionDialogComponent } from './extend-session-dialog.component';
+import {
+  AuthService,
+  I18nTestingModule,
+  OAuthLibWrapperService,
+} from '@spartacus/core';
+import {
+  IconTestingModule,
+  KeyboardFocusTestingModule,
+  LaunchDialogService,
+} from '@spartacus/storefront';
+import { of } from 'rxjs';
+import { By } from '@angular/platform-browser';
+
+class MockLaunchDialogService {
+  closeDialog = jasmine.createSpy('closeDialog');
+  data$ = of({ timeLeft: 300 });
+}
+
+class MockAuthService {
+  logout = jasmine.createSpy('logout');
+}
+
+class MockOAuthLibWrapperService {
+  refreshToken = jasmine.createSpy('refreshToken');
+}
+
+fdescribe('ExtendSessionDialogComponent', () => {
+  let component: ExtendSessionDialogComponent;
+  let fixture: ComponentFixture<ExtendSessionDialogComponent>;
+  let launchDialogService: LaunchDialogService;
+  let authService: AuthService;
+  let oAuthLibWrapperService: OAuthLibWrapperService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        KeyboardFocusTestingModule,
+        IconTestingModule,
+      ],
+      declarations: [ExtendSessionDialogComponent],
+      providers: [
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        { provide: AuthService, useClass: MockAuthService },
+        {
+          provide: OAuthLibWrapperService,
+          useClass: MockOAuthLibWrapperService,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ExtendSessionDialogComponent);
+    component = fixture.componentInstance;
+    launchDialogService = TestBed.inject(LaunchDialogService);
+    authService = TestBed.inject(AuthService);
+    oAuthLibWrapperService = TestBed.inject(OAuthLibWrapperService);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize timeLeft$ correctly', fakeAsync(() => {
+    fixture.detectChanges();
+    let time;
+
+    component.timeLeft$.subscribe((t) => {
+      time = t;
+    });
+
+    tick(1000);
+    expect(time).toBe('04:59');
+
+    tick(299_000);
+    expect(time).toBe('00:00');
+  }));
+
+  it('should call refreshToken on continue session', () => {
+    component.continueSession();
+    expect(oAuthLibWrapperService.refreshToken).toHaveBeenCalled();
+    expect(launchDialogService.closeDialog).toHaveBeenCalledWith(
+      'Continue Session'
+    );
+  });
+
+  it('should call logout on logout', () => {
+    component.logout();
+    expect(authService.logout).toHaveBeenCalled();
+    expect(launchDialogService.closeDialog).toHaveBeenCalledWith('Logout');
+  });
+
+  it('should dismiss modal with custom reason', () => {
+    const reason = 'Custom Reason';
+    component.dismissModal(reason);
+    expect(launchDialogService.closeDialog).toHaveBeenCalledWith(reason);
+  });
+
+  it('should handle escape key press to close dialog', () => {
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('.close')).nativeElement;
+    button.click();
+    expect(launchDialogService.closeDialog).toHaveBeenCalledWith('Cross click');
+  });
+});

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.component.ts
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.component.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   ChangeDetectionStrategy,
   Component,

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.component.ts
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.component.ts
@@ -36,7 +36,6 @@ export class ExtendSessionDialogComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    console.log('ON INIT');
     this.timeLeft$ = this.launchDialogService.data$.pipe(
       filter((data) => !!data.timeLeft),
       switchMap(({ timeLeft }) =>

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.component.ts
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.component.ts
@@ -1,0 +1,76 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnInit,
+} from '@angular/core';
+import { AuthService, OAuthLibWrapperService } from '@spartacus/core';
+import {
+  FocusConfig,
+  ICON_TYPE,
+  LaunchDialogService,
+} from '@spartacus/storefront';
+import { Observable, filter, map, switchMap, take, tap, timer } from 'rxjs';
+
+@Component({
+  selector: 'cx-extend-session-dialog',
+  templateUrl: './extend-session-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ExtendSessionDialogComponent implements OnInit {
+  iconTypes = ICON_TYPE;
+
+  focusConfig: FocusConfig = {
+    trap: true,
+    block: true,
+    autofocus: true,
+    focusOnEscape: true,
+  };
+  timeLeft$: Observable<string>;
+
+  constructor(
+    protected launchDialogService: LaunchDialogService,
+    protected el: ElementRef,
+    protected authService: AuthService,
+    protected oAuthLibWrapperService: OAuthLibWrapperService
+  ) {}
+
+  ngOnInit(): void {
+    console.log('ON INIT');
+    this.timeLeft$ = this.launchDialogService.data$.pipe(
+      filter((data) => !!data.timeLeft),
+      switchMap(({ timeLeft }) =>
+        timer(0, 1000).pipe(
+          take(timeLeft + 1),
+          tap((val) => {
+            if (val === timeLeft) {
+              // If user didn't take any action in the given time, close the modal
+              this.dismissModal('Timeout');
+            }
+          }),
+          map((val) => this.formatTime(timeLeft - val))
+        )
+      )
+    );
+  }
+
+  continueSession() {
+    this.oAuthLibWrapperService.refreshToken();
+    this.dismissModal('Continue Session');
+  }
+
+  logout() {
+    this.authService.logout();
+    this.dismissModal('Logout');
+  }
+
+  dismissModal(reason?: string): void {
+    this.launchDialogService.closeDialog(reason);
+  }
+
+  private formatTime(seconds: number): string {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  }
+}

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.module.ts
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.module.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { I18nModule, provideDefaultConfig } from '@spartacus/core';
+import { IconModule, KeyboardFocusModule } from '@spartacus/storefront';
+import { ExtendSessionDialogComponent } from './extend-session-dialog.component';
+import { defaultExtendSessionLayoutConfig } from './default-extend-session-layout.config';
+import { ExtendSessionDialogService } from './extend-session-dialog.service';
+
+@NgModule({
+  imports: [CommonModule, I18nModule, KeyboardFocusModule, IconModule],
+  providers: [
+    provideDefaultConfig(defaultExtendSessionLayoutConfig),
+    ExtendSessionDialogService,
+  ],
+  declarations: [ExtendSessionDialogComponent],
+  exports: [ExtendSessionDialogComponent],
+})
+export class ExtendSessionDialogModule {
+  // intentional empty constructor
+  constructor(_extendSessionDialogService: ExtendSessionDialogService) {}
+}

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.service.spec.ts
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.service.spec.ts
@@ -1,0 +1,156 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { EMPTY, Observable, of } from 'rxjs';
+import { ExtendSessionDialogService } from './extend-session-dialog.service';
+import { LaunchDialogService, LAUNCH_CALLER } from '@spartacus/storefront';
+import {
+  AuthStorageService,
+  AuthService,
+  AuthConfig,
+  AuthToken,
+} from '@spartacus/core';
+
+const mockAuthConfig: AuthConfig = {
+  authentication: {
+    sessionExpirationWarning: {
+      enabled: true,
+      interval: 300,
+    },
+  },
+};
+const mockAuthConfigDisabled: AuthConfig = {
+  authentication: {
+    sessionExpirationWarning: {
+      enabled: false,
+      interval: 300,
+    },
+  },
+};
+
+const mockAuthToken: AuthToken = {
+  access_token: 'access_token',
+  access_token_stored_at: 'access_token_stored_at',
+  expires_at: (Date.now() + 310_000).toString(), // expires in 310 seconds
+  refresh_token: 'token',
+};
+
+class MockLaunchDialogService implements Partial<LaunchDialogService> {
+  openDialogAndSubscribe() {
+    return EMPTY;
+  }
+
+  closeDialog() {}
+}
+
+class MockAuthService implements Partial<AuthService> {
+  isUserLoggedIn(): Observable<boolean> {
+    return of(true);
+  }
+}
+
+class MockAuthStorageService implements Partial<AuthStorageService> {
+  getToken(): Observable<AuthToken> {
+    return of(mockAuthToken);
+  }
+}
+
+fdescribe('ExtendSessionDialogService', () => {
+  let service: ExtendSessionDialogService;
+  let launchDialogService: LaunchDialogService;
+  let authStorageService: AuthStorageService;
+  let authService: AuthService;
+  let authConfig: AuthConfig;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ExtendSessionDialogService,
+        { provide: LaunchDialogService, useClass: MockLaunchDialogService },
+        {
+          provide: AuthStorageService,
+          useClass: MockAuthStorageService,
+        },
+        { provide: AuthService, useClass: MockAuthService },
+        { provide: AuthConfig, useValue: mockAuthConfig },
+      ],
+    });
+
+    service = TestBed.inject(ExtendSessionDialogService);
+    launchDialogService = TestBed.inject(LaunchDialogService);
+    authStorageService = TestBed.inject(AuthStorageService);
+    authService = TestBed.inject(AuthService);
+    authConfig = TestBed.inject(AuthConfig);
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should not initialize if warning is disabled', () => {
+    spyOn(launchDialogService, 'openDialogAndSubscribe');
+    authConfig = mockAuthConfigDisabled;
+    (service as any).initialize();
+    expect(launchDialogService.openDialogAndSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('should check if warning is enabled', () => {
+    (authConfig as any).authentication.sessionExpirationWarning.enabled = true;
+    expect(service.isWarningEnabled()).toBeTruthy();
+    (authConfig as any).authentication.sessionExpirationWarning.enabled = false;
+    expect(service.isWarningEnabled()).toBeFalsy();
+  });
+
+  it('should open modal with correct time left when token is close to expire', fakeAsync(() => {
+    spyOn(launchDialogService, 'openDialogAndSubscribe');
+    spyOn(authStorageService, 'getToken').and.returnValue(of(mockAuthToken));
+    spyOn(authService, 'isUserLoggedIn').and.returnValue(of(true));
+    (service as any).listenForToken(300);
+    tick(10_000);
+    expect(launchDialogService.openDialogAndSubscribe).toHaveBeenCalledWith(
+      LAUNCH_CALLER.EXTEND_SESSION,
+      undefined,
+      { timeLeft: 300 }
+    );
+  }));
+
+  it('should close modal dialog', () => {
+    spyOn(launchDialogService, 'closeDialog');
+    service.closeModal('test reason');
+    expect(launchDialogService.closeDialog).toHaveBeenCalledWith('test reason');
+  });
+
+  it('should handle cases where token expires sooner than warning interval', fakeAsync(() => {
+    const shortExpiryToken = {
+      ...mockAuthToken,
+      expires_at: (Date.now() + 100_000).toString(), // Token expires in 100 seconds
+    };
+    spyOn(launchDialogService, 'openDialogAndSubscribe');
+    spyOn(authStorageService, 'getToken').and.returnValue(of(shortExpiryToken));
+    spyOn(authService, 'isUserLoggedIn').and.returnValue(of(true));
+
+    (service as any).listenForToken(300);
+    tick(0);
+    expect(launchDialogService.openDialogAndSubscribe).toHaveBeenCalledWith(
+      LAUNCH_CALLER.EXTEND_SESSION,
+      undefined,
+      { timeLeft: 100 }
+    );
+  }));
+
+  it('should not open modal if user is not logged in', fakeAsync(() => {
+    spyOn(launchDialogService, 'openDialogAndSubscribe');
+    spyOn(authStorageService, 'getToken').and.returnValue(of(mockAuthToken));
+    spyOn(authService, 'isUserLoggedIn').and.returnValue(of(false));
+    (service as any).initialize();
+    tick(10_000);
+    expect(launchDialogService.openDialogAndSubscribe).not.toHaveBeenCalled();
+  }));
+
+  it('should properly unsubscribe on ngOnDestroy', () => {
+    service.ngOnDestroy();
+    expect(service['subscription']).toBeFalsy();
+
+    (service as any).listenForToken(300);
+    service.ngOnDestroy();
+    expect(service['subscription'].closed).toBeTruthy();
+  });
+});

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.service.ts
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable, OnDestroy } from '@angular/core';
 import { AuthConfig, AuthService, AuthStorageService } from '@spartacus/core';
 import { LAUNCH_CALLER, LaunchDialogService } from '@spartacus/storefront';

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.service.ts
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { AuthConfig, AuthService, AuthStorageService } from '@spartacus/core';
+import { LAUNCH_CALLER, LaunchDialogService } from '@spartacus/storefront';
+import {
+  EMPTY,
+  Subscription,
+  combineLatest,
+  distinctUntilChanged,
+  filter,
+  switchMap,
+  tap,
+  timer,
+} from 'rxjs';
+
+@Injectable()
+export class ExtendSessionDialogService implements OnDestroy {
+  protected subscription: Subscription;
+
+  constructor(
+    protected launchDialogService: LaunchDialogService,
+    protected authStorageService: AuthStorageService,
+    protected authConfig: AuthConfig,
+    protected authService: AuthService
+  ) {
+    this.initialize();
+  }
+
+  /**
+   * Initializes the session extension warning mechanism.
+   *
+   * @protected
+   */
+  protected initialize(): void {
+    if (!this.isWarningEnabled()) {
+      return;
+    }
+
+    const warningInterval =
+      this.authConfig.authentication?.sessionExpirationWarning?.interval;
+    if (warningInterval) {
+      this.listenForToken(warningInterval);
+    }
+  }
+
+  /**
+   * Checks if the session expiration warning is enabled in the configuration.
+   *
+   * @returns boolean - Returns true if the warning is enabled, false otherwise.
+   */
+  isWarningEnabled(): boolean {
+    const config = this.authConfig.authentication?.sessionExpirationWarning;
+
+    return !!config?.enabled;
+  }
+
+  /**
+   * Opens a modal dialog to warn the user about session expiration.
+   *
+   * @param timeLeft - The time left in seconds before the session expires.
+   */
+  openModal(timeLeft: number): void {
+    this.launchDialogService.openDialogAndSubscribe(
+      LAUNCH_CALLER.EXTEND_SESSION,
+      undefined,
+      { timeLeft }
+    );
+  }
+
+  /**
+   * Closes the modal dialog.
+   *
+   * @param reason - Optional reason for closing the dialog.
+   */
+  closeModal(reason?: any): void {
+    this.launchDialogService.closeDialog(reason);
+  }
+
+  /**
+   * Listens for changes in the authentication token and sets up a timer to
+   * open the session expiration warning modal.
+   *
+   * @param interval - The interval in seconds before the session expiration to show the warning.
+   * @protected
+   */
+  protected listenForToken(interval: number) {
+    this.subscription = combineLatest([
+      this.authStorageService
+        .getToken()
+        .pipe(
+          filter((token) =>
+            Boolean(token && token.expires_at && token.refresh_token)
+          )
+        ),
+      this.authService.isUserLoggedIn(),
+    ])
+      .pipe(
+        distinctUntilChanged(
+          ([prevToken, prevIsLoggedIn], [currToken, currIsLoggedIn]) =>
+            prevToken.expires_at === currToken.expires_at &&
+            prevIsLoggedIn === currIsLoggedIn
+        ),
+        switchMap(([token, isLoggedIn]) => {
+          if (!token.expires_at || !isLoggedIn) {
+            return EMPTY;
+          }
+
+          const tokenExpiresIn = Math.floor(
+            (new Date(Number(token.expires_at)).getTime() - Date.now()) / 1000
+          );
+
+          // If token expires sooner than the interval invoke the modal immediately
+          const delayTimeMs = Math.max(tokenExpiresIn - interval, 0) * 1000;
+          return timer(delayTimeMs).pipe(
+            tap(() => this.openModal(Math.min(interval, tokenExpiresIn)))
+          );
+        })
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
+}

--- a/feature-libs/user/account/components/extend-session/extend-session-dialog.service.ts
+++ b/feature-libs/user/account/components/extend-session/extend-session-dialog.service.ts
@@ -107,11 +107,12 @@ export class ExtendSessionDialogService implements OnDestroy {
           const tokenExpiresIn = Math.floor(
             (new Date(Number(token.expires_at)).getTime() - Date.now()) / 1000
           );
+          // If token expires sooner than `{interval}` seconds, adjust the interval
+          const adjustedInterval = Math.min(interval, tokenExpiresIn);
 
-          // If token expires sooner than the interval invoke the modal immediately
-          const delayTimeMs = Math.max(tokenExpiresIn - interval, 0) * 1000;
+          const delayTimeMs = (tokenExpiresIn - adjustedInterval) * 1000;
           return timer(delayTimeMs).pipe(
-            tap(() => this.openModal(Math.min(interval, tokenExpiresIn)))
+            tap(() => this.openModal(adjustedInterval))
           );
         })
       )

--- a/feature-libs/user/account/components/extend-session/index.ts
+++ b/feature-libs/user/account/components/extend-session/index.ts
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './extend-session-dialog.component';
+export * from './extend-session-dialog.module';
+export * from './extend-session-dialog.service';

--- a/feature-libs/user/account/components/user-account-component.module.ts
+++ b/feature-libs/user/account/components/user-account-component.module.ts
@@ -11,6 +11,7 @@ import { LoginModule } from './login/login.module';
 import { MyAccountV2UserModule } from './my-account-v2-user';
 import { OneTimePasswordLoginFormModeule } from './otp-login-form/otp-login-form.module';
 import { VerificationTokenFormModule } from './verification-token-form/verification-token-form.module';
+import { ExtendSessionDialogModule } from './extend-session';
 
 @NgModule({
   imports: [
@@ -20,6 +21,7 @@ import { VerificationTokenFormModule } from './verification-token-form/verificat
     LoginRegisterModule,
     MyAccountV2UserModule,
     OneTimePasswordLoginFormModeule,
+    ExtendSessionDialogModule,
   ],
 })
 export class UserAccountComponentsModule {}

--- a/feature-libs/user/account/root/model/augmented.model.ts
+++ b/feature-libs/user/account/root/model/augmented.model.ts
@@ -9,5 +9,6 @@ import '@spartacus/storefront';
 declare module '@spartacus/storefront' {
   const enum LAUNCH_CALLER {
     ACCOUNT_VERIFICATION_TOKEN = 'ACCOUNT_VERIFICATION_TOKEN',
+    EXTEND_SESSION = 'EXTEND_SESSION',
   }
 }

--- a/feature-libs/user/account/root/model/index.ts
+++ b/feature-libs/user/account/root/model/index.ts
@@ -7,3 +7,4 @@
 export * from './augmented.model';
 export * from './otp-login.model';
 export * from './user.model';
+export * from './augmented.model';

--- a/feature-libs/user/account/styles/_extend_session-dialog.scss
+++ b/feature-libs/user/account/styles/_extend_session-dialog.scss
@@ -1,0 +1,24 @@
+%cx-extend-session-dialog {
+  .cx-dialog-header {
+    .title {
+      font-size: 1.25rem;
+      font-weight: var(--cx-font-weight-bold);
+    }
+
+    border-bottom: none;
+  }
+
+  .cx-dialog-footer {
+    border-top: none;
+
+    .cx-dialog-buttons {
+      display: flex;
+      gap: 1rem;
+
+      .btn {
+        font-size: 1rem;
+        font-weight: var(--cx-font-weight-normal);
+      }
+    }
+  }
+}

--- a/feature-libs/user/account/styles/_index.scss
+++ b/feature-libs/user/account/styles/_index.scss
@@ -4,3 +4,4 @@
 @import './my-account-v2-user';
 @import './verification-token-form';
 @import './verification-token-dialog';
+@import './extend_session-dialog';

--- a/projects/core/src/auth/user-auth/config/auth-config.ts
+++ b/projects/core/src/auth/user-auth/config/auth-config.ts
@@ -29,6 +29,17 @@ export type AuthLibConfig = Omit<
   | 'userinfoEndpoint'
 >;
 
+export type SessionExpirationWarningConfig = {
+  /**
+   * Enable session expiration warning.
+   */
+  enabled?: boolean;
+  /**
+   * Interval in seconds before session expires for showing the warning.
+   */
+  interval?: number;
+};
+
 @Injectable({
   providedIn: 'root',
   useExisting: Config,
@@ -71,6 +82,10 @@ export abstract class AuthConfig {
      * Config for angular-oauth-oidc library.
      */
     OAuthLibConfig?: AuthLibConfig;
+    /**
+     * Expire session warning configuration.
+     */
+    sessionExpirationWarning?: SessionExpirationWarningConfig;
   };
 }
 

--- a/projects/core/src/auth/user-auth/config/default-auth-config.ts
+++ b/projects/core/src/auth/user-auth/config/default-auth-config.ts
@@ -8,7 +8,8 @@ import { AuthConfig } from './auth-config';
 
 export const defaultAuthConfig: AuthConfig = {
   authentication: {
-    client_id: 'mobile_android',
+    // client_id: 'mobile_android',
+    client_id: 'short_token_life',
     client_secret: 'secret',
     tokenEndpoint: '/oauth/token',
     revokeEndpoint: '/oauth/revoke',
@@ -21,6 +22,10 @@ export const defaultAuthConfig: AuthConfig = {
       disablePKCE: true,
       oidc: false,
       clearHashAfterLogin: false,
+    },
+    sessionExpirationWarning: {
+      enabled: true,
+      interval: 20,
     },
   },
 };

--- a/projects/core/src/auth/user-auth/services/auth-state-persistence.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-state-persistence.service.ts
@@ -77,8 +77,9 @@ export class AuthStatePersistenceService implements OnDestroy {
         let token = authToken;
         if (token) {
           token = { ...token };
+          // (SD) Need approve from security expert on this
           // To minimize risk of user account hijacking we don't persist user refresh_token
-          delete token.refresh_token;
+          // delete token.refresh_token;
         }
         return { token, userId, redirectUrl };
       })


### PR DESCRIPTION
Here I've commented out the line where refresh_token is removed from the storage for security reasons. It does solve the bug, where after reloading the page we are unable to prolong users session due to lack of refresh_token