### PR TITLE
chore: CXSPA-7900 Ajust schematics to enable  option in fresh apps

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -199,8 +199,10 @@ describe('OptimizedSsrEngine', () => {
               "debug": false,
               "renderingStrategyResolver": "() => ssr_optimization_options_1.RenderingStrategy.ALWAYS_SSR",
               "logger": "DefaultExpressServerLogger",
-              "shouldCacheRenderingResult": "({ options, entry }) => !(options.avoidCachingErrors === true && Boolean(entry.err))",
-              "avoidCachingErrors": false
+              "shouldCacheRenderingResult": "({ options, entry }) => !(options.featureToggles?.avoidCachingErrors === true && Boolean(entry.err))",
+              "featureToggles": {
+                "avoidCachingErrors": false
+              }
             }
           }
         }",
@@ -390,7 +392,9 @@ describe('OptimizedSsrEngine', () => {
       it('should not cache errors if `avoidCachingErrors` is set to true', fakeAsync(() => {
         const engineRunner = TestEngineRunner.withError({
           cache: true,
-          avoidCachingErrors: true,
+          featureToggles: {
+            avoidCachingErrors: true,
+          },
         }).request('a');
 
         tick(200);
@@ -408,7 +412,9 @@ describe('OptimizedSsrEngine', () => {
       it('should cache errors if `avoidCachingErrors` is set to false', fakeAsync(() => {
         const engineRunner = TestEngineRunner.withError({
           cache: true,
-          avoidCachingErrors: false,
+          featureToggles: {
+            avoidCachingErrors: false,
+          },
         }).request('a');
 
         tick(200);
@@ -426,7 +432,9 @@ describe('OptimizedSsrEngine', () => {
       it('should cache HTML if `avoidCachingErrors` is set to true', fakeAsync(() => {
         const engineRunner = new TestEngineRunner({
           cache: true,
-          avoidCachingErrors: true,
+          featureToggles: {
+            avoidCachingErrors: true,
+          },
         }).request('a');
 
         tick(200);
@@ -440,7 +448,9 @@ describe('OptimizedSsrEngine', () => {
       it('should cache HTML if `avoidCachingErrors` is set to false', fakeAsync(() => {
         const engineRunner = new TestEngineRunner({
           cache: true,
-          avoidCachingErrors: true,
+          featureToggles: {
+            avoidCachingErrors: true,
+          },
         }).request('a');
 
         tick(200);
@@ -1457,10 +1467,12 @@ describe('OptimizedSsrEngine', () => {
           "[spartacus] SSR optimization engine initialized",
           {
             "options": {
-              "avoidCachingErrors": false,
               "cacheSize": 3000,
               "concurrency": 10,
               "debug": false,
+              "featureToggles": {
+                "avoidCachingErrors": false,
+              },
               "forcedSsrTimeout": 60000,
               "logger": "MockExpressServerLogger",
               "maxRenderTime": 300000,
@@ -1473,7 +1485,7 @@ describe('OptimizedSsrEngine', () => {
                 : ssr_optimization_options_1.RenderingStrategy.DEFAULT;
         }",
               "reuseCurrentRendering": true,
-              "shouldCacheRenderingResult": "({ options, entry }) => !(options.avoidCachingErrors === true && Boolean(entry.err))",
+              "shouldCacheRenderingResult": "({ options, entry }) => !(options.featureToggles?.avoidCachingErrors === true && Boolean(entry.err))",
               "timeout": 3000,
             },
           },

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -5,7 +5,6 @@
  */
 
 /* webpackIgnore: true */
-import { deepMerge } from '@spartacus/core';
 import { Request, Response } from 'express';
 import * as fs from 'fs';
 import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
@@ -73,14 +72,13 @@ export class OptimizedSsrEngine {
     this.ssrOptions = ssrOptions
       ? {
           ...defaultSsrOptimizationOptions,
-
           // overrides the default options
           ...ssrOptions,
-          // deep merge the feature toggles
-          featureToggles: deepMerge(
-            { ...defaultSsrOptimizationOptions.featureToggles },
-            ssrOptions.featureToggles
-          ),
+          // merge feature toggles
+          featureToggles: {
+            ...defaultSsrOptimizationOptions.featureToggles,
+            ...ssrOptions.featureToggles,
+          },
         }
       : undefined;
 

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -5,6 +5,7 @@
  */
 
 /* webpackIgnore: true */
+import { deepMerge } from '@spartacus/core';
 import { Request, Response } from 'express';
 import * as fs from 'fs';
 import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
@@ -72,8 +73,14 @@ export class OptimizedSsrEngine {
     this.ssrOptions = ssrOptions
       ? {
           ...defaultSsrOptimizationOptions,
+
           // overrides the default options
           ...ssrOptions,
+          // deep merge the feature toggles
+          featureToggles: deepMerge(
+            { ...defaultSsrOptimizationOptions.featureToggles },
+            ssrOptions.featureToggles
+          ),
         }
       : undefined;
 

--- a/core-libs/setup/ssr/optimized-engine/rendering-cache.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache.spec.ts
@@ -9,7 +9,6 @@ import {
 const options: SsrOptimizationOptions = {
   shouldCacheRenderingResult:
     defaultSsrOptimizationOptions.shouldCacheRenderingResult,
-  avoidCachingErrors: defaultSsrOptimizationOptions.avoidCachingErrors,
 };
 
 describe('RenderingCache', () => {
@@ -169,7 +168,9 @@ describe('RenderingCache with cacheSize', () => {
       it('should cache HTML if avoidCachingErrors is false', () => {
         renderingCache = new RenderingCache({
           ...options,
-          avoidCachingErrors: false,
+          featureToggles: {
+            avoidCachingErrors: false,
+          },
         });
         renderingCache.store('a', undefined, 'a');
         expect(renderingCache.get('a')).toEqual({ html: 'a', err: undefined });
@@ -178,7 +179,9 @@ describe('RenderingCache with cacheSize', () => {
       it('should cache HTML if avoidCachingErrors is true', () => {
         renderingCache = new RenderingCache({
           ...options,
-          avoidCachingErrors: false,
+          featureToggles: {
+            avoidCachingErrors: false,
+          },
         });
         renderingCache.store('a', undefined, 'a');
         expect(renderingCache.get('a')).toEqual({ html: 'a', err: undefined });
@@ -187,7 +190,9 @@ describe('RenderingCache with cacheSize', () => {
       it('should cache errors if avoidCachingErrors is false', () => {
         renderingCache = new RenderingCache({
           ...options,
-          avoidCachingErrors: false,
+          featureToggles: {
+            avoidCachingErrors: false,
+          },
         });
         renderingCache.store('a', new Error('err'), 'a');
         expect(renderingCache.get('a')).toEqual({
@@ -199,7 +204,9 @@ describe('RenderingCache with cacheSize', () => {
       it('should not cache errors if avoidCachingErrors is true', () => {
         renderingCache = new RenderingCache({
           ...options,
-          avoidCachingErrors: true,
+          featureToggles: {
+            avoidCachingErrors: true,
+          },
         });
         renderingCache.store('a', new Error('err'), 'a');
         expect(renderingCache.get('a')).toBeFalsy();

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -162,7 +162,7 @@ export interface SsrOptimizationOptions {
      * It only affects the default `shouldCacheRenderingResult`.
      * Custom implementations of `shouldCacheRenderingResult` may ignore this setting.
      */
-    avoidCachingErrors: boolean;
+    avoidCachingErrors?: boolean;
   };
 }
 
@@ -172,7 +172,11 @@ export enum RenderingStrategy {
   ALWAYS_SSR = 1,
 }
 
-export const defaultSsrOptimizationOptions: SsrOptimizationOptions = {
+// To enforce default values for `featureToggles`
+export const defaultSsrOptimizationOptions: Required<
+  Pick<SsrOptimizationOptions, 'featureToggles'>
+> &
+  SsrOptimizationOptions = {
   cacheSize: 3000,
   concurrency: 10,
   timeout: 3_000,

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -172,11 +172,16 @@ export enum RenderingStrategy {
   ALWAYS_SSR = 1,
 }
 
-// To enforce default values for `featureToggles`
-export const defaultSsrOptimizationOptions: Required<
-  Pick<SsrOptimizationOptions, 'featureToggles'>
-> &
-  SsrOptimizationOptions = {
+/**
+ * Deeply required type for `featureToggles` property.
+ */
+type DeepRequired<T> = {
+  [P in keyof T]-?: DeepRequired<T[P]>;
+};
+
+export const defaultSsrOptimizationOptions: SsrOptimizationOptions &
+  // To not forget adding default values, when adding new feature toggles in the type in the future
+  DeepRequired<Pick<SsrOptimizationOptions, 'featureToggles'>> = {
   cacheSize: 3000,
   concurrency: 10,
   timeout: 3_000,

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -148,17 +148,22 @@ export interface SsrOptimizationOptions {
   }) => boolean;
 
   /**
-   * Determines if rendering errors should be skipped from caching.
-   *
-   * NOTE: It's a temporary feature toggle, to be removed in the future.
-   *
-   * It's recommended to set to `true` (i.e. errors are skipped from caching),
-   * which will become the default behavior, when this feature toggle is removed.
-   *
-   * It only affects the default `shouldCacheRenderingResult`.
-   * Custom implementations of `shouldCacheRenderingResult` may ignore this setting.
+   * Toggles providing granular adaptation to breaking changes in OptimizedSsrEngine.
+   * They are temporary and will be removed in the future.
+   * Each toggle has its own lifespan.
    */
-  avoidCachingErrors?: boolean;
+  featureToggles?: {
+    /**
+     * Determines if rendering errors should be skipped from caching.
+     *
+     * It's recommended to set to `true` (i.e. errors are skipped from caching),
+     * which will become the default behavior, when this feature toggle is removed.
+     *
+     * It only affects the default `shouldCacheRenderingResult`.
+     * Custom implementations of `shouldCacheRenderingResult` may ignore this setting.
+     */
+    avoidCachingErrors: boolean;
+  };
 }
 
 export enum RenderingStrategy {
@@ -180,6 +185,10 @@ export const defaultSsrOptimizationOptions: SsrOptimizationOptions = {
   ),
   logger: new DefaultExpressServerLogger(),
   shouldCacheRenderingResult: ({ options, entry }) =>
-    !(options.avoidCachingErrors === true && Boolean(entry.err)),
-  avoidCachingErrors: false,
+    !(
+      options.featureToggles?.avoidCachingErrors === true && Boolean(entry.err)
+    ),
+  featureToggles: {
+    avoidCachingErrors: false,
+  },
 };

--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -214,7 +214,9 @@ import { fileURLToPath } from 'node:url';
 import AppServerModule from './src/main.server';
 
 const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
-  avoidCachingErrors: true, // takes effect only when cache is enabled
+  featureToggles: {
+    avoidCachingErrors: true,
+  },
 });
 
 // The Express app is exported so that it can be used by serverless Functions.

--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -213,7 +213,9 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import AppServerModule from './src/main.server';
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine);
+const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
+  avoidCachingErrors: true, // takes effect only when cache is enabled
+});
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/projects/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/projects/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -11,7 +11,9 @@ import { fileURLToPath } from 'node:url';
 import AppServerModule from './src/main.server';
 
 const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
-  avoidCachingErrors: true, // takes effect only when cache is enabled
+  featureToggles: {
+    avoidCachingErrors: true,
+  },
 });
 
 // The Express app is exported so that it can be used by serverless Functions.

--- a/projects/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/projects/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -10,7 +10,9 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import AppServerModule from './src/main.server';
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine);
+const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
+  avoidCachingErrors: true, // takes effect only when cache is enabled
+});
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/projects/storefrontapp/server.ts
+++ b/projects/storefrontapp/server.ts
@@ -23,6 +23,9 @@ const ssrOptions: SsrOptimizationOptions = {
   timeout: Number(
     process.env['SSR_TIMEOUT'] ?? defaultSsrOptimizationOptions.timeout
   ),
+  featureToggles: {
+    avoidCachingErrors: true,
+  },
 };
 
 const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions);


### PR DESCRIPTION
PR contains a small adjustment to schematics that enables `avoidCachingErrors` optimization option in a fresh application to avoid tech debt.

QA steps:
- build and deploy Spartacus packages locally:
  `npx ts-node ./tools/schematics/testing.ts` in the SPA root folder`
- create new app `npx @angular/cli@17 new my-app --standalone=false --style=scss --routing=false`
- go to the project's directory and install Spartacus from local packages:
  `npx @angular/cli@17 add @spartacus/schematics@latest --ssr --baseUrl="https://40.76.109.9:9002"`
- check in `server.ts` whether `avoidCachingErrors` has been added:
  ```
  const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
    avoidCachingErrors: true, // takes effect only when cache is enabled
  });
  ```

closes [CXSPA-7900](https://jira.tools.sap/browse/CXSPA-7900)