### PR TITLE
fix: CXSPA-6950 Deprecate debug flag in OptimizedSsrOptions

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -175,7 +175,6 @@ describe('OptimizedSsrEngine', () => {
               "forcedSsrTimeout": 60000,
               "maxRenderTime": 300000,
               "reuseCurrentRendering": true,
-              "debug": false,
               "renderingStrategyResolver": "() => ssr_optimization_options_1.RenderingStrategy.ALWAYS_SSR",
               "logger": "DefaultExpressServerLogger"
             }
@@ -1275,7 +1274,6 @@ describe('OptimizedSsrEngine', () => {
               "forcedSsrTimeout": 60000,
               "maxRenderTime": 300000,
               "reuseCurrentRendering": true,
-              "debug": false,
               "renderingStrategyResolver": "(request) => {\\n    if (hasExcludedUrl(request, defaultAlwaysCsrOptions.excludedUrls)) {\\n        return ssr_optimization_options_1.RenderingStrategy.ALWAYS_CSR;\\n    }\\n    return shouldFallbackToCsr(request, options)\\n        ? ssr_optimization_options_1.RenderingStrategy.ALWAYS_CSR\\n        : ssr_optimization_options_1.RenderingStrategy.DEFAULT;\\n}",
               "logger": "DefaultExpressServerLogger"
             }
@@ -1296,7 +1294,6 @@ describe('OptimizedSsrEngine', () => {
                 "options": {
                   "cacheSize": 3000,
                   "concurrency": 10,
-                  "debug": false,
                   "forcedSsrTimeout": 60000,
                   "logger": "MockExpressServerLogger",
                   "maxRenderTime": 300000,

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -318,14 +318,15 @@ export class OptimizedSsrEngine {
     });
   }
 
+  /**
+   * @deprecated This method will be private in the future.
+   */
   protected log(
     message: string,
-    debug = true,
+    _ignoredLegacyParameter = true,
     context: ExpressServerLoggerContext
   ): void {
-    if (debug || this.ssrOptions?.debug) {
-      this.logger.log(message, context || {});
-    }
+    this.logger.log(message, context || {});
   }
 
   /** Retrieve the document from the cache or the filesystem */

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -319,7 +319,7 @@ export class OptimizedSsrEngine {
   }
 
   /**
-   * @deprecated since v2211.26 - This method will be private in the future.
+   * @deprecated since v2211.27 - This method will be private in the future.
    */
   protected log(
     message: string,

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -319,11 +319,11 @@ export class OptimizedSsrEngine {
   }
 
   /**
-   * @deprecated This method will be private in the future.
+   * @deprecated since v2211.26 - This method will be private in the future.
    */
   protected log(
     message: string,
-    _ignoredLegacyParameter = true,
+    _ignoredLegacyDebugParameter = true,
     context: ExpressServerLoggerContext
   ): void {
     this.logger.log(message, context || {});

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -114,7 +114,13 @@ export interface SsrOptimizationOptions {
   reuseCurrentRendering?: boolean;
 
   /**
-   * Enable detailed logs for troubleshooting problems
+   * @deprecated - This flag is not used anymore since v2211.26.
+   *
+   * Now all the information about the traffic and rendering is logged unconditionally:
+   * - receiving requests
+   * - responding to requests (either with HTML result, error or fallback to CSR)
+   * - start and end of renders
+   * - timeout of renders (due to passing `maxRenderTime`)
    */
   debug?: boolean;
 

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -114,7 +114,7 @@ export interface SsrOptimizationOptions {
   reuseCurrentRendering?: boolean;
 
   /**
-   * @deprecated - This flag is not used anymore since v2211.26.
+   * @deprecated - This flag is not used anymore since v2211.27.
    *
    * Now all the information about the traffic and rendering is logged unconditionally:
    * - receiving requests
@@ -151,7 +151,6 @@ export const defaultSsrOptimizationOptions: SsrOptimizationOptions = {
   forcedSsrTimeout: 60_000,
   maxRenderTime: 300_000,
   reuseCurrentRendering: true,
-  debug: false,
   renderingStrategyResolver: defaultRenderingStrategyResolver(
     defaultRenderingStrategyResolverOptions
   ),


### PR DESCRIPTION
This PR contains changes in the `debug` flag which is part of `OptimizedSsrOptions`. Due to a request from the Support Team, we enabled all logs produced by the `OptimizedSsrEngine`, regardless of the `debug` flag value. The flag itself has been deprecated.

In addition, we deprecated the protected `log` method from `OptimizedSsrEngine` which depended on the `debug` flag. We want to make it private in the future.

QA steps: 
- in the `server.ts` file, add `maxRenderTIme` with a small value to `SsrOptimizationOptions`:
  ```
  const ssrOptions: SsrOptimizationOptions = {
    timeout: Number(
      process.env['SSR_TIMEOUT'] ?? defaultSsrOptimizationOptions.timeout
    ),
    maxRenderTime: 100,
  };
  ```
- run SSR in dev mode
  `npm run dev:ssr`
- open app in the browser and verify if server logs contain message:
   ```
   {
    "message": "Rendering of /electronics-spa/en/USD completed after the specified maxRenderTime, therefore it was ignored.",
    /* ... */
  }
   ```
- in the `server.ts` file, add `maxRenderTIme` with a small value to `SsrOptimizationOptions`:
  ```
  const ssrOptions: SsrOptimizationOptions = {
    timeout: Number(
      process.env['SSR_TIMEOUT'] ?? defaultSsrOptimizationOptions.timeout
    ),
    debug: false
    maxRenderTime: 100,
  };
  ```
- reload the page and verify that the log is sill present, which means `debug` flag was not taken into consideration

closes [CXSPA-6950](https://jira.tools.sap/browse/CXSPA-6950)