### PR TITLE
feat: CXSPA-7861 Disable GitHub Code Scans on tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-        config: >
+        config: |
           name: Disable scan for tests
           paths-ignore:
             - "projects/storefrontapp-e2e-cypress/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,13 @@ on:
   schedule:
     - cron: '45 2 * * *'
 
+paths-ignore: 
+  # ignore e2e tests
+  - "projects/storefrontapp-e2e-cypress/**"
+  # ignore all unit tests
+  - "**/*.spec.ts"
+
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,11 +64,11 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-        paths-ignore: 
-          # ignore e2e tests
-          - "projects/storefrontapp-e2e-cypress/**"
-          # ignore all unit tests
-          - "**/*.spec.ts"
+        config: >
+          name: Disable scan for tests
+          paths-ignore:
+            - "projects/storefrontapp-e2e-cypress/**"
+            - "**/*.spec.ts"
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,7 +68,8 @@ jobs:
           name: Disable scan for tests
           paths-ignore:
             - "projects/storefrontapp-e2e-cypress/**"
-            - "**/*{.spec,_spec}.ts"
+            - "**/*.spec.ts"
+            - "**/*_spec.ts"
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,7 +68,7 @@ jobs:
           name: Disable scan for tests
           paths-ignore:
             - "projects/storefrontapp-e2e-cypress/**"
-            - "**/*.spec.ts"
+            - "**/*{.spec,_spec}.ts"
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,18 @@ name: "CodeQL"
 on:
   push:
     branches: [ "develop", "develop*", "release-*", "epic/*"]
+    paths-ignore: 
+    # ignore e2e tests
+    - "projects/storefrontapp-e2e-cypress/**"
+    # ignore all unit tests
+    - "**/*.spec.ts"
   pull_request:
     branches: [ "develop", "develop*", "release-*", "epic/*" ]
+    paths-ignore: 
+    # ignore e2e tests
+    - "projects/storefrontapp-e2e-cypress/**"
+    # ignore all unit tests
+    - "**/*.spec.ts"
   schedule:
     - cron: '45 2 * * *'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,18 +14,8 @@ name: "CodeQL"
 on:
   push:
     branches: [ "develop", "develop*", "release-*", "epic/*"]
-    paths-ignore: 
-    # ignore e2e tests
-    - "projects/storefrontapp-e2e-cypress/**"
-    # ignore all unit tests
-    - "**/*.spec.ts"
   pull_request:
     branches: [ "develop", "develop*", "release-*", "epic/*" ]
-    paths-ignore: 
-    # ignore e2e tests
-    - "projects/storefrontapp-e2e-cypress/**"
-    # ignore all unit tests
-    - "**/*.spec.ts"
   schedule:
     - cron: '45 2 * * *'
 
@@ -33,6 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources
@@ -73,6 +64,11 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
+          paths-ignore: 
+          # ignore e2e tests
+          - "projects/storefrontapp-e2e-cypress/**"
+          # ignore all unit tests
+          - "**/*.spec.ts"
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,6 +69,7 @@ jobs:
           paths-ignore:
             - "projects/storefrontapp-e2e-cypress/**"
             - "**/*.spec.ts"
+            - "**/*.spec.js"
             - "**/*_spec.ts"
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-          paths-ignore: 
+        paths-ignore: 
           # ignore e2e tests
           - "projects/storefrontapp-e2e-cypress/**"
           # ignore all unit tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,12 +29,6 @@ on:
   schedule:
     - cron: '45 2 * * *'
 
-paths-ignore: 
-  # ignore e2e tests
-  - "projects/storefrontapp-e2e-cypress/**"
-  # ignore all unit tests
-  - "**/*.spec.ts"
-
 
 jobs:
   analyze:


### PR DESCRIPTION
This PR contains the `codeql.yml` config adjustment for disabling code scans on e2es and unit tests.

QA:
- go to https://github.com/SAP/spartacus/actions/runs/10040268780/job/27745960779?pr=19064
- open `Perform CodeQL Analysis` > `Extracting javascript`
- verify that ignored files are not present in logs

closes [CXSPA-7861](https://jira.tools.sap/browse/CXSPA-7861)