### PR TITLE
fix: (CXSPA-942) - Provides titles for all buttons with icons only

### DIFF
--- a/feature-libs/asm/components/customer-list/customer-list.component.html
+++ b/feature-libs/asm/components/customer-list/customer-list.component.html
@@ -471,6 +471,7 @@
     class="close"
     attr.aria-label="{{ 'common.close' | cxTranslate }}"
     (click)="closeModal('Cross click')"
+    title="{{ 'common.close' | cxTranslate }}"
   >
     <span aria-hidden="true">
       <cx-icon [type]="iconTypes.CLOSE"></cx-icon>

--- a/feature-libs/asm/customer-360/components/asm-customer-360/asm-customer-360.component.html
+++ b/feature-libs/asm/customer-360/components/asm-customer-360/asm-customer-360.component.html
@@ -213,6 +213,7 @@
     type="button"
     class="close"
     attr.aria-label="{{ 'common.close' | cxTranslate }}"
+    attr.title="{{ 'common.close' | cxTranslate }}"
     (click)="closeModal('Cross click')"
   >
     <cx-icon [type]="closeIcon"></cx-icon>

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.component.html
@@ -55,6 +55,7 @@
         class="cx-asm-customer-360-promotion-listing-search-icon-reset"
         [type]="iconTypes.CLOSE"
         role="button"
+        title="{{ 'common.close' | cxTranslate }}"
         (click)="this.searchBox.value = ''"
       ></cx-icon>
       <cx-icon

--- a/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.html
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.html
@@ -19,6 +19,7 @@
           type="button"
           class="close"
           attr.aria-label="{{ 'addToCart.closeModal' | cxTranslate }}"
+          title="{{ 'common.close' | cxTranslate }}"
           (click)="dismissModal('Cross click')"
         >
           <span aria-hidden="true">
@@ -126,6 +127,7 @@
         <button
           type="button"
           class="close"
+          title="{{ 'common.close' | cxTranslate }}"
           [attr.aria-label]="'common.close' | cxTranslate"
           (click)="dismissModal('Cross click')"
         >

--- a/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.html
+++ b/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.html
@@ -26,6 +26,7 @@
           <button
             type="button"
             class="close"
+            title="{{ 'common.close' | cxTranslate }}"
             [attr.aria-label]="'common.close' | cxTranslate"
             (click)="removeVoucher(voucher.voucherCode)"
             [disabled]="cartIsLoading"

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog.component.html
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog.component.html
@@ -21,6 +21,7 @@
           [attr.aria-label]="'common.close' | cxTranslate"
           class="close"
           type="button"
+          title="{{ 'common.close' | cxTranslate }}"
         >
           <span aria-hidden="true">
             <cx-icon [type]="iconTypes.CLOSE"></cx-icon>

--- a/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.component.html
+++ b/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.component.html
@@ -13,7 +13,12 @@
       }}
     </span>
 
-    <button class="close" type="button" (click)="isVisible = !isVisible">
+    <button
+      class="close"
+      type="button"
+      title="{{ 'common.close' | cxTranslate }}"
+      (click)="isVisible = !isVisible"
+    >
       <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
     </button>
   </div>

--- a/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.component.html
+++ b/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.component.html
@@ -20,6 +20,8 @@
     <button
       class="close"
       type="button"
+      title="{{ 'common.close' | cxTranslate }}"
+      [attr.aria-label]="'common.close' | cxTranslate"
       (click)="removeMessage(cartModification)"
     >
       <cx-icon [type]="iconTypes.CLOSE"></cx-icon>

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-dialog.component.html
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-dialog.component.html
@@ -16,6 +16,7 @@
       <button
         (click)="close('Close Import Products Dialog')"
         [attr.aria-label]="'importEntriesDialog.close' | cxTranslate"
+        title="{{ 'importEntriesDialog.close' | cxTranslate }}"
         class="cx-import-entries-close close"
         type="button"
         [disabled]="(summary$ | async)?.loading"

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.html
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.html
@@ -28,6 +28,7 @@
       (click)="clear($event)"
       (keydown.enter)="clear($event)"
       [attr.aria-label]="'common.reset' | cxTranslate"
+      [attr.title]="'common.reset' | cxTranslate"
       class="quick-order-form-reset-icon"
     >
       <cx-icon [type]="iconTypes.RESET"></cx-icon>

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details-overview/saved-cart-details-overview.component.html
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details-overview/saved-cart-details-overview.component.html
@@ -6,6 +6,7 @@
           <cx-card [content]="getCartName(cart?.name) | async"></cx-card>
           <button
             [attr.aria-label]="'savedCartDetails.editSavedCart' | cxTranslate"
+            [attr.title]="'savedCartDetails.editSavedCart' | cxTranslate"
             class="cx-edit-cart"
             #element
             (click)="openDialog(cart)"

--- a/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.component.html
+++ b/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.component.html
@@ -30,6 +30,8 @@
           [disabled]="isLoading$ | async"
           class="cx-saved-cart-form-close close"
           type="button"
+          title="{{ 'common.close' | cxTranslate }}"
+          [attr.aria-label]="'common.close' | cxTranslate"
         >
           <span aria-hidden="true">
             <cx-icon [type]="iconTypes.CLOSE"></cx-icon>

--- a/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.html
+++ b/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.html
@@ -45,7 +45,7 @@
       <cx-card [content]="getPoNumberCard(poNumber$ | async) | async"></cx-card>
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="'checkoutReview.editPaymentType' | cxTranslate"
+          [attr.title]="'checkoutReview.editPaymentType' | cxTranslate"
           [routerLink]="
             {
               cxRoute: getCheckoutStepUrl(checkoutStepTypePaymentType)
@@ -66,7 +66,7 @@
       ></cx-card>
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="'checkoutReview.editPaymentType' | cxTranslate"
+          [attr.title]="'checkoutReview.editPaymentType' | cxTranslate"
           [routerLink]="
             {
               cxRoute: getCheckoutStepUrl(checkoutStepTypePaymentType)
@@ -88,7 +88,7 @@
         ></cx-card>
         <div class="cx-review-summary-edit-step">
           <a
-            [attr.aria-label]="
+            [attr.title]="
               'checkoutReview.editDeliveryAddressDetails' | cxTranslate
             "
             [routerLink]="
@@ -114,7 +114,7 @@
       ></cx-card>
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="
+          [attr.title]="
             'checkoutReview.editDeliveryAddressDetails' | cxTranslate
           "
           [routerLink]="
@@ -149,7 +149,7 @@
 
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="'checkoutReview.editDeliveryMode' | cxTranslate"
+          [attr.title]="'checkoutReview.editDeliveryMode' | cxTranslate"
           [routerLink]="
             { cxRoute: getCheckoutStepUrl(checkoutStepTypeDeliveryMode) }
               | cxUrl
@@ -172,7 +172,7 @@
       </div>
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="'checkoutReview.editPaymentDetails' | cxTranslate"
+          [attr.title]="'checkoutReview.editPaymentDetails' | cxTranslate"
           [routerLink]="
             { cxRoute: getCheckoutStepUrl(checkoutStepTypePaymentDetails) }
               | cxUrl

--- a/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.html
+++ b/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.html
@@ -41,7 +41,7 @@
       ></cx-card>
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="
+          [attr.title]="
             'checkoutReview.editDeliveryAddressDetails' | cxTranslate
           "
           [routerLink]="
@@ -76,7 +76,7 @@
 
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="'checkoutReview.editDeliveryMode' | cxTranslate"
+          [attr.title]="'checkoutReview.editDeliveryMode' | cxTranslate"
           [routerLink]="
             { cxRoute: getCheckoutStepUrl(checkoutStepTypeDeliveryMode) }
               | cxUrl
@@ -99,7 +99,7 @@
       </div>
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="'checkoutReview.editPaymentDetails' | cxTranslate"
+          [attr.title]="'checkoutReview.editPaymentDetails' | cxTranslate"
           [routerLink]="
             { cxRoute: getCheckoutStepUrl(checkoutStepTypePaymentDetails) }
               | cxUrl

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.html
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.html
@@ -10,7 +10,7 @@
     </div>
     <div class="cx-review-summary-edit-step">
       <a
-        [attr.aria-label]="'checkoutReview.editPaymentDetails' | cxTranslate"
+        [attr.title]="'checkoutReview.editPaymentDetails' | cxTranslate"
         [routerLink]="{ cxRoute: paymentDetailsStepRoute } | cxUrl"
       >
         <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>
@@ -26,7 +26,7 @@
     </div>
     <div class="cx-review-summary-edit-step">
       <a
-        [attr.aria-label]="'checkoutReview.editPaymentDetails' | cxTranslate"
+        [attr.title]="'checkoutReview.editPaymentDetails' | cxTranslate"
         [routerLink]="{ cxRoute: paymentDetailsStepRoute } | cxUrl"
       >
         <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.component.html
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.component.html
@@ -16,7 +16,7 @@
           ></cx-card>
           <div class="cx-review-summary-edit-step">
             <a
-              [attr.aria-label]="
+              [attr.title]="
                 'checkoutReview.editDeliveryAddressDetails' | cxTranslate
               "
               [routerLink]="
@@ -39,9 +39,7 @@
           ></cx-card>
           <div class="cx-review-summary-edit-step">
             <a
-              [attr.aria-label]="
-                'checkoutReview.editDeliveryMode' | cxTranslate
-              "
+              [attr.title]="'checkoutReview.editDeliveryMode' | cxTranslate"
               [routerLink]="{ cxRoute: deliveryModeStepRoute } | cxUrl"
             >
               <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close-dialog/customer-ticketing-close-dialog.component.html
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close-dialog/customer-ticketing-close-dialog.component.html
@@ -13,6 +13,7 @@
         (click)="close('Close Request Dialog')"
         [attr.aria-label]="'common.close' | cxTranslate"
         class="cx-customer-ticket-form-close close"
+        title="{{ 'common.close' | cxTranslate }}"
       >
         <span aria-hidden="true">
           <cx-icon [type]="iconTypes.CLOSE"></cx-icon>

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen-dialog/customer-ticketing-reopen-dialog.component.html
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen-dialog/customer-ticketing-reopen-dialog.component.html
@@ -14,6 +14,7 @@
         [attr.aria-label]="'common.close' | cxTranslate"
         class="cx-customer-ticket-form-close close"
         type="button"
+        title="{{ 'common.close' | cxTranslate }}"
       >
         <span aria-hidden="true">
           <cx-icon [type]="iconTypes.CLOSE"></cx-icon>

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create-dialog/customer-ticketing-create-dialog.component.html
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create-dialog/customer-ticketing-create-dialog.component.html
@@ -14,6 +14,7 @@
         [attr.aria-label]="'common.close' | cxTranslate"
         class="cx-customer-ticket-form-close close"
         type="button"
+        title="{{ 'common.close' | cxTranslate }}"
       >
         <span aria-hidden="true">
           <cx-icon [type]="iconTypes.CLOSE"></cx-icon>

--- a/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices.component.html
+++ b/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices.component.html
@@ -12,6 +12,7 @@
         type="button"
         class="close"
         attr.aria-label="{{ 'addToCart.closeModal' | cxTranslate }}"
+        title="{{ 'addToCart.closeModal' | cxTranslate }}"
         (click)="close('Close download invoices dialog')"
       >
         <span aria-hidden="true">

--- a/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.html
+++ b/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.html
@@ -15,6 +15,7 @@
           type="button"
           class="close"
           attr.aria-label="{{ 'addToCart.closeModal' | cxTranslate }}"
+          title="{{ 'addToCart.closeModal' | cxTranslate }}"
           (click)="close('Close reorder result dialog')"
         >
           <span aria-hidden="true">

--- a/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.html
+++ b/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.html
@@ -12,6 +12,7 @@
       <button
         type="button"
         class="close"
+        title="{{ 'common.close' | cxTranslate }}"
         [attr.aria-label]="'common.close' | cxTranslate"
         (click)="close('Cross click')"
       >

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
@@ -5,7 +5,13 @@
 >
   <cx-icon *ngIf="messageIcon" [type]="messageIcon"></cx-icon>
   <p>{{ message | cxTranslate }}</p>
-  <button class="close" (click)="close()" type="button">
+  <button
+    class="close"
+    (click)="close()"
+    type="button"
+    attr.aria-label="{{ 'common.close' | cxTranslate }}"
+    attr.title="{{ 'common.close' | cxTranslate }}"
+  >
     <cx-icon [type]="closeIcon"></cx-icon>
   </button>
 </div>

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/filter/unit-level-order-history-filter.component.html
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/filter/unit-level-order-history-filter.component.html
@@ -8,6 +8,7 @@
     <button
       id="closeFilterNavBtn"
       type="button"
+      title="{{ 'common.close' | cxTranslate }}"
       [attr.aria-label]="'common.close' | cxTranslate"
       (click)="closeFilterNav()"
     >
@@ -64,6 +65,7 @@
 
         <button
           type="button"
+          title="{{ 'common.close' | cxTranslate }}"
           [attr.aria-label]="'common.close' | cxTranslate"
           (click)="closeFilterNav()"
         >
@@ -133,6 +135,7 @@
 
         <button
           type="button"
+          title="{{ 'common.close' | cxTranslate }}"
           [attr.aria-label]="'common.close' | cxTranslate"
           (click)="closeFilterNav()"
         >

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.html
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.html
@@ -17,6 +17,7 @@
         (click)="close(CLOSE_WITHOUT_SELECTION)"
         class="cx-dialog-close close"
         [attr.aria-label]="'pickupOptionDialog.close' | cxTranslate"
+        [attr.title]="'pickupOptionDialog.close' | cxTranslate"
         type="button"
       >
         <span aria-hidden="true">

--- a/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.component.html
+++ b/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.component.html
@@ -21,6 +21,7 @@
         attr.aria-label="{{
           'configurator.a11y.closeConflictSolverModal' | cxTranslate
         }}"
+        title="{{ 'configurator.a11y.closeConflictSolverModal' | cxTranslate }}"
         (click)="dismissModal('Close conflict solver dialog')"
       >
         <span aria-hidden="true">

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-dialog/product-image-zoom-dialog.component.html
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-dialog/product-image-zoom-dialog.component.html
@@ -4,6 +4,7 @@
       <button
         type="button"
         class="close"
+        title="{{ 'productImageZoomDialog.close' | cxTranslate }}"
         [attr.aria-label]="'productImageZoomDialog.close' | cxTranslate"
         (click)="close('cross click')"
       >

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.html
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.html
@@ -39,6 +39,11 @@
             ? ('common.zoomOut' | cxTranslate)
             : ('common.zoomIn' | cxTranslate)
         "
+        title="{{
+          isZoomed
+            ? ('common.zoomOut' | cxTranslate)
+            : ('common.zoomIn' | cxTranslate)
+        }}"
         class="btn btn-link cx-zoom-btn"
         (click)="zoom()"
       >

--- a/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.component.html
+++ b/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.component.html
@@ -21,6 +21,7 @@
       <button
         type="button"
         class="close"
+        title="{{ confirmationContext.a11y.close | cxTranslate }}"
         [attr.aria-label]="confirmationContext.a11y.close | cxTranslate"
         (click)="dismissModal('Cross click')"
       >

--- a/feature-libs/quote/components/header/overview/quote-header-overview.component.html
+++ b/feature-libs/quote/components/header/overview/quote-header-overview.component.html
@@ -27,6 +27,7 @@
           ></cx-card>
           <button
             [attr.aria-label]="'quote.header.overview.a11y.edit' | cxTranslate"
+            [attr.title]="'quote.header.overview.a11y.edit' | cxTranslate"
             *ngIf="isQuoteEditableForBuyer(quoteDetails)"
             class="link cx-action-link cx-edit-btn"
             (click)="toggleEditMode()"

--- a/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/suggested-addresses-dialog.component.html
+++ b/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/suggested-addresses-dialog.component.html
@@ -12,6 +12,7 @@
       <button
         type="button"
         class="close"
+        title="{{ 'common.close' | cxTranslate }}"
         [attr.aria-label]="'common.close' | cxTranslate"
         (click)="closeModal('Cross click')"
       >

--- a/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.html
+++ b/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.html
@@ -12,6 +12,7 @@
         <button
           type="button"
           class="close"
+          title="{{ 'common.close' | cxTranslate }}"
           [attr.aria-label]="'common.close' | cxTranslate"
           (click)="dismissModal('Cross click')"
         >

--- a/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent.component.html
+++ b/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent.component.html
@@ -13,6 +13,7 @@
         <button
           type="button"
           class="close"
+          title="{{ 'common.close' | cxTranslate }}"
           [attr.aria-label]="'common.close' | cxTranslate"
           (click)="dismissDialog('Cross click', reconsentEvent.errorMessage)"
         >

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/dp-confirmation-dialog.component.html
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/dp-confirmation-dialog.component.html
@@ -14,6 +14,7 @@
       <button
         type="button"
         class="close"
+        title="{{ 'common.close' | cxTranslate }}"
         [attr.aria-label]="'common.close' | cxTranslate"
         (click)="dismissDialog('Cross click')"
       >

--- a/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.component.html
+++ b/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.component.html
@@ -135,7 +135,7 @@
       <cx-card [content]="content | async"></cx-card>
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="label | cxTranslate"
+          [attr.title]="label | cxTranslate"
           [routerLink]="{ cxRoute: editRoute } | cxUrl"
         >
           <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>
@@ -165,7 +165,7 @@
 
       <div class="cx-review-summary-edit-step">
         <a
-          [attr.aria-label]="'checkoutReview.editDeliveryMode' | cxTranslate"
+          [attr.title]="'checkoutReview.editDeliveryMode' | cxTranslate"
           [routerLink]="
             { cxRoute: getCheckoutStepUrl(checkoutStepTypeDeliveryMode) }
               | cxUrl

--- a/projects/assets/src/translations/en/common.json
+++ b/projects/assets/src/translations/en/common.json
@@ -29,7 +29,9 @@
     "required": "required",
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out",
-    "selected": "Selected"
+    "selected": "Selected",
+    "expand": "Expand",
+    "collapse": "Collapse"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.html
+++ b/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.html
@@ -16,7 +16,15 @@
             component.title | cxTranslate: { param: tabTitleParams[i] | async }
           }}
 
-          <span class="accordion-icon" aria-hidden="true"></span>
+          <span
+            title="{{
+              i === activeTabNum
+                ? ('common.collapse' | cxTranslate)
+                : ('common.expand' | cxTranslate)
+            }}"
+            class="accordion-icon"
+            aria-hidden="true"
+          ></span>
         </button>
 
         <div

--- a/projects/storefrontlib/cms-components/misc/global-message/global-message.component.html
+++ b/projects/storefrontlib/cms-components/misc/global-message/global-message.component.html
@@ -18,7 +18,7 @@
     <span>{{ confMsg | cxTranslate }}</span>
     <button
       class="close"
-      type="button"
+      title="{{ 'common.close' | cxTranslate }}"
       (click)="clear(messageType.MSG_TYPE_CONFIRMATION, i)"
     >
       <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
@@ -34,7 +34,7 @@
     <span>{{ infoMsg | cxTranslate }}</span>
     <button
       class="close"
-      type="button"
+      title="{{ 'common.close' | cxTranslate }}"
       (click)="clear(messageType.MSG_TYPE_INFO, i)"
     >
       <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
@@ -53,7 +53,7 @@
     <span>{{ infoMsg | cxTranslate }}</span>
     <button
       class="close"
-      type="button"
+      title="{{ 'common.close' | cxTranslate }}"
       (click)="clear(messageType.MSG_TYPE_WARNING, i)"
     >
       <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
@@ -69,7 +69,7 @@
     <span>{{ errorMsg | cxTranslate }}</span>
     <button
       class="close"
-      type="button"
+      title="{{ 'common.close' | cxTranslate }}"
       (click)="clear(messageType.MSG_TYPE_ERROR, i)"
     >
       <cx-icon [type]="iconTypes.CLOSE"></cx-icon>

--- a/projects/storefrontlib/cms-components/misc/message/message.component.html
+++ b/projects/storefrontlib/cms-components/misc/message/message.component.html
@@ -45,6 +45,7 @@
         (click)="closeMessage.emit()"
         [attr.aria-label]="'common.close' | cxTranslate"
         [cxAtMessage]="'common.close' | cxTranslate"
+        title="{{ 'common.close' | cxTranslate }}"
         class="close"
         type="button"
       >

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-dialog/coupon-dialog.component.html
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-dialog/coupon-dialog.component.html
@@ -14,6 +14,7 @@
       <button
         type="button"
         class="close"
+        title="{{ 'common.close' | cxTranslate }}"
         [attr.aria-label]="'common.close' | cxTranslate"
         (click)="close('Cross click')"
       >

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.html
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.html
@@ -16,6 +16,9 @@
     [attr.aria-label]="
       'productList.activeFilter' | cxTranslate: { filter: facet.facetValueName }
     "
+    [attr.title]="
+      'productList.activeFilter' | cxTranslate: { filter: facet.facetValueName }
+    "
   >
     <span>{{ facet.facetValueName }}</span>
     <cx-icon aria-hidden="true" [type]="closeIcon"></cx-icon>

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.html
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.html
@@ -14,6 +14,7 @@
     <button
       type="button"
       class="close"
+      title="{{ 'common.close' | cxTranslate }}"
       [attr.aria-label]="'common.close' | cxTranslate"
       (click)="close()"
     >

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.html
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.html
@@ -11,8 +11,16 @@
     [cxFocus]="{ key: facet.name }"
   >
     {{ facet.name }}
-    <cx-icon class="collapse-icon" [type]="collapseIcon"></cx-icon>
-    <cx-icon class="expand-icon" [type]="expandIcon"></cx-icon>
+    <cx-icon
+      title="{{ 'common.collapse' | cxTranslate }}"
+      class="collapse-icon"
+      [type]="collapseIcon"
+    ></cx-icon>
+    <cx-icon
+      title="{{ 'common.expand' | cxTranslate }}"
+      class="expand-icon"
+      [type]="expandIcon"
+    ></cx-icon>
   </button>
 
   <div>

--- a/projects/storefrontlib/cms-components/product/product-list/product-view/product-view.component.html
+++ b/projects/storefrontlib/cms-components/product/product-list/product-view/product-view.component.html
@@ -10,6 +10,13 @@
         ? ('productView.listView' | cxTranslate)
         : null
   }}"
+  attr.title="{{
+    viewMode === iconTypes.GRID
+      ? ('productView.gridView' | cxTranslate)
+      : viewMode === iconTypes.LIST
+        ? ('productView.listView' | cxTranslate)
+        : null
+  }}"
 >
   <cx-icon
     *ngIf="viewMode === iconTypes.GRID"

--- a/projects/storefrontlib/layout/header/hamburger-menu/hamburger-menu.component.html
+++ b/projects/storefrontlib/layout/header/hamburger-menu/hamburger-menu.component.html
@@ -9,6 +9,11 @@
       ? ('common.close' | cxTranslate)
       : ('common.menu' | cxTranslate)
   "
+  [attr.title]="
+    (isExpanded | async)
+      ? ('common.close' | cxTranslate)
+      : ('common.menu' | cxTranslate)
+  "
   aria-controls="cx-header"
 >
   <span class="hamburger-box">

--- a/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.html
+++ b/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.html
@@ -20,6 +20,7 @@
         <button
           type="button"
           class="close"
+          title="{{ 'common.close' | cxTranslate }}"
           [attr.aria-label]="'common.close' | cxTranslate"
           (click)="close('Cross click')"
         >

--- a/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.component.html
+++ b/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.component.html
@@ -2,6 +2,7 @@
   type="button"
   (click)="toggle()"
   [attr.aria-label]="state.ariaLabel | cxTranslate"
+  [attr.title]="state.ariaLabel | cxTranslate"
   [attr.aria-pressed]="state.inputType === showState.inputType"
 >
   <span aria-hidden="true">

--- a/projects/storefrontlib/shared/components/item-counter/item-counter.component.html
+++ b/projects/storefrontlib/shared/components/item-counter/item-counter.component.html
@@ -5,6 +5,7 @@
   [tabindex]="control.disabled || control.value <= min ? -1 : 0"
   [cxFocus]="{ key: 'decrement' }"
   attr.aria-label="{{ 'itemCounter.removeOne' | cxTranslate }}"
+  title="{{ 'itemCounter.removeOne' | cxTranslate }}"
 >
   -
 </button>
@@ -27,6 +28,7 @@
   [disabled]="control.disabled || control.value >= max"
   [cxFocus]="{ key: 'increment' }"
   attr.aria-label="{{ 'itemCounter.addOneMore' | cxTranslate }}"
+  title="{{ 'itemCounter.addOneMore' | cxTranslate }}"
 >
   +
 </button>

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.component.html
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.component.html
@@ -12,6 +12,7 @@
     [attr.aria-disabled]="isInactive(item)"
     (click)="pageChange(item)"
     [attr.aria-label]="getAriaLabel$(item) | async"
+    [attr.title]="getAriaLabel$(item) | async"
   >
     {{ item.label }}
   </a></ng-container

--- a/projects/storefrontlib/shared/components/popover/popover.component.html
+++ b/projects/storefrontlib/shared/components/popover/popover.component.html
@@ -6,6 +6,7 @@
       type="button"
       class="close"
       attr.aria-label="{{ 'common.close' | cxTranslate }}"
+      title="{{ 'common.close' | cxTranslate }}"
       (keydown.enter)="close($event)"
       (keydown.space)="close($event)"
       (click)="close($event)"


### PR DESCRIPTION
Ticket: [CXSPA-942](https://jira.tools.sap/browse/CXSPA-942)

Adds titles to interactive elements with an icon but no text. This includes all 'close' buttons, 'edit' buttons etc.
The default tooltip should show on mouseover.