### PR TITLE
fix: A11y added to card dialog icon buttons titles

### DIFF
--- a/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.html
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.html
@@ -19,6 +19,7 @@
           type="button"
           class="close"
           attr.aria-label="{{ 'addToCart.closeModal' | cxTranslate }}"
+          [title]="'addToCart.closeModal' | cxTranslate"
           (click)="dismissModal('Cross click')"
         >
           <span aria-hidden="true">
@@ -127,6 +128,7 @@
           type="button"
           class="close"
           [attr.aria-label]="'common.close' | cxTranslate"
+          [title]="'common.close' | cxTranslate"
           (click)="dismissModal('Cross click')"
         >
           <span aria-hidden="true">

--- a/projects/storefrontlib/shared/components/item-counter/item-counter.component.html
+++ b/projects/storefrontlib/shared/components/item-counter/item-counter.component.html
@@ -5,6 +5,7 @@
   [tabindex]="control.disabled || control.value <= min ? -1 : 0"
   [cxFocus]="{ key: 'decrement' }"
   attr.aria-label="{{ 'itemCounter.removeOne' | cxTranslate }}"
+  [title]="'itemCounter.removeOne' | cxTranslate"
 >
   -
 </button>
@@ -27,6 +28,7 @@
   [disabled]="control.disabled || control.value >= max"
   [cxFocus]="{ key: 'increment' }"
   attr.aria-label="{{ 'itemCounter.addOneMore' | cxTranslate }}"
+  [title]="'itemCounter.addOneMore' | cxTranslate"
 >
   +
 </button>


### PR DESCRIPTION
<img width="779" alt="image" src="https://github.com/user-attachments/assets/abf4eaf0-37a9-4f34-8a53-5a7a36fe4b4e">
<img width="818" alt="image" src="https://github.com/user-attachments/assets/4b3a919e-0476-4f53-aa7f-dedc27a2fffa">
<img width="273" alt="image" src="https://github.com/user-attachments/assets/6eccd454-bcd8-41f4-a7eb-8b2840b37fdb">
<img width="299" alt="image" src="https://github.com/user-attachments/assets/59e7a7e5-5861-4b94-ab8c-acfbbfd48fe3">
