### PR TITLE
refactor: do not mix reactive and static programming paradigmas in configurator-attribute-price-change.service.ts

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-base.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-base.component.spec.ts
@@ -1,13 +1,13 @@
 import { Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FeatureConfigService, I18nTestingModule } from '@spartacus/core';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { Configurator } from '../../../../core/model/configurator.model';
 import { ConfiguratorTestUtils } from '../../../../testing/configurator-test-utils';
 import { ConfiguratorUISettingsConfig } from '../../../config/configurator-ui-settings.config';
+import { ConfiguratorStorefrontUtilsService } from '../../../service/configurator-storefront-utils.service';
 import { ConfiguratorAttributePriceChangeService } from '../../price-change/configurator-attribute-price-change.service';
 import { ConfiguratorAttributeBaseComponent } from './configurator-attribute-base.component';
-import { ConfiguratorStorefrontUtilsService } from '../../../service/configurator-storefront-utils.service';
 
 const attributeCode = 1;
 const currentAttribute: Configurator.Attribute = {
@@ -25,12 +25,9 @@ let configuratorUISettingsConfig: ConfiguratorUISettingsConfig = {
   },
 };
 
-class MockConfiguratorDeltaRenderingService {
-  getPriceChangedEvents() {
-    return of(false);
-  }
-  mergePriceIntoValue(value: Configurator.Value) {
-    return value;
+class MockConfiguratorAttributePriceChangeService {
+  getChangedPrices(): Observable<Record<string, Configurator.PriceDetails>> {
+    return of({ dummy: { value: 10, currencyIso: 'USD' } });
   }
 }
 
@@ -46,7 +43,7 @@ class MockFeatureConfigService {
 
 describe('ConfiguratorAttributeBaseComponent', () => {
   let classUnderTest: ConfiguratorAttributeBaseComponent;
-  let configuratorDeltaRenderingService: ConfiguratorAttributePriceChangeService;
+  let configuratorAttributePriceChangeService: ConfiguratorAttributePriceChangeService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -59,7 +56,7 @@ describe('ConfiguratorAttributeBaseComponent', () => {
         },
         {
           provide: ConfiguratorAttributePriceChangeService,
-          useClass: MockConfiguratorDeltaRenderingService,
+          useClass: MockConfiguratorAttributePriceChangeService,
         },
         {
           provide: ConfiguratorStorefrontUtilsService,
@@ -72,12 +69,12 @@ describe('ConfiguratorAttributeBaseComponent', () => {
     classUnderTest = TestBed.inject(
       ConfiguratorAttributeBaseComponent as Type<ConfiguratorAttributeBaseComponent>
     );
-    configuratorDeltaRenderingService = TestBed.inject(
+    configuratorAttributePriceChangeService = TestBed.inject(
       ConfiguratorAttributePriceChangeService as Type<ConfiguratorAttributePriceChangeService>
     );
     spyOn(
-      configuratorDeltaRenderingService,
-      'getPriceChangedEvents'
+      configuratorAttributePriceChangeService,
+      'getChangedPrices'
     ).and.callThrough();
   });
 
@@ -527,15 +524,15 @@ describe('ConfiguratorAttributeBaseComponent', () => {
   describe('$priceChanged', () => {
     it('should emit true immediately, if delta rendering is not initialized', () => {
       let emitted = false;
-      classUnderTest.priceChangedEvent$
+      classUnderTest.changedPrices$
         .subscribe((priceChanged) => {
-          expect(priceChanged).toBe(true);
+          expect(priceChanged).toEqual({});
           emitted = true;
         })
         .unsubscribe();
       expect(emitted).toBe(true);
       expect(
-        configuratorDeltaRenderingService.getPriceChangedEvents
+        configuratorAttributePriceChangeService.getChangedPrices
       ).not.toHaveBeenCalled();
     });
 
@@ -543,15 +540,15 @@ describe('ConfiguratorAttributeBaseComponent', () => {
       productConfiguratorDeltaRenderingEnabled = true;
       classUnderTest['initPriceChangedEvent'](false, 'attrKey');
       let emitted = false;
-      classUnderTest.priceChangedEvent$
+      classUnderTest.changedPrices$
         .subscribe((priceChanged) => {
-          expect(priceChanged).toBe(true);
+          expect(priceChanged).toEqual({});
           emitted = true;
         })
         .unsubscribe();
       expect(emitted).toBe(true);
       expect(
-        configuratorDeltaRenderingService.getPriceChangedEvents
+        configuratorAttributePriceChangeService.getChangedPrices
       ).not.toHaveBeenCalled();
     });
 
@@ -560,48 +557,50 @@ describe('ConfiguratorAttributeBaseComponent', () => {
       classUnderTest['configuratorAttributePriceChangeService'] = null;
       classUnderTest['initPriceChangedEvent'](true, 'attrKey');
       let emitted = false;
-      classUnderTest.priceChangedEvent$
+      classUnderTest.changedPrices$
         .subscribe((priceChanged) => {
-          expect(priceChanged).toBe(true);
+          expect(priceChanged).toEqual({});
           emitted = true;
         })
         .unsubscribe();
       expect(emitted).toBe(true);
       expect(
-        configuratorDeltaRenderingService.getPriceChangedEvents
+        configuratorAttributePriceChangeService.getChangedPrices
       ).not.toHaveBeenCalled();
     });
 
-    it('should emit true immediately, if price changed event is initialized but delta rendering feature flag is deactivated', () => {
+    it('should emit immediately, if price changed event is initialized but delta rendering feature flag is deactivated', () => {
       productConfiguratorDeltaRenderingEnabled = false;
       classUnderTest['initPriceChangedEvent'](true, 'attrKey');
       let emitted = false;
-      classUnderTest.priceChangedEvent$
+      classUnderTest.changedPrices$
         .subscribe((priceChanged) => {
-          expect(priceChanged).toBe(true);
+          expect(priceChanged).toEqual({});
           emitted = true;
         })
         .unsubscribe();
       expect(emitted).toBe(true);
       expect(
-        configuratorDeltaRenderingService.getPriceChangedEvents
+        configuratorAttributePriceChangeService.getChangedPrices
       ).not.toHaveBeenCalled();
     });
 
-    it('should emit false immediately, if price changed event is initialized proper', () => {
+    it('should emit immediately, if price changed event is initialized proper', () => {
       productConfiguratorDeltaRenderingEnabled = true;
       classUnderTest['initPriceChangedEvent'](true, 'attrKey');
       let emitted = false;
       productConfiguratorDeltaRenderingEnabled = true;
-      classUnderTest.priceChangedEvent$
+      classUnderTest.changedPrices$
         .subscribe((priceChanged) => {
-          expect(priceChanged).toBe(false);
+          expect(priceChanged).toEqual({
+            dummy: { value: 10, currencyIso: 'USD' },
+          });
           emitted = true;
         })
         .unsubscribe();
       expect(emitted).toBe(true);
       expect(
-        configuratorDeltaRenderingService.getPriceChangedEvents
+        configuratorAttributePriceChangeService.getChangedPrices
       ).toHaveBeenCalled();
     });
   });
@@ -744,6 +743,25 @@ describe('ConfiguratorAttributeBaseComponent', () => {
           classUnderTest['isValueDisplayed'](currentAttribute, value)
         ).toBe(true);
       });
+    });
+  });
+
+  describe('enrichValueWithPrice', () => {
+    const value: Configurator.Value = { valueCode: 'val', selected: true };
+    it('should return original value if no price is known', () => {
+      expect(classUnderTest.enrichValueWithPrice(value, undefined)).toBe(value);
+    });
+
+    it('should return new value if price is known', () => {
+      const price: Configurator.PriceDetails = {
+        value: 10,
+        currencyIso: 'USD',
+      };
+      const expectedValue = { ...value };
+      expectedValue.valuePrice = price;
+      expect(classUnderTest.enrichValueWithPrice(value, price)).toEqual(
+        expectedValue
+      );
     });
   });
 });

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.spec.ts
@@ -676,31 +676,6 @@ describe('ConfiguratorAttributeSingleSelectionBaseComponent', () => {
       );
     });
 
-    it('should return aria label for value with price after price was changed', () => {
-      component.attribute.uiType =
-        Configurator.UiType.DROPDOWN_ADDITIONAL_INPUT ||
-        Configurator.UiType.RADIOBUTTON_ADDITIONAL_INPUT;
-      component.attribute.validationType = Configurator.ValidationType.NONE;
-
-      component['configuratorAttributePriceChangeService']?.['storeValuePrice'](
-        valueWithPrice.name ?? '',
-        {
-          currencyIso: '$',
-          formattedValue: '$200.00',
-          value: 200,
-        }
-      );
-      fixture.detectChanges();
-      expect(
-        component.getAriaLabel(valueWithPrice, attributeWithValuePrice)
-      ).toEqual(
-        'configurator.a11y.selectedValueOfAttributeFullWithPrice attribute:' +
-          attributeWithValuePrice.label +
-          ' price:$200.00 value:' +
-          valueWithPrice.valueDisplay +
-          ' configurator.a11y.additionalValue'
-      );
-    });
     it('should return aria label for value with price and attribute additional value', () => {
       let attributeWithValuePrice: Configurator.Attribute = {
         name: 'attribute with value price',

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.ts
@@ -199,10 +199,6 @@ export abstract class ConfiguratorAttributeSingleSelectionBaseComponent extends 
   extractValuePriceFormulaParameters(
     value?: Configurator.Value
   ): ConfiguratorPriceComponentOptions {
-    if (value && this.configuratorAttributePriceChangeService) {
-      value =
-        this.configuratorAttributePriceChangeService.mergePriceIntoValue(value);
-    }
     return {
       price: value?.valuePrice,
       isLightedUp: value ? value.selected : false,
@@ -231,10 +227,6 @@ export abstract class ConfiguratorAttributeSingleSelectionBaseComponent extends 
     value: Configurator.Value,
     attribute: Configurator.Attribute
   ): string {
-    value =
-      this.configuratorAttributePriceChangeService?.mergePriceIntoValue(
-        value
-      ) ?? value;
     const ariaLabel = this.getAriaLabelWithoutAdditionalValue(value, attribute);
     if (this.isWithAdditionalValues(this.attribute)) {
       const ariaLabelWithAdditionalValue = this.getAdditionalValueAriaLabel();

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.html
@@ -1,7 +1,7 @@
 <fieldset>
   <legend style="display: none">{{ attribute.label }}</legend>
   <div
-    *ngIf="priceChangedEvent$ | async"
+    *ngIf="changedPrices$ | async as changedPrices"
     id="{{ createAttributeIdForConfigurator(attribute) }}"
   >
     <div
@@ -32,7 +32,12 @@
             (change)="onSelect(value.valueCode)"
             [formControl]="attributeCheckBoxForms[i]"
             name="{{ createAttributeIdForConfigurator(attribute) }}"
-            [attr.aria-label]="getAriaLabelGeneric(attribute, value)"
+            [attr.aria-label]="
+              getAriaLabelGeneric(
+                attribute,
+                enrichValueWithPrice(value, changedPrices[value.name])
+              )
+            "
             [attr.aria-describedby]="
               createAttributeUiKey('label', attribute.name)
             "
@@ -63,7 +68,11 @@
         </div>
         <div class="cx-value-price">
           <cx-configurator-price
-            [formula]="extractValuePriceFormulaParameters(value)"
+            [formula]="
+              extractValuePriceFormulaParameters(
+                enrichValueWithPrice(value, changedPrices[value.name])
+              )
+            "
           ></cx-configurator-price>
         </div>
       </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.spec.ts
@@ -84,14 +84,10 @@ class MockConfiguratorStorefrontUtilsService {
   }
 }
 
-class MockConfiguratorDeltaRenderingService {
-  getPriceChangedEvents(): Observable<boolean> {
-    return of(true);
+class MockConfiguratorAttributePriceChangeService {
+  getChangedPrices(): Observable<Record<string, Configurator.PriceDetails>[]> {
+    return of([]);
   }
-  mergePriceIntoValue(value: Configurator.Value): Configurator.Value {
-    return value;
-  }
-  storeValuePrice(): void {}
 }
 
 describe('ConfiguratorAttributeCheckBoxListComponent', () => {
@@ -106,7 +102,7 @@ describe('ConfiguratorAttributeCheckBoxListComponent', () => {
         providers: [
           {
             provide: ConfiguratorAttributePriceChangeService,
-            useClass: MockConfiguratorDeltaRenderingService,
+            useClass: MockConfiguratorAttributePriceChangeService,
           },
         ],
       },

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.html
@@ -2,7 +2,7 @@
   <fieldset>
     <legend style="display: none">{{ attribute.label }}</legend>
     <div id="{{ createAttributeIdForConfigurator(attribute) }}">
-      <div class="form-check" *ngIf="priceChangedEvent$ | async">
+      <div class="form-check" *ngIf="changedPrices$ | async as changedPrices">
         <div class="cx-value-label-pair">
           <input
             id="{{
@@ -20,7 +20,15 @@
             (change)="onSelect(attributeValue.valueCode)"
             [formControl]="attributeCheckBoxForm"
             name="{{ createAttributeIdForConfigurator(attribute) }}"
-            [attr.aria-label]="getAriaLabelGeneric(attribute, attributeValue)"
+            [attr.aria-label]="
+              getAriaLabelGeneric(
+                attribute,
+                enrichValueWithPrice(
+                  attributeValue,
+                  changedPrices[attributeValue.name]
+                )
+              )
+            "
             [attr.aria-live]="
               isLastSelected(attribute.name, attributeValue.valueCode)
                 ? 'polite'
@@ -70,7 +78,14 @@
         </div>
         <div class="cx-value-price">
           <cx-configurator-price
-            [formula]="extractValuePriceFormulaParameters(attributeValue)"
+            [formula]="
+              extractValuePriceFormulaParameters(
+                enrichValueWithPrice(
+                  attributeValue,
+                  changedPrices[attributeValue.name]
+                )
+              )
+            "
           ></cx-configurator-price>
         </div>
       </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.spec.ts
@@ -63,14 +63,10 @@ class MockConfiguratorStorefrontUtilsService {
   }
 }
 
-class MockConfiguratorDeltaRenderingService {
-  getPriceChangedEvents(): Observable<boolean> {
-    return of(true);
+class MockConfiguratorAttributePriceChangeService {
+  getChangedPrices(): Observable<Record<string, Configurator.PriceDetails>[]> {
+    return of([]);
   }
-  mergePriceIntoValue(value: Configurator.Value): Configurator.Value {
-    return value;
-  }
-  storeValuePrice(): void {}
 }
 
 describe('ConfigAttributeCheckBoxComponent', () => {
@@ -84,7 +80,7 @@ describe('ConfigAttributeCheckBoxComponent', () => {
         providers: [
           {
             provide: ConfiguratorAttributePriceChangeService,
-            useClass: MockConfiguratorDeltaRenderingService,
+            useClass: MockConfiguratorAttributePriceChangeService,
           },
         ],
       },

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="priceChangedEvent$ | async">
+<ng-container *ngIf="changedPrices$ | async as changedPrices">
   <div
     class="form-group"
     *ngIf="attribute.values && attribute.values.length !== 0"
@@ -57,11 +57,25 @@
           <option
             *ngFor="let item of attribute.values"
             [selected]="item.selected"
-            [label]="getLabel(expMode, item.valueDisplay, item.valueCode, item)"
+            [label]="
+              getLabel(
+                expMode,
+                item.valueDisplay,
+                item.valueCode,
+                enrichValueWithPrice(item, changedPrices[item.name])
+              )
+            "
             [attr.aria-label]="getAriaLabel(item, attribute)"
             [value]="item.valueCode"
           >
-            {{ getLabel(expMode, item.valueDisplay, item.valueCode, item) }}
+            {{
+              getLabel(
+                expMode,
+                item.valueDisplay,
+                item.valueCode,
+                enrichValueWithPrice(item, changedPrices[item.name])
+              )
+            }}
           </option>
         </select>
         <cx-configurator-show-more
@@ -83,7 +97,14 @@
 
     <div *ngIf="!withQuantity && getSelectedValue()" class="cx-value-price">
       <cx-configurator-price
-        [formula]="extractValuePriceFormulaParameters(getSelectedValue())"
+        [formula]="
+          extractValuePriceFormulaParameters(
+            enrichValueWithPrice(
+              getSelectedValue(),
+              changedPrices[getSelectedValue().name]
+            )
+          )
+        "
       ></cx-configurator-price>
     </div>
   </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.spec.ts
@@ -99,14 +99,10 @@ class MockConfig {
   features = [{ productConfiguratorAttributeTypesV2: false }];
 }
 
-class MockConfiguratorDeltaRenderingService {
-  getPriceChangedEvents(): Observable<boolean> {
-    return of(true);
+class MockConfiguratorAttributePriceChangeService {
+  getChangedPrices(): Observable<Record<string, Configurator.PriceDetails>[]> {
+    return of([]);
   }
-  mergePriceIntoValue(value: Configurator.Value): Configurator.Value {
-    return value;
-  }
-  storeValuePrice(): void {}
 }
 
 describe('ConfiguratorAttributeDropDownComponent', () => {
@@ -167,7 +163,7 @@ describe('ConfiguratorAttributeDropDownComponent', () => {
         providers: [
           {
             provide: ConfiguratorAttributePriceChangeService,
-            useClass: MockConfiguratorDeltaRenderingService,
+            useClass: MockConfiguratorAttributePriceChangeService,
           },
         ],
       },

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.html
@@ -1,8 +1,8 @@
 <div id="{{ createAttributeIdForConfigurator(attribute) }}" class="cx-row">
   <ng-container
     *ngIf="
-      !config.features?.productConfiguratorAttributeTypesV2 &&
-      (priceChangedEvent$ | async)
+      !config.features?.productConfiguratorAttributeTypesV2 && changedPrices$
+        | async as changedPrices
     "
   >
     <div
@@ -23,7 +23,12 @@
         [formControl]="attributeCheckBoxForms[i]"
         name="{{ createAttributeIdForConfigurator(attribute) }}"
         (click)="onSelect(i)"
-        [attr.aria-label]="getAriaLabelGeneric(attribute, value)"
+        [attr.aria-label]="
+          getAriaLabelGeneric(
+            attribute,
+            enrichValueWithPrice(value, changedPrices[value.name])
+          )
+        "
         [attr.aria-live]="
           isLastSelected(attribute.name, value.valueCode) ? 'polite' : null
         "
@@ -50,7 +55,11 @@
           <div *ngIf="!getImage(value)" class="cx-img-dummy"></div>
           {{ getLabel(expMode, value.valueDisplay, value.valueCode) }}
           <cx-configurator-price
-            [formula]="extractValuePriceFormulaParameters(value)"
+            [formula]="
+              extractValuePriceFormulaParameters(
+                enrichValueWithPrice(value, changedPrices[value.name])
+              )
+            "
           ></cx-configurator-price>
         </label>
       </div>
@@ -58,8 +67,8 @@
   </ng-container>
   <ng-container
     *ngIf="
-      config.features?.productConfiguratorAttributeTypesV2 &&
-      (priceChangedEvent$ | async)
+      config.features?.productConfiguratorAttributeTypesV2 && changedPrices$
+        | async as changedPrices
     "
   >
     <ng-container *ngFor="let value of attribute.values; let i = index">
@@ -81,7 +90,12 @@
           [formControl]="attributeCheckBoxForms[i]"
           name="{{ createAttributeIdForConfigurator(attribute) }}"
           (click)="!isReadOnly(attribute) && onSelect(i)"
-          [attr.aria-label]="getAriaLabelGeneric(attribute, value)"
+          [attr.aria-label]="
+            getAriaLabelGeneric(
+              attribute,
+              enrichValueWithPrice(value, changedPrices[value.name])
+            )
+          "
           [attr.aria-live]="
             isLastSelected(attribute.name, value.valueCode) ? 'polite' : null
           "
@@ -132,7 +146,11 @@
               <cx-icon [type]="iconTypes.INFO"></cx-icon>
             </button>
             <cx-configurator-price
-              [formula]="extractValuePriceFormulaParameters(value)"
+              [formula]="
+                extractValuePriceFormulaParameters(
+                  enrichValueWithPrice(value, changedPrices[value.name])
+                )
+              "
             ></cx-configurator-price>
           </label>
         </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.spec.ts
@@ -65,14 +65,10 @@ class MockConfiguratorStorefrontUtilsService {
   }
 }
 
-class MockConfiguratorDeltaRenderingService {
-  getPriceChangedEvents(): Observable<boolean> {
-    return of(true);
+class MockConfiguratorAttributePriceChangeService {
+  getChangedPrices(): Observable<Record<string, Configurator.PriceDetails>[]> {
+    return of([]);
   }
-  mergePriceIntoValue(value: Configurator.Value): Configurator.Value {
-    return value;
-  }
-  storeValuePrice(): void {}
 }
 
 describe('ConfiguratorAttributeMultiSelectionImageComponent', () => {
@@ -90,7 +86,7 @@ describe('ConfiguratorAttributeMultiSelectionImageComponent', () => {
           providers: [
             {
               provide: ConfiguratorAttributePriceChangeService,
-              useClass: MockConfiguratorDeltaRenderingService,
+              useClass: MockConfiguratorAttributePriceChangeService,
             },
           ],
         },

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.html
@@ -11,7 +11,7 @@
         [formula]="extractPriceFormulaParameters()"
       ></cx-configurator-price>
     </div>
-    <ng-container *ngIf="priceChangedEvent$ | async">
+    <ng-container *ngIf="changedPrices$ | async as changedPrices">
       <div class="form-check" *ngFor="let value of attribute.values">
         <div class="cx-value-label-pair">
           <input
@@ -27,7 +27,12 @@
             name="{{ createAttributeIdForConfigurator(attribute) }}"
             attr.name="{{ createAttributeIdForConfigurator(attribute) }}"
             [cxFocus]="{ key: attribute.name + '-' + value.name }"
-            [attr.aria-label]="getAriaLabel(value, attribute)"
+            [attr.aria-label]="
+              getAriaLabel(
+                enrichValueWithPrice(value, changedPrices[value.name]),
+                attribute
+              )
+            "
             [attr.aria-live]="
               listenForPriceChanges &&
               attributeRadioButtonForm.value === value.valueCode
@@ -68,7 +73,11 @@
 
         <div class="cx-value-price">
           <cx-configurator-price
-            [formula]="extractValuePriceFormulaParameters(value)"
+            [formula]="
+              extractValuePriceFormulaParameters(
+                enrichValueWithPrice(value, changedPrices[value.name])
+              )
+            "
           ></cx-configurator-price>
         </div>
       </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.spec.ts
@@ -80,14 +80,10 @@ class MockConfigUtilsService {
   }
 }
 
-class MockConfiguratorDeltaRenderingService {
-  getPriceChangedEvents(): Observable<boolean> {
-    return of(true);
+class MockConfiguratorAttributePriceChangeService {
+  getChangedPrices(): Observable<Record<string, Configurator.PriceDetails>[]> {
+    return of([]);
   }
-  mergePriceIntoValue(value: Configurator.Value): Configurator.Value {
-    return value;
-  }
-  storeValuePrice(): void {}
 }
 
 describe('ConfigAttributeRadioButtonComponent', () => {
@@ -115,7 +111,7 @@ describe('ConfigAttributeRadioButtonComponent', () => {
         providers: [
           {
             provide: ConfiguratorAttributePriceChangeService,
-            useClass: MockConfiguratorDeltaRenderingService,
+            useClass: MockConfiguratorAttributePriceChangeService,
           },
         ],
       },

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.html
@@ -8,7 +8,7 @@
     >
       <ng-container *ngFor="let value of attribute.values">
         <div
-          *ngIf="value.selected && (priceChangedEvent$ | async)"
+          *ngIf="value.selected && changedPrices$ | async as changedPrices"
           class="form-check"
         >
           <span
@@ -19,7 +19,12 @@
             tabindex="0"
             class="cx-visually-hidden"
           >
-            {{ getAriaLabel(attribute, value) }}
+            {{
+              getAriaLabel(
+                attribute,
+                enrichValueWithPrice(value, changedPrices[value.name])
+              )
+            }}
           </span>
           <div class="cx-value-label-pair">
             <label
@@ -44,7 +49,11 @@
           </div>
           <div class="cx-value-price">
             <cx-configurator-price
-              [formula]="extractValuePriceFormulaParameters(value)"
+              [formula]="
+                extractValuePriceFormulaParameters(
+                  enrichValueWithPrice(value, changedPrices[value.name])
+                )
+              "
             ></cx-configurator-price>
           </div>
         </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.spec.ts
@@ -60,14 +60,10 @@ const myValues: Configurator.Value[] = [
   },
 ];
 
-class MockConfiguratorDeltaRenderingService {
-  getPriceChangedEvents(): Observable<boolean> {
-    return of(true);
+class MockConfiguratorAttributePriceChangeService {
+  getChangedPrices(): Observable<Record<string, Configurator.PriceDetails>[]> {
+    return of([]);
   }
-  mergePriceIntoValue(value: Configurator.Value): Configurator.Value {
-    return value;
-  }
-  storeValuePrice(): void {}
 }
 
 describe('ConfigAttributeReadOnlyComponent', () => {
@@ -87,7 +83,7 @@ describe('ConfigAttributeReadOnlyComponent', () => {
         providers: [
           {
             provide: ConfiguratorAttributePriceChangeService,
-            useClass: MockConfiguratorDeltaRenderingService,
+            useClass: MockConfiguratorAttributePriceChangeService,
           },
         ],
       },

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.ts
@@ -58,10 +58,6 @@ export class ConfiguratorAttributeReadOnlyComponent extends ConfiguratorAttribut
   ): string {
     let ariaLabel = '';
     if (value) {
-      value =
-        this.configuratorAttributePriceChangeService?.mergePriceIntoValue(
-          value
-        ) ?? value;
       const valueName = this.getCurrentValueName(attribute, value);
       if (value.valuePrice && value.valuePrice?.value !== 0) {
         if (value.valuePriceTotal && value.valuePriceTotal?.value !== 0) {

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.html
@@ -5,8 +5,8 @@
 >
   <ng-container
     *ngIf="
-      !config.features?.productConfiguratorAttributeTypesV2 &&
-      (priceChangedEvent$ | async)
+      !config.features?.productConfiguratorAttributeTypesV2 && changedPrices$
+        | async as changedPrices
     "
   >
     <div
@@ -36,7 +36,12 @@
         [attr.aria-checked]="
           attributeRadioButtonForm.value === value.valueCode ? 'true' : 'false'
         "
-        [attr.aria-label]="getAriaLabelGeneric(attribute, value)"
+        [attr.aria-label]="
+          getAriaLabelGeneric(
+            attribute,
+            enrichValueWithPrice(value, changedPrices[value.name])
+          )
+        "
         [attr.aria-live]="
           listenForPriceChanges &&
           attributeRadioButtonForm.value === value.valueCode
@@ -67,7 +72,11 @@
           <div *ngIf="!getImage(value)" class="cx-img-dummy"></div>
           {{ getLabel(expMode, value.valueDisplay, value.valueCode) }}
           <cx-configurator-price
-            [formula]="extractValuePriceFormulaParameters(value)"
+            [formula]="
+              extractValuePriceFormulaParameters(
+                enrichValueWithPrice(value, changedPrices[value.name])
+              )
+            "
           ></cx-configurator-price>
         </label>
       </div>
@@ -75,8 +84,8 @@
   </ng-container>
   <ng-container
     *ngIf="
-      config.features?.productConfiguratorAttributeTypesV2 &&
-      (priceChangedEvent$ | async)
+      config.features?.productConfiguratorAttributeTypesV2 && changedPrices$
+        | async as changedPrices
     "
   >
     <ng-container *ngFor="let value of attribute.values">
@@ -111,7 +120,12 @@
               ? 'true'
               : 'false'
           "
-          [attr.aria-label]="getAriaLabelGeneric(attribute, value)"
+          [attr.aria-label]="
+            getAriaLabelGeneric(
+              attribute,
+              enrichValueWithPrice(value, changedPrices[value.name])
+            )
+          "
           [attr.aria-live]="
             listenForPriceChanges &&
             attributeRadioButtonForm.value === value.valueCode
@@ -166,7 +180,11 @@
               <cx-icon [type]="iconTypes.INFO"> </cx-icon>
             </button>
             <cx-configurator-price
-              [formula]="extractValuePriceFormulaParameters(value)"
+              [formula]="
+                extractValuePriceFormulaParameters(
+                  enrichValueWithPrice(value, changedPrices[value.name])
+                )
+              "
             ></cx-configurator-price>
           </label>
         </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.spec.ts
@@ -49,14 +49,10 @@ class MockConfiguratorCommonsService {
   updateConfiguration(): void {}
 }
 
-class MockConfiguratorDeltaRenderingService {
-  getPriceChangedEvents(): Observable<boolean> {
-    return of(true);
+class MockConfiguratorAttributePriceChangeService {
+  getChangedPrices(): Observable<Record<string, Configurator.PriceDetails>[]> {
+    return of([]);
   }
-  mergePriceIntoValue(value: Configurator.Value): Configurator.Value {
-    return value;
-  }
-  storeValuePrice(): void {}
 }
 
 class MockConfig {
@@ -81,7 +77,7 @@ describe('ConfiguratorAttributeSingleSelectionImageComponent', () => {
           providers: [
             {
               provide: ConfiguratorAttributePriceChangeService,
-              useClass: MockConfiguratorDeltaRenderingService,
+              useClass: MockConfiguratorAttributePriceChangeService,
             },
           ],
         },

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.ts
@@ -82,10 +82,6 @@ export class ConfiguratorAttributeSingleSelectionImageComponent
   extractValuePriceFormulaParameters(
     value?: Configurator.Value
   ): ConfiguratorPriceComponentOptions {
-    if (value && this.configuratorAttributePriceChangeService) {
-      value =
-        this.configuratorAttributePriceChangeService.mergePriceIntoValue(value);
-    }
     return {
       price: value?.valuePrice,
       isLightedUp: value ? value.selected : false,


### PR DESCRIPTION
This is a followup from this PR discussion: https://github.com/SAP/spartacus/pull/18997#discussion_r1699002690