### PR TITLE
fix: Fix failing make-to-stock e2e test

### DIFF
--- a/feature-libs/product-multi-dimensional/list/occ/config/default-occ-product-multi-dimensional-list-config.ts
+++ b/feature-libs/product-multi-dimensional/list/occ/config/default-occ-product-multi-dimensional-list-config.ts
@@ -12,7 +12,7 @@ export const defaultOccProductMultiDimensionalListConfig: OccConfig = {
       endpoints: {
         productSearch:
           /* eslint-disable max-len */
-          'products/search?fields=products(code,name,summary,configurable,configuratorType,priceRange(maxPrice(formattedValue),minPrice(formattedValue)),multidimensional,price(FULL),images(DEFAULT),stock(FULL),averageRating,variantOptions),facets,breadcrumbs,pagination(DEFAULT),sorts(DEFAULT),freeTextSearch,currentQuery,keywordRedirectUrl',
+          'products/search?fields=products(code,name,summary,configurable,configuratorType,priceRange(maxPrice(formattedValue),minPrice(formattedValue)),multidimensional,price(FULL),images(DEFAULT),stock(FULL),averageRating,variantOptions,baseProduct),facets,breadcrumbs,pagination(DEFAULT),sorts(DEFAULT),freeTextSearch,currentQuery,keywordRedirectUrl',
         /* eslint-enable */
       },
     },


### PR DESCRIPTION
For make-to-stock scenario the base product should be available.
Due to this `default-occ-product-multi-dimensional-list-config.ts` file should be extend.