### PR TITLE
fix: site theme not initialized correctly from storage

### DIFF
--- a/projects/core/src/model/misc.model.ts
+++ b/projects/core/src/model/misc.model.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Address } from './address.model';
 import { B2BUnit } from '.';
+import { Address } from './address.model';
 
 export interface Currency {
   active?: boolean;
@@ -137,6 +137,6 @@ export interface CaptchaConfig {
 }
 
 export interface SiteTheme {
-  i18nNameKey?: string;
-  className?: string;
+  i18nNameKey: string;
+  className: string;
 }

--- a/projects/core/src/model/misc.model.ts
+++ b/projects/core/src/model/misc.model.ts
@@ -139,5 +139,4 @@ export interface CaptchaConfig {
 export interface SiteTheme {
   i18nNameKey?: string;
   className?: string;
-  default?: boolean;
 }

--- a/projects/core/src/site-context/config/config-loader/site-context-config-initializer.ts
+++ b/projects/core/src/site-context/config/config-loader/site-context-config-initializer.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { inject, Injectable } from '@angular/core';
-import { Observable, lastValueFrom } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { lastValueFrom, Observable } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 import { ConfigInitializer } from '../../../config/config-initializer/config-initializer';
 import { BaseSite } from '../../../model/misc.model';
@@ -19,11 +19,9 @@ import {
   THEME_CONTEXT_ID,
 } from '../../providers/context-ids';
 import { SiteContextConfig } from '../site-context-config';
-import { FeatureToggles } from '../../../features-config';
 
 @Injectable({ providedIn: 'root' })
 export class SiteContextConfigInitializer implements ConfigInitializer {
-  private featureToggles = inject(FeatureToggles);
   readonly scopes = ['context'];
   readonly configFactory = () => lastValueFrom(this.resolveConfig());
 
@@ -73,9 +71,10 @@ export class SiteContextConfigInitializer implements ConfigInitializer {
           source.baseStore?.currencies,
           source.baseStore?.defaultCurrency
         ),
-        ...(this.featureToggles.useNewSiteThemeSwitcher
-          ? {}
-          : { [THEME_CONTEXT_ID]: [source.theme] }),
+        // Note: The default Site Theme can be driven by the CMS, but additional possible
+        // selectable themes (like a11y high contrast themes) can be configured only
+        // in the separate Spartacus configuration.
+        [THEME_CONTEXT_ID]: [source.theme],
       },
     } as SiteContextConfig;
 

--- a/projects/core/src/site-context/config/config-loader/site-context-config-initializer.ts
+++ b/projects/core/src/site-context/config/config-loader/site-context-config-initializer.ts
@@ -73,7 +73,7 @@ export class SiteContextConfigInitializer implements ConfigInitializer {
         ),
         // Note: The default Site Theme can be driven by the CMS, but additional possible
         // selectable themes (like a11y high contrast themes) can be configured only
-        // in the separate Spartacus configuration.
+        // in the separate Spartacus configuration `config.siteTheme.optionalThemes`.
         [THEME_CONTEXT_ID]: [source.theme],
       },
     } as SiteContextConfig;

--- a/projects/core/src/site-context/providers/context-ids.ts
+++ b/projects/core/src/site-context/providers/context-ids.ts
@@ -7,7 +7,4 @@
 export const LANGUAGE_CONTEXT_ID = 'language';
 export const CURRENCY_CONTEXT_ID = 'currency';
 export const BASE_SITE_CONTEXT_ID = 'baseSite';
-/**
- * @deprecated will be removed together with the feature toggle useNewSiteThemeSwitcher
- */
 export const THEME_CONTEXT_ID = 'theme';

--- a/projects/core/src/site-theme/config/default-site-theme-config.ts
+++ b/projects/core/src/site-theme/config/default-site-theme-config.ts
@@ -9,11 +9,7 @@ import { SiteThemeConfig } from './site-theme-config';
 export const defaultSiteThemeConfig: SiteThemeConfig = {
   siteTheme: {
     siteThemes: [
-      {
-        i18nNameKey: 'themeSwitcher.themes.default',
-        className: '',
-        default: true,
-      },
+      // SPIKE TODO: rethink the key names `siteTheme.siteThemes` vs `optionalSiteThemes
       {
         i18nNameKey: 'themeSwitcher.themes.highContrastDark',
         className: 'cx-theme-high-contrast-dark',

--- a/projects/core/src/site-theme/config/default-site-theme-config.ts
+++ b/projects/core/src/site-theme/config/default-site-theme-config.ts
@@ -8,8 +8,7 @@ import { SiteThemeConfig } from './site-theme-config';
 
 export const defaultSiteThemeConfig: SiteThemeConfig = {
   siteTheme: {
-    siteThemes: [
-      // SPIKE TODO: rethink the key names `siteTheme.siteThemes` vs `optionalSiteThemes
+    optionalThemes: [
       {
         i18nNameKey: 'themeSwitcher.themes.highContrastDark',
         className: 'cx-theme-high-contrast-dark',

--- a/projects/core/src/site-theme/config/site-theme-config.ts
+++ b/projects/core/src/site-theme/config/site-theme-config.ts
@@ -14,7 +14,7 @@ import { SiteTheme } from '../../model/misc.model';
 })
 export abstract class SiteThemeConfig {
   siteTheme?: {
-    siteThemes?: Array<SiteTheme>;
+    optionalThemes?: Array<SiteTheme>;
   };
 }
 

--- a/projects/core/src/site-theme/facade/site-theme.service.spec.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.spec.ts
@@ -105,14 +105,14 @@ describe('SiteThemeService', () => {
 
   it('should return TRUE if the theme is valid', () => {
     spyOnProperty(ngrxStore, 'select').and.returnValues(mockSelect1);
-    service.isValidTheme('dark').subscribe((results) => {
+    service.isValid('dark').subscribe((results) => {
       expect(results).toBeTruthy();
     });
   });
 
   it('should return FALSE if the theme is not valid', () => {
     spyOnProperty(ngrxStore, 'select').and.returnValues(mockSelect1);
-    service.isValidTheme('light').subscribe((results) => {
+    service.isValid('light').subscribe((results) => {
       expect(results).toBeFalsy();
     });
   });

--- a/projects/core/src/site-theme/facade/site-theme.service.spec.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.spec.ts
@@ -24,7 +24,9 @@ const mockActiveTheme = 'dark';
 
 const mockSiteThemeConfig: SiteThemeConfig = {
   siteTheme: {
-    siteThemes: [{ i18nNameKey: 'dark', className: 'dark', default: false }],
+    optionalThemes: [
+      { i18nNameKey: 'dark', className: 'dark', default: false },
+    ],
   },
 };
 

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -87,10 +87,7 @@ export class SiteThemeService implements SiteContext<SiteTheme> {
   }
 
   isValid(className: string): boolean {
-    return (
-      !!className &&
-      this.themes.map((theme) => theme.className).includes(className)
-    );
+    return this.themes.map((theme) => theme.className).includes(className);
   }
 
   isInitialized(): boolean {

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -52,8 +52,7 @@ export class SiteThemeService implements SiteContext<SiteTheme> {
    * CAUTION: This property should be accessed only when those configs are stable, e.g. `ConfigInitializer.getStable('context','siteTheme'))`
    */
   protected get themes(): SiteTheme[] {
-    // SPIKE TODO: rethink the key names `siteTheme.siteThemes` vs `optionalSiteThemes
-    const optionalThemes = this.config.siteTheme?.siteThemes || [];
+    const optionalThemes = this.config.siteTheme?.optionalThemes || [];
     return [this.getDefault(), ...optionalThemes];
   }
 

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -28,26 +28,33 @@ export class SiteThemeService implements SiteContext<SiteTheme> {
   protected store = inject(Store<StateWithSiteTheme>);
   protected config = inject(Config);
 
-  protected get themes(): SiteTheme[] {
-    // There are 2 types of themes: default and optional which are configured differently
-    // 1. The default theme ID can be configured only via Spartacus config `config.context.theme`
-    //    (note: its value can be defined statically or fetched dynamically from the CMS backend).
-    const defaultThemeId = getContextParameterDefault(
-      this.config,
-      THEME_CONTEXT_ID
-    );
-    const defaultTheme: SiteTheme = {
-      className: defaultThemeId || '',
+  getDefault(): SiteTheme {
+    const defaultThemeId =
+      getContextParameterDefault(this.config, THEME_CONTEXT_ID) ?? '';
+
+    return {
+      className: defaultThemeId,
       i18nNameKey: 'themeSwitcher.themes.default',
     };
+  }
 
+  /**
+   * List of possible themes.
+   *
+   * There are 2 types of themes: default and optional which are configured differently in Spartacus config.
+   * This property combines both types of themes into a single list.
+   *
+   * 1. The default theme ID can be configured only via Spartacus config `config.context.theme`
+   *    (note: its value can be defined statically or fetched dynamically from the CMS backend).
+   * 2. The optional themes (their IDs and their i18n keys) can be configured
+   *    only via Spartacus config `config.siteTheme.siteThemes`
+   *
+   * CAUTION: This property should be accessed only when those configs are stable, e.g. `ConfigInitializer.getStable('context','siteTheme'))`
+   */
+  protected get themes(): SiteTheme[] {
     // SPIKE TODO: rethink the key names `siteTheme.siteThemes` vs `optionalSiteThemes
-
-    // 2. The optional themes (their IDs and i18n keys) can be configured
-    //    only via Spartacus config `config.siteTheme.siteThemes`
-    const optionalThemes: SiteTheme[] = this.config.siteTheme?.siteThemes || [];
-
-    return [defaultTheme, ...optionalThemes];
+    const optionalThemes = this.config.siteTheme?.siteThemes || [];
+    return [this.getDefault(), ...optionalThemes];
   }
 
   getAll(): Observable<SiteTheme[]> {

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -28,9 +28,15 @@ export class SiteThemeService implements SiteContext<SiteTheme> {
   protected store = inject(Store<StateWithSiteTheme>);
   protected config = inject(Config);
 
+  /**
+   * Fallback default theme ID to be used when `config.context.theme` is not defined.
+   */
+  protected readonly FALLBACK_DEFAULT_THEME_ID = '';
+
   getDefault(): SiteTheme {
     const defaultThemeId =
-      getContextParameterDefault(this.config, THEME_CONTEXT_ID) ?? '';
+      getContextParameterDefault(this.config, THEME_CONTEXT_ID) ??
+      this.FALLBACK_DEFAULT_THEME_ID;
 
     return {
       className: defaultThemeId,

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -38,7 +38,7 @@ export class SiteThemeService implements SiteContext<SiteTheme> {
     );
     const defaultTheme: SiteTheme = {
       className: defaultThemeId || '',
-      i18nNameKey: 'site.theme.default',
+      i18nNameKey: 'themeSwitcher.themes.default',
     };
 
     // SPIKE TODO: rethink the key names `siteTheme.siteThemes` vs `optionalSiteThemes

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -86,7 +86,7 @@ export class SiteThemeService implements SiteContext<SiteTheme> {
       });
   }
 
-  isValidTheme(className: string): boolean {
+  isValid(className: string): boolean {
     return (
       !!className &&
       this.themes.map((theme) => theme.className).includes(className)

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -7,32 +7,52 @@
 import { inject, Injectable } from '@angular/core';
 
 import { select, Store } from '@ngrx/store';
-import { filter, map, take, tap } from 'rxjs/operators';
+import { filter, take } from 'rxjs/operators';
 
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
+import { Config } from '../../config';
 import { SiteTheme } from '../../model/misc.model';
+import {
+  getContextParameterDefault,
+  SiteContext,
+  THEME_CONTEXT_ID,
+} from '../../site-context';
 import { isNotNullable } from '../../util/type-guards';
-import { SiteThemeConfig } from '../config/site-theme-config';
 import { SiteThemeActions } from '../store/actions';
 import { SiteThemeSelectors } from '../store/selectors';
 import { StateWithSiteTheme } from '../store/state';
 
 @Injectable()
-export class SiteThemeService {
+export class SiteThemeService implements SiteContext<SiteTheme> {
   protected store = inject(Store<StateWithSiteTheme>);
-  protected config = inject(SiteThemeConfig);
+  protected config = inject(Config);
+
+  protected get themes(): SiteTheme[] {
+    // There are 2 types of themes: default and optional which are configured differently
+    // 1. The default theme ID can be configured only via Spartacus config `config.context.theme`
+    //    (note: its value can be defined statically or fetched dynamically from the CMS backend).
+    const defaultThemeId = getContextParameterDefault(
+      this.config,
+      THEME_CONTEXT_ID
+    );
+    const defaultTheme: SiteTheme = {
+      className: defaultThemeId || '',
+      i18nNameKey: 'site.theme.default',
+    };
+
+    // SPIKE TODO: rethink the key names `siteTheme.siteThemes` vs `optionalSiteThemes
+
+    // 2. The optional themes (their IDs and i18n keys) can be configured
+    //    only via Spartacus config `config.siteTheme.siteThemes`
+    const optionalThemes: SiteTheme[] = this.config.siteTheme?.siteThemes || [];
+
+    return [defaultTheme, ...optionalThemes];
+  }
 
   getAll(): Observable<SiteTheme[]> {
-    return this.store.pipe(
-      select(SiteThemeSelectors.getAllSiteThemes),
-      tap((themes) => {
-        if (!themes) {
-          this.store.dispatch(new SiteThemeActions.LoadSiteThemes());
-        }
-      }),
-      filter(isNotNullable)
-    );
+    // We could return a simple value, but we return Observable only to conform the class interface `SiteContext<T>`
+    return of(this.themes);
   }
 
   /**
@@ -60,12 +80,10 @@ export class SiteThemeService {
       });
   }
 
-  isValidTheme(className: string): Observable<boolean> {
-    return this.getAll().pipe(
-      take(1),
-      map((themes) => {
-        return themes.some((theme) => theme.className === className);
-      })
+  isValidTheme(className: string): boolean {
+    return (
+      !!className &&
+      this.themes.map((theme) => theme.className).includes(className)
     );
   }
 

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -78,7 +78,7 @@ export class SiteThemeService implements SiteContext<SiteTheme> {
     this.store
       .pipe(select(SiteThemeSelectors.getActiveSiteTheme), take(1))
       .subscribe((activeTheme: string | null) => {
-        if (activeTheme !== className) {
+        if (activeTheme !== className && this.isValid(className)) {
           this.store.dispatch(
             new SiteThemeActions.SetActiveSiteTheme(className)
           );

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -47,7 +47,7 @@ export class SiteThemeService implements SiteContext<SiteTheme> {
    * 1. The default theme ID can be configured only via Spartacus config `config.context.theme`
    *    (note: its value can be defined statically or fetched dynamically from the CMS backend).
    * 2. The optional themes (their IDs and their i18n keys) can be configured
-   *    only via Spartacus config `config.siteTheme.siteThemes`
+   *    only via Spartacus config `config.siteTheme.optionalThemes`
    *
    * CAUTION: This property should be accessed only when those configs are stable, e.g. `ConfigInitializer.getStable('context','siteTheme'))`
    */

--- a/projects/core/src/site-theme/services/site-theme-initializer.spec.ts
+++ b/projects/core/src/site-theme/services/site-theme-initializer.spec.ts
@@ -1,16 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 import { EMPTY, of } from 'rxjs';
 import { ConfigInitializerService } from '../../config';
-import createSpy = jasmine.createSpy;
+import { BaseSiteService } from '../../site-context/facade/base-site.service';
 import { SiteThemeConfig } from '../config/site-theme-config';
 import { SiteThemeService } from '../facade';
 import { SiteThemeInitializer } from './site-theme-initializer';
 import { SiteThemePersistenceService } from './site-theme-persistence.service';
-import { BaseSiteService } from '../../site-context/facade/base-site.service';
+import createSpy = jasmine.createSpy;
 
 const mockSiteThemeConfig: SiteThemeConfig = {
   siteTheme: {
-    siteThemes: [{ i18nNameKey: 'dark', className: 'dark', default: true }],
+    optionalThemes: [{ i18nNameKey: 'dark', className: 'dark', default: true }],
   },
 };
 

--- a/projects/core/src/site-theme/services/site-theme-initializer.ts
+++ b/projects/core/src/site-theme/services/site-theme-initializer.ts
@@ -8,7 +8,6 @@ import { inject, Injectable, OnDestroy } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
-import { BaseSiteService } from '../../site-context/facade/base-site.service';
 import { SiteThemeService } from '../facade/site-theme.service';
 import { SiteThemePersistenceService } from './site-theme-persistence.service';
 
@@ -17,7 +16,6 @@ export class SiteThemeInitializer implements OnDestroy {
   protected siteThemeService = inject(SiteThemeService);
   protected siteThemePersistenceService = inject(SiteThemePersistenceService);
   protected configInit = inject(ConfigInitializerService);
-  protected baseSiteService = inject(BaseSiteService);
   protected subscription: Subscription;
 
   /**

--- a/projects/core/src/site-theme/services/site-theme-initializer.ts
+++ b/projects/core/src/site-theme/services/site-theme-initializer.ts
@@ -45,8 +45,8 @@ export class SiteThemeInitializer implements OnDestroy {
   }
 
   /**
-   * Sets the active language value based on the default value from the config,
-   * unless the active language has been already initialized.
+   * Sets the active theme value based on the default value from the config,
+   * unless the active theme has been already initialized.
    */
   protected setDefaultFromConfig(): void {
     if (!this.siteThemeService.isInitialized()) {

--- a/projects/core/src/site-theme/services/site-theme-initializer.ts
+++ b/projects/core/src/site-theme/services/site-theme-initializer.ts
@@ -8,11 +8,6 @@ import { inject, Injectable, OnDestroy } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
-import {
-  getContextParameterDefault,
-  SiteContextConfig,
-  THEME_CONTEXT_ID,
-} from '../../site-context';
 import { BaseSiteService } from '../../site-context/facade/base-site.service';
 import { SiteThemeService } from '../facade/site-theme.service';
 import { SiteThemePersistenceService } from './site-theme-persistence.service';
@@ -30,7 +25,7 @@ export class SiteThemeInitializer implements OnDestroy {
    */
   initialize(): void {
     this.subscription = this.configInit
-      .getStable('siteTheme')
+      .getStable('context')
       .pipe(
         switchMap(() => this.siteThemePersistenceService.initSync()),
         switchMap(() => this.setFallbackValue())
@@ -46,19 +41,17 @@ export class SiteThemeInitializer implements OnDestroy {
   protected setFallbackValue(): Observable<unknown> {
     return this.configInit
       .getStable('context')
-      .pipe(
-        tap((config: SiteContextConfig) => this.setDefaultFromConfig(config))
-      );
+      .pipe(tap(() => this.setDefaultFromConfig()));
   }
 
   /**
    * Sets the active language value based on the default value from the config,
    * unless the active language has been already initialized.
    */
-  protected setDefaultFromConfig(config: SiteContextConfig): void {
-    const contextParam = getContextParameterDefault(config, THEME_CONTEXT_ID);
-    if (!this.siteThemeService.isInitialized() && contextParam) {
-      this.siteThemeService.setActive(contextParam);
+  protected setDefaultFromConfig(): void {
+    if (!this.siteThemeService.isInitialized()) {
+      const defaultTheme = this.siteThemeService.getDefault();
+      this.siteThemeService.setActive(defaultTheme.className);
     }
   }
 

--- a/projects/core/src/site-theme/services/site-theme-initializer.ts
+++ b/projects/core/src/site-theme/services/site-theme-initializer.ts
@@ -6,12 +6,16 @@
 
 import { inject, Injectable, OnDestroy } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
-import { map, switchMap, take, tap } from 'rxjs/operators';
+import { switchMap, tap } from 'rxjs/operators';
 import { ConfigInitializerService } from '../../config/config-initializer/config-initializer.service';
-import { SiteThemeConfig } from '../config/site-theme-config';
+import {
+  getContextParameterDefault,
+  SiteContextConfig,
+  THEME_CONTEXT_ID,
+} from '../../site-context';
+import { BaseSiteService } from '../../site-context/facade/base-site.service';
 import { SiteThemeService } from '../facade/site-theme.service';
 import { SiteThemePersistenceService } from './site-theme-persistence.service';
-import { BaseSiteService } from '../../site-context/facade/base-site.service';
 
 @Injectable({ providedIn: 'root' })
 export class SiteThemeInitializer implements OnDestroy {
@@ -40,39 +44,21 @@ export class SiteThemeInitializer implements OnDestroy {
    * Sets the default value, unless the active theme has been already initialized.
    */
   protected setFallbackValue(): Observable<unknown> {
-    return this.getCustomSiteTheme().pipe(
-      switchMap((siteTheme) =>
-        this.configInit
-          .getStable('siteTheme')
-          .pipe(
-            tap((config: SiteThemeConfig) =>
-              this.setDefaultValue(siteTheme, config)
-            )
-          )
-      )
-    );
-  }
-
-  protected getCustomSiteTheme(): Observable<string | undefined> {
-    return this.baseSiteService.get().pipe(
-      map((baseSite) => baseSite?.theme),
-      take(1)
-    );
+    return this.configInit
+      .getStable('context')
+      .pipe(
+        tap((config: SiteContextConfig) => this.setDefaultFromConfig(config))
+      );
   }
 
   /**
-   * Sets the active theme value based on the default value,
-   * unless the active theme has been already initialized.
+   * Sets the active language value based on the default value from the config,
+   * unless the active language has been already initialized.
    */
-  protected setDefaultValue(
-    siteTheme: string | undefined,
-    config: SiteThemeConfig
-  ): void {
-    const defaultTheme =
-      config.siteTheme?.siteThemes?.find((theme) => theme.default)?.className ||
-      siteTheme;
-    if (!this.siteThemeService.isInitialized() && defaultTheme) {
-      this.siteThemeService.setActive(defaultTheme);
+  protected setDefaultFromConfig(config: SiteContextConfig): void {
+    const contextParam = getContextParameterDefault(config, THEME_CONTEXT_ID);
+    if (!this.siteThemeService.isInitialized() && contextParam) {
+      this.siteThemeService.setActive(contextParam);
     }
   }
 

--- a/projects/core/src/site-theme/store/actions/site-theme.action.spec.ts
+++ b/projects/core/src/site-theme/store/actions/site-theme.action.spec.ts
@@ -1,47 +1,6 @@
-import { SiteTheme } from '../../../model/misc.model';
 import { SiteThemeActions } from './index';
 
 describe('Site Theme Actions', () => {
-  describe('LoadSiteThemes Actions', () => {
-    describe('LoadSiteThemes', () => {
-      it('should create an theme', () => {
-        const action = new SiteThemeActions.LoadSiteThemes();
-        expect({ ...action }).toEqual({
-          type: SiteThemeActions.LOAD_SITE_THEMES,
-        });
-      });
-    });
-
-    describe('LoadSiteThemesFail', () => {
-      it('should create an action', () => {
-        const payload = { message: 'Load Error' };
-        const action = new SiteThemeActions.LoadSiteThemesFail(payload);
-
-        expect({ ...action }).toEqual({
-          type: SiteThemeActions.LOAD_SITE_THEMES_FAIL,
-          payload,
-        });
-      });
-    });
-
-    describe('LoadSiteThemesSuccess', () => {
-      it('should create an action', () => {
-        const payload: SiteTheme[] = [
-          {
-            i18nNameKey: 'key',
-            className: 'theme1',
-          },
-        ];
-        const action = new SiteThemeActions.LoadSiteThemesSuccess(payload);
-
-        expect({ ...action }).toEqual({
-          type: SiteThemeActions.LOAD_SITE_THEMES_SUCCESS,
-          payload,
-        });
-      });
-    });
-  });
-
   describe('SetActiveSiteTheme Action', () => {
     it('should create an action', () => {
       const action = new SiteThemeActions.SetActiveSiteTheme('black');

--- a/projects/core/src/site-theme/store/actions/site-themes.action.ts
+++ b/projects/core/src/site-theme/store/actions/site-themes.action.ts
@@ -5,27 +5,9 @@
  */
 
 import { Action } from '@ngrx/store';
-import { SiteTheme } from '../../../model/misc.model';
 
-export const LOAD_SITE_THEMES = '[Site-theme] Load Site Themes';
-export const LOAD_SITE_THEMES_FAIL = '[Site-theme] Load Site Themes Fail';
-export const LOAD_SITE_THEMES_SUCCESS = '[Site-theme] Load Site Themes Success';
 export const SET_ACTIVE_SITE_THEME = '[Site-theme] Set Active Site Theme';
 export const SITE_THEME_CHANGE = '[Site-theme] Site Theme Change';
-
-export class LoadSiteThemes implements Action {
-  readonly type = LOAD_SITE_THEMES;
-}
-
-export class LoadSiteThemesFail implements Action {
-  readonly type = LOAD_SITE_THEMES_FAIL;
-  constructor(public payload: any) {}
-}
-
-export class LoadSiteThemesSuccess implements Action {
-  readonly type = LOAD_SITE_THEMES_SUCCESS;
-  constructor(public payload: SiteTheme[]) {}
-}
 
 export class SetActiveSiteTheme implements Action {
   readonly type = SET_ACTIVE_SITE_THEME;
@@ -40,9 +22,4 @@ export class SiteThemeChange implements Action {
 }
 
 // action types
-export type SiteThemesAction =
-  | LoadSiteThemes
-  | LoadSiteThemesFail
-  | LoadSiteThemesSuccess
-  | SetActiveSiteTheme
-  | SiteThemeChange;
+export type SiteThemesAction = SetActiveSiteTheme | SiteThemeChange;

--- a/projects/core/src/site-theme/store/effects/site-themes.effect.spec.ts
+++ b/projects/core/src/site-theme/store/effects/site-themes.effect.spec.ts
@@ -2,18 +2,15 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Store } from '@ngrx/store';
-import { BehaviorSubject, of, Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { ConfigModule } from '../../../config/config.module';
 import { SiteTheme } from '../../../model/misc.model';
 import { BaseOccModule } from '../../../occ/base-occ.module';
-import { BaseSiteService } from '../../../site-context/facade/base-site.service';
 import { SiteThemeConfig } from '../../config/site-theme-config';
 import { SiteThemeActions } from '../actions/index';
 import * as fromEffects from './site-themes.effect';
 
-const themes: SiteTheme[] = [
-  { i18nNameKey: 'dark', className: 'dark', default: true },
-];
+const themes: SiteTheme[] = [{ i18nNameKey: 'dark', className: 'dark' }];
 const mockSiteThemeConfig: SiteThemeConfig = {
   siteTheme: {
     optionalThemes: themes,
@@ -24,12 +21,10 @@ describe('Themes Effects', () => {
   let actions$: Subject<SiteThemeActions.SiteThemesAction>;
   let effects: fromEffects.SiteThemesEffects;
   let mockState: BehaviorSubject<string>;
-  let baseSiteService: jasmine.SpyObj<BaseSiteService>;
 
   beforeEach(() => {
     actions$ = new Subject();
     mockState = new BehaviorSubject('');
-    const baseSiteServiceSpy = jasmine.createSpyObj('BaseSiteService', ['get']);
     const mockStore: Partial<Store<any>> = {
       select: () => mockState,
     };
@@ -40,43 +35,11 @@ describe('Themes Effects', () => {
         fromEffects.SiteThemesEffects,
         provideMockActions(() => actions$),
         { provide: Store, useValue: mockStore },
-        { provide: BaseSiteService, useValue: baseSiteServiceSpy },
         { provide: SiteThemeConfig, useValue: mockSiteThemeConfig },
       ],
     });
 
     effects = TestBed.inject(fromEffects.SiteThemesEffects);
-    baseSiteService = TestBed.inject(
-      BaseSiteService
-    ) as jasmine.SpyObj<BaseSiteService>;
-    baseSiteService.get.and.returnValue(of({ theme: 'dark' }));
-  });
-
-  describe('LoadSiteThemes$', () => {
-    it('should populate all themes from LoadSiteThemesSuccess', () => {
-      const results: any[] = [];
-      effects.loadSiteThemes$.subscribe((a) => results.push(a));
-      actions$.next(new SiteThemeActions.LoadSiteThemes());
-      expect(results).toEqual([
-        new SiteThemeActions.LoadSiteThemesSuccess(themes),
-      ]);
-    });
-
-    it('should replace default theme', () => {
-      const mockSiteTheme = 'red';
-      baseSiteService.get.and.returnValue(of({ theme: mockSiteTheme }));
-      const mockThemes = [
-        { ...themes[0], className: mockSiteTheme },
-        ...themes.slice(1),
-      ];
-      const results: any[] = [];
-      effects.loadSiteThemes$.subscribe((a) => results.push(a));
-      actions$.next(new SiteThemeActions.LoadSiteThemes());
-
-      expect(results).toEqual([
-        new SiteThemeActions.LoadSiteThemesSuccess(mockThemes),
-      ]);
-    });
   });
 
   describe('activateTheme$', () => {

--- a/projects/core/src/site-theme/store/effects/site-themes.effect.spec.ts
+++ b/projects/core/src/site-theme/store/effects/site-themes.effect.spec.ts
@@ -6,17 +6,17 @@ import { BehaviorSubject, of, Subject } from 'rxjs';
 import { ConfigModule } from '../../../config/config.module';
 import { SiteTheme } from '../../../model/misc.model';
 import { BaseOccModule } from '../../../occ/base-occ.module';
-import { SiteThemeActions } from '../actions/index';
-import * as fromEffects from './site-themes.effect';
 import { BaseSiteService } from '../../../site-context/facade/base-site.service';
 import { SiteThemeConfig } from '../../config/site-theme-config';
+import { SiteThemeActions } from '../actions/index';
+import * as fromEffects from './site-themes.effect';
 
 const themes: SiteTheme[] = [
   { i18nNameKey: 'dark', className: 'dark', default: true },
 ];
 const mockSiteThemeConfig: SiteThemeConfig = {
   siteTheme: {
-    siteThemes: themes,
+    optionalThemes: themes,
   },
 };
 

--- a/projects/core/src/site-theme/store/effects/site-themes.effect.ts
+++ b/projects/core/src/site-theme/store/effects/site-themes.effect.ts
@@ -5,74 +5,18 @@
  */
 
 import { Injectable, inject } from '@angular/core';
-import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Actions, createEffect } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import { Observable, of } from 'rxjs';
-import {
-  bufferCount,
-  catchError,
-  exhaustMap,
-  filter,
-  map,
-  take,
-} from 'rxjs/operators';
-import { LoggerService } from '../../../logger';
-import { normalizeHttpError } from '../../../util/normalize-http-error';
+import { Observable } from 'rxjs';
+import { bufferCount, filter, map } from 'rxjs/operators';
 import { SiteThemeActions } from '../actions/index';
-import { StateWithSiteTheme } from '../state';
 import { getActiveSiteTheme } from '../selectors/site-themes.selectors';
-import { SiteThemeConfig } from '../../config/site-theme-config';
-import { BaseSiteService } from '../../../site-context/facade/base-site.service';
-import { SiteTheme } from '../../../model/misc.model';
+import { StateWithSiteTheme } from '../state';
 
 @Injectable()
 export class SiteThemesEffects {
-  protected logger = inject(LoggerService);
   protected actions$ = inject(Actions);
   protected state = inject(Store<StateWithSiteTheme>);
-  protected config = inject(SiteThemeConfig);
-  protected baseSiteService = inject(BaseSiteService);
-
-  loadSiteThemes$: Observable<
-    SiteThemeActions.LoadSiteThemesSuccess | SiteThemeActions.LoadSiteThemesFail
-  > = createEffect(() =>
-    this.actions$.pipe(
-      ofType(SiteThemeActions.LOAD_SITE_THEMES),
-      exhaustMap(() => {
-        return this.getCustomSiteTheme().pipe(
-          map((siteTheme) => {
-            let siteThemes = [];
-            if (this.config.siteTheme?.siteThemes?.length) {
-              const hasDefaultTheme = this.config.siteTheme.siteThemes.some(
-                (theme) => theme.default
-              );
-              siteThemes = (this.config.siteTheme?.siteThemes || []).map(
-                (sitetheme) => {
-                  if (sitetheme.default) {
-                    return { ...sitetheme, className: siteTheme ?? '' };
-                  }
-                  return sitetheme;
-                }
-              );
-              if (!hasDefaultTheme) {
-                siteThemes.push(this.getNewDefaultTheme(siteTheme));
-              }
-            } else {
-              siteThemes.push(this.getNewDefaultTheme(siteTheme));
-            }
-            return new SiteThemeActions.LoadSiteThemesSuccess(siteThemes);
-          }),
-          catchError((error) =>
-            of(
-              new SiteThemeActions.LoadSiteThemesFail(
-                normalizeHttpError(error, this.logger)
-              )
-            )
-          )
-        );
-      })
-    )
-  );
 
   activateSiteTheme$: Observable<SiteThemeActions.SiteThemeChange> =
     createEffect(() =>
@@ -85,19 +29,4 @@ export class SiteThemesEffects {
         )
       )
     );
-
-  private getCustomSiteTheme(): Observable<string | undefined> {
-    return this.baseSiteService.get().pipe(
-      take(1),
-      map((baseSite) => baseSite?.theme)
-    );
-  }
-
-  private getNewDefaultTheme(siteTheme: string | undefined): SiteTheme {
-    return {
-      i18nNameKey: 'themeSwitcher.themes.default',
-      className: siteTheme || '',
-      default: true,
-    };
-  }
 }

--- a/projects/core/src/site-theme/store/reducers/site-themes.reducer.spec.ts
+++ b/projects/core/src/site-theme/store/reducers/site-themes.reducer.spec.ts
@@ -1,4 +1,3 @@
-import { SiteTheme } from '../../../model/misc.model';
 import { SiteThemeActions } from '../actions/index';
 import * as fromSiteThemes from './site-themes.reducer';
 
@@ -10,23 +9,6 @@ describe('Site Theme Reducer', () => {
       const state = fromSiteThemes.reducer(undefined, action);
 
       expect(state).toBe(initialState);
-    });
-  });
-
-  describe('LOAD_THEMES_SUCCESS action', () => {
-    it('should populate the theme state entities', () => {
-      const siteThemes: SiteTheme[] = [
-        { i18nNameKey: 'dark', className: 'dark', default: true },
-      ];
-
-      const entities: { [key: string]: SiteTheme } = {
-        dark: siteThemes[0],
-      };
-
-      const { initialState } = fromSiteThemes;
-      const action = new SiteThemeActions.LoadSiteThemesSuccess(siteThemes);
-      const state = fromSiteThemes.reducer(initialState, action);
-      expect(state.entities).toEqual(entities);
     });
   });
 

--- a/projects/core/src/site-theme/store/reducers/site-themes.reducer.ts
+++ b/projects/core/src/site-theme/store/reducers/site-themes.reducer.ts
@@ -4,12 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SiteTheme } from '../../../model/misc.model';
 import { SiteThemeActions } from '../actions/index';
 import { SiteThemesState } from '../state';
 
 export const initialState: SiteThemesState = {
-  entities: null,
   activeSiteTheme: null,
 };
 
@@ -18,29 +16,6 @@ export function reducer(
   action: SiteThemeActions.SiteThemesAction
 ): SiteThemesState {
   switch (action.type) {
-    case SiteThemeActions.LOAD_SITE_THEMES_SUCCESS: {
-      const siteThemes: SiteTheme[] = action.payload;
-      const entities = siteThemes.reduce(
-        (
-          siteThemeEntities: { [className: string]: SiteTheme },
-          siteTheme: SiteTheme
-        ) => {
-          return {
-            ...siteThemeEntities,
-            [siteTheme.className ?? '']: siteTheme,
-          };
-        },
-        {
-          ...state.entities,
-        }
-      );
-
-      return {
-        ...state,
-        entities,
-      };
-    }
-
     case SiteThemeActions.SET_ACTIVE_SITE_THEME: {
       const className = action.payload;
 

--- a/projects/core/src/site-theme/store/selectors/site-themes.selectors.spec.ts
+++ b/projects/core/src/site-theme/store/selectors/site-themes.selectors.spec.ts
@@ -1,26 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { select, Store, StoreModule } from '@ngrx/store';
-import { SiteTheme } from '../../../model/misc.model';
 import { SiteThemeActions } from '../actions/index';
 import * as fromReducers from '../reducers/index';
 import { SiteThemeSelectors } from '../selectors/index';
-import {
-  SiteThemeEntities,
-  SITE_THEME_FEATURE,
-  StateWithSiteTheme,
-} from '../state';
+import { SITE_THEME_FEATURE, StateWithSiteTheme } from '../state';
 
 describe('Themes Selectors', () => {
   let store: Store<StateWithSiteTheme>;
-
-  const themes: SiteTheme[] = [
-    { i18nNameKey: 'dark', className: 'dark', default: true },
-  ];
-
-  const entities = {
-    dark: themes[0],
-  };
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -31,22 +17,6 @@ describe('Themes Selectors', () => {
 
     store = TestBed.inject(Store);
     spyOn(store, 'dispatch').and.callThrough();
-  });
-
-  describe('getSiteThemeEntities', () => {
-    it('should return Themes entities', () => {
-      let result: SiteThemeEntities;
-
-      store
-        .pipe(select(SiteThemeSelectors.getSiteThemeEntities))
-        .subscribe((value) => (result = value));
-
-      expect(result).toEqual(null);
-
-      store.dispatch(new SiteThemeActions.LoadSiteThemesSuccess(themes));
-
-      expect(result).toEqual(entities);
-    });
   });
 
   describe('getActiveSiteTheme', () => {
@@ -62,22 +32,6 @@ describe('Themes Selectors', () => {
       store.dispatch(new SiteThemeActions.SetActiveSiteTheme('light'));
 
       expect(result).toEqual('light');
-    });
-  });
-
-  describe('getAllThemes', () => {
-    it('should return all themes', () => {
-      let result: SiteTheme[];
-
-      store
-        .pipe(select(SiteThemeSelectors.getAllSiteThemes))
-        .subscribe((value) => (result = value));
-
-      expect(result).toEqual(null);
-
-      store.dispatch(new SiteThemeActions.LoadSiteThemesSuccess(themes));
-
-      expect(result).toEqual(themes);
     });
   });
 });

--- a/projects/core/src/site-theme/store/selectors/site-themes.selectors.ts
+++ b/projects/core/src/site-theme/store/selectors/site-themes.selectors.ts
@@ -5,39 +5,18 @@
  */
 
 import { createSelector, MemoizedSelector } from '@ngrx/store';
-import { SiteTheme } from '../../../model/misc.model';
-import {
-  SiteThemeState,
-  SiteThemeEntities,
-  StateWithSiteTheme,
-  SiteThemesState,
-} from '../state';
+import { SiteThemesState, SiteThemeState, StateWithSiteTheme } from '../state';
 import { getSiteThemeState } from './feature.selector';
 
 const activeSiteThemeSelector = (state: SiteThemesState) =>
   state.activeSiteTheme;
-const siteThemeEntitiesSelector = (state: SiteThemesState) => state.entities;
 
 export const getSiteThemesState: MemoizedSelector<
   StateWithSiteTheme,
   SiteThemesState
 > = createSelector(getSiteThemeState, (state: SiteThemeState) => state.themes);
 
-export const getSiteThemeEntities: MemoizedSelector<
-  StateWithSiteTheme,
-  SiteThemeEntities | null
-> = createSelector(getSiteThemesState, siteThemeEntitiesSelector);
-
 export const getActiveSiteTheme: MemoizedSelector<
   StateWithSiteTheme,
   string | null
 > = createSelector(getSiteThemesState, activeSiteThemeSelector);
-
-export const getAllSiteThemes: MemoizedSelector<
-  StateWithSiteTheme,
-  SiteTheme[] | null
-> = createSelector(getSiteThemeEntities, (entities) => {
-  return entities
-    ? Object.keys(entities).map((className) => entities[className])
-    : null;
-});

--- a/projects/core/src/site-theme/store/state.ts
+++ b/projects/core/src/site-theme/store/state.ts
@@ -21,6 +21,5 @@ export interface SiteThemeEntities {
 }
 
 export interface SiteThemesState {
-  entities: SiteThemeEntities | null;
   activeSiteTheme: string | null;
 }

--- a/projects/core/src/state/utils/browser-storage.ts
+++ b/projects/core/src/state/utils/browser-storage.ts
@@ -39,10 +39,10 @@ export function getStorage(
 /**
  * Persists the given value to the given storage, piping it first through `JSON.stringify()`.
  *
- * Note: It deliberately doesn't save `undefined` values in storage.
+ * Note: It silently refuses to save `undefined` values in storage.
  *       It's because `JSON.stringify()` returns the string `"undefined"` for `undefined`.
- *       And this string is not valid JSON and will cause a runtime `SyntaxError` in `readFromStorage()`
- *       when `JSON.parse()` is called with the string `"undefined"` as an argument.
+ *       And this string is not valid JSON so it would  cause a runtime `SyntaxError`
+ *       in `readFromStorage()` when `JSON.parse()` is called with the string `"undefined"` as an argument.
  */
 export function persistToStorage(
   configKey: string,

--- a/projects/core/src/state/utils/browser-storage.ts
+++ b/projects/core/src/state/utils/browser-storage.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { isNotUndefined } from '../../util';
 import { WindowRef } from '../../window/window-ref';
 import { StorageSyncType } from '../config/state-config';
 
@@ -40,7 +41,7 @@ export function persistToStorage(
   value: any,
   storage: Storage
 ): void {
-  if (!isSsr(storage) && value) {
+  if (!isSsr(storage) && isNotUndefined(value)) {
     storage.setItem(configKey, JSON.stringify(value));
   }
 }

--- a/projects/core/src/state/utils/browser-storage.ts
+++ b/projects/core/src/state/utils/browser-storage.ts
@@ -36,6 +36,14 @@ export function getStorage(
   return storage;
 }
 
+/**
+ * Persists the given value to the given storage, piping it first through `JSON.stringify()`.
+ *
+ * Note: It deliberately doesn't save `undefined` values in storage.
+ *       It's because `JSON.stringify()` returns the string `"undefined"` for `undefined`.
+ *       And this string is not valid JSON and will cause a runtime `SyntaxError` in `readFromStorage()`
+ *       when `JSON.parse()` is called with the string `"undefined"` as an argument.
+ */
 export function persistToStorage(
   configKey: string,
   value: any,

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-theme/site-theme.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-theme/site-theme.e2e.cy.ts
@@ -20,7 +20,7 @@ context('Site Theme', { testIsolation: false }, () => {
     cy.get('cx-theme-switcher select').then(($select) => {
       const selectedOption = $select.find('option:selected');
       cy.wrap(selectedOption).should('have.attr', 'aria-label', 'Default');
-      cy.wrap(selectedOption).should('have.value', 'santorini');
+      cy.wrap(selectedOption).should('have.value', '');
     });
   });
 
@@ -40,8 +40,11 @@ context('Site Theme', { testIsolation: false }, () => {
 
     cy.get('cx-theme-switcher select')
       .select('Default')
-      .should('have.value', 'santorini');
-    cy.get('cx-storefront').should('have.class', 'santorini');
+      .should('have.value', '');
+    cy.get('cx-storefront').should(
+      'not.have.class',
+      'cx-theme-high-contrast-light'
+    );
   });
 
   it('should keep selected theme after reload the page', () => {

--- a/projects/storefrontlib/cms-components/misc/theme-switcher/theme-switcher.component.service.spec.ts
+++ b/projects/storefrontlib/cms-components/misc/theme-switcher/theme-switcher.component.service.spec.ts
@@ -33,8 +33,8 @@ describe('ThemeSwitcherComponentService', () => {
 
   it('getItems should return all themes', (done: DoneFn) => {
     const mockThemes: SiteTheme[] = [
-      { className: 'theme1' },
-      { className: 'theme2' },
+      { className: 'theme1', i18nNameKey: 'theme1' },
+      { className: 'theme2', i18nNameKey: 'theme2' },
     ];
     siteThemeService.getAll.and.returnValue(of(mockThemes));
 

--- a/projects/storefrontlib/cms-components/misc/theme-switcher/theme-switcher.component.spec.ts
+++ b/projects/storefrontlib/cms-components/misc/theme-switcher/theme-switcher.component.spec.ts
@@ -46,8 +46,8 @@ describe('ThemeSwitcherComponent', () => {
 
   it('should get items from the service', (done: DoneFn) => {
     const itemsMock: Array<SiteTheme> = [
-      { className: 'theme1' },
-      { className: 'theme2' },
+      { className: 'theme1', i18nNameKey: 'theme1' },
+      { className: 'theme2', i18nNameKey: 'theme1' },
     ];
     themeSwitcherComponentService.getItems.and.returnValue(of(itemsMock));
 

--- a/projects/storefrontlib/layout/theme/theme.service.spec.ts
+++ b/projects/storefrontlib/layout/theme/theme.service.spec.ts
@@ -84,6 +84,11 @@ describe('ThemeService', () => {
     expect(
       componentRef.location.nativeElement.classList.contains('basic-theme')
     ).toBeFalsy();
+
+    service.setTheme('');
+    expect(
+      componentRef.location.nativeElement.classList.contains('new-theme')
+    ).toBeFalsy();
   });
 
   it('should clean up subscriptions on destroy', () => {

--- a/projects/storefrontlib/layout/theme/theme.service.ts
+++ b/projects/storefrontlib/layout/theme/theme.service.ts
@@ -60,13 +60,22 @@ export class ThemeService implements OnDestroy {
   }
 
   setTheme(theme: string | undefined): void {
-    if (theme) {
-      const element = this.rootComponent.location.nativeElement;
-      // remove the old theme
-      this.renderer.removeClass(element, this.existingTheme);
-      // add the new theme
-      this.renderer.addClass(element, theme);
-      this.existingTheme = theme;
+    const element = this.rootComponent.location.nativeElement;
+
+    if (this.featureConfigService.isEnabled('useNewSiteThemeSwitcher')) {
+      if (this.existingTheme) {
+        this.renderer.removeClass(element, this.existingTheme);
+      }
+      if (theme) {
+        this.renderer.addClass(element, theme);
+        this.existingTheme = theme;
+      }
+    } else {
+      if (theme) {
+        this.renderer.removeClass(element, this.existingTheme);
+        this.renderer.addClass(element, theme);
+        this.existingTheme = theme;
+      }
     }
   }
 }


### PR DESCRIPTION
**BEFORE:**
- theme value was not restored correctly from local storage on page start
- we performed a mandatory call to OCC endpoint /basesites, even if customers didn't want to use CMS-driven theming

<details>
<summary>
Elaborating more:
</summary>

When we attempted to set a value from storage on page start, we encountered an ASYNC mechanism of validation (which in the background called the OCC endpoint /basesites). Unfortunately, then we immediately expected the value to have been set (despite it was delayed by an async validation) - we checked synchronously the value of the `isInitialized()`. This race condition led to setting improper value to ngrx on the page start.

Besides this problem, we also forced all customers to make in an APP_INITIALIZER an _obligatory_ render-blocking http call to OCC endpount /basesites, (even regardless if they used CMS-driven theming or not). Please note that we already had a different generic mechanism (`SiteContextConfigInitializer`) which performs such a render-blocking call, but customers only if customers decide to load site context data from CMS (alternatively they can configure site context statically in Spartacus config). It's a tradeoff each customer need to make - to have dynamic CMS-driven site context, Spartacus needs to make a http roundtrip.
</details>

**AFTER:**
- theme value is restored correctly from storage on page start
- we let the existing mechanism `SiteContextConfigInitializer` to possibly fetch the theme from CMS - only if a customer decides to load site context data from CMS. Alternatively, a customer can configure the theme statically in Spartacus config `config.context`.

**Side changes that needed to be made:**
1. Reverted the deprecation on the confi  `config.context[THEME_CONTEXT_ID]: string`
2. Renamed the new config `config.siteTheme.siteThemes` to `config.siteTheme.optionalThemes`.
3. The themes are _back again_ being configured via scattered 2 different configs (Note: it was the case at first in the main PR, until I first suggested to unify those configs for simplicity; only now I realized negative consequences unifying them, so reverting this decision), so now:
   - the config `config.context[THEME_CONTEXT_ID]: string` defines the default theme ID (which can be configured manually in Spartacus config OR it can be populated dynamically by the `SiteContextConfigInitializer` if a customers decides so. So we preserve the old behavior.
   - now the new config `config.siteTheme.optionalThemes: SiteTheme[]` defines ONLY the optional themes (like high contrast ones), with their IDs (class names) and a11y labels
4. If the default theme ID defined in `config.context[THEME_CONTEXT_ID]: string` is left undefined, we use an empty string `''` as the default theme ID - resulting in storing `''` in the `localStorage` and setting NO css class in DOM in case when this theme is activated
5. Fixed the mechanism of `StatePersistenceService` (the function `persistToStorage` to be precise) to allow for storing an empty string `''` - which, to my surprise, was previously impossible (due to a condition `if(value)...`). Now only the `undefined` values are prevented. For more, see the JSDoc comment with explanation in `persistToStorage()` function
6. Removed the whole NGRX code for setting/getting possible Themes. Now all Themes can be determined synchronously based on configs.
7. When a customer doesn't configure manually the default theme's ID (`config.context.theme`) and when they don't enable fetching a theme from CMS (via `StatePersistenceService`), then we we use a fallback value - an empty string `''` - as the css class / ID of the default theme. This matches the original behavior on the `develop` branch - to not set any css class when config.context.theme is not defined.


**QA steps:**
Prerequisites:
- you need to display a ThemeSwitcher component in every page (it's a CMS component but currently we're lacking sample data for it in our dev server) - here is a quick way to do it:
  - in `storefront-component.module.ts` line 29, add an import of the module `ThemeSwitcherModule` (from `'../../cms-components/misc/theme-switcher/theme-switcher.module';`)
  - in `storefront.component.html` line 1, add `<cx-theme-switcher />`
- Open Spartacus and open DevTools -> Application tab -> local storage

TEST CASES:

1. TEST CASE: When a default theme ID is NOT configured - `config.context.theme` is undefined
   1. (note: in our storefront app, no default theme ID is configured)
   1. Clear the entry for the key `spartacus⚿⚿siteTheme`, if exists.
   1. Refresh the page
   1. 👉 Verify that the entry `spartacus⚿⚿siteTheme` has a value `''` (empty string)
   1. 👉 Verify that when you run in the console `[...document.querySelector('cx-storefront').classList]`, the list doesn't contain any class related to theming
   1. In the top of the page in the ThemeSwitcher, change the theme to `HC-dark`
   1. 👉 Verify that the entry `spartacus⚿⚿siteTheme` has a value `'cx-theme-high-contrast-dark'`
   1. 👉 Verify that when you run in the console `[...document.querySelector('cx-storefront').classList]`, the list contains `'cx-theme-high-contrast-dark'`
   1. Refresh the page
   1. 👉 Verify that the entry `spartacus⚿⚿siteTheme` has a value `'cx-theme-high-contrast-dark'`
   1. 👉 Verify that when you run in the console `[...document.querySelector('cx-storefront').classList]`, the list contains `'cx-theme-high-contrast-dark'`
   1. In the top of the page in the ThemeSwitcher, change the theme back to `Default`
   1. 👉 Verify that the entry `spartacus⚿⚿siteTheme` has a value `''` (empty string)
   1. 👉 Verify that when you run in the console `[...document.querySelector('cx-storefront').classList]`, the list doesn't contain any class related to theming (e.g. it DOES NOT contain anymore `'cx-theme-high-contrast-dark'`)
1. TEST CASE: When a default theme ID IS configured - `config.context.theme` is defined
   1. in `spartacus-b2c-configuration.module.ts` in line 40, in the `context` config, add a new key: `theme: ['spike']`
   1. 👉👉👉 verify all analogically as in the previous TEST CASE, but instead of `''` you should see `spike`
1. TEST CASE: When a default theme ID is automatically configured, based on CMS Basesites  - `config.context.theme` is populated by the `SiteContextConfigInitializer`
   1. in `spartacus-b2c-configuration.module.ts` comment-out lines 36-40, effectively removing the static `context` config. (This will trigger loading loading this config from CMS Basesites. For more see [docs](https://help.sap.com/docs/SAP_COMMERCE_COMPOSABLE_STOREFRONT/eaef8c61b6d9477daf75bff9ac1b7eb4/9d2e339c2b094e4f99df1c2d7cc999a8.html?q=automatic%20site%20context))
   1. 👉👉👉 verify all analogically as in the previous TEST CASE, but instead of `''` you should see `santorini`

closes https://jira.tools.sap/browse/CXSPA-8153