### PR TITLE
fix: Organize imports in s4 service modules

### DIFF
--- a/integration-libs/s4-service/order/core/s4-service-order-core.module.ts
+++ b/integration-libs/s4-service/order/core/s4-service-order-core.module.ts
@@ -6,12 +6,18 @@
 
 import { NgModule } from '@angular/core';
 import { CxDatePipe } from '@spartacus/core';
-import { CancelServiceOrderService } from './facade';
-import { CancelServiceOrderFacade } from '@spartacus/s4-service/root';
-import { CancelServiceOrderConnector } from './connector';
-import { RescheduleServiceOrderService } from './facade';
-import { RescheduleServiceOrderFacade } from '@spartacus/s4-service/root';
-import { RescheduleServiceOrderConnector } from './connector';
+import {
+  CancelServiceOrderFacade,
+  RescheduleServiceOrderFacade,
+} from '@spartacus/s4-service/root';
+import {
+  CancelServiceOrderConnector,
+  RescheduleServiceOrderConnector,
+} from './connector';
+import {
+  CancelServiceOrderService,
+  RescheduleServiceOrderService,
+} from './facade';
 
 @NgModule({
   providers: [

--- a/integration-libs/s4-service/order/occ/s4-service-order-occ.module.ts
+++ b/integration-libs/s4-service/order/occ/s4-service-order-occ.module.ts
@@ -6,11 +6,15 @@
 
 import { NgModule } from '@angular/core';
 import { provideDefaultConfig } from '@spartacus/core';
+import {
+  CancelServiceOrderAdapter,
+  RescheduleServiceOrderAdapter,
+} from '../core/connector';
+import {
+  OccCancelServiceOrderAdapter,
+  OccRescheduleServiceOrderAdapter,
+} from './adapters';
 import { defaultOccServiceOrderConfig } from './config/default-occ-s4-service-config';
-import { CancelServiceOrderAdapter } from '../core/connector';
-import { OccCancelServiceOrderAdapter } from './adapters';
-import { RescheduleServiceOrderAdapter } from '../core/connector';
-import { OccRescheduleServiceOrderAdapter } from './adapters';
 
 @NgModule({
   providers: [


### PR DESCRIPTION
Duplicated imports where combined into one