### PR TITLE
chore: Enable schematics tests

### DIFF
--- a/feature-libs/asm/schematics/add-asm/index_spec.ts
+++ b/feature-libs/asm/schematics/add-asm/index_spec.ts
@@ -24,7 +24,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/asm.scss';
 
-xdescribe('Spartacus Asm schematics: ng-add', () => {
+describe('Spartacus Asm schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_ASM,
     collectionPath

--- a/feature-libs/cart/schematics/add-cart/index_spec.ts
+++ b/feature-libs/cart/schematics/add-cart/index_spec.ts
@@ -32,7 +32,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/cart.scss';
 
-xdescribe('Spartacus Cart schematics: ng-add', () => {
+describe('Spartacus Cart schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_CART,
     collectionPath

--- a/feature-libs/checkout/schematics/add-checkout/index_spec.ts
+++ b/feature-libs/checkout/schematics/add-checkout/index_spec.ts
@@ -30,7 +30,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/checkout.scss';
 
-xdescribe('Spartacus Checkout schematics: ng-add', () => {
+describe('Spartacus Checkout schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_CHECKOUT,
     collectionPath

--- a/feature-libs/customer-ticketing/schematics/add-customer-ticketing/index_spec.ts
+++ b/feature-libs/customer-ticketing/schematics/add-customer-ticketing/index_spec.ts
@@ -23,7 +23,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/customer-ticketing.scss';
 
-xdescribe('Spartacus Customer Ticketing schematics: ng-add', () => {
+describe('Spartacus Customer Ticketing schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_CUSTOMER_TICKETING,
     collectionPath

--- a/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/index_spec.ts
+++ b/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/index_spec.ts
@@ -28,7 +28,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/estimated-delivery-date.scss';
 
-xdescribe('Spartacus Estimated-Delivery-Date schematics: ng-add', () => {
+describe('Spartacus Estimated-Delivery-Date schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_ESTIMATED_DELIVERY_DATE,
     collectionPath

--- a/feature-libs/order/schematics/add-order/index_spec.ts
+++ b/feature-libs/order/schematics/add-order/index_spec.ts
@@ -25,7 +25,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/order.scss';
 
-xdescribe('Spartacus Order schematics: ng-add', () => {
+describe('Spartacus Order schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_ORDER,
     collectionPath

--- a/feature-libs/organization/schematics/add-organization/index_spec.ts
+++ b/feature-libs/organization/schematics/add-organization/index_spec.ts
@@ -34,7 +34,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/organization.scss';
 
-xdescribe('Spartacus Organization schematics: ng-add', () => {
+describe('Spartacus Organization schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_ORGANIZATION,
     collectionPath

--- a/feature-libs/pdf-invoices/schematics/add-pdf-invoices/index_spec.ts
+++ b/feature-libs/pdf-invoices/schematics/add-pdf-invoices/index_spec.ts
@@ -23,7 +23,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/pdf-invoices.scss';
 
-xdescribe('Spartacus PDF Invoices schematics: ng-add', () => {
+describe('Spartacus PDF Invoices schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_PDF_INVOICES,
     collectionPath

--- a/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index_spec.ts
+++ b/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index_spec.ts
@@ -27,7 +27,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/pickup-in-store.scss';
 
-xdescribe('Spartacus Pickup in Store schematics: ng-add', () => {
+describe('Spartacus Pickup in Store schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_PICKUP_IN_STORE,
     collectionPath

--- a/feature-libs/product-configurator/schematics/add-product-configurator/index_spec.ts
+++ b/feature-libs/product-configurator/schematics/add-product-configurator/index_spec.ts
@@ -28,7 +28,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/product-configurator.scss';
 
-xdescribe('Spartacus product configurator schematics: ng-add', () => {
+describe('Spartacus product configurator schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_PRODUCT_CONFIGURATOR,
     collectionPath

--- a/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/index_spec.ts
+++ b/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/index_spec.ts
@@ -10,14 +10,14 @@ import {
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
 import {
-  LibraryOptions as SpartacusProductOptions,
-  PRODUCT_MULTI_DIMENSIONAL_SELECTOR_FEATURE_NAME,
   PRODUCT_MULTI_DIMENSIONAL_LIST_FEATURE_NAME,
-  productMultiDimensionalSelectorFeatureModulePath,
-  productMultiDimensionalListFeatureModulePath,
+  PRODUCT_MULTI_DIMENSIONAL_SELECTOR_FEATURE_NAME,
   SPARTACUS_PRODUCT,
   SPARTACUS_SCHEMATICS,
   SpartacusOptions,
+  LibraryOptions as SpartacusProductOptions,
+  productMultiDimensionalListFeatureModulePath,
+  productMultiDimensionalSelectorFeatureModulePath,
 } from '@spartacus/schematics';
 import * as path from 'path';
 import { peerDependencies } from '../../package.json';
@@ -25,7 +25,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/product-multi-dimensional.scss';
 
-xdescribe('Spartacus Product Multi-Dimensional schematics: ng-add', () => {
+describe('Spartacus Product Multi-Dimensional schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_PRODUCT,
     collectionPath

--- a/feature-libs/product/schematics/add-product/index_spec.ts
+++ b/feature-libs/product/schematics/add-product/index_spec.ts
@@ -30,7 +30,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/product.scss';
 
-xdescribe('Spartacus Product schematics: ng-add', () => {
+describe('Spartacus Product schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_PRODUCT,
     collectionPath

--- a/feature-libs/qualtrics/schematics/add-qualtrics/index_spec.ts
+++ b/feature-libs/qualtrics/schematics/add-qualtrics/index_spec.ts
@@ -23,7 +23,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/qualtrics-embedded-feedback.scss';
 
-xdescribe('Spartacus Qualtrics schematics: ng-add', () => {
+describe('Spartacus Qualtrics schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_QUALTRICS,
     collectionPath

--- a/feature-libs/quote/schematics/add-quote/index_spec.ts
+++ b/feature-libs/quote/schematics/add-quote/index_spec.ts
@@ -25,7 +25,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/quote.scss';
 
-xdescribe('Spartacus Quote schematics: ng-add', () => {
+describe('Spartacus Quote schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_QUOTE,
     collectionPath

--- a/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/index_spec.ts
+++ b/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/index_spec.ts
@@ -23,7 +23,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/requested-delivery-date.scss';
 
-xdescribe('Spartacus Requested Delivery Date schematics: ng-add', () => {
+describe('Spartacus Requested Delivery Date schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_REQUESTED_DELIVERY_DATE,
     collectionPath

--- a/feature-libs/smartedit/schematics/add-smartedit/index_spec.ts
+++ b/feature-libs/smartedit/schematics/add-smartedit/index_spec.ts
@@ -22,7 +22,7 @@ import { peerDependencies } from '../../package.json';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('Spartacus SmartEdit schematics: ng-add', () => {
+describe('Spartacus SmartEdit schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_SMARTEDIT,
     collectionPath

--- a/feature-libs/storefinder/schematics/add-storefinder/index_spec.ts
+++ b/feature-libs/storefinder/schematics/add-storefinder/index_spec.ts
@@ -23,7 +23,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/storefinder.scss';
 
-xdescribe('Spartacus Storefinder schematics: ng-add', () => {
+describe('Spartacus Storefinder schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_STOREFINDER,
     collectionPath

--- a/feature-libs/tracking/schematics/add-tracking/index_spec.ts
+++ b/feature-libs/tracking/schematics/add-tracking/index_spec.ts
@@ -25,7 +25,7 @@ import { peerDependencies } from '../../package.json';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('Spartacus Tracking schematics: ng-add', () => {
+describe('Spartacus Tracking schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_TRACKING,
     collectionPath

--- a/feature-libs/user/schematics/add-user/index_spec.ts
+++ b/feature-libs/user/schematics/add-user/index_spec.ts
@@ -24,7 +24,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/user.scss';
 
-xdescribe('Spartacus User schematics: ng-add', () => {
+describe('Spartacus User schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_USER,
     collectionPath

--- a/integration-libs/cdc/schematics/add-cdc/index_spec.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index_spec.ts
@@ -30,7 +30,7 @@ import {
 import * as path from 'path';
 import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
-xdescribe('Spartacus CDC schematics: ng-add', () => {
+describe('Spartacus CDC schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_CDC,
     collectionPath

--- a/integration-libs/cdp/schematics/add-cdp/index_spec.ts
+++ b/integration-libs/cdp/schematics/add-cdp/index_spec.ts
@@ -24,7 +24,7 @@ import * as path from 'path';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('Spartacus CDP schematics: ng-add', () => {
+describe('Spartacus CDP schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_CDP,
     collectionPath

--- a/integration-libs/cpq-quote/schematics/add-cpq-quote/index_spec.ts
+++ b/integration-libs/cpq-quote/schematics/add-cpq-quote/index_spec.ts
@@ -27,7 +27,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const featureModulePath =
   'src/app/spartacus/features/cpq-quote/cpq-quote-feature.module.ts';
-xdescribe('Spartacus Cpq-quote', () => {
+describe('Spartacus Cpq-quote', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_CPQ_QUOTE,
     collectionPath

--- a/integration-libs/digital-payments/schematics/add-digital-payments/index_spec.ts
+++ b/integration-libs/digital-payments/schematics/add-digital-payments/index_spec.ts
@@ -28,7 +28,7 @@ import { peerDependencies } from '../../package.json';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('Spartacus Digital-Payments schematics: ng-add', () => {
+describe('Spartacus Digital-Payments schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_DIGITAL_PAYMENTS,
     collectionPath

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/index_spec.ts
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/index_spec.ts
@@ -24,7 +24,7 @@ import { peerDependencies } from '../../package.json';
 const collectionPath = path.join(__dirname, '../collection.json');
 const scssFilePath = 'src/styles/spartacus/epd-visualization.scss';
 
-xdescribe('Spartacus SAP EPD Visualization integration schematics: ng-add', () => {
+describe('Spartacus SAP EPD Visualization integration schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_EPD_VISUALIZATION,
     collectionPath

--- a/integration-libs/omf/schematics/add-omf/index_spec.ts
+++ b/integration-libs/omf/schematics/add-omf/index_spec.ts
@@ -11,22 +11,22 @@ import {
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
 import {
   OMF_FEATURE_NAME,
-  SPARTACUS_SCHEMATICS,
-  SPARTACUS_OMF,
+  ORDER_FEATURE_NAME,
   LibraryOptions as OmfOptions,
+  SPARTACUS_OMF,
+  SPARTACUS_ORDER,
+  SPARTACUS_SCHEMATICS,
   SpartacusOptions,
   omfFeatureModulePath,
-  ORDER_FEATURE_NAME,
-  orderWrapperModulePath,
-  SPARTACUS_ORDER,
   orderFeatureModulePath,
+  orderWrapperModulePath,
 } from '@spartacus/schematics';
 import * as path from 'path';
 import { peerDependencies } from '../../package.json';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('Spartacus OMF Schematics: ng-add', () => {
+describe('Spartacus OMF Schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_OMF,
     collectionPath

--- a/integration-libs/opps/schematics/add-opps/index_spec.ts
+++ b/integration-libs/opps/schematics/add-opps/index_spec.ts
@@ -24,7 +24,7 @@ import { peerDependencies } from '../../package.json';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('Spartacus Opps Schematics: ng-add', () => {
+describe('Spartacus Opps Schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_OPPS,
     collectionPath

--- a/integration-libs/s4-service/schematics/add-s4-service/index_spec.ts
+++ b/integration-libs/s4-service/schematics/add-s4-service/index_spec.ts
@@ -30,7 +30,7 @@ import { peerDependencies } from '../../package.json';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('Spartacus S/4HANA Service Integration (S4-Service) Schematics: ng-add', () => {
+describe('Spartacus S/4HANA Service Integration (S4-Service) Schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_S4_SERVICE,
     collectionPath

--- a/integration-libs/s4om/schematics/add-s4om/index_spec.ts
+++ b/integration-libs/s4om/schematics/add-s4om/index_spec.ts
@@ -23,7 +23,7 @@ const collectionPath = path.join(__dirname, '../collection.json');
 const featureModulePath =
   'src/app/spartacus/features/s4om/s4om-feature.module.ts';
 
-xdescribe('Spartacus S4OM schematics: ng-add', () => {
+describe('Spartacus S4OM schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner('schematics', collectionPath);
 
   let appTree: UnitTestTree;

--- a/integration-libs/segment-refs/schematics/add-segment-refs/index_spec.ts
+++ b/integration-libs/segment-refs/schematics/add-segment-refs/index_spec.ts
@@ -24,7 +24,7 @@ import { peerDependencies } from '../../package.json';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('Spartacus segment-refs schematics: ng-add', () => {
+describe('Spartacus segment-refs schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_SEGMENT_REFS,
     collectionPath

--- a/projects/schematics/src/add-cms-component/index_spec.ts
+++ b/projects/schematics/src/add-cms-component/index_spec.ts
@@ -78,7 +78,7 @@ function assertContentDoesNotExist(
   }
 }
 
-xdescribe('add-cms-component', () => {
+describe('add-cms-component', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_SCHEMATICS,
     collectionPath

--- a/projects/schematics/src/add-spartacus/index_spec.ts
+++ b/projects/schematics/src/add-spartacus/index_spec.ts
@@ -55,7 +55,7 @@ const defaultOptions: SpartacusOptions = {
 
 const newLineRegEx = /(?:\\[rn]|[\r\n]+)+/g;
 
-xdescribe('add-spartacus', () => {
+describe('add-spartacus', () => {
   beforeEach(async () => {
     appTree = await schematicRunner.runExternalSchematic(
       '@schematics/angular',

--- a/projects/schematics/src/add-ssr/index_spec.ts
+++ b/projects/schematics/src/add-ssr/index_spec.ts
@@ -15,7 +15,7 @@ import { getPathResultsForFile } from '../shared/utils/file-utils';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('add-ssr', () => {
+describe('add-ssr', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_SCHEMATICS,
     collectionPath

--- a/projects/schematics/src/ng-add/index_spec.ts
+++ b/projects/schematics/src/ng-add/index_spec.ts
@@ -15,7 +15,7 @@ import { getPathResultsForFile } from '../shared/utils/file-utils';
 
 const collectionPath = path.join(__dirname, '../collection.json');
 
-xdescribe('Spartacus Schematics: ng-add', () => {
+describe('Spartacus Schematics: ng-add', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_SCHEMATICS,
     collectionPath

--- a/projects/schematics/src/shared/schematics-config-mappings_spec.ts
+++ b/projects/schematics/src/shared/schematics-config-mappings_spec.ts
@@ -51,7 +51,7 @@ import {
   getSchematicsConfigByFeatureOrThrow,
 } from './schematics-config-mappings';
 
-xdescribe('schematics-config-mappings', () => {
+describe('schematics-config-mappings', () => {
   describe('libraryFeatureMapping', () => {
     it('should generate a correct mapping', () => {
       const result = generateMappings().libraryFeatureMapping;

--- a/projects/schematics/src/shared/utils/config-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/config-utils_spec.ts
@@ -13,7 +13,7 @@ import {
 } from './config-utils';
 import { getModulePropertyInitializer } from './new-module-utils';
 
-xdescribe('Storefront config utils', () => {
+describe('Storefront config utils', () => {
   let project: Project;
   let sourceFile: SourceFile;
   beforeEach(() => {

--- a/projects/schematics/src/shared/utils/dependency-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/dependency-utils_spec.ts
@@ -33,7 +33,7 @@ import {
   collectCrossSpartacusPeerDeps,
 } from './dependency-utils';
 
-xdescribe('dependency-util', () => {
+describe('dependency-util', () => {
   describe('analyzeCrossFeatureDependencies', () => {
     it('DP - should return the correct set of ordered sub-features', () => {
       const result = analyzeCrossFeatureDependencies([

--- a/projects/schematics/src/shared/utils/feature-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/feature-utils_spec.ts
@@ -33,7 +33,7 @@ import {
   userFeatureModulePath,
 } from './test-utils';
 
-xdescribe('Feature utils', () => {
+describe('Feature utils', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_SCHEMATICS,
     path.join(__dirname, '../../collection.json')

--- a/projects/schematics/src/shared/utils/file-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/file-utils_spec.ts
@@ -299,7 +299,7 @@ const schematicRunner = new SchematicTestRunner(
   collectionPath
 );
 
-xdescribe('File utils', () => {
+describe('File utils', () => {
   let appTree: UnitTestTree;
   const workspaceOptions: WorkspaceOptions = {
     name: 'workspace',

--- a/projects/schematics/src/shared/utils/graph-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/graph-utils_spec.ts
@@ -12,6 +12,7 @@ import {
   SPARTACUS_DIGITAL_PAYMENTS,
   SPARTACUS_EPD_VISUALIZATION,
   SPARTACUS_ESTIMATED_DELIVERY_DATE,
+  SPARTACUS_OMF,
   SPARTACUS_OPPS,
   SPARTACUS_ORDER,
   SPARTACUS_ORGANIZATION,
@@ -25,7 +26,6 @@ import {
   SPARTACUS_REQUESTED_DELIVERY_DATE,
   SPARTACUS_S4OM,
   SPARTACUS_S4_SERVICE,
-  SPARTACUS_OMF,
   SPARTACUS_SEGMENT_REFS,
   SPARTACUS_SMARTEDIT,
   SPARTACUS_STOREFINDER,
@@ -39,7 +39,7 @@ import {
   kahnsAlgorithm,
 } from './graph-utils';
 
-xdescribe('Graph utils', () => {
+describe('Graph utils', () => {
   describe('library dependency graph', () => {
     it('scenario #1 - should be able to find a correct installation order', () => {
       const graph = new Graph([

--- a/projects/schematics/src/shared/utils/import-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/import-utils_spec.ts
@@ -42,7 +42,7 @@ import { createProgram, saveAndFormat } from './program';
 import { getProjectTsConfigPaths } from './project-tsconfig-paths';
 import { appModulePath, cartBaseFeatureModulePath } from './test-utils';
 
-xdescribe('Import utils', () => {
+describe('Import utils', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_SCHEMATICS,
     path.join(__dirname, '../../collection.json')

--- a/projects/schematics/src/shared/utils/lib-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/lib-utils_spec.ts
@@ -25,7 +25,7 @@ import {
 
 const xxxFeaturePath = `src/app/spartacus/features/xxx/xxx-feature.module.ts`;
 
-xdescribe('Lib utils', () => {
+describe('Lib utils', () => {
   const schematicRunner = new SchematicTestRunner(
     'schematics',
     path.join(__dirname, '../../collection.json')

--- a/projects/schematics/src/shared/utils/logger-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/logger-utils_spec.ts
@@ -17,7 +17,7 @@ import {
   formatFeatureStart,
 } from './logger-utils';
 
-xdescribe('Logger utils', () => {
+describe('Logger utils', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_SCHEMATICS,
     path.join(__dirname, '../../collection.json')

--- a/projects/schematics/src/shared/utils/module-file-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/module-file-utils_spec.ts
@@ -46,7 +46,7 @@ import { Component } from '@angular/core';
 export class Test {}
 `;
 
-xdescribe('Module file utils', () => {
+describe('Module file utils', () => {
   let appTree: UnitTestTree;
   const workspaceOptions: WorkspaceOptions = {
     name: 'workspace',

--- a/projects/schematics/src/shared/utils/new-module-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/new-module-utils_spec.ts
@@ -23,7 +23,7 @@ import { createProgram } from './program';
 import { getProjectTsConfigPaths } from './project-tsconfig-paths';
 import { appModulePath } from './test-utils';
 
-xdescribe('New Module utils', () => {
+describe('New Module utils', () => {
   const schematicRunner = new SchematicTestRunner(
     SPARTACUS_SCHEMATICS,
     path.join(__dirname, '../../collection.json')

--- a/projects/schematics/src/shared/utils/package-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/package-utils_spec.ts
@@ -23,7 +23,7 @@ const schematicRunner = new SchematicTestRunner(
   collectionPath
 );
 
-xdescribe('Package utils', () => {
+describe('Package utils', () => {
   let appTree: UnitTestTree;
   const workspaceOptions: WorkspaceOptions = {
     name: 'workspace',

--- a/projects/schematics/src/shared/utils/schematics-config-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/schematics-config-utils_spec.ts
@@ -6,7 +6,7 @@ import {
 } from '../libs-constants';
 import { getConfiguredDependencies } from './schematics-config-utils';
 
-xdescribe('schematics-config-util', () => {
+describe('schematics-config-util', () => {
   describe('getConfiguredDependencies', () => {
     it('should return the correct feature dependencies for the given feature', () => {
       const result = getConfiguredDependencies(DIGITAL_PAYMENTS_FEATURE_NAME);

--- a/projects/schematics/src/shared/utils/styling-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/styling-utils_spec.ts
@@ -7,7 +7,7 @@ import {
 const sourceRoot = '/src';
 const project = { sourceRoot } as WorkspaceProject;
 
-xdescribe('Styling utils', () => {
+describe('Styling utils', () => {
   describe('getStylesConfigFilePath', () => {
     it('should provide the path of the styles config file in the project source root.', () => {
       const stylesConfigFilePath = getStylesConfigFilePath(sourceRoot);

--- a/projects/schematics/src/shared/utils/transform-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/transform-utils_spec.ts
@@ -1,6 +1,6 @@
 import { parseCSV } from './transform-utils';
 
-xdescribe('parseCSV', () => {
+describe('parseCSV', () => {
   it('should use the default values if no raw value is provided', () => {
     const result = parseCSV(undefined, ['default', 'values']);
     expect(result).toEqual(`'default', 'values'`);

--- a/projects/schematics/src/shared/utils/workspace-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/workspace-utils_spec.ts
@@ -35,7 +35,7 @@ const schematicRunner = new SchematicTestRunner(
   collectionPath
 );
 
-xdescribe('Workspace utils', () => {
+describe('Workspace utils', () => {
   let appTree: UnitTestTree;
   const workspaceOptions: WorkspaceOptions = {
     name: 'workspace',


### PR DESCRIPTION
Enabling schematics tests that were disabled to build libs for release.
Disabling is a workaround to finish build before 1 hour timeout on azure.