### PR TITLE
test: Fix failing e2e tests on ccv2

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.ccv2-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.ccv2-e2e.cy.ts
@@ -91,7 +91,7 @@ const ATTR_NAMES = {
   ],
 };
 
-const CPQ_BACKEND_URL = '**/api/configuration/v1/configurations/**';
+const CPQ_BACKEND_URL = `${Cypress.env('OCC_PREFIX')}/${POWERTOOLS}/cpqconfigurator/**`;
 
 context('CPQ Configuration', () => {
   beforeEach(() => {
@@ -123,14 +123,16 @@ context('CPQ Configuration', () => {
       configurationCpq.selectAttributeAndWait(
         ATTR_COF_CUPS,
         RADGRP,
-        VAL_COF_CUPS_300
+        VAL_COF_CUPS_300,
+        true
       );
       configuration.checkValueSelected(RADGRP, ATTR_COF_CUPS, VAL_COF_CUPS_300);
 
       configurationCpq.selectAttributeAndWait(
         ATTR_COF_CUPS,
         RADGRP,
-        VAL_COF_CUPS_500
+        VAL_COF_CUPS_500,
+        true
       );
       configuration.checkValueSelected(RADGRP, ATTR_COF_CUPS, VAL_COF_CUPS_500);
     });
@@ -149,14 +151,16 @@ context('CPQ Configuration', () => {
       configurationCpq.selectAttributeAndWait(
         ATTR_COF_MODE,
         CHKBOX,
-        VAL_COF_MODE
+        VAL_COF_MODE,
+        true
       );
       configuration.checkValueSelected(CHKBOX, ATTR_COF_MODE, VAL_COF_MODE);
 
       configurationCpq.selectAttributeAndWait(
         ATTR_COF_MODE,
         CHKBOX,
-        VAL_COF_MODE
+        VAL_COF_MODE,
+        true
       );
       configurationCpq.checkValueNotSelected(
         CHKBOX,
@@ -200,7 +204,8 @@ context('CPQ Configuration', () => {
       configurationCpq.selectAttributeAndWait(
         ATTR_CAM_BODY,
         RADGRP_PROD,
-        VAL_CAM_BODY_EOS80D
+        VAL_CAM_BODY_EOS80D,
+        true
       );
       configurationCpq.checkValueNotSelected(
         RADGRP_PROD,
@@ -231,7 +236,8 @@ context('CPQ Configuration', () => {
       configurationCpq.selectAttributeAndWait(
         ATTR_CAM_INS,
         DDLB_PROD,
-        VAL_CB_INS_Y2
+        VAL_CB_INS_Y2,
+        true
       );
       configurationCpq.checkValueNotSelected(
         DDLB_PROD,
@@ -259,7 +265,8 @@ context('CPQ Configuration', () => {
       configurationCpq.selectAttributeAndWait(
         ATTR_CAM_MC,
         CHKBOX_PROD,
-        VAL_CAM_MC_64
+        VAL_CAM_MC_64,
+        true
       );
       configuration.checkValueSelected(
         CHKBOX_PROD,
@@ -271,12 +278,14 @@ context('CPQ Configuration', () => {
       configurationCpq.selectAttributeAndWait(
         ATTR_CAM_MC,
         CHKBOX_PROD,
-        VAL_CAM_MC_128
+        VAL_CAM_MC_128,
+        true
       );
       configurationCpq.checkValueNotSelected(
         CHKBOX_PROD,
         ATTR_CAM_MC,
-        VAL_CAM_MC_128
+        VAL_CAM_MC_128,
+        true
       );
       configuration.checkValueSelected(CHKBOX_PROD, ATTR_CAM_MC, VAL_CAM_MC_64);
     });
@@ -355,7 +364,8 @@ context('CPQ Configuration', () => {
       configurationCpq.selectProductCard(
         RADGRP,
         ATTR_CAM_BODY,
-        VAL_CAM_BODY_D850
+        VAL_CAM_BODY_D850,
+        true
       );
       configurationCpq.checkPrice(
         RADGRP_PROD,
@@ -370,7 +380,13 @@ context('CPQ Configuration', () => {
         ATTR_CAM_MC,
         VAL_CAM_MC_128
       );
-      configurationCpq.setQuantity(CHKBOX_PROD, 2, ATTR_CAM_MC, VAL_CAM_MC_128);
+      configurationCpq.setQuantity(
+        CHKBOX_PROD,
+        2,
+        ATTR_CAM_MC,
+        VAL_CAM_MC_128,
+        true
+      );
       configurationCpq.checkPrice(
         CHKBOX_PROD,
         '2x($100.00) +$200.00',
@@ -378,8 +394,18 @@ context('CPQ Configuration', () => {
         VAL_CAM_MC_128
       );
 
-      configurationCpq.selectProductCard(CHKBOX, ATTR_CAM_LEN, VAL_CAM_LEN_SI);
-      configurationCpq.selectProductCard(CHKBOX, ATTR_CAM_LEN, VAL_CAM_LEN_NI);
+      configurationCpq.selectProductCard(
+        CHKBOX,
+        ATTR_CAM_LEN,
+        VAL_CAM_LEN_SI,
+        true
+      );
+      configurationCpq.selectProductCard(
+        CHKBOX,
+        ATTR_CAM_LEN,
+        VAL_CAM_LEN_NI,
+        true
+      );
       configurationCpq.checkPrice(
         CHKBOX_PROD,
         '$800.00',
@@ -397,14 +423,16 @@ context('CPQ Configuration', () => {
       configurationCpq.deSelectProductCard(
         RADGRP,
         ATTR_CAM_BAG,
-        VAL_CAM_BAG_LP
+        VAL_CAM_BAG_LP,
+        true
       );
 
       configuration.clickOnNextBtn(GRP_CAM_IAW);
       configurationCpq.selectAttributeAndWait(
         ATTR_CAM_PROF,
         RADGRP,
-        VAL_CAM_PROF_Y
+        VAL_CAM_PROF_Y,
+        true
       );
       //wait for this option to disappear
       configuration.checkAttrValueNotDisplayed(
@@ -413,7 +441,12 @@ context('CPQ Configuration', () => {
         VAL_CB_INS_Y2
       );
 
-      configurationCpq.selectProductCard(DDLB, ATTR_CAM_INS, VAL_CB_INS_P4);
+      configurationCpq.selectProductCard(
+        DDLB,
+        ATTR_CAM_INS,
+        VAL_CB_INS_P4,
+        true
+      );
       configurationCpq.checkPrice(
         DDLB_PROD,
         '$600.00',


### PR DESCRIPTION
To run e2e tests against P3 ccv2, 
1. Start npm server locally:
> export CX_CPQ=true CX_B2B=true CX_BASE_URL="https://api.cg79x9wuu9-eccommerc1-p3-public.model-t.myhybris.cloud" && npm start
2. Adjust `cypress.config.ci.ts` file accordingly:
> API_URL: 'https://api.cg79x9wuu9-eccommerc1-p3-public.model-t.myhybris.cloud'
3. Start e2e tests locally:
> npm run e2e:open:ci:b2b


