### PR TITLE
fix: context.error was not printed because JSON.stringify(Error) doesn't work by default in JS

### DIFF
--- a/core-libs/setup/ssr/logger/default-inspect-options.ts
+++ b/core-libs/setup/ssr/logger/default-inspect-options.ts
@@ -2,7 +2,7 @@ import type { InspectOptions } from 'node:util';
 
 // PRIVATE API
 /**
- * Default options used for formatting log messages.
+ * Default options used for formatting log messages in NodeJS.
  *
  * They are meant to be passed to `formatWithOptions()` function from the `node:util` module
  * for logging purposes.

--- a/core-libs/setup/ssr/logger/default-inspect-options.ts
+++ b/core-libs/setup/ssr/logger/default-inspect-options.ts
@@ -1,0 +1,24 @@
+import type { InspectOptions } from 'node:util';
+
+// PRIVATE API
+/**
+ * Default options used for formatting log messages.
+ *
+ * They are meant to be passed to `formatWithOptions()` function from the `node:util` module
+ * for logging purposes.
+ */
+export const DEFAULT_INSPECT_OPTIONS: InspectOptions = {
+  /**
+   * Prevent automatically breaking a long string message into multiple lines.
+   * Otherwise, multi-line logs would be treated on the server as separate logs.
+   */
+  breakLength: Infinity,
+
+  /**
+   * Prevent the depth of the logged object to be limited to 2 (which is a NodeJS default).
+   * Otherwise, the object's properties at nested levels higher than 2 would not be visible in the logs.
+   *
+   * The value 10 was chosen arbitrarily. It can be adjusted in the future, if needed.
+   */
+  depth: 10,
+};

--- a/core-libs/setup/ssr/logger/loggers/default-express-server-logger.ts
+++ b/core-libs/setup/ssr/logger/loggers/default-express-server-logger.ts
@@ -6,7 +6,9 @@
 
 import { isDevMode } from '@angular/core';
 import { Request } from 'express';
+import { formatWithOptions } from 'util';
 import { getRequestContext } from '../../optimized-engine/request-context';
+import { DEFAULT_INSPECT_OPTIONS } from '../default-inspect-options';
 import {
   ExpressServerLogger,
   ExpressServerLoggerContext,
@@ -83,7 +85,17 @@ export class DefaultExpressServerLogger implements ExpressServerLogger {
       });
     }
 
+    if (context.error) {
+      Object.assign(outputContext, {
+        error: this.mapError(context.error),
+      });
+    }
+
     return outputContext;
+  }
+
+  protected mapError(error: unknown): string {
+    return formatWithOptions(DEFAULT_INSPECT_OPTIONS, error);
   }
 
   /**

--- a/core-libs/setup/ssr/logger/loggers/express-server-logger.ts
+++ b/core-libs/setup/ssr/logger/loggers/express-server-logger.ts
@@ -13,6 +13,7 @@ import { Request } from 'express';
  */
 export interface ExpressServerLoggerContext {
   request?: Request;
+  error?: unknown;
   [_key: string]: any;
 }
 

--- a/core-libs/setup/ssr/logger/services/express-logger.service.ts
+++ b/core-libs/setup/ssr/logger/services/express-logger.service.ts
@@ -8,6 +8,7 @@ import { Injectable, inject } from '@angular/core';
 import { LoggerService } from '@spartacus/core';
 import { formatWithOptions } from 'util';
 import { REQUEST } from '../../tokens/express.tokens';
+import { DEFAULT_INSPECT_OPTIONS } from '../default-inspect-options';
 import { EXPRESS_SERVER_LOGGER } from '../loggers';
 
 /**
@@ -53,9 +54,7 @@ export class ExpressLoggerService implements LoggerService {
 
   protected formatLogMessage(message?: any, ...optionalParams: any[]): string {
     return formatWithOptions(
-      // Prevent automatically breaking a long string message into multiple lines.
-      // Otherwise, multi-line logs would be treated on the server as separate log
-      { breakLength: Infinity },
+      DEFAULT_INSPECT_OPTIONS,
       message,
       ...optionalParams
     );


### PR DESCRIPTION
Previously, the logged message `Request is resolved with the SSR rendering error` was printed by `OptimizedSsrEngine` alongside with the JSON.strinfied property `context.error` which ended up looking like an empty object `{}` (even if it was not empty, but a real Error object instead!). It was because of a natural thing in JavaScript: `JSON.stringify()` invoked on object of type `Error` always returns `{}` (it's becasue properties of the `Error` object are _non-enumerable_; for more see https://stackoverflow.com/a/68640559/11734692).

Now the `context.error` property is printed as a pretty error string. How it's done: the `context.error` property is first converted into a pretty string with the help of the `formatWithOptions()` function of native `node:util` package. Btw. `formatWithOptions()` is the same mechanism that is used by the `console.log()` under the hood to convert a given object into a string.
And when performing later the `JSON.stringify()` on the `context` object, the `context.error` property has been already converted into a pretty string describing an error. So `JSON.stringify` simply re-returns this string. See the following example of a pretty error string:

```
CmsPageNotFoundOutboundHttpError: CMS Page Not Found
    at HttpErrorHandlerInterceptor2.handleError (/opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:1695890)
    at Object.error (/opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:1695743)
    at /opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:585551
    at OperatorSubscriber2._this._error (/opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:507051)
    at Subscriber2.error (/opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:460681)
    at OperatorSubscriber2._this._error (/opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:507088)
    at Subscriber2.error (/opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:460681)
    at Subscriber2._error (/opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:461147)
    at Subscriber2.error (/opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:460681)
    at /opt/app/spartacusstore/dist/spartacusstore/server/main.js:1:585584 {
  [cause]: HttpErrorResponse { headers: HttpHeaders { normalizedNames: [Map], lazyUpdate: null, headers: [Map] }, status: 404, statusText: 'Unknown Error', url: 'https://api.cg79x9wuu9-eccommerc1-p5-public.model-t.myhybris.cloud/occ/v2/electronics-spa/cms/pages2?pageType=ContentPage&pageLabelOrId=%2Fnot-found&lang=en&curr=USD', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for https://api.cg79x9wuu9-eccommerc1-p5-public.model-t.myhybris.cloud/occ/v2/electronics-spa/cms/pages2?pageType=ContentPage&pageLabelOrId=%2Fnot-found&lang=en&curr=USD: 404 ', error: { errors: [Array] } }
}
```

As you can see in the example above, some nested properties of the `[cause]` property, are described by `Array` or `Map`. This has been fixed also in this PR, by configuring `depth: 10` (instead of the default `2`) in the options passed to the `formatWithOptions()` util.

TODO:
- add unit tests

closes  https://jira.tools.sap/browse/CXSPA-8360