### PR TITLE
fix: prevent `CmsService.getComponentData()` invoked with an empty string `uid` from unnecesarily calling Ngrx and Backend

### DIFF
--- a/projects/core/src/cms/facade/cms.service.spec.ts
+++ b/projects/core/src/cms/facade/cms.service.spec.ts
@@ -73,6 +73,16 @@ describe('CmsService', () => {
 
   describe('getComponentData', () => {
     describe('when pageContext is NOT provided', () => {
+      describe('when uid is empty', () => {
+        it('should emit null', inject([CmsService], (service: CmsService) => {
+          let result;
+          service.getComponentData('').subscribe((res) => {
+            result = res;
+          });
+          expect(result).toBeNull();
+        }));
+      });
+
       it('should use the current page context and dispatch LoadCmsComponent', inject(
         [CmsService],
         (service: CmsService) => {
@@ -116,6 +126,16 @@ describe('CmsService', () => {
       ));
     });
     describe('when pageContext is provided', () => {
+      describe('when uid is empty', () => {
+        it('should emit null', inject([CmsService], (service: CmsService) => {
+          let result;
+          service.getComponentData('').subscribe((res) => {
+            result = res;
+          });
+          expect(result).toBeNull();
+        }));
+      });
+
       it('should use the provided page context and dispatch LoadCmsComponent', inject(
         [CmsService],
         (service: CmsService) => {

--- a/projects/core/src/cms/facade/cms.service.ts
+++ b/projects/core/src/cms/facade/cms.service.ts
@@ -74,9 +74,9 @@ export class CmsService {
   getComponentData<T extends CmsComponent | null>(
     uid: string,
     pageContext?: PageContext
-  ): Observable<T | null> {
+  ): Observable<T> {
     if (uid === '') {
-      return of(null);
+      return of(null) as Observable<T>;
     }
 
     const context = serializePageContext(pageContext, true);

--- a/projects/core/src/cms/facade/cms.service.ts
+++ b/projects/core/src/cms/facade/cms.service.ts
@@ -74,7 +74,11 @@ export class CmsService {
   getComponentData<T extends CmsComponent | null>(
     uid: string,
     pageContext?: PageContext
-  ): Observable<T> {
+  ): Observable<T | null> {
+    if (uid === '') {
+      return of(null);
+    }
+
     const context = serializePageContext(pageContext, true);
     if (!this.components[uid]) {
       // create the component data structure, if it doesn't already exist

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.ts
@@ -6,7 +6,7 @@
 
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { CmsComponentWithChildren, CmsService, Product } from '@spartacus/core';
-import { Observable, combineLatest, of } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
 import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
 import { CmsComponentData } from '../../../../cms-structure/page/model/cms-component-data';
 import { CurrentProductService } from '../../current-product.service';
@@ -25,12 +25,9 @@ export class ProductDetailsTabComponent implements OnInit {
     protected cmsService: CmsService
   ) {}
   children$: Observable<any[]> = this.componentData.data$.pipe(
-    switchMap((data) => {
-      if (!data?.children) {
-        return of([]);
-      }
-      return combineLatest(
-        (data?.children).split(' ').map((component) =>
+    switchMap((data) =>
+      combineLatest(
+        (data?.children ?? '').split(' ').map((component) =>
           this.cmsService.getComponentData<any>(component).pipe(
             distinctUntilChanged(),
             map((child) => {
@@ -48,8 +45,8 @@ export class ProductDetailsTabComponent implements OnInit {
             })
           )
         )
-      );
-    })
+      )
+    )
   );
 
   ngOnInit() {

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.ts
@@ -6,7 +6,7 @@
 
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { CmsComponentWithChildren, CmsService, Product } from '@spartacus/core';
-import { combineLatest, Observable } from 'rxjs';
+import { Observable, combineLatest, of } from 'rxjs';
 import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
 import { CmsComponentData } from '../../../../cms-structure/page/model/cms-component-data';
 import { CurrentProductService } from '../../current-product.service';
@@ -25,9 +25,12 @@ export class ProductDetailsTabComponent implements OnInit {
     protected cmsService: CmsService
   ) {}
   children$: Observable<any[]> = this.componentData.data$.pipe(
-    switchMap((data) =>
-      combineLatest(
-        (data?.children ?? '').split(' ').map((component) =>
+    switchMap((data) => {
+      if (!data?.children) {
+        return of([]);
+      }
+      return combineLatest(
+        (data?.children).split(' ').map((component) =>
           this.cmsService.getComponentData<any>(component).pipe(
             distinctUntilChanged(),
             map((child) => {
@@ -45,8 +48,8 @@ export class ProductDetailsTabComponent implements OnInit {
             })
           )
         )
-      )
-    )
+      );
+    })
   );
 
   ngOnInit() {


### PR DESCRIPTION
Previously:
When the `CmsService.getComponentData()` was invoked with an empty string `uid` argument, then it called Backend (and also Ngrx along the way), which resulted in a Failure Ngrx action. And it emitted `null` value. 

See `componentIds=` in the backend URL in the screenshot below:
<img width="1217" alt="image" src="https://github.com/user-attachments/assets/a6f05dde-5c72-4fb8-81d6-784ef6703afb">


Observations:
- It doesn't make sense to make a call to Backend with and empty `uid` - we want to prevent it.
- The Failure Ngrx action happening during SSR, made the SSR of PDP fail (return 500) - which breaks SEO - so we want to prevent it.

Fix:
Now we validate the `uid` argument of `CmsService.getComponentData()` and emit `null` immediately if the `uid` is empty. In such case, we don't call the backend anymore (would caused getting empty response from Backend and a failure from Ngrx).

fixes https://jira.tools.sap/browse/CXSPA-8389