### PR TITLE
fix(a11y): Focus outline overlapping with breadcrumbs separator

### DIFF
--- a/projects/storefrontstyles/scss/components/content/navigation/_breadcrumb.scss
+++ b/projects/storefrontstyles/scss/components/content/navigation/_breadcrumb.scss
@@ -74,6 +74,11 @@ html[dir='rtl'] cx-breadcrumb nav span:not(:last-child):after {
 
           @include forFeature('a11yImproveContrast') {
             color: var(--cx-color-primary);
+
+            &:focus {
+              outline-offset: -4px;
+              box-shadow: inset 0 0 0 2px var(--cx-color-inverse);
+            }
           }
         }
       }


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-7954