### PR TITLE
test(ssr e2e): redirect also the STDERR stream to the file `.ssr.log`

### DIFF
--- a/projects/ssr-tests/src/utils/ssr.utils.ts
+++ b/projects/ssr-tests/src/utils/ssr.utils.ts
@@ -51,7 +51,7 @@ export async function startSsrServer({
   timeout = DEFAULT_SSR_TIMEOUT,
 }: SsrServerOptions = {}) {
   child = childProcess.spawn(
-    `NODE_TLS_REJECT_UNAUTHORIZED=0 SSR_CACHE=${cache} SSR_TIMEOUT=${timeout} PORT=${port} npm run serve:ssr --prefix ../../> .ssr.log`,
+    `NODE_TLS_REJECT_UNAUTHORIZED=0 SSR_CACHE=${cache} SSR_TIMEOUT=${timeout} PORT=${port} npm run serve:ssr --prefix ../../> .ssr.log 2>&1`,
     { detached: true, shell: true }
   );
 

--- a/projects/ssr-tests/src/utils/ssr.utils.ts
+++ b/projects/ssr-tests/src/utils/ssr.utils.ts
@@ -51,6 +51,7 @@ export async function startSsrServer({
   timeout = DEFAULT_SSR_TIMEOUT,
 }: SsrServerOptions = {}) {
   child = childProcess.spawn(
+    // `2>&1` - redirect stderr to stdout, so also `console.error` and `console.warn` messages are captured in the log file
     `NODE_TLS_REJECT_UNAUTHORIZED=0 SSR_CACHE=${cache} SSR_TIMEOUT=${timeout} PORT=${port} npm run serve:ssr --prefix ../../> .ssr.log 2>&1`,
     { detached: true, shell: true }
   );


### PR DESCRIPTION
Otherwise error logs could be not asserted in the e2e. It will be needed in the future tests of logs content in cases when SSR fails.

BEFORE:
![image](https://github.com/user-attachments/assets/6c3f1136-f0c7-4df5-bb43-7faff2875279)

AFTER:
![image](https://github.com/user-attachments/assets/46fd5a75-dffe-4377-b0b2-2eff99bb47bf)


fixes https://jira.tools.sap/browse/CXSPA-8501