### PR TITLE
fix: submit API invoked when add to cart or proceed to checkout

### DIFF
--- a/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.spec.ts
+++ b/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.spec.ts
@@ -46,13 +46,15 @@ describe('OpfPaymentHostedFieldsService', () => {
   };
 
   const mockActiveCartFacade = {
-    getActiveCartId: jasmine
-      .createSpy('getActiveCartId')
+    takeActiveCartId: jasmine
+      .createSpy('takeActiveCartId')
       .and.returnValue(of('mockActiveCartId')),
   };
 
   const mockUserIdService = {
-    getUserId: jasmine.createSpy('getUserId').and.returnValue(of('mockUserId')),
+    takeUserId: jasmine
+      .createSpy('takeUserId')
+      .and.returnValue(of('mockUserId')),
   };
 
   const mockRoutingService = {
@@ -132,8 +134,8 @@ describe('OpfPaymentHostedFieldsService', () => {
 
   describe('submitPayment', () => {
     it('should submit payment and handle success', (done) => {
-      mockUserIdService.getUserId.and.returnValue(of('mockUserId'));
-      mockActiveCartFacade.getActiveCartId.and.returnValue(
+      mockUserIdService.takeUserId.and.returnValue(of('mockUserId'));
+      mockActiveCartFacade.takeActiveCartId.and.returnValue(
         of('mockActiveCartId')
       );
       mockOpfPaymentConnector.submitPayment.and.returnValue(
@@ -172,8 +174,8 @@ describe('OpfPaymentHostedFieldsService', () => {
 
   describe('submitCompletePayment', () => {
     it('should submit complete payment and handle success', (done) => {
-      mockUserIdService.getUserId.and.returnValue(of('mockUserId'));
-      mockActiveCartFacade.getActiveCartId.and.returnValue(
+      mockUserIdService.takeUserId.and.returnValue(of('mockUserId'));
+      mockActiveCartFacade.takeActiveCartId.and.returnValue(
         of('mockActiveCartId')
       );
       mockOpfPaymentConnector.submitCompletePayment.and.returnValue(


### PR DESCRIPTION
https://jira.tools.sap/browse/CXSPA-8490
submitPayment Observable was never unsubscribed, so getCartId() was still kicking when cart changed.
fix:
using  takeUserId and takeCartId which are non-stream obs (unlike getUserId and getCartId).
We are now sure observable gets completed

I think the issue came when we changed toPromise() into toLastValue().
Using toFirstValue() also fixes the problem but not sure about side effects it can produce