### PR TITLE
chore(prepend-license-bot): don't skip file names with longer words containing 'spec', e.g. 'inSPECtor' or 'SPECial'

### DIFF
--- a/ci-scripts/prepend-license.sh
+++ b/ci-scripts/prepend-license.sh
@@ -1,3 +1,7 @@
-FILES=`find . -not -path '**/node_modules/**' -not -name '*spec*' -name '*.ts' -print`
+# Find .ts files that:
+# - are not in node_modules
+# - do not have 'spec' in their name
+#   (however words containing a substring 'spec' are allowed, e.g. 'inSPECtor' or 'SPECial')
+FILES=`find . -not -path '**/node_modules/**' -not -regex ".*[^a-zA-Z]spec[^a-zA-Z].*" -name '*.ts' -print`
 
 reuse annotate --copyright="SAP Spartacus team <spartacus-team@sap.com>" --license="Apache-2.0" --multi-line $FILES


### PR DESCRIPTION
fixes https://jira.tools.sap/browse/CXSPA-8509