### PR TITLE
fix: (CXSPA-8023) - Product Carousel Failing e2e hotfix

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-carousel/product-carousel.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-carousel/product-carousel.e2e.cy.ts
@@ -110,7 +110,7 @@ context('Product carousel', () => {
           );
 
           cypressButton.then((button) => {
-            if (!button.is(':disabled')) {
+            if (!button.is('[aria-disabled="true"]')) {
               cypressButton.click();
               clickNextButton();
             }


### PR DESCRIPTION
Replaced outdated selector causing the e2e to fail.