### PR TITLE
(DO NOT MERGE) spike: use totally different URL for Product Stock/Availability (not /product)

### DIFF
--- a/backend-proxy.ts
+++ b/backend-proxy.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as http from 'http';
 const httpProxy = require('http-proxy');
 

--- a/backend-proxy.ts
+++ b/backend-proxy.ts
@@ -1,0 +1,124 @@
+import * as http from 'http';
+const httpProxy = require('http-proxy');
+
+// backend-proxy.ts
+// USAGE
+// npx nodemon backend-proxy.ts
+
+/**
+ * Options to start a proxy server.
+ */
+interface ProxyOptions {
+  /**
+   * The url to reroute requests to.
+   */
+  target: string;
+
+  requestInterceptor?: (params: {
+    req: http.IncomingMessage;
+    res: http.ServerResponse;
+
+    /**
+     * A function to forward the request to the original target.
+     */
+    forward: () => void;
+  }) => void;
+
+  responseInterceptor?: (params: {
+    /**
+     * The body of the response from the upstream server.
+     *
+     * Note: we're exposing separately from the `proxyRes` object for convenience
+     *       (because extracting it manually from `proxyRes` is very cumbersome)
+     */
+    body: string;
+
+    /**
+     * The response from the upstream server.
+     */
+    proxyRes: http.IncomingMessage;
+
+    /**
+     * The request that was sent to the upstream server.
+     */
+    req: http.IncomingMessage;
+
+    /**
+     * The response that will be sent to the client.
+     */
+    res: http.ServerResponse;
+  }) => void;
+}
+export async function startBackendProxyServer(
+  options: ProxyOptions
+): Promise<http.Server> {
+  const proxy = httpProxy.createProxyServer({
+    secure: false,
+    selfHandleResponse: !!options.responseInterceptor,
+  });
+  if (options.responseInterceptor) {
+    proxy.on(
+      'proxyRes',
+      (
+        proxyRes: http.IncomingMessage,
+        req: http.IncomingMessage,
+        res: http.ServerResponse
+      ) => {
+        // We have to buffer the response body before passing it to the interceptor
+        let bodyBuffer: Buffer[] = [];
+        proxyRes.on('data', (chunk) => {
+          bodyBuffer.push(chunk);
+        });
+        proxyRes.on('end', () => {
+          const body = Buffer.concat(bodyBuffer).toString();
+
+          // Pass the body to the interceptor
+          if (options.responseInterceptor) {
+            options.responseInterceptor({
+              body,
+              proxyRes,
+              res,
+              req,
+            });
+          } else {
+            res.end(body);
+          }
+        });
+      }
+    );
+  }
+
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const forward = () => {
+        proxy.web(req, res, { target: options.target });
+      };
+      if (options.requestInterceptor) {
+        options.requestInterceptor({ req, res, forward });
+      } else {
+        forward();
+      }
+    });
+
+    server.listen(9002, () => {
+      resolve(server);
+      console.log('Backend proxy server started on port 9002');
+    });
+  });
+}
+
+startBackendProxyServer({
+  target: 'https://40.76.109.9:9002',
+  requestInterceptor: ({ req, forward }) => {
+    if (req?.url?.includes('spike-new-availability-api')) {
+      req.url = req.url.replace(
+        'spike-new-availability-api?lang=en&curr=USD',
+        'products/300938?fields=stock(DEFAULT)'
+      );
+      console.log(req.url);
+      setTimeout(forward, 3_000); // SPIKE DELAY CALL FOR STOCK
+    } else {
+      forward();
+    }
+  },
+});

--- a/projects/core/src/occ/adapters/product/default-occ-product-config.ts
+++ b/projects/core/src/occ/adapters/product/default-occ-product-config.ts
@@ -16,12 +16,12 @@ export const defaultOccProductConfig: OccConfig = {
             'products/${productCode}?fields=DEFAULT,averageRating,images(FULL),classifications,manufacturer,numberOfReviews,categories(FULL),baseOptions,baseProduct,variantOptions,variantType',
           list: 'products/${productCode}?fields=code,purchasable,name,summary,price(formattedValue),images(DEFAULT,galleryIndex),baseProduct',
           details:
-            'products/${productCode}?fields=averageRating,stock(DEFAULT),description,availableForPickup,code,url,price(DEFAULT),numberOfReviews,manufacturer,categories(FULL),priceRange,multidimensional,tags,images(FULL)',
+            'products/${productCode}?fields=averageRating,description,availableForPickup,code,url,price(DEFAULT),numberOfReviews,manufacturer,categories(FULL),priceRange,multidimensional,tags,images(FULL)',
           promotions:
             'products/${productCode}?fields=potentialPromotions(description)',
           attributes: 'products/${productCode}?fields=classifications',
           price: 'products/${productCode}?fields=price(formattedValue)',
-          stock: 'products/${productCode}?fields=stock(DEFAULT)',
+          stock: 'spike-new-availability-api',
           list_item:
             'products/${productCode}?fields=code,name,price(formattedValue),images(DEFAULT),baseProduct',
         },
@@ -48,7 +48,11 @@ export const defaultOccProductConfig: OccConfig = {
     loadingScopes: {
       product: {
         details: {
-          include: [ProductScope.LIST, ProductScope.VARIANTS],
+          include: [
+            ProductScope.LIST,
+            ProductScope.VARIANTS,
+            ProductScope.STOCK,
+          ],
         },
       },
     },

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -22,9 +22,9 @@ import { translationChunksConfig, translations } from '@spartacus/assets';
 import {
   I18nConfig,
   OccConfig,
-  provideConfig,
   RoutingConfig,
   TestConfigModule,
+  provideConfig,
 } from '@spartacus/core';
 import { StoreFinderConfig } from '@spartacus/storefinder/core';
 import { GOOGLE_MAPS_DEVELOPMENT_KEY_CONFIG } from '@spartacus/storefinder/root';
@@ -63,7 +63,7 @@ if (!environment.production) {
     provideConfig(<OccConfig>{
       backend: {
         occ: {
-          baseUrl: environment.occBaseUrl,
+          baseUrl: 'http://localhost:9002',
           prefix: environment.occApiPrefix,
         },
       },

--- a/projects/storefrontlib/cms-components/product/product-intro/product-intro.component.html
+++ b/projects/storefrontlib/cms-components/product/product-intro/product-intro.component.html
@@ -1,3 +1,8 @@
+<h3>
+  SPIKE stock:
+  <pre>{{ (product$ | async)?.stock | json }}</pre>
+</h3>
+<hr />
 <ng-container *ngIf="product$ | async as product">
   <div class="rating" *ngIf="product?.averageRating">
     <cx-star-rating [rating]="product?.averageRating ?? 0"></cx-star-rating>


### PR DESCRIPTION
Assumptions:
- new OCC backend API for loading Stock info is named `/spike-new-availability-api`
- because there is not such a real API in OCC, I've introduced a backend proxy: `backend-proxy.ts` hosted on `http://localhost:9002`
  - it's forwarding all requests to the OCC dev server.
  - it's intercepting requests to `/spike-new-availability-api` and translating it to a real call for stock for an example product `'products/300938?fields=stock(DEFAULT)'` - for demonstration purposes
  - thanks to this, in Spartacus we call a new API, but behind the scenes we're getting a valid response from the backend
- *I only guess the new API might be slower than the old one*, that's why I've included a deliberate 3 seconds delay to the response from the new API in the proxy - for demonstration purposes

Approach:
- changed OCC endpoint config in Spartacus for the `ProductLoadingScope.STOCK` - to be the `/spike-new-availability-api`
- removed field `stock` from the `ProductLoadingScope.DETAILS`, but configured somewhere else that calling for `DETAILS` implicitly will include calling `STOCK` too. Thanks to this, when fetching all the data for the scope DETAILS, the new API for Stock/Availability will be called for stock + the regular call to old API /product for other fields.
- in PDP UI added a spike component that displays the stock information for a product that was loaded and cached in NgRx

Consequences:
- Nothing it displayed, until all calls to all APIs for product details (i.e. call to a new Stock/Availability API for stock AND a regular call to old API /product for other fields). Behind the scenes (in Spartacus Adapter layer) both responses are merged in to a cohesive Product model. Then the rest of the application is not aware that data came composed from various sources
- The old API /product is not requested to return a field `stock`. Instead, the new Stock/Availability API is used for this purpose. And behind the scenes 

Considerations:
- as an alternative - to avoid this complexity on the frontend - I'd consider making this composition on the backend (or backend-for-frontend middleware service). I'd rather like the backend to e.g. flip a feature toggle and then serve the product data all on the old endpount /product. But behind the scenes in the backend it could compose the response from the old product data approach + take Stock/Availability from the new place.