### PR TITLE
set flaky for ssr e2e test

### DIFF
--- a/projects/ssr-tests/src/ssr-testing.spec.ts
+++ b/projects/ssr-tests/src/ssr-testing.spec.ts
@@ -73,7 +73,7 @@ describe('SSR E2E', () => {
         })
       );
 
-      it(
+      it.skip(
         'should receive response with status 500 if HTTP error occurred when calling other than cms/pages API URL',
         LogUtils.attachLogsToErrors(async () => {
           backendProxy = await ProxyUtils.startBackendProxyServer({


### PR DESCRIPTION
This is to temporarily set flaky for SSR e2e tests until the issue is resolved.
ticket for resolve this issue https://jira.tools.sap/browse/CXSPA-8570
