### PR TITLE
fix: add feature toggle to enable all meta tags in csr

### DIFF
--- a/projects/core/src/cms/facade/page-meta.service.spec.ts
+++ b/projects/core/src/cms/facade/page-meta.service.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '../page';
 import { CmsService } from './cms.service';
 import { PageMetaService } from './page-meta.service';
+import { FeatureConfigService } from '@spartacus/core';
 
 const mockContentPage: Page = {
   type: PageType.CONTENT_PAGE,
@@ -152,6 +153,7 @@ class PageWithAllResolvers
 describe('PageMetaService', () => {
   let service: PageMetaService;
   let cmsService: CmsService;
+  let featureConfigService: FeatureConfigService;
 
   describe('browser', () => {
     let resolver: PageWithAllResolvers;
@@ -174,7 +176,8 @@ describe('PageMetaService', () => {
           },
         ],
       });
-
+      featureConfigService = TestBed.inject(FeatureConfigService);
+      spyOn(featureConfigService, 'isEnabled').and.returnValue(false);
       service = TestBed.inject(PageMetaService);
       cmsService = TestBed.inject(CmsService);
 

--- a/projects/core/src/cms/page/config/page-meta.config.ts
+++ b/projects/core/src/cms/page/config/page-meta.config.ts
@@ -47,9 +47,11 @@ export interface PageMetaResolverConfig {
   method: string;
 
   /**
-   * Disables specific resolvers in CSR mode. Some of the resolvers are
-   * not needed in CSR app, as they're only used for crawlers who will
-   * be served from SSR rendered pages.
+   * Disables specific resolvers in CSR mode.
+   *
+   * @deprecated since 2211.31 - this option will be removed in the future together
+   *              with the feature toggle `allPageMetaResolversEnabledInCsr`
+   *              (then all resolvers will be enabled in CSR).
    */
   disabledInCsr?: boolean;
 }

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -584,11 +584,12 @@ export interface FeatureTogglesInterface {
   enablePasswordsCannotMatchInPasswordUpdateForm?: boolean;
 
   /**
-   * Enables or disables the resolution of all page meta resolvers in a Client-Side Rendering (CSR) environment.
+   * Enables *all* page meta resolvers in Client-Side Rendering (CSR),
+   * ignoring the configuration option set for specific resolvers
+   * `config.pageMeta.resolvers[index].disabledInCsr`.
    *
-   * When set to `true`, all page meta resolvers will be activated during client-side rendering,
-   * allowing the app to dynamically resolve metadata (such as title, description, etc.) based on the current page.
-   * This can be useful in CSR apps where page metadata needs to be updated without a full server-side refresh.
+   * Note: The config option `disabledInCsr` is now deprecated and will be removed
+   *       in the future together with this feature toggle.
    */
   allPageMetaResolversEnabledInCsr?: boolean;
 }

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -582,6 +582,15 @@ export interface FeatureTogglesInterface {
    * the old password.
    */
   enablePasswordsCannotMatchInPasswordUpdateForm?: boolean;
+
+  /**
+   * Enables or disables the resolution of all page meta resolvers in a Client-Side Rendering (CSR) environment.
+   *
+   * When set to `true`, all page meta resolvers will be activated during client-side rendering,
+   * allowing the app to dynamically resolve metadata (such as title, description, etc.) based on the current page.
+   * This can be useful in CSR apps where page metadata needs to be updated without a full server-side refresh.
+   */
+  allPageMetaResolversEnabledInCsr?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -673,4 +682,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   useSiteThemeService: false,
   enableConsecutiveCharactersPasswordRequirement: false,
   enablePasswordsCannotMatchInPasswordUpdateForm: false,
+  allPageMetaResolversEnabledInCsr: false,
 };

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -374,6 +374,7 @@ if (environment.cpq) {
         useSiteThemeService: false,
         enableConsecutiveCharactersPasswordRequirement: true,
         enablePasswordsCannotMatchInPasswordUpdateForm: true,
+        allPageMetaResolversEnabledInCsr: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
closes: [CXSPA-8074](https://jira.tools.sap/browse/CXSPA-8074)

This PR introduces a new configuration option, `allPageMetaResolversEnabledInCsr`, to the Spartacus app. This toggle allows the developer to enable or disable all page meta resolvers specifically for Client-Side Rendering (CSR).

Key Changes:

- Added the `allPageMetaResolversEnabledInCsr` configuration option:

     - When set to true, all page meta resolvers are enabled for CSR. This ensures that meta tags are dynamically generated and updated for each page during client-side navigation.

     - When set to false, meta resolvers will not be triggered in CSR, and meta tags will only be generated on the server-side.

- Modified the logic in `PageMetaService` to check the value of `allPageMetaResolversEnabledInCsr` before applying resolvers during CSR.