### PR TITLE
[POC] Upgrade Bootstrap to v5

### DIFF
--- a/feature-libs/checkout/base/styles/components/steps/review/_review-submit.scss
+++ b/feature-libs/checkout/base/styles/components/steps/review/_review-submit.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 %cx-review-submit {
   @include media-breakpoint-down(md) {
     padding: 20px 0;
@@ -46,7 +47,7 @@
       justify-content: space-between;
 
       @include media-breakpoint-down(md) {
-        background-color: theme-color('inverse');
+        background-color: map.get($theme-colors, 'inverse');
         border-style: solid;
         border-width: 1px;
         border-color: var(--cx-color-light);

--- a/feature-libs/checkout/base/styles/components/steps/review/_review.scss
+++ b/feature-libs/checkout/base/styles/components/steps/review/_review.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 %cx-checkout-review-shipping,
 %cx-checkout-review-payment,
 %cx-checkout-review-overview,
@@ -49,7 +51,7 @@
 
     .cx-review-summary-payment-card {
       margin: 30px;
-      background-color: theme-color('inverse');
+      background-color: map.get($theme-colors, 'inverse');
       width: 45%;
       flex-grow: 1;
       border: 1px solid var(--cx-color-medium);

--- a/feature-libs/organization/user-registration/styles/_user-registration-form.scss
+++ b/feature-libs/organization/user-registration/styles/_user-registration-form.scss
@@ -2,7 +2,7 @@
   @import '@spartacus/styles/scss/cxbase/mixins';
   @import '@spartacus/styles/scss/cxbase/blocks/buttons';
   a {
-    @extend .btn, .btn-block, .btn-secondary;
+    @extend .btn, .btn-secondary, .btn-block !optional;
     &:focus {
       @include visible-focus();
     }

--- a/feature-libs/pickup-in-store/styles/_my-preferred-store.scss
+++ b/feature-libs/pickup-in-store/styles/_my-preferred-store.scss
@@ -37,7 +37,7 @@
     }
     cx-card {
       .cx-card-actions {
-        @extend .btn, .btn-sm, .btn-block;
+        @extend .btn, .btn-sm, .btn-block !optional;
         @extend .btn-outline-text !optional;
         border-width: 2px;
         border-style: solid;

--- a/feature-libs/product-configurator/rulebased/styles/_configurator-conflict-and-error-messages.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-conflict-and-error-messages.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 %cx-configuration-conflict-and-error-messages {
   &:not(:empty) {
     display: flex;
@@ -46,7 +47,7 @@
       }
 
       &-error {
-        background-color: mix(#ffffff, theme-color('danger'), 85%);
+        background-color: mix(#ffffff, map.get($theme-colors, 'danger'), 85%);
         border: var(--cx-border, none);
         .alert-icon {
           cx-icon {
@@ -57,7 +58,7 @@
       }
 
       &-invalid-warning {
-        background-color: mix(#ffffff, theme-color('warning'), 78%);
+        background-color: mix(#ffffff, map.get($theme-colors, 'warning'), 78%);
         border: var(--cx-border, none);
         .alert-icon {
           cx-icon {

--- a/feature-libs/product-configurator/rulebased/styles/_configurator-conflict-description.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-conflict-description.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 %cx-configurator-conflict-description {
   display: flex;
   flex-direction: row;
@@ -6,10 +7,10 @@
   padding-inline-end: 5px;
   padding-block-start: 5px;
   padding-block-end: 5px;
-  background-color: mix(#ffffff, theme-color('warning'), 78%);
+  background-color: mix(#ffffff, map.get($theme-colors, 'warning'), 78%);
 
   cx-icon {
-    color: theme-color('warning');
+    color: map.get($theme-colors, 'warning');
     align-self: center;
     font-size: 30px;
     padding-inline-start: 15px;

--- a/feature-libs/product-configurator/rulebased/styles/_configurator-conflict-suggestion.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-conflict-suggestion.scss
@@ -1,9 +1,10 @@
+@use 'sass:map';
 %cx-configurator-conflict-suggestion {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
-  background-color: mix(#ffffff, theme-color('light'), 90%);
+  background-color: mix(#ffffff, map.get($theme-colors, 'light'), 90%);
   border: 1px solid var(--cx-color-light);
   border-radius: 2px;
   padding-inline-start: 15px;

--- a/feature-libs/product-configurator/rulebased/styles/_configurator-group-menu.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-group-menu.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 %cx-configurator-group-menu {
   &:not(:empty) {
     .cx-group-menu,
@@ -131,7 +132,11 @@
         }
 
         &.cx-menu-conflict {
-          background-color: mix(#ffffff, theme-color('warning'), 78%);
+          background-color: mix(
+            #ffffff,
+            map.get($theme-colors, 'warning'),
+            78%
+          );
         }
       }
 

--- a/feature-libs/product-configurator/rulebased/styles/_configurator-overview-notification-banner.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-overview-notification-banner.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 %cx-configurator-overview-notification-banner {
   display: none;
 
@@ -14,7 +15,7 @@
       }
     }
     .cx-conflict-notification-banner {
-      background-color: mix(#ffffff, theme-color('warning'), 78%);
+      background-color: mix(#ffffff, map.get($theme-colors, 'warning'), 78%);
       .cx-icon {
         color: var(--cx-color-warning);
       }

--- a/feature-libs/product-configurator/rulebased/styles/_configurator-update-message.scss
+++ b/feature-libs/product-configurator/rulebased/styles/_configurator-update-message.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 %cx-configurator-update-message {
   position: absolute;
   width: 100%;
@@ -16,7 +18,7 @@
     padding-inline-end: 10px;
     padding-block-start: 10px;
     padding-block-end: 10px;
-    background-color: mix(#ffffff, theme-color('info'), 80%);
+    background-color: mix(#ffffff, map.get($theme-colors, 'info'), 80%);
     position: sticky;
 
     &.visible {

--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,7 @@
   },
   "targetDefaults": {
     "build": {
-      "cache": true
+      "cache": false
     },
     "lint": {
       "cache": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@ngrx/store": "^17.0.1",
         "@types/google.maps": "^3.54.0",
         "angular-oauth2-oidc": "^17.0.1",
-        "bootstrap": "^4.6.2",
+        "bootstrap": "^5.3.0",
         "comment-json": "^4.2.3",
         "express": "^4.21.0",
         "hamburgers": "^1.2.1",
@@ -7474,6 +7474,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
@@ -10422,9 +10432,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "funding": [
         {
           "type": "github",
@@ -10436,8 +10446,7 @@
         }
       ],
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {
@@ -16740,12 +16749,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "peer": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -19272,17 +19275,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/portfinder": {
@@ -29116,6 +29108,12 @@
       "dev": true,
       "optional": true
     },
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
+    },
     "@rollup/plugin-json": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
@@ -31270,9 +31268,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "requires": {}
     },
     "brace-expansion": {
@@ -35920,12 +35918,6 @@
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "dev": true
     },
-    "jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "peer": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -37801,12 +37793,6 @@
       "requires": {
         "find-up": "^4.0.0"
       }
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "peer": true
     },
     "portfinder": {
       "version": "1.0.32",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@ngrx/store": "^17.0.1",
     "@types/google.maps": "^3.54.0",
     "angular-oauth2-oidc": "^17.0.1",
-    "bootstrap": "^4.6.2",
+    "bootstrap": "^5.3.0",
     "comment-json": "^4.2.3",
     "express": "^4.21.0",
     "hamburgers": "^1.2.1",

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -482,7 +482,7 @@
     "@ngrx/store": "^17.0.1",
     "@types/google.maps": "^3.54.0",
     "angular-oauth2-oidc": "^17.0.1",
-    "bootstrap": "^4.6.2",
+    "bootstrap": "^5.3.0",
     "comment-json": "^4.2.3",
     "express": "^4.21.0",
     "hamburgers": "^1.2.1",

--- a/projects/storefrontapp/project.json
+++ b/projects/storefrontapp/project.json
@@ -5,6 +5,11 @@
   "projectType": "application",
   "prefix": "cx",
   "generators": {},
+  "cli": {
+    "cache": {
+      "enabled": false
+    }
+  },
   "targets": {
     "build": {
       "executor": "@angular-builders/custom-webpack:browser",

--- a/projects/storefrontstyles/scss/app.scss
+++ b/projects/storefrontstyles/scss/app.scss
@@ -2,6 +2,8 @@
 @import 'fonts';
 
 // Bootstrap modules (these are things we are NOT changing at all)
+@import 'bootstrap/scss/maps';
+@import 'bootstrap/scss/root';
 @import 'bootstrap/scss/reboot';
 @import 'bootstrap/scss/type';
 @import 'bootstrap/scss/grid';

--- a/projects/storefrontstyles/scss/components/misc/chat-messaging/_avatar.scss
+++ b/projects/storefrontstyles/scss/components/misc/chat-messaging/_avatar.scss
@@ -1,8 +1,14 @@
+@use 'sass:map';
+
 %cx-avatar {
   .cx-avatar {
     height: 4.375rem;
     min-width: 4.375rem;
-    background-color: mix(theme-color('inverse'), theme-color('primary'), 90%);
+    background-color: mix(
+      map.get($theme-colors, 'inverse'),
+      map.get($theme-colors, 'primary'),
+      90%
+    );
     border-radius: 50%;
     justify-content: center;
     align-items: center;

--- a/projects/storefrontstyles/scss/components/misc/chat-messaging/_messaging.scss
+++ b/projects/storefrontstyles/scss/components/misc/chat-messaging/_messaging.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 %cx-messaging {
   .container {
     display: flex;
@@ -51,8 +53,8 @@
         padding: 20px 28px;
         border: 1px solid var(--cx-color-light);
         background-color: mix(
-          theme-color('inverse'),
-          theme-color('primary'),
+          map.get($theme-colors, 'inverse'),
+          map.get($theme-colors, 'primary'),
           90%
         );
         border-radius: 0px 16px 16px 16px;

--- a/projects/storefrontstyles/scss/cxbase/blocks/accordion.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/accordion.scss
@@ -1,18 +1,21 @@
+@use 'sass:map';
+
 @import '../../theme';
 @import '../../functions';
 @import '../../mixins';
+
 .accordion {
   .card {
     margin-bottom: 20px;
     border: none;
     &-header {
-      background-color: theme-color('background');
+      background-color: map.get($theme-colors, 'background');
       padding: 25px 20px;
       border: none;
       h5 {
         font-size: $font-size-base * 1.375;
         font-weight: 600;
-        color: theme-color('text');
+        color: map.get($theme-colors, 'text');
 
         @include forFeature('a11yImproveContrast') {
           @include type('3');
@@ -38,7 +41,7 @@
             }
           }
           &[aria-expanded='true'] {
-            color: theme-color('primary');
+            color: map.get($theme-colors, 'primary');
             &:after {
               content: '\2013';
             }

--- a/projects/storefrontstyles/scss/cxbase/blocks/alert.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/alert.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @import '../../theme';
 @import '../../mixins';
 @import 'bootstrap/scss/alert';
@@ -40,7 +41,7 @@
   }
 
   &-success {
-    background-color: mix(#ffffff, theme-color('success'), 80%);
+    background-color: mix(#ffffff, map.get($theme-colors, 'success'), 80%);
     border: var(--cx-border, none);
     .alert-icon {
       cx-icon {
@@ -50,7 +51,7 @@
   }
 
   &-danger {
-    background-color: mix(#ffffff, theme-color('danger'), 85%);
+    background-color: mix(#ffffff, map.get($theme-colors, 'danger'), 85%);
     border: var(--cx-border, none);
     .alert-icon {
       cx-icon {
@@ -60,7 +61,7 @@
   }
 
   &-info {
-    background-color: mix(#ffffff, theme-color('info'), 80%);
+    background-color: mix(#ffffff, map.get($theme-colors, 'info'), 80%);
     border: var(--cx-border, none);
     .alert-icon {
       cx-icon {
@@ -70,7 +71,7 @@
   }
 
   &-warning {
-    background-color: mix(#ffffff, theme-color('warning'), 78%);
+    background-color: mix(#ffffff, map.get($theme-colors, 'warning'), 78%);
     border: var(--cx-border, none);
     .alert-icon {
       cx-icon {

--- a/projects/storefrontstyles/scss/cxbase/blocks/carousel.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/carousel.scss
@@ -1,6 +1,7 @@
+@use 'sass:map';
+
 @import '../../theme';
 @import '../../mixins';
-
 // None of the styles here below are customizable at component level
 // analyze how deep we want to customize these
 
@@ -16,11 +17,11 @@
   }
 
   > .active {
-    background-color: theme-color('primary');
+    background-color: map.get($theme-colors, 'primary');
   }
 
   > li {
-    background-color: theme-color('light');
+    background-color: map.get($theme-colors, 'light');
     width: 12px;
     height: 12px;
     border-radius: 50%;

--- a/projects/storefrontstyles/scss/cxbase/blocks/forms.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/forms.scss
@@ -1,6 +1,5 @@
 @import '../../theme';
 @import 'bootstrap/scss/forms';
-@import 'bootstrap/scss/custom-forms';
 
 .form-control {
   margin-bottom: 0.25rem;

--- a/projects/storefrontstyles/scss/cxbase/blocks/message.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/message.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @import '../../theme';
 @import '../../mixins';
 
@@ -80,7 +81,7 @@
   }
 
   &-success {
-    background-color: mix(#ffffff, theme-color('success'), 80%);
+    background-color: mix(#ffffff, map.get($theme-colors, 'success'), 80%);
     border: 1px solid var(--cx-color-success);
 
     .cx-message-icon {
@@ -91,7 +92,7 @@
   }
 
   &-danger {
-    background-color: mix(#ffffff, theme-color('danger'), 85%);
+    background-color: mix(#ffffff, map.get($theme-colors, 'danger'), 85%);
     border: 1px solid var(--cx-color-danger);
 
     .cx-message-icon {
@@ -102,7 +103,7 @@
   }
 
   &-info {
-    background-color: mix(#ffffff, theme-color('info'), 80%);
+    background-color: mix(#ffffff, map.get($theme-colors, 'info'), 80%);
     border: 1px solid var(--cx-color-info);
 
     .cx-message-icon {
@@ -113,7 +114,7 @@
   }
 
   &-warning {
-    background-color: mix(#ffffff, theme-color('warning'), 78%);
+    background-color: mix(#ffffff, map.get($theme-colors, 'warning'), 78%);
     border: 1px solid var(--cx-color-warning);
 
     .cx-message-icon {

--- a/projects/storefrontstyles/scss/cxbase/blocks/tables.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/tables.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 @import '../../theme';
 
 .table {
@@ -12,7 +14,7 @@
       font-size: $small-font-size;
       font-weight: $font-weight-semi;
       text-transform: uppercase;
-      color: theme-color('secondary');
+      color: map.get($theme-colors, 'secondary');
 
       @include forFeature('a11yImproveContrast') {
         @include type('6');
@@ -39,7 +41,7 @@
       tr {
         min-height: 74px;
         &:hover {
-          background-color: theme-color('background');
+          background-color: map.get($theme-colors, 'background');
         }
       }
     }
@@ -68,7 +70,7 @@
       content: ' ';
       height: 18px;
       width: 2px;
-      background-color: theme-color('secondary');
+      background-color: map.get($theme-colors, 'secondary');
       top: 30%;
     }
     &:before {

--- a/projects/storefrontstyles/scss/cxbase/blocks/tooltip.scss
+++ b/projects/storefrontstyles/scss/cxbase/blocks/tooltip.scss
@@ -1,10 +1,12 @@
+@use 'sass:map';
+
 @import '../../theme';
 @import 'bootstrap/scss/tooltip';
 
 .bs-tooltip-left {
   .arrow {
     &:before {
-      border-left-color: theme-color('text');
+      border-left-color: map.get($theme-colors, 'text');
     }
   }
 }
@@ -16,7 +18,7 @@
 }
 
 .tooltip-inner {
-  background-color: theme-color('text');
+  background-color: map.get($theme-colors, 'text');
   padding: 9px 15px;
   box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
 }

--- a/projects/storefrontstyles/scss/cxbase/layout/app.scss
+++ b/projects/storefrontstyles/scss/cxbase/layout/app.scss
@@ -1,10 +1,12 @@
+@use 'sass:map';
+
 @import '../../theme';
 @import '../../functions';
 @import '../../mixins';
 
 .cx-app {
   &__breadcrumb {
-    background-color: theme-color('background');
+    background-color: map.get($theme-colors, 'background');
     text-align: center;
     padding-top: 25px;
   }

--- a/projects/storefrontstyles/scss/misc/_hamburger.scss
+++ b/projects/storefrontstyles/scss/misc/_hamburger.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 // We use the hamburgers from https://github.com/jonsuh/hamburgers
 // In order to allow for custom hamburgers, we use the `cx-hamburger`
 // selector. This selector extends the hamburger selectors provided
@@ -7,7 +9,7 @@ $cx-hamburger-type: squeeze !default;
 
 $hamburger-types: ($cx-hamburger-type);
 
-$hamburger-layer-color: theme-color('inverse') !default;
+$hamburger-layer-color: map.get($theme-colors, 'inverse') !default;
 $hamburger-layer-width: 26px !default;
 $hamburger-layer-height: 3px !default;
 $hamburger-layer-spacing: 4px !default;

--- a/projects/storefrontstyles/scss/root.scss
+++ b/projects/storefrontstyles/scss/root.scss
@@ -24,6 +24,12 @@
 
   --cx-border-style: solid;
 
+  --bs-font-sans-serif: 'Open Sans', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+
+  --bs-body-font-family: var(--bs-font-sans-serif);
+
   body {
     text-align: start;
   }

--- a/projects/storefrontstyles/scss/theme/santorini-updated/_variables.scss
+++ b/projects/storefrontstyles/scss/theme/santorini-updated/_variables.scss
@@ -7,6 +7,7 @@
 //   3) Set new values for component variables - app/__/_.scss
 // You cannot:
 //   1) Add new variables
+@use 'sass:map';
 @import '../../cxbase/functions';
 
 //fonts (see _fonts.scss to import)
@@ -126,9 +127,9 @@ $alert-padding-y: 20px;
 $alert-border-radius: 0;
 
 $input-placeholder-color: lighten($body-color, 50);
-$input-border-color: theme-color('light');
-$input-focus-border-color: theme-color('dark');
-$input-focus-bg: theme-color('background');
+$input-border-color: map.get($theme-colors, 'light');
+$input-focus-border-color: map.get($theme-colors, 'dark');
+$input-focus-bg: map.get($theme-colors, 'background');
 
 $custom-select-bg: color('white');
 $custom-select-border-color: $input-border-color;

--- a/projects/storefrontstyles/scss/theme/santorini/_variables.scss
+++ b/projects/storefrontstyles/scss/theme/santorini/_variables.scss
@@ -7,6 +7,7 @@
 //   3) Set new values for component variables - app/__/_.scss
 // You cannot:
 //   1) Add new variables
+@use 'sass:map';
 @import '../../cxbase/functions';
 
 //fonts (see _fonts.scss to import)
@@ -127,9 +128,9 @@ $alert-padding-y: 20px;
 $alert-border-radius: 0;
 
 $input-placeholder-color: lighten($body-color, 50);
-$input-border-color: theme-color('light');
-$input-focus-border-color: theme-color('dark');
-$input-focus-bg: theme-color('background');
+$input-border-color: map.get($theme-colors, 'light');
+$input-focus-border-color: map.get($theme-colors, 'dark');
+$input-focus-bg: map.get($theme-colors, 'background');
 
 $custom-select-bg: color('white');
 $custom-select-border-color: $input-border-color;

--- a/projects/storefrontstyles/scss/theme/sparta/_variables.scss
+++ b/projects/storefrontstyles/scss/theme/sparta/_variables.scss
@@ -7,6 +7,7 @@
 //   3) Set new values for component variables - app/__/_.scss
 // You cannot:
 //   1) Add new variables
+@use 'sass:map';
 @import '../../cxbase/functions';
 
 //fonts (see _fonts.scss to import)
@@ -123,9 +124,9 @@ $alert-padding-y: 20px;
 $alert-border-radius: 0;
 
 $input-placeholder-color: lighten($body-color, 50);
-$input-border-color: theme-color('light');
-$input-focus-border-color: theme-color('dark');
-$input-focus-bg: theme-color('background');
+$input-border-color: map.get($theme-colors, 'light');
+$input-focus-border-color: map.get($theme-colors, 'dark');
+$input-focus-bg: map.get($theme-colors, 'background');
 
 $custom-select-bg: color('white');
 $custom-select-border-color: $input-border-color;


### PR DESCRIPTION
This PR contains a PoC of upgrade to Bootstrap v5

caveats:
- quite a long list of breaking changes (https://getbootstrap.com/docs/5.3/migration/#v530)
- at first glance
  -  class `.btn-block` often used in our project, has been removed
  - alerts are not working (alert message is not visible)
- to be verified the rest of them if they affect us and how
  - e.g. if changes in the template due to new API are breaking for our customers
- upgrade to Bootstrap v5 will force customers to upgrade Bootstrap in their project - BREAKING CHANGE 