### PR TITLE
PoC: fix support guest checkout with external login page

### DIFF
--- a/feature-libs/checkout/base/components/guards/checkout-auth.guard.ts
+++ b/feature-libs/checkout/base/components/guards/checkout-auth.guard.ts
@@ -12,7 +12,7 @@ import {
   AuthService,
   SemanticPathService,
 } from '@spartacus/core';
-import { combineLatest, Observable } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { CheckoutConfigService } from '../services/checkout-config.service';
 
@@ -54,7 +54,12 @@ export class CheckoutAuthGuard {
     this.authRedirectService.saveCurrentNavigationUrl();
     if (this.checkoutConfigService.isGuestCheckout()) {
       return this.router.createUrlTree(
-        [this.semanticPathService.get('login')],
+        // If we redirected to the route /login, then we would be redirected to an EXTERNAL Login page
+        // by the LoginGuard.
+        // Instead we want to land on a page that will show us 2 options:
+        // 1. Link to `/login` that wll be handled by a `LoginGuard` and redirect to an external Login page.
+        // 2. Continue as guest (give email)
+        [this.semanticPathService.get('checkoutRequireAuth')],
         { queryParams: { forced: true } }
       );
     } else {

--- a/feature-libs/checkout/base/root/checkout-root.module.ts
+++ b/feature-libs/checkout/base/root/checkout-root.module.ts
@@ -5,12 +5,14 @@
  */
 
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { CART_BASE_FEATURE } from '@spartacus/cart/base/root';
 import {
   CmsConfig,
   provideDefaultConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
+import { CmsPageGuard, PageLayoutComponent } from '@spartacus/storefront';
 import { defaultCheckoutConfig } from './config/default-checkout-config';
 import { defaultCheckoutRoutingConfig } from './config/default-checkout-routing-config';
 import { CheckoutEventModule } from './events/checkout-event.module';
@@ -49,8 +51,43 @@ export function defaultCheckoutComponentsConfig() {
 }
 
 @NgModule({
-  imports: [CheckoutEventModule],
+  imports: [
+    CheckoutEventModule,
+
+    // We need to add a new route.
+    // Normally, I'd define a new ContentPage in CMS and not use `RouterModule.forChild()`.
+    // But JUST FOR DEMONSTRATION PURPOSES, I took the shortcut here.
+    // I've added a new route (from the Spartacus point of view), but under the hood I reuse
+    // an existing CMS page content (so I don't need to define a new page in the CMS sample data now).
+    // See the mapping below: `pageLabel: '/login'`
+    // In other words, when entering the route `/checkout-require-auth`,
+    // it will not trigger a regular `LoginGuard` (which would redirect to an EXTERNAL login page).
+    // but instead it will show us a page content of the old login page.
+    RouterModule.forChild([
+      {
+        // @ts-ignore
+        path: null,
+        canActivate: [CmsPageGuard],
+        component: PageLayoutComponent,
+        data: {
+          cxRoute: 'checkoutRequireAuth',
+          pageLabel: '/login',
+        },
+      },
+    ]),
+  ],
   providers: [
+    provideDefaultConfig({
+      routing: {
+        routes: {
+          checkoutRequireAuth: {
+            paths: ['checkout-require-auth'],
+            authFlow: true,
+          },
+        },
+      },
+    }),
+
     ...interceptors,
     provideDefaultConfig(defaultCheckoutRoutingConfig),
     provideDefaultConfig(defaultCheckoutConfig),

--- a/feature-libs/user/account/components/login-form/login-form.component.html
+++ b/feature-libs/user/account/components/login-form/login-form.component.html
@@ -1,6 +1,17 @@
 <cx-spinner class="overlay" *ngIf="isUpdating$ | async"></cx-spinner>
 
-<form (ngSubmit)="onSubmit()" [formGroup]="form">
+<!--
+  FOR DEMONSTRATION PURPOSES I've reused the contents of the old login page.
+  As a consequence, I need to tweak a bit the old form component - to not show
+  the fields for the username and password, but instead just show a link to the
+  regular `/login` route, which will be handled by the LoginGuard that will
+  redirect to the external login page.
+-->
+<form
+  (ngSubmit)="onSubmit()"
+  [formGroup]="form"
+  *ngIf="!loginAsGuest; else loginAsGuestForm"
+>
   <!-- TODO: (CXSPA-5953) Remove feature flags next major -->
   <label>
     <span class="label-content">
@@ -70,6 +81,15 @@
     {{ 'loginForm.signIn' | cxTranslate }}
   </button>
 </form>
+
+<ng-template #loginAsGuestForm>
+  <a
+    class="btn btn-block btn-primary"
+    [routerLink]="{ cxRoute: 'login' } | cxUrl"
+  >
+    {{ 'loginForm.signIn' | cxTranslate }}
+  </a>
+</ng-template>
 
 <ng-template #requiredAsterisk>
   <abbr

--- a/feature-libs/user/account/components/login-form/login-form.component.ts
+++ b/feature-libs/user/account/components/login-form/login-form.component.ts
@@ -4,8 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeDetectionStrategy, Component, HostBinding } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  OnInit,
+  inject,
+} from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { LoginFormComponentService } from './login-form-component.service';
 
@@ -14,8 +21,14 @@ import { LoginFormComponentService } from './login-form-component.service';
   templateUrl: './login-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LoginFormComponent {
+export class LoginFormComponent implements OnInit {
   constructor(protected service: LoginFormComponentService) {}
+
+  protected activatedRoute = inject(ActivatedRoute);
+  loginAsGuest = false;
+  ngOnInit(): void {
+    this.loginAsGuest = this.activatedRoute.snapshot.queryParams['forced'];
+  }
 
   form: UntypedFormGroup = this.service.form;
   isUpdating$: Observable<boolean> = this.service.isUpdating$;

--- a/feature-libs/user/account/styles/_login-form.scss
+++ b/feature-libs/user/account/styles/_login-form.scss
@@ -6,6 +6,10 @@
     button {
       flex: 100%;
     }
+    // a fix to make the link look like a full-width button
+    a {
+      flex: 100%;
+    }
   }
 
   @include cx-highContrastTheme {

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -22,9 +22,9 @@ import { translationChunksConfig, translations } from '@spartacus/assets';
 import {
   I18nConfig,
   OccConfig,
-  provideConfig,
   RoutingConfig,
   TestConfigModule,
+  provideConfig,
 } from '@spartacus/core';
 import { StoreFinderConfig } from '@spartacus/storefinder/core';
 import { GOOGLE_MAPS_DEVELOPMENT_KEY_CONFIG } from '@spartacus/storefinder/root';
@@ -98,6 +98,20 @@ if (!environment.production) {
       provide: USE_LEGACY_MEDIA_COMPONENT,
       useValue: false,
     },
+    provideConfig({
+      // Enable external login - with the Oauth Authorization Code Flow
+      authentication: {
+        client_id: 'client4kyma',
+        OAuthLibConfig: {
+          responseType: 'code',
+        },
+      },
+
+      // Enable guest checkout feature
+      checkout: {
+        guest: true,
+      },
+    }),
   ],
   bootstrap: [StorefrontComponent],
 })


### PR DESCRIPTION
Problem: as of today, the Guest Checkout doesn't fully support the OAuth flows with a login page hosted on an external domain.
It's becasue, currently the `CheckoutAuthGuard` redirects anonymous users to a `/login` page which triggers the `LoginGuard` that immediately redirects the user to an external login page hosted on external domain.
Instead, we'd like to show to the user a landing page with 2 options to choose from:
1. Link to `/login` route that wll be handled by a `LoginGuard` and redirect to an external Login page.
2. Continue as guest (give email)

For this purpose, I needed to create a separate landing page to be a separate route from `/login` - I named it `/checkout-require-auth`. Thanks to this, when you visit this checkout landing page, the regular `LoginGuard` doesn't immediately kick in, because this guard it's bind only to the `/login` route.

TODO: Rough edges to polish before merging:
- the route name `/checkout-require-auth` was chosen arbitrarily without much thinking. Perhaps `/checkout-auth` or sth similar would sound better
- the new behavior of the `CheckoutAuthGuard` should be covered with a feature toggle (aka "breaking changes toggle"), no to impose this change on customers immediately after bumping Spartacus version, but only when they flip the toggle (note: the toggle will become active by default after 6 months and removed after 12 months, according to our policy of feature toggles)
- add unit tests / e2e tests

QA steps:
1. run `npm run start`
2. open http://localhost:4200
3. add a product to cart
4. proceed to checkout
5. ☑️ verify that you're presented with a landing page with 2 options to choose from: "Sign In" and "Guest Checkout"
6. ☑️ verify that clicking "Sign In" redirects you to an external login page. (you can use the login `gi.sun@rustic-hw.com` there)
7. finalize the checkout
8. **Logout and repeat steps 2-5**
9. ☑️ verify that clicking "Guest Checkout" redirects you to a page where you enter just your email
10. finalize your checkout

