### PR TITLE
Revert "chore: update open-sans (#19253)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@angular/router": "^17.0.5",
         "@angular/service-worker": "^17.0.5",
         "@angular/ssr": "^17.0.5",
-        "@fontsource/open-sans": "~5.0.12",
+        "@fontsource/open-sans": "^4.5.14",
         "@fortawesome/fontawesome-free": "6.5.1",
         "@ng-select/ng-select": "^12.0.4",
         "@ngrx/effects": "^17.0.1",
@@ -5352,10 +5352,9 @@
       }
     },
     "node_modules/@fontsource/open-sans": {
-      "version": "5.0.30",
-      "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-5.0.30.tgz",
-      "integrity": "sha512-u5Siu6un1R0Q5UZ9lr56YujMe5xjXWoJm3qJUiEKk6IMKqOkedT/NsbAgIQtaqJL1jMZbpCVXGVCd97ahQYeKQ==",
-      "license": "OFL-1.1"
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-4.5.14.tgz",
+      "integrity": "sha512-mBXIIETBlW8q/ocuUN0hyGow2iuf75hQEHQt8R/RJ/HcphVbLg8KB7pHYGbFGDqs75W+SWvTC7JkVeAjT65BuQ=="
     },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "6.5.1",
@@ -27592,9 +27591,9 @@
       "dev": true
     },
     "@fontsource/open-sans": {
-      "version": "5.0.30",
-      "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-5.0.30.tgz",
-      "integrity": "sha512-u5Siu6un1R0Q5UZ9lr56YujMe5xjXWoJm3qJUiEKk6IMKqOkedT/NsbAgIQtaqJL1jMZbpCVXGVCd97ahQYeKQ=="
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-4.5.14.tgz",
+      "integrity": "sha512-mBXIIETBlW8q/ocuUN0hyGow2iuf75hQEHQt8R/RJ/HcphVbLg8KB7pHYGbFGDqs75W+SWvTC7JkVeAjT65BuQ=="
     },
     "@fortawesome/fontawesome-free": {
       "version": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@angular/router": "^17.0.5",
     "@angular/service-worker": "^17.0.5",
     "@angular/ssr": "^17.0.5",
-    "@fontsource/open-sans": "~5.0.12",
+    "@fontsource/open-sans": "^4.5.14",
     "@fortawesome/fontawesome-free": "6.5.1",
     "@ng-select/ng-select": "^12.0.4",
     "@ngrx/effects": "^17.0.1",

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -46,7 +46,7 @@
     "rxjs": "^7.8.0"
   },
   "@spartacus/styles": {
-    "@fontsource/open-sans": "~5.0.12",
+    "@fontsource/open-sans": "^4.5.14",
     "@fortawesome/fontawesome-free": "6.5.1",
     "@ng-select/ng-select": "^12.0.4",
     "bootstrap": "^4.6.2"
@@ -477,7 +477,7 @@
     "@angular/router": "^17.0.5",
     "@angular/service-worker": "^17.0.5",
     "@angular/ssr": "^17.0.5",
-    "@fontsource/open-sans": "~5.0.12",
+    "@fontsource/open-sans": "^4.5.14",
     "@fortawesome/fontawesome-free": "6.5.1",
     "@ng-select/ng-select": "^12.0.4",
     "@ngrx/effects": "^17.0.1",

--- a/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -55,7 +55,7 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "@angular/router": "^17.0.0",
     "@angular/service-worker": "^17.0.5",
     "@angular/ssr": "^17.0.5",
-    "@fontsource/open-sans": "~5.0.12",
+    "@fontsource/open-sans": "^4.5.14",
     "@fortawesome/fontawesome-free": "6.5.1",
     "@ng-select/ng-select": "^12.0.4",
     "@ngrx/effects": "^17.0.1",

--- a/projects/storefrontstyles/package.json
+++ b/projects/storefrontstyles/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {},
   "peerDependencies": {
-    "@fontsource/open-sans": "~5.0.12",
+    "@fontsource/open-sans": "^4.5.14",
     "@fortawesome/fontawesome-free": "6.5.1",
     "@ng-select/ng-select": "^12.0.4",
     "bootstrap": "^4.6.2"


### PR DESCRIPTION
This reverts commit c3b8410b896efc3f0bcd022ba3f6e8e4ff2e5f37 (PR https://github.com/SAP/spartacus/pull/19253)

Reverting it, because ideally we don't want to force customers to bump their direct dependencies in the middle of the year, but only in our yearly Framework Upgrade Release instead.

related to https://jira.tools.sap/browse/CXSPA-6488