### PR TITLE
chore: remove TODO comment related to CXSPA-6793, as won't fix

### DIFF
--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -282,7 +282,6 @@ if (environment.cpq) {
       provide: USE_MY_ACCOUNT_V2_NOTIFICATION_PREFERENCE,
       useValue: environment.myAccountV2,
     },
-    // CXSPA-6793: refactor to`provideFeatureToggles` and `satisfies` keyword
     provideFeatureTogglesFactory(() => {
       const appFeatureToggles: Required<FeatureToggles> = {
         showDeliveryOptionsTranslation: true,


### PR DESCRIPTION
We won't change the syntax to use to `satisfies` keyword

Reason:
- in case of a missing property, the error message is more readable currently. See screenshots below
   CURRENTLY:
   ![image](https://github.com/user-attachments/assets/0d9a792f-e946-417b-9801-ee7e02817bae)
   IF WE USED `satisfies` keyword:
   ![image](https://github.com/user-attachments/assets/9f87b0fe-9365-4658-90ef-13b7f58d829a)
- moreover, if we changed the syntax from `provideFeatureTogglesFactory` to `provideFeatureToggles`, it would change the indentation for all lines with toggles, which is prone to code conflicts with other pending branches
   ![image](https://github.com/user-attachments/assets/b17c06b4-c6d4-4825-a620-95b556f6df33)

All that said, I don't find it justified to refactor it to use `satisfies` keyword, therefore removing the TODO comment as won't fix

closes https://jira.tools.sap/browse/CXSPA-6793