### PR TITLE
GHAS. Translations. Fix Incomplete string escaping or encoding

### DIFF
--- a/scripts/i18n/convert-translations-json-2-ts.ts
+++ b/scripts/i18n/convert-translations-json-2-ts.ts
@@ -148,7 +148,7 @@ function stringify(obj: any, indent: string = ''): string {
       return '`' + obj.replace(/`/g, '\\`') + '`';
     }
     if (obj.includes("'")) {
-      return `"${obj.replace(/"/g, '\\"')}"`;
+      return `"${obj.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
     }
     return `'${obj}'`;
   } else if (typeof obj !== 'object' || obj === null) {


### PR DESCRIPTION
Fixes [https://github.com/SAP/spartacus/security/code-scanning/55](https://github.com/SAP/spartacus/security/code-scanning/55)

To fix the problem, we need to ensure that backslashes are properly escaped in the `stringify` function. This can be done by adding a step to replace backslashes with double backslashes before handling other characters. Specifically, we should update the `replace` method on line 151 to first escape backslashes and then handle double quotes.

- Update the `stringify` function to include backslash escaping.
- Modify the `replace` method to handle backslashes before replacing double quotes.
- Ensure that the changes are made in the `scripts/i18n/convert-translations-json-2-ts.ts` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
