### PR TITLE
chore: Remove cypress .npmrc

### DIFF
--- a/projects/storefrontapp-e2e-cypress/.npmrc
+++ b/projects/storefrontapp-e2e-cypress/.npmrc
@@ -1,2 +1,0 @@
-@continuum:registry=https://npm.levelaccess.net/continuum/
-          //npm.levelaccess.net/continuum/:_authToken=${CONTINUUM_REGISTRY_TOKEN}


### PR DESCRIPTION
There are external pipelines that are failing in the e2e step because the environment variable `CONTINUUM_REGISTRY_TOKEN` is not being correctly applied. Lets try to [remove the .npmrc file](https://stackoverflow.com/questions/52015748/npm-failed-to-replace-env-in-config-npm-token) from the e2e directory and see if that helps.

Note that we need to come back for a solution to Access Continuum that works on all pipelines and dev machines.