### PR TITLE
fix: (CXSPA-8668) - Image zoom legacy media component styles

### DIFF
--- a/feature-libs/product/image-zoom/styles/_product-image-zoom-view.scss
+++ b/feature-libs/product/image-zoom/styles/_product-image-zoom-view.scss
@@ -42,9 +42,6 @@ cx-product-image-zoom-view {
     .cx-default-image-zoom {
       display: flex;
       justify-content: center;
-      &:has(picture) {
-        max-height: calc(90vh - 200px);
-      }
       @include media-breakpoint-up(lg) {
         height: calc(90vh - 200px);
         // TODO: (CXSPA-7492) - Remove feature flag next major release.

--- a/feature-libs/product/image-zoom/styles/_product-image-zoom-view.scss
+++ b/feature-libs/product/image-zoom/styles/_product-image-zoom-view.scss
@@ -42,13 +42,16 @@ cx-product-image-zoom-view {
     .cx-default-image-zoom {
       display: flex;
       justify-content: center;
-      max-height: calc(90vh - 200px);
-
+      &:has(picture) {
+        max-height: calc(90vh - 200px);
+      }
       @include media-breakpoint-up(lg) {
         height: calc(90vh - 200px);
         // TODO: (CXSPA-7492) - Remove feature flag next major release.
         @include forFeature('a11yKeyboardAccessibleZoom') {
-          height: unset;
+          &:has(picture) {
+            height: unset;
+          }
         }
       }
 

--- a/feature-libs/product/image-zoom/styles/_product-image-zoom-view.scss
+++ b/feature-libs/product/image-zoom/styles/_product-image-zoom-view.scss
@@ -42,6 +42,7 @@ cx-product-image-zoom-view {
     .cx-default-image-zoom {
       display: flex;
       justify-content: center;
+      max-height: calc(90vh - 200px);
       @include media-breakpoint-up(lg) {
         height: calc(90vh - 200px);
         // TODO: (CXSPA-7492) - Remove feature flag next major release.

--- a/feature-libs/product/image-zoom/styles/_product-image-zoom-view.scss
+++ b/feature-libs/product/image-zoom/styles/_product-image-zoom-view.scss
@@ -43,6 +43,7 @@ cx-product-image-zoom-view {
       display: flex;
       justify-content: center;
       max-height: calc(90vh - 200px);
+
       @include media-breakpoint-up(lg) {
         height: calc(90vh - 200px);
         // TODO: (CXSPA-7492) - Remove feature flag next major release.


### PR DESCRIPTION
Closes: [CXSPA-8668](https://jira.tools.sap/browse/CXSPA-8668)

Let's use a more specific selector to make sure the legacy media component remains unchanged. 
This way both versions behave predictably.