### PR TITLE
fix: Adjust billing address feature to change to sapBillingAddress key in API

### DIFF
--- a/feature-libs/cart/base/root/models/cart.model.ts
+++ b/feature-libs/cart/base/root/models/cart.model.ts
@@ -81,6 +81,7 @@ export interface Cart {
   paymentInfo?: PaymentDetails;
   paymentType?: PaymentType;
   paymentAddress?: Address;
+  sapBillingAddress?: Address;
   pickupItemsQuantity?: number;
   pickupOrderGroups?: PickupOrderEntryGroup[];
   potentialOrderPromotions?: PromotionResult[];

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.spec.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.spec.ts
@@ -53,7 +53,7 @@ describe('OpfCheckoutBillingAddressFormService', () => {
     mockActiveCartFacade = {
       reloadActiveCart: () => of(true),
       isStable: () => of(true),
-      getActive: () => of({ paymentAddress: mockPaymentAddress } as Cart),
+      getActive: () => of({ sapBillingAddress: mockPaymentAddress } as Cart),
     };
 
     mockGlobalMessageService = {
@@ -167,7 +167,7 @@ describe('OpfCheckoutBillingAddressFormService', () => {
 
   it('should get payment address', () => {
     spyOn(mockActiveCartFacade, 'getActive').and.returnValue(
-      of({ paymentAddress: mockPaymentAddress } as Cart)
+      of({ sapBillingAddress: mockPaymentAddress } as Cart)
     );
 
     service['getPaymentAddress']().subscribe((result) => {
@@ -177,7 +177,7 @@ describe('OpfCheckoutBillingAddressFormService', () => {
 
   it('should not get payment address when not present', () => {
     spyOn(mockActiveCartFacade, 'getActive').and.returnValue(
-      of({ paymentAddress: undefined } as Cart)
+      of({ sapBillingAddress: undefined } as Cart)
     );
 
     service['getPaymentAddress']().subscribe((result) => {
@@ -196,7 +196,7 @@ describe('OpfCheckoutBillingAddressFormService', () => {
 
   it('should not get payment address when it is not present', (done) => {
     spyOn(mockActiveCartFacade, 'getActive').and.returnValue(
-      of({ paymentAddress: undefined } as Cart)
+      of({ sapBillingAddress: undefined } as Cart)
     );
 
     service['getPaymentAddress']().subscribe((result) => {

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.ts
@@ -21,9 +21,9 @@ import {
 } from '@spartacus/core';
 import {
   BehaviorSubject,
-  combineLatest,
   EMPTY,
   Observable,
+  combineLatest,
   throwError,
 } from 'rxjs';
 import {
@@ -174,7 +174,7 @@ export class OpfCheckoutBillingAddressFormService {
   protected getPaymentAddress(): Observable<Address | undefined> {
     return this.activeCartService
       .getActive()
-      .pipe(map((cart: Cart) => cart.paymentAddress));
+      .pipe(map((cart: Cart) => cart.sapBillingAddress));
   }
 
   protected getAddressWithId(address: Address): Address {


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-8630

Checkout billing address service expected to get `cart.paymentAddress` from active cart but it got `sapBillingAddress` instead. Property changed on API https://jira.tools.sap/browse/CXSPA-8357.