### PR TITLE
feat: add guest mode for ApplePay

### DIFF
--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.service.spec.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.service.spec.ts
@@ -13,7 +13,7 @@ import {
   OpfQuickBuyTransactionService,
 } from '@spartacus/opf/quick-buy/core';
 import { OpfQuickBuyDeliveryType } from '@spartacus/opf/quick-buy/root';
-import { Subject, of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { OpfQuickBuyButtonsService } from '../opf-quick-buy-buttons.service';
 import { ApplePaySessionFactory } from './apple-pay-session/apple-pay-session.factory';
 import { ApplePayService } from './apple-pay.service';
@@ -99,7 +99,7 @@ describe('ApplePayService', () => {
         'getCurrentCartTotalPrice',
         'setDeliveryMode',
         'getSelectedDeliveryMode',
-        'deleteUserAddresses',
+        'handleCartGuestUser',
       ]
     );
 
@@ -136,6 +136,9 @@ describe('ApplePayService', () => {
     applePayObservableFactoryMock.initApplePayEventsHandler.and.returnValue(
       applePayObservableTestController
     );
+    opfQuickBuyTransactionServiceMock.handleCartGuestUser.and.returnValue(
+      of(true)
+    );
   });
 
   it('should be created', () => {
@@ -152,7 +155,7 @@ describe('ApplePayService', () => {
     );
 
     applePayObservableFactoryMock.initApplePayEventsHandler.and.returnValue(
-      throwError('Error')
+      throwError(() => 'Error')
     );
 
     opfQuickBuyTransactionServiceMock.getMerchantName.and.returnValue(

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.service.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.service.ts
@@ -175,24 +175,28 @@ export class ApplePayService {
       countryCode,
     };
 
-    return forkJoin({
-      deliveryInfo:
-        this.opfQuickBuyTransactionService.getTransactionDeliveryInfo(),
-      merchantName: this.opfQuickBuyTransactionService.getMerchantName(),
-    }).pipe(
-      switchMap(({ deliveryInfo, merchantName }) => {
-        this.transactionDetails.total.label = merchantName;
-        initialRequest.total.label = merchantName;
-        this.transactionDetails.deliveryInfo = deliveryInfo;
+    return this.opfQuickBuyTransactionService.handleCartGuestUser().pipe(
+      switchMap(() => {
+        return forkJoin({
+          deliveryInfo:
+            this.opfQuickBuyTransactionService.getTransactionDeliveryInfo(),
+          merchantName: this.opfQuickBuyTransactionService.getMerchantName(),
+        }).pipe(
+          switchMap(({ deliveryInfo, merchantName }) => {
+            this.transactionDetails.total.label = merchantName;
+            initialRequest.total.label = merchantName;
+            this.transactionDetails.deliveryInfo = deliveryInfo;
 
-        return of(undefined);
-      }),
-      map((opfQuickBuyDeliveryInfo) => {
-        if (!opfQuickBuyDeliveryInfo) {
-          return initialRequest;
-        }
-        this.transactionDetails.deliveryInfo = opfQuickBuyDeliveryInfo;
-        return initialRequest;
+            return of(undefined);
+          }),
+          map((opfQuickBuyDeliveryInfo) => {
+            if (!opfQuickBuyDeliveryInfo) {
+              return initialRequest;
+            }
+            this.transactionDetails.deliveryInfo = opfQuickBuyDeliveryInfo;
+            return initialRequest;
+          })
+        );
       })
     );
   }

--- a/integration-libs/opf/quick-buy/core/services/opf-quick-buy-transaction.service.spec.ts
+++ b/integration-libs/opf/quick-buy/core/services/opf-quick-buy-transaction.service.spec.ts
@@ -107,6 +107,7 @@ describe('OpfQuickBuyTransactionService', () => {
     authService = jasmine.createSpyObj('AuthService', ['isUserLoggedIn']);
     cartGuestUserFacade = jasmine.createSpyObj('CartGuestUserFacade', [
       'createCartGuestUser',
+      'updateCartGuestUser',
     ]);
 
     TestBed.configureTestingModule({
@@ -497,6 +498,47 @@ describe('OpfQuickBuyTransactionService', () => {
           );
           expect(result).toBe(true);
           expect(multiCartFacade.reloadCart).toHaveBeenCalled();
+        })
+        .unsubscribe();
+    });
+  });
+
+  describe('updateCartGuestUserEmail', () => {
+    it('should call `updateCartGuestUser` from `CartGuestUserFacade` with params', () => {
+      userIdService.takeUserId.and.returnValue(of('userId'));
+      activeCartFacade.takeActiveCartId.and.returnValue(of('cartId'));
+      multiCartFacade.reloadCart.and.returnValue();
+      cartGuestUserFacade.updateCartGuestUser.and.returnValue(of({}));
+      activeCartFacade.isGuestCart.and.returnValue(of(true));
+      const mockEmailAddr = 'mockemail@mockemail.com';
+      service
+        .updateCartGuestUserEmail(mockEmailAddr)
+        .subscribe((result) => {
+          expect(cartGuestUserFacade.updateCartGuestUser).toHaveBeenCalledWith(
+            'userId',
+            'cartId',
+            { email: mockEmailAddr }
+          );
+          expect(result).toBe(true);
+          expect(multiCartFacade.reloadCart).toHaveBeenCalled();
+        })
+        .unsubscribe();
+    });
+
+    it('should return false when no email', () => {
+      userIdService.takeUserId.and.returnValue(of('userId'));
+      activeCartFacade.takeActiveCartId.and.returnValue(of('cartId'));
+      multiCartFacade.reloadCart.and.returnValue();
+      cartGuestUserFacade.updateCartGuestUser.and.returnValue(of({}));
+      activeCartFacade.isGuestCart.and.returnValue(of(true));
+      const mockEmailAddr = '';
+      service
+        .updateCartGuestUserEmail(mockEmailAddr)
+        .subscribe((result) => {
+          expect(result).toBeFalsy();
+          expect(
+            cartGuestUserFacade.updateCartGuestUser
+          ).not.toHaveBeenCalled();
         })
         .unsubscribe();
     });

--- a/integration-libs/opf/quick-buy/core/services/opf-quick-buy-transaction.service.ts
+++ b/integration-libs/opf/quick-buy/core/services/opf-quick-buy-transaction.service.ts
@@ -8,6 +8,7 @@ import { inject, Injectable } from '@angular/core';
 import {
   ActiveCartFacade,
   Cart,
+  CartGuestUser,
   CartGuestUserFacade,
   DeliveryMode,
   MultiCartFacade,
@@ -196,6 +197,36 @@ export class OpfQuickBuyTransactionService {
             tap(() => this.multiCartFacade.reloadCart(cartId)),
             map(() => true)
           );
+      })
+    );
+  }
+
+  protected UpdateCartGuestUser(
+    cartGuestUser: CartGuestUser
+  ): Observable<boolean> {
+    return combineLatest([
+      this.userIdService.takeUserId(),
+      this.activeCartFacade.takeActiveCartId(),
+    ]).pipe(
+      take(1),
+      switchMap(([userId, cartId]) => {
+        return this.cartGuestUserFacade
+          .updateCartGuestUser(userId, cartId, cartGuestUser)
+          .pipe(
+            tap(() => this.multiCartFacade.reloadCart(cartId)),
+            map(() => true)
+          );
+      })
+    );
+  }
+
+  updateCartGuestUserEmail(email: string): Observable<boolean> {
+    return this.activeCartFacade.isGuestCart().pipe(
+      take(1),
+      switchMap((isGuestCart) => {
+        return isGuestCart && email
+          ? this.UpdateCartGuestUser({ email })
+          : of(false);
       })
     );
   }

--- a/integration-libs/opf/quick-buy/core/services/opf-quick-buy-transaction.service.ts
+++ b/integration-libs/opf/quick-buy/core/services/opf-quick-buy-transaction.service.ts
@@ -201,7 +201,7 @@ export class OpfQuickBuyTransactionService {
     );
   }
 
-  protected UpdateCartGuestUser(
+  protected updateCartGuestUser(
     cartGuestUser: CartGuestUser
   ): Observable<boolean> {
     return combineLatest([
@@ -225,7 +225,7 @@ export class OpfQuickBuyTransactionService {
       take(1),
       switchMap((isGuestCart) => {
         return isGuestCart && email
-          ? this.UpdateCartGuestUser({ email })
+          ? this.updateCartGuestUser({ email })
           : of(false);
       })
     );


### PR DESCRIPTION
- Create guest user only after form is displayed, at session validation time. Otherwise getting and error (InvalidAccessError: Must create a new ApplePaySession from a user gesture handler.)
- Add the email addr to guest user cart when payment gets submitted.