### PR TITLE
fix(a11y): Prevent search label from being read twice (#19490)

### DIFF
--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.html
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.html
@@ -82,7 +82,6 @@
         [attr.tabindex]="
           a11ySearchBoxMobileFocusEnabled ? getTabIndex(isMobile | async) : null
         "
-        [attr.aria-label]="'searchBox.placeholder' | cxTranslate"
         (focus)="a11ySearchBoxMobileFocusEnabled ? null : open()"
         (click)="open()"
         (input)="search(searchInput.value)"


### PR DESCRIPTION
See: https://github.com/SAP/spartacus/pull/19490