### PR TITLE
refactor(opf,cart,checkout): use Angular 'inject' function for DI instead of constructors

### DIFF
--- a/feature-libs/cart/base/core/connectors/access-code/cart-access-code.connector.ts
+++ b/feature-libs/cart/base/core/connectors/access-code/cart-access-code.connector.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { CartAccessCodeAdapter } from './cart-access-code.adapter';
 
 @Injectable()
 export class CartAccessCodeConnector {
-  constructor(protected adapter: CartAccessCodeAdapter) {}
+  protected adapter = inject(CartAccessCodeAdapter);
 
   public getCartAccessCode(
     userId: string,

--- a/feature-libs/cart/base/core/connectors/guest-user/cart-guest-user.connector.ts
+++ b/feature-libs/cart/base/core/connectors/guest-user/cart-guest-user.connector.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { CartGuestUser } from '@spartacus/cart/base/root';
 import { Observable } from 'rxjs';
 import { CartGuestUserAdapter } from './cart-guest-user.adapter';
 
 @Injectable()
 export class CartGuestUserConnector {
-  constructor(protected adapter: CartGuestUserAdapter) {}
+  protected adapter = inject(CartGuestUserAdapter);
 
   public createCartGuestUser(
     userId: string,

--- a/feature-libs/cart/base/core/facade/cart-access-code.service.ts
+++ b/feature-libs/cart/base/core/facade/cart-access-code.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { CartAccessCodeFacade } from '@spartacus/cart/base/root';
 import { Command, CommandService, QueryService } from '@spartacus/core';
 import { Observable } from 'rxjs';
@@ -12,6 +12,10 @@ import { CartAccessCodeConnector } from '../connectors';
 
 @Injectable()
 export class CartAccessCodeService implements CartAccessCodeFacade {
+  protected queryService = inject(QueryService);
+  protected commandService = inject(CommandService);
+  protected cartAccessCodeConnector = inject(CartAccessCodeConnector);
+
   protected getCartAccessCodeCommand: Command<
     {
       userId: string;
@@ -21,12 +25,6 @@ export class CartAccessCodeService implements CartAccessCodeFacade {
   > = this.commandService.create(({ userId, cartId }) =>
     this.cartAccessCodeConnector.getCartAccessCode(userId, cartId)
   );
-
-  constructor(
-    protected queryService: QueryService,
-    protected commandService: CommandService,
-    protected cartAccessCodeConnector: CartAccessCodeConnector
-  ) {}
 
   getCartAccessCode(
     userId: string,

--- a/feature-libs/cart/base/occ/adapters/occ-cart-access-code.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-access-code.adapter.ts
@@ -23,12 +23,9 @@ import { Observable, catchError } from 'rxjs';
 @Injectable()
 export class OccCartAccessCodeAdapter implements CartAccessCodeAdapter {
   protected logger = inject(LoggerService);
-
-  constructor(
-    protected http: HttpClient,
-    protected occEndpointsService: OccEndpointsService,
-    protected converterService: ConverterService
-  ) {}
+  protected http = inject(HttpClient);
+  protected occEndpointsService = inject(OccEndpointsService);
+  protected converterService = inject(ConverterService);
 
   getCartAccessCode(
     userId: string,

--- a/feature-libs/checkout/base/components/services/checkout-flow-orchestrator.service.spec.ts
+++ b/feature-libs/checkout/base/components/services/checkout-flow-orchestrator.service.spec.ts
@@ -25,14 +25,15 @@ describe('CheckoutFlowOrchestratorService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [StoreModule.forRoot({})],
-      providers: [CheckoutFlowOrchestratorService, BaseSiteService],
+      providers: [
+        CheckoutFlowOrchestratorService,
+        BaseSiteService,
+        { provide: CheckoutConfig, useValue: mockCheckoutConfig },
+      ],
     });
 
     baseSiteService = TestBed.inject(BaseSiteService);
-    service = new CheckoutFlowOrchestratorService(
-      mockCheckoutConfig,
-      baseSiteService
-    );
+    service = TestBed.inject(CheckoutFlowOrchestratorService);
   });
 
   it('should be created', () => {

--- a/feature-libs/checkout/base/components/services/checkout-flow-orchestrator.service.ts
+++ b/feature-libs/checkout/base/components/services/checkout-flow-orchestrator.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { CheckoutConfig, CheckoutFlow } from '@spartacus/checkout/base/root';
 import { BaseSiteService } from '@spartacus/core';
 import { Observable } from 'rxjs';
@@ -14,10 +14,10 @@ import { map, take } from 'rxjs/operators';
   providedIn: 'root',
 })
 export class CheckoutFlowOrchestratorService {
-  constructor(
-    protected checkoutConfig: CheckoutConfig,
-    protected baseSiteService: BaseSiteService
-  ) {
+  protected checkoutConfig = inject(CheckoutConfig);
+  protected baseSiteService = inject(BaseSiteService);
+
+  constructor() {
     this.getPaymentProvider().subscribe((paymentProvider) => {
       this.paymentProviderName = paymentProvider;
     });

--- a/feature-libs/checkout/base/core/connectors/checkout-billing-address/checkout-billing-address.connector.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-billing-address/checkout-billing-address.connector.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Address } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { CheckoutBillingAddressAdapter } from './checkout-billing-address.adapter';
 
 @Injectable()
 export class CheckoutBillingAddressConnector {
-  constructor(protected adapter: CheckoutBillingAddressAdapter) {}
+  protected adapter = inject(CheckoutBillingAddressAdapter);
 
   public setBillingAddress(
     userId: string,

--- a/feature-libs/checkout/base/core/facade/checkout-billing-address.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-billing-address.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {
   CheckoutBillingAddressFacade,
@@ -17,7 +17,7 @@ import {
   OCC_USER_ID_ANONYMOUS,
   UserIdService,
 } from '@spartacus/core';
-import { combineLatest, Observable } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
 import { map, switchMap, take } from 'rxjs/operators';
 import { CheckoutBillingAddressConnector } from '../connectors/checkout-billing-address/checkout-billing-address.connector';
 
@@ -25,6 +25,14 @@ import { CheckoutBillingAddressConnector } from '../connectors/checkout-billing-
 export class CheckoutBillingAddressService
   implements CheckoutBillingAddressFacade
 {
+  protected activeCartFacade = inject(ActiveCartFacade);
+  protected userIdService = inject(UserIdService);
+  protected commandService = inject(CommandService);
+  protected checkoutBillingAddressConnector = inject(
+    CheckoutBillingAddressConnector
+  );
+  protected checkoutQueryFacade = inject(CheckoutQueryFacade);
+
   protected setBillingAddressCommand = this.commandService.create<Address>(
     (address) =>
       this.checkoutPreconditions().pipe(
@@ -43,14 +51,6 @@ export class CheckoutBillingAddressService
       strategy: CommandStrategy.CancelPrevious,
     }
   );
-
-  constructor(
-    protected activeCartFacade: ActiveCartFacade,
-    protected userIdService: UserIdService,
-    protected commandService: CommandService,
-    protected checkoutBillingAddressConnector: CheckoutBillingAddressConnector,
-    protected checkoutQueryFacade: CheckoutQueryFacade
-  ) {}
 
   /**
    * Performs the necessary checkout preconditions.

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-billing-address.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-billing-address.adapter.ts
@@ -24,12 +24,9 @@ export class OccCheckoutBillingAddressAdapter
   implements CheckoutBillingAddressAdapter
 {
   protected logger = inject(LoggerService);
-
-  constructor(
-    protected http: HttpClient,
-    protected occEndpoints: OccEndpointsService,
-    protected converter: ConverterService
-  ) {}
+  protected http = inject(HttpClient);
+  protected occEndpoints = inject(OccEndpointsService);
+  protected converter = inject(ConverterService);
 
   public setBillingAddress(
     userId: string,

--- a/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.component.ts
+++ b/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.component.ts
@@ -11,6 +11,7 @@ import {
   ElementRef,
   HostListener,
   OnInit,
+  inject,
 } from '@angular/core';
 import { OpfErrorDialogOptions } from '@spartacus/opf/base/root';
 import { FocusConfig, LaunchDialogService } from '@spartacus/storefront';
@@ -24,6 +25,11 @@ import { OpfErrorModalService } from './opf-error-modal.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpfErrorModalComponent implements OnInit {
+  protected launchDialogService = inject(LaunchDialogService);
+  protected el = inject(ElementRef);
+  protected cd = inject(ChangeDetectorRef);
+  protected opfErrorModalService = inject(OpfErrorModalService);
+
   focusConfig: FocusConfig = {
     trap: true,
     block: true,
@@ -40,12 +46,7 @@ export class OpfErrorModalComponent implements OnInit {
     }
   }
 
-  constructor(
-    protected launchDialogService: LaunchDialogService,
-    protected el: ElementRef,
-    protected cd: ChangeDetectorRef,
-    protected opfErrorModalService: OpfErrorModalService
-  ) {
+  constructor() {
     // Mechanism needed to trigger the cpnt life cycle hooks.
     timer(1).subscribe({
       complete: () => {

--- a/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.service.ts
+++ b/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { TranslationService } from '@spartacus/core';
 import {
   OpfErrorDialogOptions,
@@ -17,7 +17,7 @@ import { map, switchMap } from 'rxjs/operators';
   providedIn: 'root',
 })
 export class OpfErrorModalService {
-  constructor(protected translationService: TranslationService) {}
+  protected translationService = inject(TranslationService);
 
   getMessageAndConfirmTranslations(dialogOptions: OpfErrorDialogOptions) {
     return combineLatest([

--- a/integration-libs/opf/base/core/connectors/opf-base.connector.ts
+++ b/integration-libs/opf/base/core/connectors/opf-base.connector.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { OpfActiveConfiguration } from '@spartacus/opf/base/root';
 import { Observable } from 'rxjs';
 import { OpfBaseAdapter } from './opf-base.adapter';
 
 @Injectable()
 export class OpfBaseConnector {
-  constructor(protected adapter: OpfBaseAdapter) {}
+  protected adapter = inject(OpfBaseAdapter);
 
   public getActiveConfigurations(): Observable<OpfActiveConfiguration[]> {
     return this.adapter.getActiveConfigurations();

--- a/integration-libs/opf/base/core/facade/opf-base.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-base.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   CommandService,
   Query,
@@ -20,16 +20,14 @@ import { OpfBaseConnector } from '../connectors/opf-base.connector';
 
 @Injectable()
 export class OpfBaseService implements OpfBaseFacade {
+  protected queryService = inject(QueryService);
+  protected commandService = inject(CommandService);
+  protected opfBaseConnector = inject(OpfBaseConnector);
+
   protected activeConfigurationsQuery: Query<OpfActiveConfiguration[]> =
     this.queryService.create<OpfActiveConfiguration[]>(() =>
       this.opfBaseConnector.getActiveConfigurations()
     );
-
-  constructor(
-    protected queryService: QueryService,
-    protected commandService: CommandService,
-    protected opfBaseConnector: OpfBaseConnector
-  ) {}
 
   getActiveConfigurationsState(): Observable<
     QueryState<OpfActiveConfiguration[] | undefined>

--- a/integration-libs/opf/base/core/services/opf-endpoints.service.ts
+++ b/integration-libs/opf/base/core/services/opf-endpoints.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   BaseSiteService,
   DynamicAttributes,
@@ -17,13 +17,13 @@ import { OpfApiConfig, OpfConfig } from '@spartacus/opf/base/root';
   providedIn: 'root',
 })
 export class OpfEndpointsService {
+  protected opfConfig = inject(OpfConfig);
+  protected opfApiConfig = inject(OpfApiConfig);
+  protected baseSiteService = inject(BaseSiteService);
+
   private _activeBaseSite: string;
 
-  constructor(
-    protected opfConfig: OpfConfig,
-    protected opfApiConfig: OpfApiConfig,
-    protected baseSiteService: BaseSiteService
-  ) {
+  constructor() {
     if (this.baseSiteService) {
       this.baseSiteService
         .getActive()

--- a/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
+++ b/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
@@ -26,14 +26,11 @@ import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class OpfApiBaseAdapter implements OpfBaseAdapter {
+  protected http = inject(HttpClient);
+  protected converter = inject(ConverterService);
+  protected opfEndpointsService = inject(OpfEndpointsService);
+  protected config = inject(OpfConfig);
   protected logger = inject(LoggerService);
-
-  constructor(
-    protected http: HttpClient,
-    protected converter: ConverterService,
-    protected opfEndpointsService: OpfEndpointsService,
-    protected config: OpfConfig
-  ) {}
 
   protected headerWithNoLanguage: { [name: string]: string } = {
     accept: 'application/json',

--- a/integration-libs/opf/base/root/events/opf-event.listener.ts
+++ b/integration-libs/opf/base/root/events/opf-event.listener.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { CreateCartEvent } from '@spartacus/cart/base/root';
 import { EventService, LoginEvent } from '@spartacus/core';
 import { OrderPlacedEvent } from '@spartacus/order/root';
@@ -15,12 +15,12 @@ import { OpfMetadataStoreService } from '../services';
   providedIn: 'root',
 })
 export class OpfEventListenerService implements OnDestroy {
+  protected eventService = inject(EventService);
+  protected opfMetadataStoreService = inject(OpfMetadataStoreService);
+
   protected subscriptions = new Subscription();
 
-  constructor(
-    protected eventService: EventService,
-    protected opfMetadataStoreService: OpfMetadataStoreService
-  ) {
+  constructor() {
     this.onOpfPaymentMetadataResetConditionsMet();
   }
 

--- a/integration-libs/opf/base/root/services/opf-metadata-state-persistence.service.ts
+++ b/integration-libs/opf/base/root/services/opf-metadata-state-persistence.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { StatePersistenceService } from '@spartacus/core';
 import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -24,13 +24,10 @@ export interface SyncedOpfState {
  */
 @Injectable({ providedIn: 'root' })
 export class OpfMetadataStatePersistanceService implements OnDestroy {
+  protected statePersistenceService = inject(StatePersistenceService);
+  protected opfMetadataStoreService = inject(OpfMetadataStoreService);
+
   protected subscription = new Subscription();
-
-  constructor(
-    protected statePersistenceService: StatePersistenceService,
-    protected opfMetadataStoreService: OpfMetadataStoreService
-  ) {}
-
   /**
    * Identifier used for storage key.
    */

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+} from '@angular/core';
 import { Address, Country } from '@spartacus/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
@@ -16,6 +21,8 @@ import { OpfCheckoutBillingAddressFormService } from './opf-checkout-billing-add
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpfCheckoutBillingAddressFormComponent implements OnInit {
+  protected service = inject(OpfCheckoutBillingAddressFormService);
+
   iconTypes = ICON_TYPE;
 
   billingAddress$ = this.service.billingAddress$;
@@ -26,8 +33,6 @@ export class OpfCheckoutBillingAddressFormComponent implements OnInit {
   isAddingBillingAddressInProgress = false;
 
   countries$: Observable<Country[]>;
-
-  constructor(protected service: OpfCheckoutBillingAddressFormService) {}
 
   ngOnInit() {
     this.countries$ = this.service.getCountries();

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ActiveCartFacade, Cart } from '@spartacus/cart/base/root';
 import {
   CheckoutBillingAddressFacade,
@@ -40,6 +40,18 @@ import { OpfCheckoutPaymentWrapperService } from '../opf-checkout-payment-wrappe
 
 @Injectable()
 export class OpfCheckoutBillingAddressFormService {
+  protected checkoutDeliveryAddressFacade = inject(
+    CheckoutDeliveryAddressFacade
+  );
+  protected checkoutBillingAddressFacade = inject(CheckoutBillingAddressFacade);
+  protected userPaymentService = inject(UserPaymentService);
+  protected checkoutPaymentService = inject(CheckoutPaymentFacade);
+  protected activeCartService = inject(ActiveCartFacade);
+  protected globalMessageService = inject(GlobalMessageService);
+  protected opfCheckoutPaymentWrapperService = inject(
+    OpfCheckoutPaymentWrapperService
+  );
+
   protected readonly billingAddressSub = new BehaviorSubject<
     Address | undefined
   >(undefined);
@@ -50,16 +62,6 @@ export class OpfCheckoutBillingAddressFormService {
   billingAddress$ = this.billingAddressSub.asObservable();
   isLoadingAddress$ = this._$isLoadingAddress.asObservable();
   isSameAsDelivery$ = this._$isSameAsDelivery.asObservable();
-
-  constructor(
-    protected checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
-    protected checkoutBillingAddressFacade: CheckoutBillingAddressFacade,
-    protected userPaymentService: UserPaymentService,
-    protected checkoutPaymentService: CheckoutPaymentFacade,
-    protected activeCartService: ActiveCartFacade,
-    protected globalMessageService: GlobalMessageService,
-    protected opfCheckoutPaymentWrapperService: OpfCheckoutPaymentWrapperService
-  ) {}
 
   getCountries(): Observable<Country[]> {
     return this.userPaymentService.getAllBillingCountries().pipe(

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.ts
@@ -15,17 +15,9 @@ import {
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
-import { ActiveCartFacade, Cart, PaymentType } from '@spartacus/cart/base/root';
-import {
-  CheckoutReviewSubmitComponent,
-  CheckoutStepService,
-} from '@spartacus/checkout/base/components';
-import {
-  CheckoutDeliveryAddressFacade,
-  CheckoutDeliveryModesFacade,
-  CheckoutPaymentFacade,
-} from '@spartacus/checkout/base/root';
-import { CmsService, Page, TranslationService } from '@spartacus/core';
+import { Cart, PaymentType } from '@spartacus/cart/base/root';
+import { CheckoutReviewSubmitComponent } from '@spartacus/checkout/base/components';
+import { CmsService, Page } from '@spartacus/core';
 import { OpfMetadataStoreService } from '@spartacus/opf/base/root';
 import { OPF_EXPLICIT_TERMS_AND_CONDITIONS_COMPONENT } from '@spartacus/opf/checkout/root';
 
@@ -42,18 +34,10 @@ export class OpfCheckoutPaymentAndReviewComponent
   implements OnInit
 {
   protected fb = inject(UntypedFormBuilder);
-  protected checkoutDeliveryAddressFacade = inject(
-    CheckoutDeliveryAddressFacade
-  );
-  protected checkoutPaymentFacade = inject(CheckoutPaymentFacade);
-  protected activeCartFacade = inject(ActiveCartFacade);
-  protected translationService = inject(TranslationService);
-  protected checkoutStepService = inject(CheckoutStepService);
-  protected checkoutDeliveryModesFacade = inject(CheckoutDeliveryModesFacade);
   protected opfMetadataStoreService = inject(OpfMetadataStoreService);
+  protected cmsService = inject(CmsService);
 
   protected defaultTermsAndConditionsFieldValue = false;
-  protected cmsService = inject(CmsService);
 
   explicitTermsAndConditions$: Observable<boolean | undefined> = this.cmsService
     .getCurrentPage()
@@ -85,17 +69,6 @@ export class OpfCheckoutPaymentAndReviewComponent
     return this.activeCartFacade
       .getActive()
       .pipe(map((cart: Cart) => cart.paymentType));
-  }
-
-  constructor() {
-    super(
-      this.checkoutDeliveryAddressFacade,
-      this.checkoutPaymentFacade,
-      this.activeCartFacade,
-      this.translationService,
-      this.checkoutStepService,
-      this.checkoutDeliveryModesFacade
-    );
   }
 
   protected isCmsComponentInPage(cmsComponentUid: string, page: Page): boolean {

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.ts
@@ -41,6 +41,17 @@ export class OpfCheckoutPaymentAndReviewComponent
   extends CheckoutReviewSubmitComponent
   implements OnInit
 {
+  protected fb = inject(UntypedFormBuilder);
+  protected checkoutDeliveryAddressFacade = inject(
+    CheckoutDeliveryAddressFacade
+  );
+  protected checkoutPaymentFacade = inject(CheckoutPaymentFacade);
+  protected activeCartFacade = inject(ActiveCartFacade);
+  protected translationService = inject(TranslationService);
+  protected checkoutStepService = inject(CheckoutStepService);
+  protected checkoutDeliveryModesFacade = inject(CheckoutDeliveryModesFacade);
+  protected opfMetadataStoreService = inject(OpfMetadataStoreService);
+
   protected defaultTermsAndConditionsFieldValue = false;
   protected cmsService = inject(CmsService);
 
@@ -76,23 +87,14 @@ export class OpfCheckoutPaymentAndReviewComponent
       .pipe(map((cart: Cart) => cart.paymentType));
   }
 
-  constructor(
-    protected fb: UntypedFormBuilder,
-    protected checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
-    protected checkoutPaymentFacade: CheckoutPaymentFacade,
-    protected activeCartFacade: ActiveCartFacade,
-    protected translationService: TranslationService,
-    protected checkoutStepService: CheckoutStepService,
-    protected checkoutDeliveryModesFacade: CheckoutDeliveryModesFacade,
-    protected opfMetadataStoreService: OpfMetadataStoreService
-  ) {
+  constructor() {
     super(
-      checkoutDeliveryAddressFacade,
-      checkoutPaymentFacade,
-      activeCartFacade,
-      translationService,
-      checkoutStepService,
-      checkoutDeliveryModesFacade
+      this.checkoutDeliveryAddressFacade,
+      this.checkoutPaymentFacade,
+      this.activeCartFacade,
+      this.translationService,
+      this.checkoutStepService,
+      this.checkoutDeliveryModesFacade
     );
   }
 

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.ts
@@ -11,6 +11,7 @@ import {
   OnDestroy,
   OnInit,
   ViewContainerRef,
+  inject,
 } from '@angular/core';
 import {
   DomSanitizer,
@@ -34,6 +35,11 @@ import { OpfCheckoutPaymentWrapperService } from './opf-checkout-payment-wrapper
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpfCheckoutPaymentWrapperComponent implements OnInit, OnDestroy {
+  protected service = inject(OpfCheckoutPaymentWrapperService);
+  protected sanitizer = inject(DomSanitizer);
+  protected globalFunctionsService = inject(OpfGlobalFunctionsFacade);
+  protected vcr = inject(ViewContainerRef);
+
   @Input() selectedPaymentId: number;
 
   renderPaymentMethodEvent$ = this.service.getRenderPaymentMethodEvent();
@@ -41,13 +47,6 @@ export class OpfCheckoutPaymentWrapperComponent implements OnInit, OnDestroy {
   RENDER_PATTERN = OpfPaymentRenderPattern;
 
   sub: Subscription = new Subscription();
-
-  constructor(
-    protected service: OpfCheckoutPaymentWrapperService,
-    protected sanitizer: DomSanitizer,
-    protected globalFunctionsService: OpfGlobalFunctionsFacade,
-    protected vcr: ViewContainerRef
-  ) {}
 
   renderHtml(html: string): SafeHtml {
     return this.sanitizer.bypassSecurityTrustHtml(html);

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   ActiveCartFacade,
   CartAccessCodeFacade,
@@ -44,6 +44,16 @@ import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
 
 @Injectable()
 export class OpfCheckoutPaymentWrapperService {
+  protected opfPaymentFacade = inject(OpfPaymentFacade);
+  protected opfResourceLoaderService = inject(OpfResourceLoaderService);
+  protected userIdService = inject(UserIdService);
+  protected activeCartService = inject(ActiveCartFacade);
+  protected routingService = inject(RoutingService);
+  protected globalMessageService = inject(GlobalMessageService);
+  protected orderFacade = inject(OrderFacade);
+  protected opfMetadataStoreService = inject(OpfMetadataStoreService);
+  protected cartAccessCodeFacade = inject(CartAccessCodeFacade);
+
   protected lastPaymentOptionId?: number;
 
   protected activeCartId?: string;
@@ -53,18 +63,6 @@ export class OpfCheckoutPaymentWrapperService {
       isLoading: false,
       isError: false,
     });
-
-  constructor(
-    protected opfPaymentFacade: OpfPaymentFacade,
-    protected opfResourceLoaderService: OpfResourceLoaderService,
-    protected userIdService: UserIdService,
-    protected activeCartService: ActiveCartFacade,
-    protected routingService: RoutingService,
-    protected globalMessageService: GlobalMessageService,
-    protected orderFacade: OrderFacade,
-    protected opfMetadataStoreService: OpfMetadataStoreService,
-    protected cartAccessCodeFacade: CartAccessCodeFacade
-  ) {}
 
   protected executeScriptFromHtml(html: string): void {
     /**

--- a/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.ts
@@ -10,6 +10,7 @@ import {
   Input,
   OnDestroy,
   OnInit,
+  inject,
 } from '@angular/core';
 import {
   GlobalMessageService,
@@ -31,6 +32,10 @@ import { tap } from 'rxjs/operators';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpfCheckoutPaymentsComponent implements OnInit, OnDestroy {
+  protected opfBaseService = inject(OpfBaseFacade);
+  protected opfMetadataStoreService = inject(OpfMetadataStoreService);
+  protected globalMessageService = inject(GlobalMessageService);
+
   protected subscription = new Subscription();
 
   activeConfigurations$ = this.opfBaseService
@@ -58,12 +63,6 @@ export class OpfCheckoutPaymentsComponent implements OnInit, OnDestroy {
   explicitTermsAndConditions: boolean | null | undefined;
 
   selectedPaymentId?: number;
-
-  constructor(
-    protected opfBaseService: OpfBaseFacade,
-    protected opfMetadataStoreService: OpfMetadataStoreService,
-    protected globalMessageService: GlobalMessageService
-  ) {}
 
   /**
    * Method pre-selects (based on terms and conditions state)

--- a/integration-libs/opf/cta/core/connectors/opf-cta.connector.ts
+++ b/integration-libs/opf/cta/core/connectors/opf-cta.connector.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { CtaScriptsRequest, CtaScriptsResponse } from '@spartacus/opf/cta/root';
 
 import { Observable } from 'rxjs';
@@ -12,7 +12,7 @@ import { OpfCtaAdapter } from './opf-cta.adapter';
 
 @Injectable()
 export class OpfCtaConnector {
-  constructor(protected adapter: OpfCtaAdapter) {}
+  protected adapter = inject(OpfCtaAdapter);
 
   public getCtaScripts(
     ctaScriptsRequest: CtaScriptsRequest

--- a/integration-libs/opf/cta/core/facade/opf-cta.service.ts
+++ b/integration-libs/opf/cta/core/facade/opf-cta.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Command, CommandService } from '@spartacus/core';
 import {
   CtaScriptsRequest,
@@ -16,6 +16,9 @@ import { OpfCtaConnector } from '../connectors';
 
 @Injectable()
 export class OpfCtaService implements OpfCtaFacade {
+  protected commandService = inject(CommandService);
+  protected opfCtaConnector = inject(OpfCtaConnector);
+
   protected _readyForScriptEvent: Subject<string> = new Subject();
   readyForScriptEvent$: Observable<string> =
     this._readyForScriptEvent.asObservable();
@@ -28,11 +31,6 @@ export class OpfCtaService implements OpfCtaFacade {
   > = this.commandService.create((payload) => {
     return this.opfCtaConnector.getCtaScripts(payload.ctaScriptsRequest);
   });
-
-  constructor(
-    protected commandService: CommandService,
-    protected opfCtaConnector: OpfCtaConnector
-  ) {}
 
   getCtaScripts(ctaScriptsRequest: CtaScriptsRequest) {
     return this.ctaScriptsCommand.execute({ ctaScriptsRequest });

--- a/integration-libs/opf/cta/opf-api/adapters/opf-api-cta.adapter.ts
+++ b/integration-libs/opf/cta/opf-api/adapters/opf-api-cta.adapter.ts
@@ -26,6 +26,11 @@ import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class OpfApiCtaAdapter implements OpfCtaAdapter {
+  protected http = inject(HttpClient);
+  protected converter = inject(ConverterService);
+  protected opfEndpointsService = inject(OpfEndpointsService);
+  protected config = inject(OpfConfig);
+
   protected logger = inject(LoggerService);
 
   protected headerWithNoLanguage: { [name: string]: string } = {
@@ -41,13 +46,6 @@ export class OpfApiCtaAdapter implements OpfCtaAdapter {
     ...this.headerWithNoLanguage,
     'Content-Language': 'en-us',
   };
-
-  constructor(
-    protected http: HttpClient,
-    protected converter: ConverterService,
-    protected opfEndpointsService: OpfEndpointsService,
-    protected config: OpfConfig
-  ) {}
 
   getCtaScripts(
     ctaScriptsRequest: CtaScriptsRequest

--- a/integration-libs/opf/payment/core/connectors/opf-payment.connector.ts
+++ b/integration-libs/opf/payment/core/connectors/opf-payment.connector.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   OpfPaymentAfterRedirectScriptResponse,
   OpfPaymentInitiationConfig,
@@ -22,7 +22,7 @@ import { OpfPaymentAdapter } from './opf-payment.adapter';
 
 @Injectable()
 export class OpfPaymentConnector {
-  constructor(protected adapter: OpfPaymentAdapter) {}
+  protected adapter = inject(OpfPaymentAdapter);
 
   public verifyPayment(
     paymentSessionId: string,

--- a/integration-libs/opf/payment/core/facade/opf-payment.service.ts
+++ b/integration-libs/opf/payment/core/facade/opf-payment.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Command, CommandService, QueryService } from '@spartacus/core';
 import {
   OpfPaymentAfterRedirectScriptResponse,
@@ -22,6 +22,13 @@ import { OpfPaymentHostedFieldsService } from '../services/opf-payment-hosted-fi
 
 @Injectable()
 export class OpfPaymentService implements OpfPaymentFacade {
+  protected queryService = inject(QueryService);
+  protected commandService = inject(CommandService);
+  protected opfPaymentConnector = inject(OpfPaymentConnector);
+  protected opfPaymentHostedFieldsService = inject(
+    OpfPaymentHostedFieldsService
+  );
+
   protected verifyPaymentCommand: Command<
     {
       paymentSessionId: string;
@@ -76,13 +83,6 @@ export class OpfPaymentService implements OpfPaymentFacade {
   > = this.commandService.create((payload) =>
     this.opfPaymentConnector.initiatePayment(payload.paymentConfig)
   );
-
-  constructor(
-    protected queryService: QueryService,
-    protected commandService: CommandService,
-    protected opfPaymentConnector: OpfPaymentConnector,
-    protected opfPaymentHostedFieldsService: OpfPaymentHostedFieldsService
-  ) {}
 
   verifyPayment(
     paymentSessionId: string,

--- a/integration-libs/opf/payment/core/services/opf-payment-error-handler.service.ts
+++ b/integration-libs/opf/payment/core/services/opf-payment-error-handler.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   GlobalMessageService,
   GlobalMessageType,
@@ -19,10 +19,8 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class OpfPaymentErrorHandlerService {
-  constructor(
-    protected globalMessageService: GlobalMessageService,
-    protected routingService: RoutingService
-  ) {}
+  protected globalMessageService = inject(GlobalMessageService);
+  protected routingService = inject(RoutingService);
 
   protected displayError(error: OpfPaymentError | undefined): void {
     this.globalMessageService.add(

--- a/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.ts
+++ b/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   ActiveCartFacade,
   CartAccessCodeFacade,
@@ -44,17 +44,17 @@ import { getBrowserInfo } from '../utils/opf-payment-utils';
 
 @Injectable()
 export class OpfPaymentHostedFieldsService {
-  constructor(
-    protected opfPaymentConnector: OpfPaymentConnector,
-    protected winRef: WindowRef,
-    protected cartAccessCodeFacade: CartAccessCodeFacade,
-    protected activeCartFacade: ActiveCartFacade,
-    protected userIdService: UserIdService,
-    protected routingService: RoutingService,
-    protected orderFacade: OrderFacade,
-    protected globalMessageService: GlobalMessageService,
-    protected opfPaymentErrorHandlerService: OpfPaymentErrorHandlerService
-  ) {}
+  protected opfPaymentConnector = inject(OpfPaymentConnector);
+  protected winRef = inject(WindowRef);
+  protected cartAccessCodeFacade = inject(CartAccessCodeFacade);
+  protected activeCartFacade = inject(ActiveCartFacade);
+  protected userIdService = inject(UserIdService);
+  protected routingService = inject(RoutingService);
+  protected orderFacade = inject(OrderFacade);
+  protected globalMessageService = inject(GlobalMessageService);
+  protected opfPaymentErrorHandlerService = inject(
+    OpfPaymentErrorHandlerService
+  );
 
   submitPayment(submitInput: OpfPaymentSubmitInput): Observable<boolean> {
     const {

--- a/integration-libs/opf/payment/opf-api/adapters/opf-api-payment.adapter.ts
+++ b/integration-libs/opf/payment/opf-api/adapters/opf-api-payment.adapter.ts
@@ -43,14 +43,11 @@ import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class OpfApiPaymentAdapter implements OpfPaymentAdapter {
+  protected http = inject(HttpClient);
+  protected converter = inject(ConverterService);
+  protected opfEndpointsService = inject(OpfEndpointsService);
+  protected config = inject(OpfConfig);
   protected logger = inject(LoggerService);
-
-  constructor(
-    protected http: HttpClient,
-    protected converter: ConverterService,
-    protected opfEndpointsService: OpfEndpointsService,
-    protected config: OpfConfig
-  ) {}
 
   protected headerWithNoLanguage: { [name: string]: string } = {
     accept: 'application/json',

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Component, OnDestroy, OnInit, ViewContainerRef } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewContainerRef,
+  inject,
+} from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorModel } from '@spartacus/core';
 import { OpfKeyValueMap, OpfPage } from '@spartacus/opf/base/root';
@@ -19,14 +25,14 @@ import { OpfPaymentVerificationService } from './opf-payment-verification.servic
   templateUrl: './opf-payment-verification.component.html',
 })
 export class OpfPaymentVerificationComponent implements OnInit, OnDestroy {
+  protected route = inject(ActivatedRoute);
+  protected opfPaymentVerificationService = inject(
+    OpfPaymentVerificationService
+  );
+  protected vcr = inject(ViewContainerRef);
+
   protected subscription?: Subscription;
   protected isHostedFieldPattern = false;
-
-  constructor(
-    protected route: ActivatedRoute,
-    protected opfPaymentVerificationService: OpfPaymentVerificationService,
-    protected vcr: ViewContainerRef
-  ) {}
 
   ngOnInit(): void {
     this.opfPaymentVerificationService.checkIfProcessingCartIdExist();

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.service.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, ViewContainerRef } from '@angular/core';
+import { Injectable, ViewContainerRef, inject } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import {
   GlobalMessageService,
@@ -39,15 +39,13 @@ import {
   providedIn: 'root',
 })
 export class OpfPaymentVerificationService {
-  constructor(
-    protected orderFacade: OrderFacade,
-    protected routingService: RoutingService,
-    protected globalMessageService: GlobalMessageService,
-    protected opfPaymentFacade: OpfPaymentFacade,
-    protected opfMetadataStoreService: OpfMetadataStoreService,
-    protected opfResourceLoaderService: OpfResourceLoaderService,
-    protected globalFunctionsService: OpfGlobalFunctionsFacade
-  ) {}
+  protected orderFacade = inject(OrderFacade);
+  protected routingService = inject(RoutingService);
+  protected globalMessageService = inject(GlobalMessageService);
+  protected opfPaymentFacade = inject(OpfPaymentFacade);
+  protected opfMetadataStoreService = inject(OpfMetadataStoreService);
+  protected opfResourceLoaderService = inject(OpfResourceLoaderService);
+  protected globalFunctionsService = inject(OpfGlobalFunctionsFacade);
 
   opfDefaultPaymentError: HttpErrorModel = {
     statusText: 'Payment Verification Error',

--- a/integration-libs/opf/quick-buy/core/connectors/opf-quick-buy.connector.ts
+++ b/integration-libs/opf/quick-buy/core/connectors/opf-quick-buy.connector.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   ApplePaySessionVerificationRequest,
   ApplePaySessionVerificationResponse,
@@ -14,7 +14,7 @@ import { OpfQuickBuyAdapter } from './opf-quick-buy.adapter';
 
 @Injectable()
 export class OpfQuickBuyConnector {
-  constructor(protected adapter: OpfQuickBuyAdapter) {}
+  protected adapter = inject(OpfQuickBuyAdapter);
 
   public getApplePayWebSession(
     applePayWebRequest: ApplePaySessionVerificationRequest,

--- a/integration-libs/opf/quick-buy/core/facade/opf-quick-buy.service.ts
+++ b/integration-libs/opf/quick-buy/core/facade/opf-quick-buy.service.ts
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   ActiveCartFacade,
   CartAccessCodeFacade,
 } from '@spartacus/cart/base/root';
 import {
-  backOff,
   Command,
   CommandService,
   DEFAULT_AUTHORIZATION_ERROR_RETRIES_COUNT,
-  isAuthorizationError,
   LoggerService,
-  tryNormalizeHttpError,
   UserIdService,
+  backOff,
+  isAuthorizationError,
+  tryNormalizeHttpError,
 } from '@spartacus/core';
 import {
   ApplePaySessionVerificationRequest,
@@ -36,6 +36,13 @@ import { OpfQuickBuyConnector } from '../connectors';
 
 @Injectable()
 export class OpfQuickBuyService implements OpfQuickBuyFacade {
+  protected commandService = inject(CommandService);
+  protected opfQuickBuyConnector = inject(OpfQuickBuyConnector);
+  protected cartAccessCodeFacade = inject(CartAccessCodeFacade);
+  protected activeCartFacade = inject(ActiveCartFacade);
+  protected userIdService = inject(UserIdService);
+  protected logger = inject(LoggerService);
+
   protected applePaySessionCommand: Command<
     {
       applePayWebSessionRequest: ApplePaySessionVerificationRequest;
@@ -72,15 +79,6 @@ export class OpfQuickBuyService implements OpfQuickBuyFacade {
       })
     );
   });
-
-  constructor(
-    protected commandService: CommandService,
-    protected opfQuickBuyConnector: OpfQuickBuyConnector,
-    protected cartAccessCodeFacade: CartAccessCodeFacade,
-    protected activeCartFacade: ActiveCartFacade,
-    protected userIdService: UserIdService,
-    protected logger: LoggerService
-  ) {}
 
   getApplePayWebSession(
     applePayWebSessionRequest: ApplePaySessionVerificationRequest

--- a/integration-libs/opf/quick-buy/opf-api/adapters/opf-api-quick-buy.adapter.ts
+++ b/integration-libs/opf/quick-buy/opf-api/adapters/opf-api-quick-buy.adapter.ts
@@ -5,12 +5,12 @@
  */
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
-  backOff,
   ConverterService,
-  isServerError,
   LoggerService,
+  backOff,
+  isServerError,
   tryNormalizeHttpError,
 } from '@spartacus/core';
 import { OpfEndpointsService } from '@spartacus/opf/base/core';
@@ -32,14 +32,11 @@ import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class OpfApiQuickBuyAdapter implements OpfQuickBuyAdapter {
+  protected http = inject(HttpClient);
+  protected converter = inject(ConverterService);
+  protected opfEndpointsService = inject(OpfEndpointsService);
+  protected config = inject(OpfConfig);
   protected logger = inject(LoggerService);
-
-  constructor(
-    protected http: HttpClient,
-    protected converter: ConverterService,
-    protected opfEndpointsService: OpfEndpointsService,
-    protected config: OpfConfig
-  ) {}
 
   protected headerWithNoLanguage: { [name: string]: string } = {
     accept: 'application/json',


### PR DESCRIPTION
Use `inject` in:
- all classes in `opf` project
- new classes in `cart` and `checkout` project