### PR TITLE
chore: Upgrade to Angular 18 - Replace deprecated RouterTestingModule

### DIFF
--- a/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.spec.ts
+++ b/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   ActiveCartFacade,
   Cart,
@@ -129,7 +128,6 @@ describe('AddToCartComponent', () => {
     return TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
-        RouterTestingModule,
         SpinnerModule,
         I18nTestingModule,
         ReactiveFormsModule,

--- a/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.spec.ts
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.spec.ts
@@ -12,7 +12,6 @@ import {
   UntypedFormControl,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   ActiveCartFacade,
   Cart,
@@ -147,7 +146,6 @@ describe('AddedToCartDialogComponent', () => {
       imports: [
         FormsModule,
         ReactiveFormsModule,
-        RouterTestingModule,
         SpinnerModule,
         I18nTestingModule,
         PromotionsModule,

--- a/feature-libs/cart/base/components/cart-details/cart-details.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-details/cart-details.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CartConfigService } from '@spartacus/cart/base/core';
 import {
   ActiveCartFacade,
@@ -96,7 +95,7 @@ describe('CartDetailsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, PromotionsModule, I18nTestingModule],
+      imports: [PromotionsModule, I18nTestingModule],
       declarations: [
         CartDetailsComponent,
         MockCartItemListComponent,

--- a/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.component.spec.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectorRef, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Event, NavigationEnd, Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { ProgressButtonModule } from '@spartacus/storefront';
 import { Subject } from 'rxjs';
@@ -27,7 +26,7 @@ describe('CartProceedToCheckoutComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule, ProgressButtonModule],
+      imports: [I18nTestingModule, ProgressButtonModule],
       declarations: [CartProceedToCheckoutComponent, MockUrlPipe],
       providers: [
         {

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   ActiveCartFacade,
   CartItemComponentOptions,
@@ -130,12 +129,7 @@ describe('CartItemListComponent', () => {
 
   function configureTestingModule(): TestBed {
     return TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        PromotionsModule,
-        I18nTestingModule,
-      ],
+      imports: [ReactiveFormsModule, PromotionsModule, I18nTestingModule],
       declarations: [CartItemListComponent, MockCartItemComponent],
       providers: [
         { provide: ActiveCartFacade, useClass: MockActiveCartService },

--- a/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.spec.ts
@@ -15,7 +15,6 @@ import {
   UntypedFormControl,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CartItemContext, PromotionLocation } from '@spartacus/cart/base/root';
 import { I18nTestingModule } from '@spartacus/core';
 import { OutletModule } from '@spartacus/storefront';
@@ -115,12 +114,7 @@ describe('CartItemComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule,
-        ReactiveFormsModule,
-        I18nTestingModule,
-        OutletModule,
-      ],
+      imports: [ReactiveFormsModule, I18nTestingModule, OutletModule],
       declarations: [
         CartItemComponent,
         MockMediaComponent,

--- a/feature-libs/cart/base/components/mini-cart/mini-cart.component.spec.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.component.spec.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter, RouterLink } from '@angular/router';
 import { I18nTestingModule, UrlCommandRoute } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
 import { MiniCartComponentService } from './mini-cart-component.service';
@@ -39,9 +39,11 @@ describe('MiniCartComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule, RouterLink],
       declarations: [MiniCartComponent, MockUrlPipe, MockCxIconComponent],
       providers: [
+        provideRouter([]),
+
         {
           provide: MiniCartComponentService,
           useValue: mockMiniCartComponentService,

--- a/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.component.spec.ts
+++ b/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.component.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CartModification,
   CartValidationFacade,
@@ -75,7 +74,6 @@ describe('CartItemValidationWarningComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [
         CartItemValidationWarningComponent,
         MockCxIconComponent,

--- a/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.component.spec.ts
+++ b/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.component.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CartModification,
   CartValidationFacade,
@@ -82,7 +81,6 @@ describe('CartValidationWarningsComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [
         CartValidationWarningsComponent,
         MockCxIconComponent,

--- a/feature-libs/cart/base/core/guards/cart-validation.guard.spec.ts
+++ b/feature-libs/cart/base/core/guards/cart-validation.guard.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   ActiveCartFacade,
   CartModification,
@@ -106,7 +105,6 @@ describe(`CartValidationGuard`, () => {
           useClass: MockCartConfigService,
         },
       ],
-      imports: [RouterTestingModule],
     });
 
     guard = TestBed.inject(CartValidationGuard);

--- a/feature-libs/cart/import-export/components/export-entries/export-order-entries.component.spec.ts
+++ b/feature-libs/cart/import-export/components/export-entries/export-order-entries.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import {
@@ -112,11 +111,7 @@ describe('ExportOrderEntriesComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        StoreModule.forRoot({}),
-        I18nTestingModule,
-        RouterTestingModule,
-      ],
+      imports: [StoreModule.forRoot({}), I18nTestingModule],
       providers: [
         {
           provide: ExportOrderEntriesToCsvService,

--- a/feature-libs/cart/import-export/components/import-export/import-export-order-entries.component.spec.ts
+++ b/feature-libs/cart/import-export/components/import-export/import-export-order-entries.component.spec.ts
@@ -1,6 +1,5 @@
 import { Component, ElementRef, Input, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   AddOrderEntriesContext,
   GetOrderEntriesContext,
@@ -75,7 +74,7 @@ describe('ImportExportComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, PageComponentModule],
+      imports: [PageComponentModule],
       providers: [{ provide: ContextService, useClass: MockContextService }],
       declarations: [
         ImportExportOrderEntriesComponent,

--- a/feature-libs/cart/quick-order/components/quick-order/table/item/quick-order-item.component.spec.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/table/item/quick-order-item.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import { QuickOrderFacade } from '@spartacus/cart/quick-order/root';
 import { I18nTestingModule } from '@spartacus/core';
@@ -59,7 +58,7 @@ describe('QuickOrderItemComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, I18nTestingModule, RouterTestingModule],
+      imports: [ReactiveFormsModule, I18nTestingModule],
       declarations: [
         QuickOrderItemComponent,
         MockUrlPipe,

--- a/feature-libs/cart/saved-cart/components/add-to-saved-cart/add-to-saved-cart.component.spec.ts
+++ b/feature-libs/cart/saved-cart/components/add-to-saved-cart/add-to-saved-cart.component.spec.ts
@@ -1,6 +1,5 @@
 import { ElementRef, ViewContainerRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
 import { ActiveCartFacade, Cart } from '@spartacus/cart/base/root';
 import {
@@ -8,13 +7,13 @@ import {
   I18nTestingModule,
   RoutingService,
 } from '@spartacus/core';
-import { LaunchDialogService, LAUNCH_CALLER } from '@spartacus/storefront';
+import { LAUNCH_CALLER, LaunchDialogService } from '@spartacus/storefront';
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
-import { AddToSavedCartComponent } from './add-to-saved-cart.component';
 import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
+import { AddToSavedCartComponent } from './add-to-saved-cart.component';
 
 const mockCart: Cart = {
   code: '123456789',
@@ -59,12 +58,7 @@ describe('AddToSavedCartComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        StoreModule.forRoot({}),
-        I18nTestingModule,
-        UrlTestingModule,
-        RouterTestingModule,
-      ],
+      imports: [StoreModule.forRoot({}), I18nTestingModule, UrlTestingModule],
       declarations: [AddToSavedCartComponent, MockFeatureDirective],
       providers: [
         { provide: ActiveCartFacade, useClass: MockActiveCartService },

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details-overview/saved-cart-details-overview.component.spec.ts
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details-overview/saved-cart-details-overview.component.spec.ts
@@ -1,13 +1,12 @@
 import { DebugElement, ElementRef, ViewContainerRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { Cart } from '@spartacus/cart/base/root';
 import { I18nTestingModule, TranslationService } from '@spartacus/core';
 import {
   CardModule,
   IconTestingModule,
-  LaunchDialogService,
   LAUNCH_CALLER,
+  LaunchDialogService,
 } from '@spartacus/storefront';
 import { EMPTY, Observable, of } from 'rxjs';
 import { SavedCartDetailsService } from '../saved-cart-details.service';
@@ -56,12 +55,7 @@ describe('SavedCartDetailsOverviewComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        I18nTestingModule,
-        IconTestingModule,
-        CardModule,
-        RouterTestingModule,
-      ],
+      imports: [I18nTestingModule, IconTestingModule, CardModule],
       declarations: [SavedCartDetailsOverviewComponent],
       providers: [
         {

--- a/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.spec.ts
+++ b/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { Cart } from '@spartacus/cart/base/root';
 import {
   SavedCartFacade,
@@ -109,7 +108,7 @@ describe('SavedCartListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       declarations: [SavedCartListComponent, MockUrlPipe, MockFeatureDirective],
       providers: [
         { provide: RoutingService, useClass: MockRoutingService },

--- a/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.spec.ts
+++ b/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { Cart, OrderEntry } from '@spartacus/cart/base/root';
 import { WishListFacade } from '@spartacus/cart/wish-list/root';
 import {
@@ -119,7 +118,7 @@ describe('AddToWishListComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         AddToWishListComponent,
         MockIconComponent,

--- a/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.spec.ts
+++ b/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.spec.ts
@@ -11,7 +11,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import { I18nTestingModule } from '@spartacus/core';
 import {
@@ -87,7 +86,7 @@ describe('WishListItemComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         WishListItemComponent,
         MockPictureComponent,

--- a/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.spec.ts
+++ b/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   ActiveCartFacade,
   Cart,
@@ -218,7 +217,6 @@ describe('B2BCheckoutReviewSubmitComponent', () => {
       imports: [
         I18nTestingModule,
         PromotionsModule,
-        RouterTestingModule,
         IconTestingModule,
         OutletModule,
       ],

--- a/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.spec.ts
+++ b/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { RedirectCommand, UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import { CheckoutConfigService } from '@spartacus/checkout/base/components';
 import {
@@ -103,7 +102,6 @@ describe('CheckoutAuthGuard', () => {
           useClass: MockGlobalMessageService,
         },
       ],
-      imports: [RouterTestingModule],
     });
     checkoutGuard = TestBed.inject(CheckoutB2BAuthGuard);
     authService = TestBed.inject(AuthService);

--- a/feature-libs/checkout/b2b/components/guards/checkout-b2b-steps-set.guard.spec.ts
+++ b/feature-libs/checkout/b2b/components/guards/checkout-b2b-steps-set.guard.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   ActiveCartFacade,
   DeliveryMode,
@@ -151,7 +150,6 @@ describe(`CheckoutB2BStepsSetGuard`, () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         CheckoutB2BStepsSetGuard,
         { provide: CheckoutStepService, useClass: MockCheckoutStepService },

--- a/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.spec.ts
@@ -1,7 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   GlobalMessageService,
   I18nTestingModule,
@@ -10,8 +9,8 @@ import {
 import { OrderFacade } from '@spartacus/order/root';
 import {
   AtMessageModule,
-  LaunchDialogService,
   LAUNCH_CALLER,
+  LaunchDialogService,
 } from '@spartacus/storefront';
 import { of } from 'rxjs';
 import { CheckoutPlaceOrderComponent } from './checkout-place-order.component';
@@ -49,12 +48,7 @@ describe('CheckoutPlaceOrderComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        I18nTestingModule,
-        AtMessageModule,
-      ],
+      imports: [ReactiveFormsModule, I18nTestingModule, AtMessageModule],
       declarations: [MockUrlPipe, CheckoutPlaceOrderComponent],
       providers: [
         { provide: OrderFacade, useClass: MockOrderFacade },

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-bottom/checkout-progress-mobile-bottom.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-bottom/checkout-progress-mobile-bottom.component.spec.ts
@@ -1,7 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CheckoutStep, CheckoutStepType } from '@spartacus/checkout/base/root';
 import { I18nTestingModule } from '@spartacus/core';
 import { BehaviorSubject, Observable, of } from 'rxjs';
@@ -49,7 +48,7 @@ describe('CheckoutProgressMobileBottomComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         CheckoutProgressMobileBottomComponent,
         MockTranslateUrlPipe,

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.component.spec.ts
@@ -1,7 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActiveCartFacade, Cart } from '@spartacus/cart/base/root';
 import { CheckoutStep, CheckoutStepType } from '@spartacus/checkout/base/root';
 import { I18nTestingModule } from '@spartacus/core';
@@ -62,7 +61,7 @@ describe('CheckoutProgressMobileTopComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [CheckoutProgressMobileTopComponent, MockTranslateUrlPipe],
       providers: [
         { provide: CheckoutStepService, useClass: MockCheckoutStepService },

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress.component.spec.ts
@@ -1,7 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CheckoutStep, CheckoutStepType } from '@spartacus/checkout/base/root';
 import { I18nTestingModule } from '@spartacus/core';
 import { BehaviorSubject, Observable, of } from 'rxjs';
@@ -58,7 +57,7 @@ describe('CheckoutProgressComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         CheckoutProgressComponent,
         MockTranslateUrlPipe,

--- a/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   ActiveCartFacade,
   Cart,
@@ -150,7 +149,6 @@ describe('CheckoutReviewSubmitComponent', () => {
       imports: [
         I18nTestingModule,
         PromotionsModule,
-        RouterTestingModule,
         IconTestingModule,
         OutletModule,
       ],

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.spec.ts
@@ -1,6 +1,5 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CheckoutPaymentFacade,
   CheckoutStep,
@@ -85,7 +84,7 @@ describe('CheckoutReviewPaymentComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule, IconTestingModule],
+      imports: [I18nTestingModule, IconTestingModule],
       declarations: [
         CheckoutReviewPaymentComponent,
         MockUrlPipe,

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CheckoutDeliveryAddressFacade,
   CheckoutDeliveryModesFacade,
@@ -135,12 +134,7 @@ describe('CheckoutReviewShippingComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        I18nTestingModule,
-        RouterTestingModule,
-        IconTestingModule,
-        OutletModule,
-      ],
+      imports: [I18nTestingModule, IconTestingModule, OutletModule],
       declarations: [
         CheckoutReviewShippingComponent,
         MockUrlPipe,

--- a/feature-libs/checkout/base/components/guards/cart-not-empty.guard.spec.ts
+++ b/feature-libs/checkout/base/components/guards/cart-not-empty.guard.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import { SemanticPathService } from '@spartacus/core';
 import { EMPTY, of } from 'rxjs';
@@ -35,7 +34,6 @@ describe('CartNotEmptyGuard', () => {
           useClass: MockActiveCartService,
         },
       ],
-      imports: [RouterTestingModule],
     });
 
     cartNotEmptyGuard = TestBed.inject(CartNotEmptyGuard);

--- a/feature-libs/checkout/base/components/guards/checkout-auth.guard.spec.ts
+++ b/feature-libs/checkout/base/components/guards/checkout-auth.guard.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { RedirectCommand, UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {
   AuthRedirectService,
@@ -76,7 +75,6 @@ describe('CheckoutAuthGuard', () => {
           useClass: MockGlobalMessageService,
         },
       ],
-      imports: [RouterTestingModule],
     });
     checkoutGuard = TestBed.inject(CheckoutAuthGuard);
     authService = TestBed.inject(AuthService);

--- a/feature-libs/checkout/base/components/guards/checkout-steps-set.guard.spec.ts
+++ b/feature-libs/checkout/base/components/guards/checkout-steps-set.guard.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {
   CheckoutDeliveryAddressFacade,
@@ -111,7 +110,6 @@ describe(`CheckoutStepsSetGuard`, () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         CheckoutStepsSetGuard,
         { provide: CheckoutStepService, useClass: MockCheckoutStepService },

--- a/feature-libs/checkout/base/components/guards/checkout.guard.spec.ts
+++ b/feature-libs/checkout/base/components/guards/checkout.guard.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import { CheckoutStep, CheckoutStepType } from '@spartacus/checkout/base/root';
 import {
@@ -78,7 +77,6 @@ describe(`CheckoutGuard`, () => {
           useClass: MockExpressCheckoutService,
         },
       ],
-      imports: [RouterTestingModule],
     });
 
     guard = TestBed.inject(CheckoutGuard);

--- a/feature-libs/checkout/base/components/guards/not-checkout-auth.guard.spec.ts
+++ b/feature-libs/checkout/base/components/guards/not-checkout-auth.guard.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { RedirectCommand, UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import { AuthService, SemanticPathService } from '@spartacus/core';
 import { EMPTY, of } from 'rxjs';
@@ -36,7 +35,6 @@ describe('NotCheckoutAuthGuard', () => {
           useClass: CartServiceStub,
         },
       ],
-      imports: [RouterTestingModule],
     });
     authService = TestBed.inject(AuthService);
     guard = TestBed.inject(NotCheckoutAuthGuard);

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.spec.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.spec.ts
@@ -1,7 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   GlobalMessageService,
   I18nTestingModule,
@@ -9,16 +8,16 @@ import {
 } from '@spartacus/core';
 import {
   DaysOfWeek,
-  OrderFacade,
   ORDER_TYPE,
+  OrderFacade,
   recurrencePeriod,
   ScheduledReplenishmentOrderFacade,
   ScheduleReplenishmentForm,
 } from '@spartacus/order/root';
 import {
   AtMessageModule,
-  LaunchDialogService,
   LAUNCH_CALLER,
+  LaunchDialogService,
 } from '@spartacus/storefront';
 import { BehaviorSubject, EMPTY, of } from 'rxjs';
 import { CheckoutReplenishmentFormService } from '../services/checkout-replenishment-form.service';
@@ -92,12 +91,7 @@ describe('CheckoutScheduledReplenishmentPlaceOrderComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        I18nTestingModule,
-        AtMessageModule,
-      ],
+      imports: [ReactiveFormsModule, I18nTestingModule, AtMessageModule],
       declarations: [
         MockUrlPipe,
         CheckoutScheduledReplenishmentPlaceOrderComponent,

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.spec.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import {
   DaysOfWeek,
@@ -39,7 +38,7 @@ describe('CheckoutScheduleReplenishmentOrderComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule, IconTestingModule],
+      imports: [I18nTestingModule, IconTestingModule],
       declarations: [CheckoutScheduleReplenishmentOrderComponent],
       providers: [
         {

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.spec.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   RoutingService,
@@ -208,7 +207,7 @@ describe('CustomerTicketingListComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         CustomerTicketingListComponent,
         MockPaginationComponent,

--- a/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.component.spec.ts
+++ b/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.component.spec.ts
@@ -1,7 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   RoutingService,
@@ -69,7 +68,7 @@ describe('MyAccountV2CustomerTicketingComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         MyAccountV2CustomerTicketingComponent,
         MockTranslatePipe,

--- a/feature-libs/estimated-delivery-date/show-estimated-delivery-date/components/estimated-delivery-date.component.spec.ts
+++ b/feature-libs/estimated-delivery-date/show-estimated-delivery-date/components/estimated-delivery-date.component.spec.ts
@@ -1,15 +1,14 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CartItemContext, OrderEntry } from '@spartacus/cart/base/root';
 import { LanguageService } from '@spartacus/core';
+import { Consignment, Order, OrderHistoryFacade } from '@spartacus/order/root';
 import { I18nTestingModule, TranslationService } from 'projects/core/src/i18n';
 import { Observable, ReplaySubject, of } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { EstimatedDeliveryDateComponent } from './estimated-delivery-date.component';
 import { ArrivalSlots } from '../../root/model';
-import { Consignment, Order, OrderHistoryFacade } from '@spartacus/order/root';
+import { EstimatedDeliveryDateComponent } from './estimated-delivery-date.component';
 
 class MockCartItemContext implements Partial<CartItemContext> {
   item$ = new ReplaySubject<OrderEntry>(1);
@@ -55,7 +54,7 @@ describe('EstimatedDeliveryDateCartEntryComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      imports: [ReactiveFormsModule, I18nTestingModule],
       declarations: [
         EstimatedDeliveryDateComponent,
         MockConfigureEstimatedDeliveryDateComponent,

--- a/feature-libs/order/components/amend-order/amend-order-actions/amend-order-actions.component.spec.ts
+++ b/feature-libs/order/components/amend-order/amend-order-actions/amend-order-actions.component.spec.ts
@@ -1,14 +1,13 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { StoreModule } from '@ngrx/store';
 import {
   I18nTestingModule,
   RoutingConfigService,
   RoutingService,
 } from '@spartacus/core';
 import { AmendOrderActionsComponent } from './amend-order-actions.component';
-import { StoreModule } from '@ngrx/store';
-import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 
 @Pipe({
   name: 'cxUrl',
@@ -32,11 +31,7 @@ describe('AmendOrderActionsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule,
-        I18nTestingModule,
-        StoreModule.forRoot({}),
-      ],
+      imports: [I18nTestingModule, StoreModule.forRoot({})],
       declarations: [MockUrlPipe, AmendOrderActionsComponent],
       providers: [
         {

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.component.spec.ts
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.component.spec.ts
@@ -2,11 +2,10 @@ import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import {
+  ReactiveFormsModule,
   UntypedFormControl,
   UntypedFormGroup,
-  ReactiveFormsModule,
 } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import { I18nTestingModule } from '@spartacus/core';
 import { Order } from '@spartacus/order/root';
@@ -68,12 +67,7 @@ describe('CancelOrderConfirmationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        CommonModule,
-        RouterTestingModule,
-        I18nTestingModule,
-        ReactiveFormsModule,
-      ],
+      imports: [CommonModule, I18nTestingModule, ReactiveFormsModule],
       providers: [
         { provide: OrderAmendService, useClass: MockOrderAmendService },
       ],

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.component.spec.ts
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.component.spec.ts
@@ -2,7 +2,6 @@ import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import { FormErrorsModule } from '@spartacus/storefront';
 import { of } from 'rxjs';
@@ -46,7 +45,7 @@ describe('CancelOrderComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, FormErrorsModule],
+      imports: [FormErrorsModule],
       providers: [
         { provide: OrderAmendService, useClass: MockOrderAmendService },
       ],

--- a/feature-libs/order/components/amend-order/cancellations/order-cancellation.guard.spec.ts
+++ b/feature-libs/order/components/amend-order/cancellations/order-cancellation.guard.spec.ts
@@ -5,7 +5,6 @@ import {
   Validators,
 } from '@angular/forms';
 import { RedirectCommand, UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { SemanticPathService } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
 import { OrderCancellationGuard } from './order-cancellation.guard';
@@ -48,7 +47,6 @@ describe(`OrderCancellationGuard`, () => {
           useClass: MockOrderCancellationService,
         },
       ],
-      imports: [RouterTestingModule],
     });
 
     guard = TestBed.inject(OrderCancellationGuard);

--- a/feature-libs/order/components/amend-order/returns/order-return.guard.spec.ts
+++ b/feature-libs/order/components/amend-order/returns/order-return.guard.spec.ts
@@ -5,7 +5,6 @@ import {
   Validators,
 } from '@angular/forms';
 import { RedirectCommand, UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { SemanticPathService } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
 import { OrderReturnGuard } from './order-return.guard';
@@ -46,7 +45,6 @@ describe(`OrderReturnGuard`, () => {
           useClass: MockOrderReturnService,
         },
       ],
-      imports: [RouterTestingModule],
     });
 
     guard = TestBed.inject(OrderReturnGuard);

--- a/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.component.spec.ts
+++ b/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.component.spec.ts
@@ -1,11 +1,10 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import {
+  ReactiveFormsModule,
   UntypedFormControl,
   UntypedFormGroup,
-  ReactiveFormsModule,
 } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import { I18nTestingModule } from '@spartacus/core';
 import { Order } from '@spartacus/order/root';
@@ -67,7 +66,7 @@ describe('ReturnOrderConfirmationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule, ReactiveFormsModule],
+      imports: [I18nTestingModule, ReactiveFormsModule],
       providers: [
         { provide: OrderAmendService, useClass: MockOrderAmendService },
       ],

--- a/feature-libs/order/components/amend-order/returns/return-order/return-order.component.spec.ts
+++ b/feature-libs/order/components/amend-order/returns/return-order/return-order.component.spec.ts
@@ -2,7 +2,6 @@ import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import { FormErrorsModule } from '@spartacus/storefront';
 import { of } from 'rxjs';
@@ -46,7 +45,7 @@ describe('ReturnOrderComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, FormErrorsModule],
+      imports: [FormErrorsModule],
       providers: [
         { provide: OrderAmendService, useClass: MockOrderAmendService },
       ],

--- a/feature-libs/order/components/guards/order-confirmation.guard.spec.ts
+++ b/feature-libs/order/components/guards/order-confirmation.guard.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { RoutingService, SemanticPathService } from '@spartacus/core';
 import { OrderFacade } from '@spartacus/order/root';
 import { of } from 'rxjs';
@@ -29,7 +28,6 @@ describe(`OrderConfirmationGuard`, () => {
         { provide: OrderFacade, useClass: MockOrderFacade },
         { provide: SemanticPathService, useClass: MockSemanticPathService },
       ],
-      imports: [RouterTestingModule],
     });
 
     guard = TestBed.inject(OrderConfirmationGuard);

--- a/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.spec.ts
+++ b/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   RoutingService,
@@ -96,7 +95,7 @@ describe(' MyAccountV2OrdersComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         MyAccountV2OrdersComponent,
         MockUrlPipe,

--- a/feature-libs/order/components/order-details/my-account-v2/order-details-actions/my-account-v2-order-details-actions.component.spec.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/order-details-actions/my-account-v2-order-details-actions.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, DebugElement, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   EventService,
   I18nModule,
@@ -53,7 +52,7 @@ describe('MyAccountV2OrderDetailsActionsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nModule, RouterTestingModule],
+      imports: [I18nModule],
       providers: [
         { provide: TranslationService, useClass: MockTranslationService },
         { provide: OrderDetailsService, useClass: MockOrderDetailsService },

--- a/feature-libs/order/components/order-details/order-detail-actions/order-detail-actions.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-actions/order-detail-actions.component.spec.ts
@@ -1,7 +1,6 @@
 import { DebugElement, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { FeaturesConfig, I18nTestingModule } from '@spartacus/core';
 import { Order } from '@spartacus/order/root';
 import { of } from 'rxjs';
@@ -36,7 +35,7 @@ describe('OrderDetailActionsComponent', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       providers: [
         { provide: OrderDetailsService, useValue: mockOrderDetailsService },
         {

--- a/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { PromotionLocation } from '@spartacus/cart/base/root';
 import { FeaturesConfig, I18nTestingModule } from '@spartacus/core';
 import { Consignment, Order } from '@spartacus/order/root';
@@ -83,12 +82,7 @@ describe('OrderConsignedEntriesComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        CardModule,
-        I18nTestingModule,
-        RouterTestingModule,
-        OutletModule,
-      ],
+      imports: [CardModule, I18nTestingModule, OutletModule],
       providers: [
         {
           provide: FeaturesConfig,

--- a/feature-libs/order/components/order-details/order-detail-items/order-detail-items.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/order-detail-items.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CmsOrderDetailItemsComponent,
   I18nTestingModule,
@@ -160,13 +159,7 @@ describe('OrderDetailItemsComponent', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [
-        CardModule,
-        I18nTestingModule,
-        PromotionsModule,
-        RouterTestingModule,
-        OutletModule,
-      ],
+      imports: [CardModule, I18nTestingModule, PromotionsModule, OutletModule],
       providers: [
         { provide: OrderDetailsService, useValue: mockOrderDetailsService },
         { provide: CmsComponentData, useValue: MockCmsComponentData },

--- a/feature-libs/order/components/order-details/order-detail-reorder/order-detail-reorder.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-reorder/order-detail-reorder.component.spec.ts
@@ -1,7 +1,6 @@
 import { ElementRef, ViewContainerRef } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { Order } from '@spartacus/order/root';
 import { LAUNCH_CALLER, LaunchDialogService } from '@spartacus/storefront';
@@ -40,7 +39,6 @@ describe('Order detail reorder component', () => {
       imports: [I18nTestingModule],
       declarations: [OrderDetailReorderComponent],
       providers: [
-        RouterTestingModule,
         {
           provide: LaunchDialogService,
           useClass: MockLaunchDialogService,

--- a/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.spec.ts
+++ b/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.spec.ts
@@ -2,7 +2,6 @@ import { Component, DebugElement, Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CartModificationList,
   MultiCartFacade,
@@ -124,7 +123,6 @@ describe('ReorderDialogComponent', () => {
       imports: [
         FormsModule,
         ReactiveFormsModule,
-        RouterTestingModule,
         SpinnerModule,
         I18nTestingModule,
         PromotionsModule,

--- a/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.component.spec.ts
+++ b/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.component.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Params } from '@angular/router';
 import {
   I18nTestingModule,
   RoutingService,
@@ -22,7 +22,6 @@ import {
 } from '../../../root/facade';
 import { Order, OrderHistoryList, OrderHistoryView } from '../../../root/model';
 import { MyAccountV2OrderHistoryComponent } from './my-account-v2-order-history.component';
-import { Params } from '@angular/router';
 
 const mockOrders: OrderHistoryList = {
   orders: [
@@ -131,7 +130,7 @@ describe('MyAccountV2OrderHistoryComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         MyAccountV2OrderHistoryComponent,
         MockUrlPipe,

--- a/feature-libs/order/components/order-history/order-history.component.spec.ts
+++ b/feature-libs/order/components/order-history/order-history.component.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Params } from '@angular/router';
 import {
   I18nTestingModule,
   RoutingService,
@@ -23,7 +23,6 @@ import {
 } from '@spartacus/order/root';
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { OrderHistoryComponent } from './order-history.component';
-import { Params } from '@angular/router';
 
 const mockOrders: OrderHistoryList = {
   orders: [
@@ -158,7 +157,7 @@ describe('OrderHistoryComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         OrderHistoryComponent,
         MockUrlPipe,

--- a/feature-libs/order/components/replenishment-order-details/replenishment-order-cancellation/replenishment-order-cancellation.component.spec.ts
+++ b/feature-libs/order/components/replenishment-order-details/replenishment-order-cancellation/replenishment-order-cancellation.component.spec.ts
@@ -7,13 +7,12 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import {
   ReplenishmentOrder,
   ReplenishmentOrderHistoryFacade,
 } from '@spartacus/order/root';
-import { LaunchDialogService, LAUNCH_CALLER } from '@spartacus/storefront';
+import { LAUNCH_CALLER, LaunchDialogService } from '@spartacus/storefront';
 import { BehaviorSubject, EMPTY, Observable } from 'rxjs';
 import { ReplenishmentOrderCancellationComponent } from './replenishment-order-cancellation.component';
 
@@ -63,7 +62,7 @@ describe('ReplenishmentOrderCancellationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       declarations: [ReplenishmentOrderCancellationComponent, MockUrlPipe],
       providers: [
         {

--- a/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.spec.ts
+++ b/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.spec.ts
@@ -11,7 +11,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, RoutingService } from '@spartacus/core';
 import {
   ReplenishmentOrderHistoryFacade,
@@ -124,7 +123,7 @@ describe('ReplenishmentOrderHistoryComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         ReplenishmentOrderHistoryComponent,
         MockUrlPipe,

--- a/feature-libs/order/components/return-request-list/order-return-request-list.component.spec.ts
+++ b/feature-libs/order/components/return-request-list/order-return-request-list.component.spec.ts
@@ -1,7 +1,7 @@
 import { DebugElement, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
 import { I18nTestingModule, TranslationService } from '@spartacus/core';
 import {
   OrderReturnRequestFacade,
@@ -27,6 +27,10 @@ const mockReturns: ReturnRequestList = {
 };
 
 const mockReturnRequestList$ = new BehaviorSubject(mockReturns);
+
+class ActivatedRouteMock {
+  constructor(public snapshot: any) {}
+}
 
 @Pipe({
   name: 'cxUrl',
@@ -63,9 +67,13 @@ describe('OrderReturnRequestListComponent', () => {
   let el: DebugElement;
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, ListNavigationModule, I18nTestingModule],
+      imports: [ListNavigationModule, I18nTestingModule],
       declarations: [OrderReturnRequestListComponent, MockUrlPipe],
       providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: new ActivatedRouteMock({}),
+        },
         {
           provide: OrderReturnRequestFacade,
           useClass: MockOrderReturnRequestService,

--- a/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CostCenter, EntitiesModel } from '@spartacus/core';
 import { BudgetService } from '@spartacus/organization/administration/core';
 import { TableService, TableStructure } from '@spartacus/storefront';
@@ -59,7 +58,6 @@ describe('BudgetCostCenterListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         BudgetCostCenterListService,
         {

--- a/feature-libs/organization/administration/components/budget/details/budget-details.component.spec.ts
+++ b/feature-libs/organization/administration/components/budget/details/budget-details.component.spec.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { Budget } from '@spartacus/organization/administration/core';
+import { FocusDirective } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { EMPTY, of, Subject } from 'rxjs';
 import {
@@ -16,7 +16,6 @@ import { ItemService } from '../../shared/item.service';
 import { MessageTestingModule } from '../../shared/message/message.testing.module';
 import { BudgetDetailsComponent } from './budget-details.component';
 import createSpy = jasmine.createSpy;
-import { FocusDirective } from '@spartacus/storefront';
 
 const mockCode = 'b1';
 
@@ -43,7 +42,6 @@ describe('BudgetDetailsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        RouterTestingModule,
         I18nTestingModule,
         UrlTestingModule,
         CardTestingModule,

--- a/feature-libs/organization/administration/components/cost-center/budgets/assigned/cost-center-assigned-budget-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/cost-center/budgets/assigned/cost-center-assigned-budget-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EntitiesModel } from '@spartacus/core';
 import {
   Budget,
@@ -55,7 +54,6 @@ describe('CostCenterAssignedBudgetListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         CostCenterAssignedBudgetListService,
         {

--- a/feature-libs/organization/administration/components/cost-center/budgets/cost-center-budget-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/cost-center/budgets/cost-center-budget-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EntitiesModel } from '@spartacus/core';
 import {
   Budget,
@@ -62,7 +61,6 @@ describe('CostCenterBudgetListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         CostCenterBudgetListService,
         {

--- a/feature-libs/organization/administration/components/cost-center/details/cost-center-details.component.spec.ts
+++ b/feature-libs/organization/administration/components/cost-center/details/cost-center-details.component.spec.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CostCenter, I18nTestingModule } from '@spartacus/core';
+import { FocusDirective } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { EMPTY, of, Subject } from 'rxjs';
 import { DisableInfoModule } from '../../shared';
@@ -12,7 +12,6 @@ import { MessageTestingModule } from '../../shared/message/message.testing.modul
 import { MessageService } from '../../shared/message/services/message.service';
 import { CostCenterDetailsComponent } from './cost-center-details.component';
 import createSpy = jasmine.createSpy;
-import { FocusDirective } from '@spartacus/storefront';
 
 const mockCode = 'c1';
 
@@ -39,7 +38,6 @@ describe('CostCenterDetailsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        RouterTestingModule,
         I18nTestingModule,
         UrlTestingModule,
         CardTestingModule,

--- a/feature-libs/organization/administration/components/permission/details/permission-details.component.spec.ts
+++ b/feature-libs/organization/administration/components/permission/details/permission-details.component.spec.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { Permission } from '@spartacus/organization/administration/core';
+import { FocusDirective } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { EMPTY, of, Subject } from 'rxjs';
 import { DisableInfoModule } from '../../shared';
@@ -15,7 +15,6 @@ import { MessageService } from '../../shared/message/services/message.service';
 import { PermissionDetailsComponent } from './permission-details.component';
 
 import createSpy = jasmine.createSpy;
-import { FocusDirective } from '@spartacus/storefront';
 
 const mockCode = 'p1';
 
@@ -42,7 +41,6 @@ describe('PermissionDetailsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        RouterTestingModule,
         I18nTestingModule,
         UrlTestingModule,
         CardTestingModule,

--- a/feature-libs/organization/administration/components/shared/card/card.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/card/card.component.spec.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { GlobalMessageService, I18nTestingModule } from '@spartacus/core';
 import { PopoverModule, SplitViewService } from '@spartacus/storefront';
 import { IconTestingModule } from 'projects/storefrontlib/cms-components/misc/icon/testing/icon-testing.module';
@@ -35,7 +34,6 @@ describe('CardComponent', () => {
         // SplitViewTestingModule,
         IconTestingModule,
         I18nTestingModule,
-        RouterTestingModule,
         MessageTestingModule,
         PopoverModule,
       ],

--- a/feature-libs/organization/administration/components/shared/list/list.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/list/list.component.spec.ts
@@ -9,7 +9,7 @@ import {
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
 import { NgSelectModule } from '@ng-select/ng-select';
 import {
   EntitiesModel,
@@ -84,6 +84,10 @@ class MockItemService {
   launchDetails = createSpy('launchDetails');
 }
 
+class ActivatedRouteMock {
+  constructor(public snapshot: any) {}
+}
+
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'cx-table',
@@ -121,7 +125,6 @@ describe('ListComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        RouterTestingModule,
         I18nTestingModule,
         UrlTestingModule,
         SplitViewTestingModule,
@@ -138,6 +141,10 @@ describe('ListComponent', () => {
         MockFeatureDirective,
       ],
       providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: new ActivatedRouteMock({}),
+        },
         {
           provide: ListService,
           useClass: MockBaseListService,

--- a/feature-libs/organization/administration/components/shared/message/base-message.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/message/base-message.component.spec.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { GlobalMessageType, I18nTestingModule } from '@spartacus/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { IconTestingModule } from 'projects/storefrontlib/cms-components/misc/icon/testing/icon-testing.module';
@@ -33,7 +32,6 @@ describe('BaseMessageComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        RouterTestingModule,
         PaginationTestingModule,
         KeyboardFocusTestingModule,
         I18nTestingModule,

--- a/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.component.spec.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { IconTestingModule } from 'projects/storefrontlib/cms-components/misc/icon/testing/icon-testing.module';
 import { KeyboardFocusTestingModule } from 'projects/storefrontlib/layout/a11y/keyboard-focus/focus-testing.module';
@@ -30,7 +29,6 @@ describe('ConfirmationMessageComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        RouterTestingModule,
         PaginationTestingModule,
         KeyboardFocusTestingModule,
         I18nTestingModule,

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.spec.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { IconTestingModule } from 'projects/storefrontlib/cms-components/misc/icon/testing/icon-testing.module';
 import { KeyboardFocusTestingModule } from 'projects/storefrontlib/layout/a11y/keyboard-focus/focus-testing.module';
@@ -29,7 +28,6 @@ describe('NotificationMessageComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        RouterTestingModule,
         PaginationTestingModule,
         KeyboardFocusTestingModule,
         I18nTestingModule,

--- a/feature-libs/organization/administration/components/shared/sub-list/assign-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/sub-list/assign-cell.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
+import {
+  LoadStatus,
+  OrganizationItemStatus,
+} from '@spartacus/organization/administration/core';
 import { OutletContextData } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { Observable, of } from 'rxjs';
@@ -9,10 +12,6 @@ import { ListService } from '../list/list.service';
 import { MessageService } from '../message/services/message.service';
 import { AssignCellComponent } from './assign-cell.component';
 import { SubListService } from './sub-list.service';
-import {
-  LoadStatus,
-  OrganizationItemStatus,
-} from '@spartacus/organization/administration/core';
 
 class MockItemService {
   key$ = of('code1');
@@ -43,7 +42,7 @@ describe('AssignCellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [AssignCellComponent],
-      imports: [RouterTestingModule, UrlTestingModule, I18nTestingModule],
+      imports: [UrlTestingModule, I18nTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/shared/sub-list/sub-list.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/sub-list/sub-list.component.spec.ts
@@ -8,8 +8,8 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EntitiesModel, I18nTestingModule } from '@spartacus/core';
+import { FocusConfig } from '@spartacus/storefront';
 import { PaginationTestingModule } from 'projects/storefrontlib/shared/components/list-navigation/pagination/testing/pagination-testing.module';
 import { of } from 'rxjs';
 import { CardTestingModule } from '../card/card.testing.module';
@@ -18,7 +18,7 @@ import { ListService } from '../list/list.service';
 import { MessageTestingModule } from '../message/message.testing.module';
 import { SubListComponent } from './sub-list.component';
 import createSpy = jasmine.createSpy;
-import { FocusConfig } from '@spartacus/storefront';
+import { ActivatedRoute } from '@angular/router';
 
 const mockList: EntitiesModel<any> = {
   values: [
@@ -73,6 +73,10 @@ class MockItemService {
   launchDetails = createSpy('launchDetails');
 }
 
+class ActivatedRouteMock {
+  constructor(public snapshot: any) {}
+}
+
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector
   selector: '[cxFocus]',
@@ -93,7 +97,6 @@ describe('SubListComponent', () => {
         CardTestingModule,
         MessageTestingModule,
         I18nTestingModule,
-        RouterTestingModule,
         PaginationTestingModule,
       ],
       declarations: [
@@ -110,6 +113,10 @@ describe('SubListComponent', () => {
         {
           provide: ItemService,
           useClass: MockItemService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: new ActivatedRouteMock({}),
         },
       ],
     }).compileComponents();

--- a/feature-libs/organization/administration/components/shared/table/active-link/active-link-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/table/active-link/active-link-cell.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { OutletContextData } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { ActiveLinkCellComponent } from '..';
@@ -20,7 +19,7 @@ describe('ActiveLinkCellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ActiveLinkCellComponent],
-      imports: [RouterTestingModule, UrlTestingModule],
+      imports: [UrlTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/shared/table/amount/amount-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/table/amount/amount-cell.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { OutletContextData } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { AmountCellComponent } from '..';
@@ -11,7 +10,7 @@ describe('AmountCellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [AmountCellComponent],
-      imports: [RouterTestingModule, UrlTestingModule],
+      imports: [UrlTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/shared/table/cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/table/cell.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import {
   OutletContextData,
@@ -24,7 +23,7 @@ describe('CellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [CellComponent],
-      imports: [RouterTestingModule, UrlTestingModule, I18nTestingModule],
+      imports: [UrlTestingModule, I18nTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/shared/table/date-range/date-range-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/table/date-range/date-range-cell.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { OutletContextData } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
@@ -13,7 +12,7 @@ describe('DateRangeCellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [DateRangeCellComponent],
-      imports: [RouterTestingModule, UrlTestingModule, I18nTestingModule],
+      imports: [UrlTestingModule, I18nTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/shared/table/limit/limit-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/table/limit/limit-cell.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { Permission } from '@spartacus/organization/administration/core';
 import { OutletContextData } from '@spartacus/storefront';
@@ -14,7 +13,7 @@ describe('LimitCellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [LimitCellComponent],
-      imports: [RouterTestingModule, UrlTestingModule, I18nTestingModule],
+      imports: [UrlTestingModule, I18nTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/shared/table/roles/roles-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/table/roles/roles-cell.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { OutletContextData } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
@@ -13,7 +12,7 @@ describe('RolesCellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [RolesCellComponent],
-      imports: [RouterTestingModule, UrlTestingModule, I18nTestingModule],
+      imports: [UrlTestingModule, I18nTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/shared/table/status/status-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/table/status/status-cell.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { OutletContextData } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
@@ -12,7 +11,7 @@ describe('StatusCellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [StatusCellComponent],
-      imports: [RouterTestingModule, UrlTestingModule, I18nTestingModule],
+      imports: [UrlTestingModule, I18nTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/shared/table/unit/unit-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/table/unit/unit-cell.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { OutletContextData } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
@@ -12,7 +11,7 @@ describe('UnitCellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [UnitCellComponent],
-      imports: [RouterTestingModule, UrlTestingModule, I18nTestingModule],
+      imports: [UrlTestingModule, I18nTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/unit/links/addresses/list/unit-address-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/list/unit-address-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { Address, EntitiesModel } from '@spartacus/core';
 import { OrgUnitService } from '@spartacus/organization/administration/core';
 import { TableService, TableStructure } from '@spartacus/storefront';
@@ -38,7 +37,6 @@ describe('UnitAddressListService', () => {
   let service: UnitAddressListService;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UnitAddressListService,
         {

--- a/feature-libs/organization/administration/components/unit/links/approvers/assigned/unit-assigned-approver-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/unit/links/approvers/assigned/unit-assigned-approver-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { B2BUnit, B2BUser, B2BUserRole, EntitiesModel } from '@spartacus/core';
 import {
   B2BUserService,
@@ -54,7 +53,6 @@ describe('UnitAssignedApproverListService', () => {
   let unitService: OrgUnitService;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UnitAssignedApproverListService,
         {

--- a/feature-libs/organization/administration/components/unit/links/approvers/unit-approver-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/unit/links/approvers/unit-approver-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { B2BUser, B2BUserRole, EntitiesModel } from '@spartacus/core';
 import {
   B2BUserService,
@@ -66,7 +65,6 @@ describe('UnitApproverListService', () => {
   let userService: B2BUserService;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UnitApproverListService,
         {

--- a/feature-libs/organization/administration/components/unit/links/children/unit-children.service.spec.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/unit-children.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { B2BUnit, EntitiesModel } from '@spartacus/core';
 import { OrgUnitService } from '@spartacus/organization/administration/core';
 import { TableService, TableStructure } from '@spartacus/storefront';
@@ -39,7 +38,6 @@ describe('UnitCostCenterListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UnitChildrenService,
         {

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.service.spec.ts
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CostCenter, EntitiesModel } from '@spartacus/core';
 import { OrgUnitService } from '@spartacus/organization/administration/core';
 import { TableService, TableStructure } from '@spartacus/storefront';
@@ -39,7 +38,6 @@ describe('UnitCostCenterListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UnitCostCenterListService,
         {

--- a/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.spec.ts
@@ -5,7 +5,6 @@ import {
   tick,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   FeatureConfigService,
   I18nTestingModule,
@@ -50,12 +49,7 @@ describe('ToggleLinkCellComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ToggleLinkCellComponent],
-      imports: [
-        RouterTestingModule,
-        UrlTestingModule,
-        IconModule,
-        I18nTestingModule,
-      ],
+      imports: [UrlTestingModule, IconModule, I18nTestingModule],
       providers: [
         {
           provide: OutletContextData,

--- a/feature-libs/organization/administration/components/user-group/details/user-group-details.component.spec.ts
+++ b/feature-libs/organization/administration/components/user-group/details/user-group-details.component.spec.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
+import { Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { DeleteItemModule } from '@spartacus/organization/administration/components';
 import { Budget } from '@spartacus/organization/administration/core';
+import { FocusConfig } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { EMPTY, of, Subject } from 'rxjs';
 import { CardTestingModule } from '../../shared/card/card.testing.module';
@@ -11,8 +12,6 @@ import { ItemService } from '../../shared/item.service';
 import { MessageService } from '../../shared/message/services/message.service';
 import { UserGroupDetailsComponent } from './user-group-details.component';
 import createSpy = jasmine.createSpy;
-import { Directive, Input } from '@angular/core';
-import { FocusConfig } from '@spartacus/storefront';
 
 const mockCode = 'u1';
 
@@ -46,7 +45,6 @@ describe('UserGroupDetailsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        RouterTestingModule,
         I18nTestingModule,
         UrlTestingModule,
         CardTestingModule,

--- a/feature-libs/organization/administration/components/user-group/permissions/assigned/user-group-assigned-permission-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user-group/permissions/assigned/user-group-assigned-permission-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EntitiesModel } from '@spartacus/core';
 import {
   LoadStatus,
@@ -58,7 +57,6 @@ describe('UserGroupAssignedPermissionsListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserGroupAssignedPermissionsListService,
         {

--- a/feature-libs/organization/administration/components/user-group/permissions/user-group-permission-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user-group/permissions/user-group-permission-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EntitiesModel } from '@spartacus/core';
 import {
   LoadStatus,
@@ -64,7 +63,6 @@ describe('UserGroupPermissionListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserGroupPermissionListService,
         {

--- a/feature-libs/organization/administration/components/user-group/users/assigned/user-group-assigned-user-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user-group/users/assigned/user-group-assigned-user-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { B2BUser, EntitiesModel } from '@spartacus/core';
 import {
   B2BUserService,
@@ -57,7 +56,6 @@ describe('UserGroupAssignedUsersListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserGroupAssignedUserListService,
         {

--- a/feature-libs/organization/administration/components/user-group/users/user-group-user-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user-group/users/user-group-user-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { B2BUser, EntitiesModel } from '@spartacus/core';
 import {
   B2BUserService,
@@ -60,7 +59,6 @@ describe('UserGroupUserListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserGroupUserListService,
         {

--- a/feature-libs/organization/administration/components/user/approvers/assigned/user-assigned-approver-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user/approvers/assigned/user-assigned-approver-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { B2BUser, EntitiesModel } from '@spartacus/core';
 import { B2BUserService } from '@spartacus/organization/administration/core';
 import { TableService, TableStructure } from '@spartacus/storefront';
@@ -41,7 +40,6 @@ describe('UserAssignedApproverListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserAssignedApproverListService,
         {

--- a/feature-libs/organization/administration/components/user/approvers/user-approver-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user/approvers/user-approver-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { B2BUser, EntitiesModel } from '@spartacus/core';
 import {
   B2BUserService,
@@ -62,7 +61,6 @@ describe('UserApproverListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserApproverListService,
         {

--- a/feature-libs/organization/administration/components/user/details/user-details.component.spec.ts
+++ b/feature-libs/organization/administration/components/user/details/user-details.component.spec.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
+import { Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   B2BUser,
   B2BUserRight,
@@ -11,6 +11,7 @@ import {
   B2BUserService,
   Budget,
 } from '@spartacus/organization/administration/core';
+import { FocusConfig } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { EMPTY, of, Subject } from 'rxjs';
 import { DisableInfoModule } from '../../shared';
@@ -22,8 +23,6 @@ import { MessageTestingModule } from '../../shared/message/message.testing.modul
 import { MessageService } from '../../shared/message/services/message.service';
 import { UserDetailsComponent } from './user-details.component';
 import createSpy = jasmine.createSpy;
-import { Directive, Input } from '@angular/core';
-import { FocusConfig } from '@spartacus/storefront';
 
 const mockCode = 'c1';
 
@@ -84,7 +83,6 @@ describe('UserDetailsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        RouterTestingModule,
         I18nTestingModule,
         UrlTestingModule,
         CardTestingModule,

--- a/feature-libs/organization/administration/components/user/permissions/assigned/user-assigned-permission-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user/permissions/assigned/user-assigned-permission-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { B2BUser, EntitiesModel } from '@spartacus/core';
 import {
   B2BUserService,
@@ -54,7 +53,6 @@ describe('UserAssignedPermissionListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserAssignedPermissionListService,
         {

--- a/feature-libs/organization/administration/components/user/permissions/user-permission-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user/permissions/user-permission-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EntitiesModel } from '@spartacus/core';
 import {
   B2BUserService,
@@ -59,7 +58,6 @@ describe('UserPermissionListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserPermissionListService,
         {

--- a/feature-libs/organization/administration/components/user/user-groups/assigned/user-assigned-user-group-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user/user-groups/assigned/user-assigned-user-group-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EntitiesModel } from '@spartacus/core';
 import {
   B2BUserService,
@@ -55,7 +54,6 @@ describe('UserAssignedUserGroupListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserAssignedUserGroupListService,
         {

--- a/feature-libs/organization/administration/components/user/user-groups/user-user-group-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user/user-groups/user-user-group-list.service.spec.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EntitiesModel } from '@spartacus/core';
 import {
   B2BUserService,
@@ -60,7 +59,6 @@ describe('UserUserGroupListService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         UserUserGroupListService,
         {

--- a/feature-libs/organization/administration/core/guards/org-unit.guard.spec.ts
+++ b/feature-libs/organization/administration/core/guards/org-unit.guard.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
 import {
   GlobalMessageService,
@@ -34,7 +33,7 @@ describe('OrgUnitGuard', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, StoreModule.forRoot({})],
+      imports: [StoreModule.forRoot({})],
       providers: [
         OrgUnitGuard,
         {

--- a/feature-libs/organization/administration/core/guards/user.guard.spec.ts
+++ b/feature-libs/organization/administration/core/guards/user.guard.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
 import {
   GlobalMessageService,
@@ -34,7 +33,7 @@ describe('UserGuard', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, StoreModule.forRoot({})],
+      imports: [StoreModule.forRoot({})],
       providers: [
         UserGuard,
         {

--- a/feature-libs/organization/order-approval/components/details/order-approval-detail-form/order-approval-detail-form.component.spec.ts
+++ b/feature-libs/organization/order-approval/components/details/order-approval-detail-form/order-approval-detail-form.component.spec.ts
@@ -8,7 +8,6 @@ import {
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
 import { BehaviorSubject, Observable, of } from 'rxjs';
@@ -89,7 +88,7 @@ describe('OrderApprovalDetailFormComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, I18nTestingModule, RouterTestingModule],
+      imports: [ReactiveFormsModule, I18nTestingModule],
       declarations: [
         OrderApprovalDetailFormComponent,
         MockFormErrorsComponent,

--- a/feature-libs/organization/order-approval/components/list/order-approval-list.component.spec.ts
+++ b/feature-libs/organization/order-approval/components/list/order-approval-list.component.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   EntitiesModel,
   I18nTestingModule,
@@ -21,6 +20,7 @@ import { OrderApproval } from '../../core/model/order-approval.model';
 import { OrderApprovalService } from '../../core/services/order-approval.service';
 import { OrderApprovalListComponent } from './order-approval-list.component';
 import createSpy = jasmine.createSpy;
+import { ActivatedRoute } from '@angular/router';
 
 const mockOrderApprovals: EntitiesModel<OrderApproval> = {
   pagination: {
@@ -70,6 +70,10 @@ const mockOrderApprovals: EntitiesModel<OrderApproval> = {
   ],
 };
 
+class MockActivatedRoute {
+  constructor(public snapshot: any) {}
+}
+
 @Component({
   template: '',
   selector: 'cx-sorting',
@@ -106,14 +110,10 @@ describe('OrderApprovalListComponent?', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        I18nTestingModule,
-        RouterTestingModule,
-        UrlTestingModule,
-        PaginationTestingModule,
-      ],
+      imports: [I18nTestingModule, UrlTestingModule, PaginationTestingModule],
       declarations: [OrderApprovalListComponent, MockSortingComponent],
       providers: [
+        { provide: ActivatedRoute, useValue: new MockActivatedRoute({}) },
         { provide: RoutingService, useClass: MockRoutingService },
         { provide: OrderApprovalService, useClass: MockOrderApprovalService },
         { provide: RoutingService, useClass: MockRoutingService },

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.spec.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.spec.ts
@@ -7,8 +7,8 @@ import {
   PipeTransform,
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   PaginationModel,
@@ -17,13 +17,12 @@ import {
   TranslationService,
 } from '@spartacus/core';
 import { Order, OrderHistoryList } from '@spartacus/order/root';
+import { ICON_TYPE } from '@spartacus/storefront';
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { OrderHistoryQueryParams } from '../../core/model/unit-order.model';
 import { UnitOrderFacade } from '../../root/facade';
-import { UnitLevelOrderHistoryComponent } from './unit-level-order-history.component';
 import { UnitLevelOrderHistoryFilterComponent } from './filter/unit-level-order-history-filter.component';
-import { ICON_TYPE } from '@spartacus/storefront';
-import { ReactiveFormsModule } from '@angular/forms';
+import { UnitLevelOrderHistoryComponent } from './unit-level-order-history.component';
 
 const mockOrderList: OrderHistoryList | undefined = {
   orders: [
@@ -162,7 +161,7 @@ describe('UnitLevelOrderHistoryComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule, ReactiveFormsModule],
+      imports: [I18nTestingModule, ReactiveFormsModule],
       declarations: [
         UnitLevelOrderHistoryComponent,
         MockUrlPipe,

--- a/feature-libs/organization/user-registration/components/form/user-registration-form.component.spec.ts
+++ b/feature-libs/organization/user-registration/components/form/user-registration-form.component.spec.ts
@@ -2,7 +2,6 @@ import { DebugElement, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { NgSelectModule } from '@ng-select/ng-select';
 import {
   Country,
@@ -136,7 +135,6 @@ describe('UserRegistrationFormComponent', () => {
         NgSelectModule,
         I18nTestingModule,
         FormErrorsModule,
-        RouterTestingModule,
       ],
       declarations: [
         UserRegistrationFormComponent,

--- a/feature-libs/pickup-in-store/components/container/store-list/store-list.component.spec.ts
+++ b/feature-libs/pickup-in-store/components/container/store-list/store-list.component.spec.ts
@@ -1,7 +1,10 @@
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { I18nTestingModule, PointOfServiceStock } from '@spartacus/core';
@@ -15,10 +18,6 @@ import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-fe
 import { MockIntendedPickupLocationService } from '../../../core/facade/intended-pickup-location.service.spec';
 import { MockPickupLocationsSearchService } from '../../../core/facade/pickup-locations-search.service.spec';
 import { StoreListComponent } from './store-list.component';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
 
 describe('StoreListComponent', () => {
   let component: StoreListComponent;
@@ -30,7 +29,6 @@ describe('StoreListComponent', () => {
       declarations: [StoreListComponent, MockFeatureDirective],
       imports: [
         I18nTestingModule,
-        RouterTestingModule,
         SpinnerModule,
         StoreModule.forRoot({}),
         EffectsModule.forRoot([]),

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.spec.ts
@@ -5,7 +5,6 @@ import {
   ReactiveFormsModule,
   UntypedFormControl,
 } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CartItemContext,
   OrderEntry,
@@ -46,7 +45,7 @@ describe('ConfiguratorCartEntryInfoComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      imports: [ReactiveFormsModule, I18nTestingModule],
       declarations: [
         ConfiguratorCartEntryInfoComponent,
         MockConfigureCartEntryComponent,

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.spec.ts
@@ -1,7 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { AbstractOrderContext } from '@spartacus/cart/base/components';
 import { AbstractOrderType, OrderEntry } from '@spartacus/cart/base/root';
 import {
@@ -25,6 +24,10 @@ const orderCode = '01008765';
 const savedCartCode = '0108336';
 const quoteCode = '01008764';
 const productCode = 'PRODUCT_CODE';
+
+class MockActivatedRoute {
+  constructor(public snapshot: any) {}
+}
 
 class MockAbstractOrderContext {
   key$ = of({ id: quoteCode, type: AbstractOrderType.QUOTE });
@@ -62,9 +65,10 @@ describe('ConfigureCartEntryComponent', () => {
     routerState = mockRouterState;
 
     return TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule, RouterModule],
+      imports: [I18nTestingModule, RouterModule],
       declarations: [ConfigureCartEntryComponent, MockUrlPipe],
       providers: [
+        { provide: ActivatedRoute, useValue: new MockActivatedRoute({}) },
         {
           provide: RoutingService,
           useClass: MockRoutingService,

--- a/feature-libs/product-configurator/common/components/configure-product/configure-product.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configure-product/configure-product.component.spec.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
 import {
   I18nTestingModule,
@@ -13,6 +13,7 @@ import {
   CurrentProductService,
   ProductListItemContext,
 } from '@spartacus/storefront';
+import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
 import { Observable, of } from 'rxjs';
 import { ConfiguratorProductScope } from '../../core/model/configurator-product-scope';
 import { CommonConfiguratorTestUtilsService } from '../../testing/common-configurator-test-utils.service';
@@ -21,8 +22,6 @@ import {
   ReadOnlyPostfix,
 } from './../../core/model/common-configurator.model';
 import { ConfigureProductComponent } from './configure-product.component';
-import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
-import { By } from '@angular/platform-browser';
 
 const productCode = 'CONF_LAPTOP';
 const configuratorType = ConfiguratorType.VARIANT;
@@ -113,11 +112,7 @@ function setupWithCurrentProductService(
     }).compileComponents();
   } else if (useCurrentProductServiceOnly) {
     TestBed.configureTestingModule({
-      imports: [
-        I18nTestingModule,
-        RouterTestingModule,
-        StoreModule.forRoot({}),
-      ],
+      imports: [I18nTestingModule, StoreModule.forRoot({})],
       declarations: [
         ConfigureProductComponent,
         MockUrlPipe,
@@ -136,11 +131,7 @@ function setupWithCurrentProductService(
     }).compileComponents();
   } else {
     TestBed.configureTestingModule({
-      imports: [
-        I18nTestingModule,
-        RouterTestingModule,
-        StoreModule.forRoot({}),
-      ],
+      imports: [I18nTestingModule, StoreModule.forRoot({})],
       declarations: [
         ConfigureProductComponent,
         MockUrlPipe,

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
@@ -1,6 +1,5 @@
 import { Type } from '@angular/core';
 import { TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   RouterState,
@@ -32,7 +31,7 @@ describe('ConfigRouterExtractorService', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       providers: [
         {
           provide: RoutingService,

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.spec.ts
@@ -9,7 +9,7 @@ import {
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+
 import { I18nTestingModule, Product, ProductService } from '@spartacus/core';
 import {
   ItemCounterComponent,
@@ -22,10 +22,10 @@ import { take } from 'rxjs/operators';
 import { CommonConfiguratorTestUtilsService } from '../../../../common/testing/common-configurator-test-utils.service';
 import { Configurator } from '../../../core/model/configurator.model';
 import { ConfiguratorPriceComponentOptions } from '../../price/configurator-price.component';
+import { ConfiguratorStorefrontUtilsService } from '../../service/configurator-storefront-utils.service';
 import { ConfiguratorShowMoreComponent } from '../../show-more/configurator-show-more.component';
 import { ConfiguratorAttributeQuantityComponentOptions } from '../quantity/configurator-attribute-quantity.component';
 import { ConfiguratorAttributeProductCardComponent } from './configurator-attribute-product-card.component';
-import { ConfiguratorStorefrontUtilsService } from '../../service/configurator-storefront-utils.service';
 
 const product: Product = {
   name: 'Product Name',
@@ -157,7 +157,6 @@ describe('ConfiguratorAttributeProductCardComponent', () => {
       imports: [
         I18nTestingModule,
         ReactiveFormsModule,
-        RouterTestingModule,
         UrlTestingModule,
         MediaModule,
       ],

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.spec.ts
@@ -7,24 +7,25 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
+
+import { ActivatedRoute } from '@angular/router';
 import { I18nTestingModule } from '@spartacus/core';
 import { ItemCounterComponent, MediaModule } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { CommonConfiguratorTestUtilsService } from '../../../../../common/testing/common-configurator-test-utils.service';
+import { ConfiguratorCommonsService } from '../../../../core/facade/configurator-commons.service';
 import { Configurator } from '../../../../core/model/configurator.model';
-import { ConfiguratorAttributeCompositionContext } from '../../composition/configurator-attribute-composition.model';
+import { ConfiguratorTestUtils } from '../../../../testing/configurator-test-utils';
 import { ConfiguratorPriceComponentOptions } from '../../../price/configurator-price.component';
+import { ConfiguratorStorefrontUtilsService } from '../../../service/configurator-storefront-utils.service';
 import { ConfiguratorShowMoreComponent } from '../../../show-more/configurator-show-more.component';
+import { ConfiguratorAttributeCompositionContext } from '../../composition/configurator-attribute-composition.model';
 import {
   ConfiguratorAttributeProductCardComponent,
   ConfiguratorAttributeProductCardComponentOptions,
 } from '../../product-card/configurator-attribute-product-card.component';
 import { ConfiguratorAttributeQuantityComponentOptions } from '../../quantity/configurator-attribute-quantity.component';
 import { ConfiguratorAttributeMultiSelectionBundleComponent } from './configurator-attribute-multi-selection-bundle.component';
-import { ConfiguratorTestUtils } from '../../../../testing/configurator-test-utils';
-import { ConfiguratorCommonsService } from '../../../../core/facade/configurator-commons.service';
-import { ConfiguratorStorefrontUtilsService } from '../../../service/configurator-storefront-utils.service';
 
 @Component({
   selector: 'cx-configurator-attribute-product-card',
@@ -62,6 +63,10 @@ function getSelected(
 
 class MockConfiguratorCommonsService {
   updateConfiguration(): void {}
+}
+
+class MockActivatedRoute {
+  constructor(public snapshot: any) {}
 }
 
 describe('ConfiguratorAttributeMultiSelectionBundleComponent', () => {
@@ -102,7 +107,6 @@ describe('ConfiguratorAttributeMultiSelectionBundleComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         I18nTestingModule,
-        RouterTestingModule,
         UrlTestingModule,
         ReactiveFormsModule,
         MediaModule,
@@ -116,6 +120,7 @@ describe('ConfiguratorAttributeMultiSelectionBundleComponent', () => {
         MockConfiguratorPriceComponent,
       ],
       providers: [
+        { provide: ActivatedRoute, useValue: new MockActivatedRoute({}) },
         {
           provide: ConfiguratorAttributeCompositionContext,
           useValue: ConfiguratorTestUtils.getAttributeContext(),

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.spec.ts
@@ -6,10 +6,11 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
+
 import { NgSelectModule } from '@ng-select/ng-select';
 import { I18nTestingModule } from '@spartacus/core';
 
+import { ActivatedRoute } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { MockFeatureLevelDirective } from 'projects/storefrontlib/shared/test/mock-feature-level-directive';
@@ -68,6 +69,10 @@ class MockConfigUtilsService {
   isCartEntryOrGroupVisited(): Observable<boolean> {
     return of(showRequiredErrorMessage);
   }
+}
+
+class MockActivatedRoute {
+  constructor(public snapshot: any) {}
 }
 
 describe('ConfiguratorAttributeSingleSelectionBundleDropdownComponent', () => {
@@ -203,13 +208,13 @@ describe('ConfiguratorAttributeSingleSelectionBundleDropdownComponent', () => {
         ReactiveFormsModule,
         NgSelectModule,
         I18nTestingModule,
-        RouterTestingModule,
         UrlTestingModule,
         StoreModule.forRoot({}),
         StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
       ],
 
       providers: [
+        { provide: ActivatedRoute, useValue: new MockActivatedRoute({}) },
         {
           provide: ConfiguratorAttributeCompositionContext,
           useValue: ConfiguratorTestUtils.getAttributeContext(),

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.spec.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
+
+import { ActivatedRoute } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
 import { I18nTestingModule } from '@spartacus/core';
 import { ItemCounterComponent } from '@spartacus/storefront';
@@ -58,6 +59,10 @@ function getFirstValue(
   return values ? values[0] : { valueCode: 'a' };
 }
 
+class MockActivatedRoute {
+  constructor(public snapshot: any) {}
+}
+
 describe('ConfiguratorAttributeSingleSelectionBundleComponent', () => {
   let component: ConfiguratorAttributeSingleSelectionBundleComponent;
   let fixture: ComponentFixture<ConfiguratorAttributeSingleSelectionBundleComponent>;
@@ -97,7 +102,6 @@ describe('ConfiguratorAttributeSingleSelectionBundleComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         I18nTestingModule,
-        RouterTestingModule,
         ReactiveFormsModule,
         StoreModule.forRoot({}),
         StoreModule.forFeature(CONFIGURATOR_FEATURE, getConfiguratorReducers),
@@ -111,6 +115,7 @@ describe('ConfiguratorAttributeSingleSelectionBundleComponent', () => {
         MockConfiguratorAttributeQuantityComponent,
       ],
       providers: [
+        { provide: ActivatedRoute, useValue: new MockActivatedRoute({}) },
         {
           provide: ConfiguratorAttributeCompositionContext,
           useValue: ConfiguratorTestUtils.getAttributeContext(),

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.spec.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+
 import {
   CommonConfigurator,
   ConfiguratorModelUtils,
@@ -122,10 +122,14 @@ class MockCxIconComponent {
   @Input() type: any;
 }
 
+class MockActivatedRoute {
+  constructor(public snapshot: any) {}
+}
+
 describe('ConfigOverviewNotificationBannerComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterModule, RouterTestingModule],
+      imports: [RouterModule],
       declarations: [
         ConfiguratorOverviewNotificationBannerComponent,
         MockTranslatePipe,
@@ -133,6 +137,7 @@ describe('ConfigOverviewNotificationBannerComponent', () => {
         MockCxIconComponent,
       ],
       providers: [
+        { provide: ActivatedRoute, useValue: new MockActivatedRoute({}) },
         {
           provide: ConfiguratorRouterExtractorService,
           useClass: MockConfigRouterExtractorService,

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.spec.ts
@@ -12,7 +12,7 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+
 import {
   I18nTestingModule,
   RouterState,
@@ -23,14 +23,14 @@ import {
   ConfiguratorModelUtils,
   ConfiguratorRouter,
 } from '@spartacus/product-configurator/common';
+import { KeyboardFocusService } from '@spartacus/storefront';
 import { NEVER, Observable, of } from 'rxjs';
 import { CommonConfiguratorTestUtilsService } from '../../../common/testing/common-configurator-test-utils.service';
 import { ConfiguratorCommonsService } from '../../core/facade/configurator-commons.service';
-import { ConfiguratorStorefrontUtilsService } from '../service/configurator-storefront-utils.service';
 import { ConfiguratorGroupsService } from '../../core/facade/configurator-groups.service';
 import { Configurator } from '../../core/model/configurator.model';
 import { ConfiguratorTestUtils } from '../../testing/configurator-test-utils';
-import { KeyboardFocusService } from '@spartacus/storefront';
+import { ConfiguratorStorefrontUtilsService } from '../service/configurator-storefront-utils.service';
 import { ConfiguratorTabBarComponent } from './configurator-tab-bar.component';
 
 const PRODUCT_CODE = 'CONF_LAPTOP';
@@ -108,7 +108,7 @@ describe('ConfigTabBarComponent', () => {
 
     routerStateObservable = of(mockRouterState);
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterModule, RouterTestingModule],
+      imports: [I18nTestingModule, RouterModule],
       declarations: [ConfiguratorTabBarComponent, MockUrlPipe],
       providers: [
         {

--- a/feature-libs/product-configurator/textfield/components/add-to-cart-button/configurator-textfield-add-to-cart-button.component.spec.ts
+++ b/feature-libs/product-configurator/textfield/components/add-to-cart-button/configurator-textfield-add-to-cart-button.component.spec.ts
@@ -5,7 +5,7 @@ import {
   Type,
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+
 import {
   I18nTestingModule,
   RouterState,
@@ -83,7 +83,7 @@ describe('ConfigTextfieldAddToCartButtonComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         ConfiguratorTextfieldAddToCartButtonComponent,
         MockUrlPipe,

--- a/feature-libs/product/variants/components/guards/product-variants.guard.spec.ts
+++ b/feature-libs/product/variants/components/guards/product-variants.guard.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   Product,
   ProductService,
@@ -70,7 +69,6 @@ describe('ProductVariantsGuard', () => {
         },
         SemanticPathService,
       ],
-      imports: [RouterTestingModule],
     });
 
     guard = TestBed.inject(ProductVariantsGuard);

--- a/feature-libs/product/variants/components/product-variants-container/product-variants-container.component.spec.ts
+++ b/feature-libs/product/variants/components/product-variants-container/product-variants-container.component.spec.ts
@@ -1,19 +1,18 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NavigationExtras } from '@angular/router';
 import {
+  BaseOption,
+  I18nTestingModule,
   Product,
   RoutingService,
   UrlCommandRoute,
   UrlCommands,
   VariantType,
-  I18nTestingModule,
-  BaseOption,
 } from '@spartacus/core';
 import { CurrentProductService } from '@spartacus/storefront';
 import { Observable, of } from 'rxjs';
 import { ProductVariantsContainerComponent } from './product-variants-container.component';
-import { NavigationExtras } from '@angular/router';
 
 const mockProduct: Product = {
   name: 'mockProduct',
@@ -97,7 +96,7 @@ describe('ProductVariantsContainerComponent', () => {
         MockCxProductSizeSelectorComponent,
         MockCxProductColorSelectorComponent,
       ],
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       providers: [
         {
           provide: RoutingService,

--- a/feature-libs/product/variants/components/variant-color-selector/product-variant-color-selector.component.spec.ts
+++ b/feature-libs/product/variants/components/variant-color-selector/product-variant-color-selector.component.spec.ts
@@ -1,16 +1,15 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NavigationExtras } from '@angular/router';
 import {
-  I18nTestingModule,
   BaseOption,
-  VariantType,
+  I18nTestingModule,
   RoutingService,
   UrlCommands,
-  VariantQualifier,
   VariantOptionQualifier,
+  VariantQualifier,
+  VariantType,
 } from '@spartacus/core';
 import { ProductVariantColorSelectorComponent } from './product-variant-color-selector.component';
-import { RouterTestingModule } from '@angular/router/testing';
-import { NavigationExtras } from '@angular/router';
 
 const mockVariant: BaseOption = {
   selected: {
@@ -51,7 +50,7 @@ describe('ProductVariantColorSelectorComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ProductVariantColorSelectorComponent],
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       providers: [{ provide: RoutingService, useClass: MockRoutingService }],
     }).compileComponents();
 

--- a/feature-libs/product/variants/components/variant-size-selector/product-variant-size-selector.component.spec.ts
+++ b/feature-libs/product/variants/components/variant-size-selector/product-variant-size-selector.component.spec.ts
@@ -1,17 +1,16 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NavigationExtras } from '@angular/router';
 import {
   I18nTestingModule,
-  RoutingService,
-  UrlCommands,
   Product,
   ProductService,
-  VariantQualifier,
+  RoutingService,
+  UrlCommands,
   VariantOptionQualifier,
+  VariantQualifier,
 } from '@spartacus/core';
-import { ProductVariantSizeSelectorComponent } from './product-variant-size-selector.component';
-import { NavigationExtras } from '@angular/router';
 import { Observable, of } from 'rxjs';
+import { ProductVariantSizeSelectorComponent } from './product-variant-size-selector.component';
 
 const mockProduct = {
   code: 'p1',
@@ -54,7 +53,7 @@ describe('ProductVariantSizeSelectorComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ProductVariantSizeSelectorComponent],
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       providers: [
         { provide: RoutingService, useClass: MockRoutingService },
         {

--- a/feature-libs/product/variants/components/variant-style-selector/product-variant-style-selector.component.spec.ts
+++ b/feature-libs/product/variants/components/variant-style-selector/product-variant-style-selector.component.spec.ts
@@ -1,6 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   BaseOption,
   I18nTestingModule,
@@ -92,7 +91,7 @@ describe('ProductVariantStyleSelectorComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ProductVariantStyleSelectorComponent, MockUrlPipe],
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       providers: [
         {
           provide: OccConfig,

--- a/feature-libs/quote/components/cart-guard/quote-cart.guard.spec.ts
+++ b/feature-libs/quote/components/cart-guard/quote-cart.guard.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 
 import {
   ActivatedRouterStateSnapshot,
@@ -92,7 +91,6 @@ describe('QuoteCartGuard', () => {
         { provide: QuoteCartService, useClass: MockQuoteCartService },
         { provide: SemanticPathService, useClass: MockSemanticPathService },
       ],
-      imports: [RouterTestingModule],
     });
 
     isQuoteCartActive = false;

--- a/feature-libs/quote/components/header/overview/quote-header-overview.component.spec.ts
+++ b/feature-libs/quote/components/header/overview/quote-header-overview.component.spec.ts
@@ -1,6 +1,5 @@
 import { Component, Input, Type } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   EventService,
   I18nTestingModule,
@@ -16,13 +15,13 @@ import {
 import { CardModule, ICON_TYPE } from '@spartacus/storefront';
 
 import { BehaviorSubject, NEVER, Observable, of } from 'rxjs';
+import { QuoteUIConfig } from '../../config';
 import { CommonQuoteTestUtilsService } from '../../testing/common-quote-test-utils.service';
 import {
   EditCard,
   SaveEvent,
 } from '../buyer-edit/quote-header-buyer-edit.component';
 import { QuoteHeaderOverviewComponent } from './quote-header-overview.component';
-import { QuoteUIConfig } from '../../config';
 
 const totalPriceFormattedValue = '$20';
 
@@ -99,7 +98,7 @@ describe('QuoteHeaderOverviewComponent', () => {
   beforeEach(waitForAsync(() => {
     initMocks();
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, CardModule, RouterTestingModule],
+      imports: [I18nTestingModule, CardModule],
       declarations: [
         QuoteHeaderOverviewComponent,
         MockCxIconComponent,

--- a/feature-libs/quote/components/links/quote-links.component.spec.ts
+++ b/feature-libs/quote/components/links/quote-links.component.spec.ts
@@ -4,17 +4,16 @@ import {
   TestBed,
   tick,
 } from '@angular/core/testing';
-import { Router, Routes } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, RouterModule, Routes } from '@angular/router';
 import {
   EventService,
-  I18nTestingModule,
-  Price,
   FeatureConfigService,
   GlobalMessageService,
-  HttpErrorModel,
-  Translatable,
   GlobalMessageType,
+  HttpErrorModel,
+  I18nTestingModule,
+  Price,
+  Translatable,
 } from '@spartacus/core';
 import {
   CartUtilsService,
@@ -112,8 +111,8 @@ describe('QuoteLinksComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         I18nTestingModule,
-        RouterTestingModule.withRoutes(mockRoutes),
         UrlTestingModule,
+        RouterModule.forRoot(mockRoutes),
       ],
       declarations: [QuoteLinksComponent],
       providers: [

--- a/feature-libs/quote/components/list/quote-list.component.spec.ts
+++ b/feature-libs/quote/components/list/quote-list.component.spec.ts
@@ -7,7 +7,6 @@ import {
   PipeTransform,
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   LanguageService,
@@ -138,7 +137,7 @@ describe('QuoteListComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         QuoteListComponent,
         MockUrlPipe,

--- a/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { RoutingService, TranslationService } from '@spartacus/core';
 import { StoreFinderService } from '@spartacus/storefinder/core';
 import { SpinnerModule } from '@spartacus/storefront';
@@ -54,7 +53,7 @@ describe('StoreFinderGridComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, SpinnerModule],
+      imports: [SpinnerModule],
       declarations: [
         StoreFinderGridComponent,
         MockStoreFinderListItemComponent,

--- a/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.spec.ts
@@ -1,8 +1,9 @@
 import { CommonModule } from '@angular/common';
+import { provideLocationMocks } from '@angular/common/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { I18nTestingModule } from '@spartacus/core';
 import { StoreFinderService } from '@spartacus/storefinder/core';
 import { OutletModule } from '@spartacus/storefront';
@@ -107,11 +108,12 @@ describe('StoreFinderListItemComponent', () => {
         CommonModule,
         ReactiveFormsModule,
         I18nTestingModule,
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         OutletModule,
       ],
       declarations: [StoreFinderListItemComponent],
       providers: [
+        provideLocationMocks(),
         { provide: StoreFinderService, useClass: MockStoreFinderService },
       ],
     }).compileComponents();

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
@@ -1,8 +1,11 @@
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, PointOfService } from '@spartacus/core';
 import {
   GoogleMapRendererService,
@@ -13,10 +16,6 @@ import { EMPTY } from 'rxjs';
 import { StoreFinderMapComponent } from '../../store-finder-map/store-finder-map.component';
 import { StoreFinderListComponent } from './store-finder-list.component';
 import { LocationDisplayMode } from './store-finder-list.model';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
 import createSpy = jasmine.createSpy;
 
 const location: PointOfService = {
@@ -57,7 +56,7 @@ describe('StoreFinderDisplayListComponent', () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [StoreFinderListComponent, StoreFinderMapComponent],
-      imports: [RouterTestingModule, SpinnerModule, I18nTestingModule],
+      imports: [SpinnerModule, I18nTestingModule],
       providers: [
         {
           provide: GoogleMapRendererService,

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-search-result.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-search-result.component.spec.ts
@@ -1,7 +1,6 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import {
   StoreFinderConfig,
@@ -42,7 +41,7 @@ describe('StoreFinderListComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [StoreFinderSearchResultComponent, MockFeatureDirective],
       providers: [

--- a/feature-libs/storefinder/components/store-finder-search/store-finder-search.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-search/store-finder-search.component.spec.ts
@@ -2,7 +2,6 @@ import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, RoutingService } from '@spartacus/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
@@ -51,7 +50,7 @@ describe('StoreFinderSearchComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      imports: [ReactiveFormsModule, I18nTestingModule],
       declarations: [
         StoreFinderSearchComponent,
         MockUrlPipe,

--- a/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.spec.ts
@@ -1,9 +1,8 @@
 import { Component, Input } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { I18nTestingModule } from '@spartacus/core';
-import { StoreFinderStoreDescriptionComponent } from './store-finder-store-description.component';
 import { StoreFinderService } from '@spartacus/storefinder/core';
+import { StoreFinderStoreDescriptionComponent } from './store-finder-store-description.component';
 
 class StoreFinderServiceMock {
   getStoreLatitude() {}
@@ -26,7 +25,7 @@ describe('StoreFinderStoreDescriptionComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         StoreFinderStoreDescriptionComponent,
         MockScheduleComponent,

--- a/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   PointOfService,
@@ -55,7 +54,7 @@ describe('StoreFinderStoreComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SpinnerModule, RouterTestingModule, I18nTestingModule],
+      imports: [SpinnerModule, I18nTestingModule],
       declarations: [
         StoreFinderStoreComponent,
         MockStoreFinderStoreDescriptionComponent,

--- a/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.spec.ts
@@ -1,7 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, RoutingService } from '@spartacus/core';
 import { StoreFinderService } from '@spartacus/storefinder/core';
 import { SpinnerModule } from '@spartacus/storefront';
@@ -35,7 +34,7 @@ describe('StoreFinderStoresCountComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [SpinnerModule, I18nTestingModule, RouterTestingModule],
+      imports: [SpinnerModule, I18nTestingModule],
       declarations: [StoreFinderStoresCountComponent, MockFeatureDirective],
       providers: [
         {

--- a/feature-libs/storefinder/components/store-finder/store-finder.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder/store-finder.component.spec.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { StoreFinderComponent } from './store-finder.component';
 
 @Component({
@@ -15,7 +14,6 @@ describe('StoreFinderComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [StoreFinderComponent, MockStoreFinderHeaderComponent],
     }).compileComponents();
   }));

--- a/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   AuthService,
   GlobalMessageService,
@@ -35,12 +34,7 @@ describe('LoginFormComponentService', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        I18nTestingModule,
-        FormErrorsModule,
-      ],
+      imports: [ReactiveFormsModule, I18nTestingModule, FormErrorsModule],
       declarations: [],
       providers: [
         LoginFormComponentService,

--- a/feature-libs/user/account/components/login-form/login-form.component.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form.component.spec.ts
@@ -6,7 +6,6 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { FormErrorsModule, SpinnerModule } from '@spartacus/storefront';
 import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
@@ -43,7 +42,6 @@ describe('LoginFormComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
-        RouterTestingModule,
         I18nTestingModule,
         FormErrorsModule,
         SpinnerModule,

--- a/feature-libs/user/account/components/login-register/login-register.component.spec.ts
+++ b/feature-libs/user/account/components/login-register/login-register.component.spec.ts
@@ -2,10 +2,9 @@ import { DebugElement, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, RoutingService } from '@spartacus/core';
-import { LoginRegisterComponent } from './login-register.component';
 import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
+import { LoginRegisterComponent } from './login-register.component';
 class MockRoutingService implements Partial<RoutingService> {
   go = () => Promise.resolve(true);
 }
@@ -31,7 +30,7 @@ describe('LoginRegisterComponent', () => {
   }
 
   const testBedDefaults = {
-    imports: [RouterTestingModule, I18nTestingModule],
+    imports: [I18nTestingModule],
     declarations: [LoginRegisterComponent, MockUrlPipe, MockFeatureDirective],
     providers: [
       { provide: ActivatedRoute, useClass: MockActivatedRoute },

--- a/feature-libs/user/account/components/login/login.component.spec.ts
+++ b/feature-libs/user/account/components/login/login.component.spec.ts
@@ -2,16 +2,15 @@ import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   AuthService,
   I18nTestingModule,
   RoutingService,
   User,
 } from '@spartacus/core';
+import { UserAccountFacade } from '@spartacus/user/account/root';
 import { Observable, of } from 'rxjs';
 import { LoginComponent } from './login.component';
-import { UserAccountFacade } from '@spartacus/user/account/root';
 import createSpy = jasmine.createSpy;
 
 const mockUserDetails: User = {
@@ -62,7 +61,7 @@ describe('LoginComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [LoginComponent, MockDynamicSlotComponent, MockUrlPipe],
       providers: [
         {

--- a/feature-libs/user/account/components/my-account-v2-user/my-account-v2-user.component.spec.ts
+++ b/feature-libs/user/account/components/my-account-v2-user/my-account-v2-user.component.spec.ts
@@ -1,18 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MyAccountV2UserComponent } from './my-account-v2-user.component';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
 import {
   AuthService,
   I18nTestingModule,
   RoutingService,
   User,
 } from '@spartacus/core';
-import { ActivatedRoute } from '@angular/router';
-import { UserAccountFacade } from '../../root/facade';
 import { Observable, of } from 'rxjs';
-import { RouterTestingModule } from '@angular/router/testing';
+import { UserAccountFacade } from '../../root/facade';
+import { MyAccountV2UserComponent } from './my-account-v2-user.component';
 import createSpy = jasmine.createSpy;
-import { Pipe, PipeTransform } from '@angular/core';
-import { By } from '@angular/platform-browser';
 
 class MockAuthService {
   login = createSpy();
@@ -52,7 +51,7 @@ describe('MyAccountV2UserComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [MyAccountV2UserComponent, MockUrlPipe],
       providers: [
         {

--- a/feature-libs/user/account/components/otp-login-form/otp-login-form.component.spec.ts
+++ b/feature-libs/user/account/components/otp-login-form/otp-login-form.component.spec.ts
@@ -2,7 +2,6 @@ import { DebugElement, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, RoutingService, WindowRef } from '@spartacus/core';
 import { FormErrorsModule, SpinnerModule } from '@spartacus/storefront';
 import { VerificationTokenService } from '@spartacus/user/account/core';
@@ -62,7 +61,6 @@ describe('OneTimePasswordLoginFormComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
-        RouterTestingModule,
         I18nTestingModule,
         FormErrorsModule,
         SpinnerModule,

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   AuthService,
   GlobalMessageService,
@@ -35,12 +34,7 @@ describe('VerificationTokenFormComponentService', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        I18nTestingModule,
-        FormErrorsModule,
-      ],
+      imports: [ReactiveFormsModule, I18nTestingModule, FormErrorsModule],
       declarations: [],
       providers: [
         VerificationTokenFormComponentService,

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form.component.spec.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form.component.spec.ts
@@ -11,7 +11,6 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, RoutingService } from '@spartacus/core';
 import {
   FormErrorsModule,
@@ -67,7 +66,6 @@ describe('VerificationTokenFormComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
-        RouterTestingModule,
         I18nTestingModule,
         FormErrorsModule,
         SpinnerModule,

--- a/feature-libs/user/profile/components/address-book/address-book.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-book.component.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   Address,
   GlobalMessageService,
@@ -99,12 +98,7 @@ describe('AddressBookComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        SpinnerModule,
-        I18nTestingModule,
-        CardModule,
-        RouterTestingModule,
-      ],
+      imports: [SpinnerModule, I18nTestingModule, CardModule],
       providers: [
         {
           provide: AddressBookComponentService,

--- a/feature-libs/user/profile/components/close-account/components/close-account/close-account.component.spec.ts
+++ b/feature-libs/user/profile/components/close-account/components/close-account/close-account.component.spec.ts
@@ -1,16 +1,15 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { By } from '@angular/platform-browser';
 import { I18nTestingModule, RoutingService } from '@spartacus/core';
 import {
   ICON_TYPE,
-  LaunchDialogService,
   LAUNCH_CALLER,
+  LaunchDialogService,
 } from '@spartacus/storefront';
+import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
 import { of } from 'rxjs';
 import { CloseAccountComponent } from './close-account.component';
-import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
-import { By } from '@angular/platform-browser';
 
 @Component({
   selector: 'cx-icon',
@@ -45,7 +44,7 @@ describe('CloseAccountComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         CloseAccountComponent,
         MockUrlPipe,

--- a/feature-libs/user/profile/components/forgot-password/forgot-password-component.service.spec.ts
+++ b/feature-libs/user/profile/components/forgot-password/forgot-password-component.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   AuthConfigService,
   GlobalMessageService,
@@ -38,12 +37,7 @@ describe('ForgotPasswordComponentService', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        I18nTestingModule,
-        FormErrorsModule,
-      ],
+      imports: [ReactiveFormsModule, I18nTestingModule, FormErrorsModule],
       declarations: [],
       providers: [
         ForgotPasswordComponentService,

--- a/feature-libs/user/profile/components/forgot-password/forgot-password.component.spec.ts
+++ b/feature-libs/user/profile/components/forgot-password/forgot-password.component.spec.ts
@@ -6,7 +6,6 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, RoutingService } from '@spartacus/core';
 import { FormErrorsModule, SpinnerModule } from '@spartacus/storefront';
 import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
@@ -48,7 +47,6 @@ describe('ForgotPasswordComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
-        RouterTestingModule,
         I18nTestingModule,
         FormErrorsModule,
         SpinnerModule,

--- a/feature-libs/user/profile/components/register/register.component.spec.ts
+++ b/feature-libs/user/profile/components/register/register.component.spec.ts
@@ -6,7 +6,6 @@ import {
   UntypedFormControl,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { NgSelectModule } from '@ng-select/ng-select';
 import {
   ANONYMOUS_CONSENT_STATUS,
@@ -166,7 +165,6 @@ describe('RegisterComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
-        RouterTestingModule,
         I18nTestingModule,
         FormErrorsModule,
         NgSelectModule,

--- a/feature-libs/user/profile/components/reset-password/reset-password.component.spec.ts
+++ b/feature-libs/user/profile/components/reset-password/reset-password.component.spec.ts
@@ -6,7 +6,6 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { FormErrorsModule, SpinnerModule } from '@spartacus/storefront';
 import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
@@ -41,7 +40,6 @@ describe('ResetPasswordComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
-        RouterTestingModule,
         I18nTestingModule,
         FormErrorsModule,
         SpinnerModule,

--- a/feature-libs/user/profile/components/update-email/my-account-v2-email.component.spec.ts
+++ b/feature-libs/user/profile/components/update-email/my-account-v2-email.component.spec.ts
@@ -5,12 +5,11 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import {
+  ReactiveFormsModule,
   UntypedFormControl,
   UntypedFormGroup,
-  ReactiveFormsModule,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, User } from '@spartacus/core';
 import {
   FormErrorsModule,
@@ -18,10 +17,10 @@ import {
 } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { BehaviorSubject, Subject, of } from 'rxjs';
-import { MyAccountV2EmailComponent } from './my-account-v2-email.component';
-import createSpy = jasmine.createSpy;
-import { UpdateEmailComponentService } from './update-email-component.service';
 import { UserProfileFacade } from '../../root/facade';
+import { MyAccountV2EmailComponent } from './my-account-v2-email.component';
+import { UpdateEmailComponentService } from './update-email-component.service';
+import createSpy = jasmine.createSpy;
 
 @Component({
   selector: 'cx-spinner',
@@ -67,7 +66,6 @@ describe('MyAccountV2EmailComponent', () => {
         ReactiveFormsModule,
         I18nTestingModule,
         FormErrorsModule,
-        RouterTestingModule,
         UrlTestingModule,
         PasswordVisibilityToggleModule,
       ],

--- a/feature-libs/user/profile/components/update-email/update-email.component.spec.ts
+++ b/feature-libs/user/profile/components/update-email/update-email.component.spec.ts
@@ -10,7 +10,6 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import {
   FormErrorsModule,
@@ -54,7 +53,6 @@ describe('UpdateEmailComponent', () => {
         ReactiveFormsModule,
         I18nTestingModule,
         FormErrorsModule,
-        RouterTestingModule,
         UrlTestingModule,
         PasswordVisibilityToggleModule,
       ],

--- a/feature-libs/user/profile/components/update-password/my-account-v2-password.component.spec.ts
+++ b/feature-libs/user/profile/components/update-password/my-account-v2-password.component.spec.ts
@@ -10,7 +10,6 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import {
   FormErrorsModule,
@@ -19,8 +18,8 @@ import {
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { BehaviorSubject } from 'rxjs';
 import { MyAccountV2PasswordComponent } from './my-account-v2-password.component';
-import createSpy = jasmine.createSpy;
 import { UpdatePasswordComponentService } from './update-password-component.service';
+import createSpy = jasmine.createSpy;
 
 @Component({
   selector: 'cx-spinner',
@@ -55,7 +54,6 @@ describe('MyAccountV2PasswordComponent', () => {
         ReactiveFormsModule,
         I18nTestingModule,
         FormErrorsModule,
-        RouterTestingModule,
         UrlTestingModule,
         PasswordVisibilityToggleModule,
       ],

--- a/feature-libs/user/profile/components/update-password/update-password.component.spec.ts
+++ b/feature-libs/user/profile/components/update-password/update-password.component.spec.ts
@@ -10,7 +10,6 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, RoutingService } from '@spartacus/core';
 import {
   FormErrorsModule,
@@ -60,7 +59,6 @@ describe('UpdatePasswordComponent', () => {
         ReactiveFormsModule,
         I18nTestingModule,
         FormErrorsModule,
-        RouterTestingModule,
         UrlTestingModule,
         PasswordVisibilityToggleModule,
       ],

--- a/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.spec.ts
+++ b/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.spec.ts
@@ -6,20 +6,19 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import {
+  ReactiveFormsModule,
   UntypedFormControl,
   UntypedFormGroup,
-  ReactiveFormsModule,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { FeaturesConfigModule, I18nTestingModule } from '@spartacus/core';
 import { FormErrorsModule } from '@spartacus/storefront';
 import { UrlTestingModule } from 'projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { BehaviorSubject, Subject, of } from 'rxjs';
 import { MyAccountV2ProfileComponent } from './my-account-v2-profile.component';
-import createSpy = jasmine.createSpy;
 import { UpdateProfileComponentService } from './update-profile-component.service';
+import createSpy = jasmine.createSpy;
 @Component({
   selector: 'cx-spinner',
   template: ` <div>spinner</div> `,
@@ -56,7 +55,6 @@ describe('MyAccountV2ProfileComponent', () => {
         ReactiveFormsModule,
         I18nTestingModule,
         FormErrorsModule,
-        RouterTestingModule,
         UrlTestingModule,
         NgSelectModule,
         FeaturesConfigModule,

--- a/feature-libs/user/profile/components/update-profile/update-profile.component.spec.ts
+++ b/feature-libs/user/profile/components/update-profile/update-profile.component.spec.ts
@@ -7,7 +7,6 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { NgSelectModule } from '@ng-select/ng-select';
 import {
   FeaturesConfig,
@@ -70,7 +69,6 @@ describe('UpdateProfileComponent', () => {
         ReactiveFormsModule,
         I18nTestingModule,
         FormErrorsModule,
-        RouterTestingModule,
         UrlTestingModule,
         NgSelectModule,
       ],

--- a/integration-libs/cdc/root/guards/cdc-logout.guard.spec.ts
+++ b/integration-libs/cdc/root/guards/cdc-logout.guard.spec.ts
@@ -1,7 +1,6 @@
 import { Component, NgZone } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, RouterModule } from '@angular/router';
 import {
   AuthService,
   CmsService,
@@ -60,7 +59,7 @@ describe('CdcLogoutGuard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
           {
             path: 'logout',
             component: MockPageLayoutComponent,

--- a/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.spec.ts
+++ b/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { Store } from '@ngrx/store';
 import { CdcJsService } from '@spartacus/cdc/root';
 import {
@@ -53,12 +52,7 @@ describe('CdcLoginComponentService', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        I18nTestingModule,
-        FormErrorsModule,
-      ],
+      imports: [ReactiveFormsModule, I18nTestingModule, FormErrorsModule],
       declarations: [],
       providers: [
         CdcLoginFormComponentService,

--- a/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.spec.ts
+++ b/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CdcJsService } from '@spartacus/cdc/root';
 import {
   AuthConfigService,
@@ -53,12 +52,7 @@ describe('CDCForgotPasswordComponentService', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        RouterTestingModule,
-        I18nTestingModule,
-        FormErrorsModule,
-      ],
+      imports: [ReactiveFormsModule, I18nTestingModule, FormErrorsModule],
       declarations: [],
       providers: [
         CDCForgotPasswordComponentService,

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.spec.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   PageContext,
   PageType,
@@ -167,7 +166,6 @@ describe('MerchandisingCarouselComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [
         MerchandisingCarouselComponent,
         MockCarouselComponent,

--- a/integration-libs/cds/src/recent-searches/recent-searches.component.spec.ts
+++ b/integration-libs/cds/src/recent-searches/recent-searches.component.spec.ts
@@ -5,20 +5,19 @@
  *
  */
 
+import { CUSTOM_ELEMENTS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  RecentSearchesComponent,
-  SearchBoxOutlet,
-} from './recent-searches.component';
-import { RecentSearchesService } from './recent-searches.service';
+import { I18nTestingModule } from '@spartacus/core';
 import {
   OutletContextData,
   SearchBoxComponentService,
 } from '@spartacus/storefront';
 import { BehaviorSubject, of } from 'rxjs';
-import { I18nTestingModule } from '@spartacus/core';
-import { CUSTOM_ELEMENTS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
-import { RouterTestingModule } from '@angular/router/testing';
+import {
+  RecentSearchesComponent,
+  SearchBoxOutlet,
+} from './recent-searches.component';
+import { RecentSearchesService } from './recent-searches.service';
 
 @Pipe({
   name: 'cxHighlight',
@@ -58,7 +57,7 @@ describe('RecentSearchesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       declarations: [RecentSearchesComponent, MockHighlightPipe, MockUrlPipe],
       providers: [
         {

--- a/integration-libs/cds/src/trending-searches/trending-searches.component.spec.ts
+++ b/integration-libs/cds/src/trending-searches/trending-searches.component.spec.ts
@@ -5,17 +5,16 @@
  *
  */
 
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { I18nTestingModule } from '@spartacus/core';
 import {
   OutletContextData,
   SearchBoxComponentService,
 } from '@spartacus/storefront';
 import { BehaviorSubject, of } from 'rxjs';
-import { I18nTestingModule } from '@spartacus/core';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { RouterTestingModule } from '@angular/router/testing';
-import { TrendingSearchesComponent } from './trending-searches.component';
 import { SearchBoxOutletTrendingSearches } from './model';
+import { TrendingSearchesComponent } from './trending-searches.component';
 import { TrendingSearchesService } from './trending-searches.service';
 
 describe('TrendingSearchesComponent', () => {
@@ -32,7 +31,7 @@ describe('TrendingSearchesComponent', () => {
   };
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       declarations: [TrendingSearchesComponent],
       providers: [
         {

--- a/integration-libs/cpq-quote/cpq-quote-discount/components/cpq-quote-discount-tbody/cpq-quote.component.spec.ts
+++ b/integration-libs/cpq-quote/cpq-quote-discount/components/cpq-quote-discount-tbody/cpq-quote.component.spec.ts
@@ -1,12 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CpqQuoteDiscountComponent } from './cpq-quote.component';
-import { CartItemContext, OrderEntry } from '@spartacus/cart/base/root';
-import { ReplaySubject, of } from 'rxjs';
 import { Component, Input } from '@angular/core';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CartItemContext, OrderEntry } from '@spartacus/cart/base/root';
+import { CpqDiscounts } from '@spartacus/cpq-quote/root';
+import { ReplaySubject, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { CpqQuoteService } from '../../cpq-qute.service';
-import { CpqDiscounts } from '@spartacus/cpq-quote/root';
+import { CpqQuoteDiscountComponent } from './cpq-quote.component';
 
 class MockCartItemContext implements Partial<CartItemContext> {
   item$ = new ReplaySubject<OrderEntry>(1);
@@ -32,7 +31,6 @@ describe('CpqQuoteDiscountComponent', () => {
     };
     mockCartItemContext = new MockCartItemContext();
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [
         CpqQuoteDiscountComponent,
         MockConfigureCpqDiscountsComponent,

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.component.spec.ts
@@ -1,11 +1,14 @@
 import { CommonModule } from '@angular/common';
 import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nModule,
   MockTranslatePipe,
@@ -16,10 +19,6 @@ import { IconModule } from '@spartacus/storefront';
 import { Observable, of } from 'rxjs';
 import { VisualPickingProductFilterComponent } from './visual-picking-product-filter.component';
 import { VisualPickingProductFilterService } from './visual-picking-product-filter.service';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
 
 class MockVisualPickingProductFilterService {
   set filter(filter: string) {
@@ -46,14 +45,7 @@ describe('VisualPickingProductFilterComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [VisualPickingProductFilterComponent, MockTranslatePipe],
-      imports: [
-        RouterTestingModule,
-        I18nModule,
-        CommonModule,
-        FormsModule,
-        UrlModule,
-        IconModule,
-      ],
+      imports: [I18nModule, CommonModule, FormsModule, UrlModule, IconModule],
       providers: [
         {
           provide: VisualPickingProductFilterService,

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.spec.ts
@@ -9,7 +9,6 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   ActiveCartFacade,
   Cart,
@@ -120,7 +119,6 @@ describe('CompactAddToCartComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
-        RouterTestingModule,
         SpinnerModule,
         I18nTestingModule,
         ReactiveFormsModule,

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { LoggerService } from '@spartacus/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { EMPTY } from 'rxjs';
@@ -47,7 +46,6 @@ describe('PagedList Component', () => {
   let headerTemplate: any;
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [
         PagedListComponent,
         MockCxIconComponent,

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.spec.ts
@@ -1,11 +1,15 @@
 import { CommonModule } from '@angular/common';
 import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { Component, EventEmitter } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { Actions } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { AddToCartModule } from '@spartacus/cart/base/components/add-to-cart';
@@ -28,10 +32,6 @@ import { VisualPickingProductListItem } from './model/visual-picking-product-lis
 import { PagedListModule } from './paged-list/paged-list.module';
 import { VisualPickingProductListComponent } from './visual-picking-product-list.component';
 import { VisualPickingProductListService } from './visual-picking-product-list.service';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
 
 const MockCmsComponentData = <CmsComponentData<CmsComponent>>{
   data$: of({}),
@@ -147,7 +147,7 @@ describe('VisualPickingProductListComponent', () => {
       imports: [
         CommonModule,
         StoreModule.forRoot({}),
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
           {
             path: 'product',
             component: MockPageLayoutComponent,

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.spec.ts
@@ -1,12 +1,16 @@
 import { CommonModule } from '@angular/common';
 import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { Component, EventEmitter } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import {
   MockTranslatePipe,
   Product,
@@ -34,10 +38,6 @@ import { VisualPickingProductListComponent } from './product-list/visual-picking
 import { VisualPickingProductListService } from './product-list/visual-picking-product-list.service';
 import { VisualPickingTabComponent } from './visual-picking-tab.component';
 import { VisualPickingTabService } from './visual-picking-tab.service';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
 
 const currentProduct: Product = {
   code: 'currentProduct',
@@ -129,7 +129,7 @@ describe('VisualPickingTabComponent', () => {
         IconModule,
         FormsModule,
         UrlModule,
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
           {
             path: 'product',
             component: MockPageLayoutComponent,

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.spec.ts
@@ -1,10 +1,13 @@
 import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { Component, ElementRef, EventEmitter } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   LanguageService,
@@ -33,10 +36,6 @@ import { VisualViewerAnimationSliderModule } from './toolbar/visual-viewer-anima
 import { VisualViewerToolbarButtonModule } from './toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.module';
 import { VisualViewerComponent } from './visual-viewer.component';
 import { VisualViewerService } from './visual-viewer.service';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
 
 class MockVisualViewerService {
   set backgroundTopColor(backgroundTopColor: string) {
@@ -265,7 +264,6 @@ describe('VisualViewerComponent', () => {
       TestBed.configureTestingModule({
         declarations: [VisualViewerComponent],
         imports: [
-          RouterTestingModule,
           I18nTestingModule,
           VisualViewerToolbarButtonModule,
           VisualViewerAnimationSliderModule,
@@ -308,7 +306,6 @@ describe('VisualViewerComponent', () => {
       TestBed.configureTestingModule({
         declarations: [VisualViewerComponent],
         imports: [
-          RouterTestingModule,
           I18nTestingModule,
           VisualViewerToolbarButtonModule,
           VisualViewerAnimationSliderModule,

--- a/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.component.spec.ts
+++ b/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   ActiveCartFacade,
   Cart,
@@ -30,18 +29,18 @@ import {
   QueryState,
   UserCostCenterService,
 } from '@spartacus/core';
+import {
+  CheckoutServiceDetailsFacade,
+  CheckoutServiceSchedulePickerService,
+  S4ServiceDeliveryModeConfig,
+  ServiceDateTime,
+} from '@spartacus/s4-service/root';
 import { Card, OutletModule, PromotionsModule } from '@spartacus/storefront';
 import { IconTestingModule } from 'projects/storefrontlib/cms-components/misc/icon/testing/icon-testing.module';
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { ServiceCheckoutReviewSubmitComponent } from './service-checkout-review-submit.component';
 
 import createSpy = jasmine.createSpy;
-import {
-  CheckoutServiceDetailsFacade,
-  CheckoutServiceSchedulePickerService,
-  ServiceDateTime,
-  S4ServiceDeliveryModeConfig,
-} from '@spartacus/s4-service/root';
 const mockServiceDeliveryModeConfig: S4ServiceDeliveryModeConfig = {
   s4ServiceDeliveryMode: {
     code: 'fast-service',
@@ -255,7 +254,6 @@ describe('ServiceCheckoutReviewSubmitComponent', () => {
       imports: [
         I18nTestingModule,
         PromotionsModule,
-        RouterTestingModule,
         IconTestingModule,
         OutletModule,
       ],

--- a/integration-libs/s4-service/order/components/cancel-service-order/cancel-service-order.component.spec.ts
+++ b/integration-libs/s4-service/order/components/cancel-service-order/cancel-service-order.component.spec.ts
@@ -1,20 +1,22 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { CancelServiceOrderComponent } from './cancel-service-order.component';
-import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
-import { I18nTestingModule } from '@spartacus/core';
-import { of, throwError } from 'rxjs';
-import { By } from '@angular/platform-browser';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { OrderDetailsService } from '@spartacus/order/components';
-import { CancelServiceOrderFacade } from '@spartacus/s4-service/root';
-import { GlobalMessageService, GlobalMessageType } from '@spartacus/core';
-import { RoutingService } from '@spartacus/core';
-import { Pipe, PipeTransform } from '@angular/core';
 import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Pipe, PipeTransform } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import {
+  GlobalMessageService,
+  GlobalMessageType,
+  I18nTestingModule,
+  RoutingService,
+} from '@spartacus/core';
+import { OrderDetailsService } from '@spartacus/order/components';
+import { CancelServiceOrderFacade } from '@spartacus/s4-service/root';
+import { of, throwError } from 'rxjs';
+import { CancelServiceOrderComponent } from './cancel-service-order.component';
 
 // Mock classes
 class MockOrderDetailsService {
@@ -60,7 +62,7 @@ describe('CancelServiceOrderComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [CancelServiceOrderComponent, MockUrlPipe],
-      imports: [ReactiveFormsModule, RouterTestingModule, I18nTestingModule],
+      imports: [ReactiveFormsModule, I18nTestingModule],
       providers: [
         { provide: OrderDetailsService, useClass: MockOrderDetailsService },
         {

--- a/integration-libs/s4-service/order/components/guards/cancel-service-order.guard.spec.ts
+++ b/integration-libs/s4-service/order/components/guards/cancel-service-order.guard.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { SemanticPathService } from '@spartacus/core';
 import { OrderDetailsService } from '@spartacus/order/components';
 import { of } from 'rxjs';
@@ -25,7 +24,6 @@ describe('CancelServiceOrderGuard', () => {
         { provide: OrderDetailsService, useClass: MockOrderDetailsService },
         { provide: SemanticPathService, useClass: MockSemanticPathService },
       ],
-      imports: [RouterTestingModule],
     });
 
     guard = TestBed.inject(CancelServiceOrderGuard);

--- a/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.spec.ts
+++ b/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.spec.ts
@@ -1,9 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { S4ServiceOrderDetailActionsComponent } from './s4-service-order-detail-actions.component';
-import { RouterTestingModule } from '@angular/router/testing';
 import { Component, DebugElement, Pipe, PipeTransform } from '@angular/core';
-import { EMPTY, Observable, of } from 'rxjs';
+import { By } from '@angular/platform-browser';
 import {
   GlobalMessageService,
   GlobalMessageType,
@@ -13,9 +11,10 @@ import {
   TranslationService,
 } from '@spartacus/core';
 import { OrderDetailsService } from '@spartacus/order/components';
-import { CheckoutServiceSchedulePickerService } from '@spartacus/s4-service/root';
-import { By } from '@angular/platform-browser';
 import { Order } from '@spartacus/order/root';
+import { CheckoutServiceSchedulePickerService } from '@spartacus/s4-service/root';
+import { EMPTY, Observable, of } from 'rxjs';
+import { S4ServiceOrderDetailActionsComponent } from './s4-service-order-detail-actions.component';
 
 const mockOrder1 = {
   serviceCancellable: true,
@@ -78,7 +77,7 @@ describe('S4ServiceOrderDetailActionsComponent', () => {
     }
 
     TestBed.configureTestingModule({
-      imports: [I18nModule, RouterTestingModule],
+      imports: [I18nModule],
       providers: [
         { provide: TranslationService, useClass: MockTranslationService },
         { provide: OrderDetailsService, useClass: MockOrderDetailsService },

--- a/integration-libs/s4om/root/components/schedule-lines/schedule-lines.component.spec.ts
+++ b/integration-libs/s4om/root/components/schedule-lines/schedule-lines.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CartItemContext, OrderEntry } from '@spartacus/cart/base/root';
 import { LanguageService } from '@spartacus/core';
 import { ScheduleLine } from '@spartacus/s4om/root';
@@ -42,7 +41,7 @@ describe('ScheduleLinesCartEntryComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      imports: [ReactiveFormsModule, I18nTestingModule],
       declarations: [
         ScheduleLinesComponent,
         MockConfigureScheduleLineComponent,

--- a/projects/core/src/auth/client-auth/services/client-error-handling.service.spec.ts
+++ b/projects/core/src/auth/client-auth/services/client-error-handling.service.spec.ts
@@ -1,6 +1,5 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { Observable, of } from 'rxjs';
 import { ClientToken } from '../models/client-token.model';
 import { ClientErrorHandlingService } from './client-error-handling.service';
@@ -33,7 +32,6 @@ describe('ClientErrorHandlingService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         ClientErrorHandlingService,
         { provide: ClientTokenService, useClass: MockClientTokenService },

--- a/projects/core/src/auth/user-auth/guards/auth.guard.spec.ts
+++ b/projects/core/src/auth/user-auth/guards/auth.guard.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { RedirectCommand, UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EMPTY, Observable, of } from 'rxjs';
 import { SemanticPathService } from '../../../routing/configurable-routes/url-translation/semantic-path.service';
 import { AuthService } from '../facade/auth.service';
@@ -44,7 +43,6 @@ describe('AuthGuard', () => {
           useClass: MockAuthRedirectService,
         },
       ],
-      imports: [RouterTestingModule],
     });
     guard = TestBed.inject(AuthGuard);
     authService = TestBed.inject(AuthService);

--- a/projects/core/src/auth/user-auth/guards/not-auth.guard.spec.ts
+++ b/projects/core/src/auth/user-auth/guards/not-auth.guard.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { RedirectCommand, UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { EMPTY, Observable, of } from 'rxjs';
 import { SemanticPathService } from '../../../routing/configurable-routes/url-translation/semantic-path.service';
 import { AuthService } from '../facade/auth.service';
@@ -28,7 +27,6 @@ describe('NotAuthGuard', () => {
         { provide: SemanticPathService, useClass: SemanticPathServiceStub },
         { provide: AuthService, useClass: AuthServiceStub },
       ],
-      imports: [RouterTestingModule],
     });
     authService = TestBed.inject(AuthService);
     guard = TestBed.inject(NotAuthGuard);

--- a/projects/core/src/auth/user-auth/services/auth-redirect.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/auth-redirect.service.spec.ts
@@ -1,7 +1,6 @@
 import { Component, NgZone } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Navigation, Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Navigation, Router, RouterModule } from '@angular/router';
 import { RoutingService } from '../../../routing/facade/routing.service';
 import { AuthFlowRoutesService } from './auth-flow-routes.service';
 import { AuthRedirectStorageService } from './auth-redirect-storage.service';
@@ -40,7 +39,7 @@ describe('AuthRedirectService', () => {
         { provide: AuthFlowRoutesService, useClass: MockAuthFlowRoutesService },
       ],
       imports: [
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
           { path: 'login', component: TestComponent },
 
           { path: 'some/url', redirectTo: 'some/url/after/redirects' },

--- a/projects/core/src/routing/configurable-routes/url-translation/semantic-path.service.spec.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/semantic-path.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { RouteConfig } from '../routes-config';
 import { RoutingConfigService } from '../routing-config.service';
 import { SemanticPathService } from './semantic-path.service';
@@ -16,7 +15,6 @@ describe('SemanticPathService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [
         SemanticPathService,
         UrlParsingService,

--- a/projects/core/src/routing/configurable-routes/url-translation/url-parsing.service.spec.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/url-parsing.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { UrlParsingService } from './url-parsing.service';
 
 describe('UrlParsingService', () => {
@@ -7,7 +6,6 @@ describe('UrlParsingService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       providers: [UrlParsingService],
     });
     service = TestBed.inject(UrlParsingService);

--- a/projects/core/src/routing/external-routes/external-routes.service.spec.ts
+++ b/projects/core/src/routing/external-routes/external-routes.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, RouterModule } from '@angular/router';
 import { UrlMatcherService } from '../services/url-matcher.service';
 import { ExternalRoutesConfig } from './external-routes-config';
 import { ExternalRoutesGuard } from './external-routes.guard';
@@ -30,7 +29,7 @@ describe('ExternalRoutesService', () => {
       ],
 
       imports: [
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
           {
             path: '**',
             component: {} as any,

--- a/projects/core/src/routing/facade/routing-params.service.spec.ts
+++ b/projects/core/src/routing/facade/routing-params.service.spec.ts
@@ -1,7 +1,6 @@
 import { Component, NgZone } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, RouterModule } from '@angular/router';
 import { RoutingParamsService } from './routing-params.service';
 
 @Component({
@@ -19,7 +18,7 @@ describe('RoutingParamsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
           {
             path: '',
             component: MockComponent,

--- a/projects/core/src/routing/facade/routing.service.spec.ts
+++ b/projects/core/src/routing/facade/routing.service.spec.ts
@@ -1,7 +1,6 @@
 import { Location } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import * as NgrxStore from '@ngrx/store';
 import { Store, StoreModule } from '@ngrx/store';
 import { WindowRef } from '@spartacus/core';
@@ -47,7 +46,7 @@ describe('RoutingService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [StoreModule.forRoot({}), RouterTestingModule],
+      imports: [StoreModule.forRoot({})],
       providers: [
         RoutingService,
         WindowRef,

--- a/projects/core/src/routing/store/effects/router.effect.spec.ts
+++ b/projects/core/src/routing/store/effects/router.effect.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, RouterModule } from '@angular/router';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { hot } from 'jasmine-marbles';
@@ -20,7 +19,7 @@ describe('Router Effects', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes(mockRoutes)],
+      imports: [RouterModule.forRoot(mockRoutes)],
       providers: [
         fromEffects.RouterEffects,
         provideMockActions(() => actions$),

--- a/projects/core/src/routing/store/reducers/router.reducer.spec.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.spec.ts
@@ -1,7 +1,6 @@
 import { Component, NgZone } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, RouterModule } from '@angular/router';
 import * as fromNgrxRouter from '@ngrx/router-store';
 import {
   RouterStateSerializer,
@@ -48,7 +47,7 @@ describe('Router Reducer', () => {
       declarations: [TestComponent],
       imports: [
         StoreModule.forRoot(fromReducer.reducerToken),
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
           { path: '', component: TestComponent },
           {
             path: 'category/:categoryCode',

--- a/projects/storefrontlib/cms-components/content/banner-carousel/banner-carousel.spec.ts
+++ b/projects/storefrontlib/cms-components/content/banner-carousel/banner-carousel.spec.ts
@@ -1,17 +1,16 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import {
   CmsBannerCarouselComponent,
   CmsBannerCarouselEffect,
   CmsComponent,
   CmsService,
 } from '@spartacus/core';
-import { CarouselComponent } from '../../../shared/components/carousel/carousel.component';
 import { of } from 'rxjs';
 import {
   CmsComponentData,
   ComponentWrapperDirective,
 } from '../../../cms-structure/index';
+import { CarouselComponent } from '../../../shared/components/carousel/carousel.component';
 import { IconComponent } from '../../misc';
 import { BannerCarouselComponent } from './banner-carousel.component';
 
@@ -36,7 +35,6 @@ describe('CreateComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [
         BannerCarouselComponent,
         CarouselComponent,

--- a/projects/storefrontlib/cms-components/content/banner/banner.component.spec.ts
+++ b/projects/storefrontlib/cms-components/content/banner/banner.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CmsBannerComponent,
   CmsService,
@@ -82,7 +81,7 @@ describe('BannerComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, FeaturesConfigModule],
+      imports: [FeaturesConfigModule],
       declarations: [
         BannerComponent,
         MockMediaComponent,

--- a/projects/storefrontlib/cms-components/content/link/link.component.spec.ts
+++ b/projects/storefrontlib/cms-components/content/link/link.component.spec.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
 import { CmsLinkComponent } from '@spartacus/core';
 import { CmsComponentData } from '@spartacus/storefront';
 import { BehaviorSubject, Observable } from 'rxjs';
@@ -27,6 +27,10 @@ class MockCmsComponentData {
   }
 }
 
+class MockActivatedRoute {
+  constructor(public snapshot: any) {}
+}
+
 describe('LinkComponent', () => {
   let linkComponent: LinkComponent;
   let fixture: ComponentFixture<LinkComponent>;
@@ -34,9 +38,13 @@ describe('LinkComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, GenericLinkModule],
+      imports: [GenericLinkModule],
       declarations: [LinkComponent],
       providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: new MockActivatedRoute({}),
+        },
         {
           provide: CmsComponentData,
           useClass: MockCmsComponentData,

--- a/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.spec.ts
+++ b/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.spec.ts
@@ -2,7 +2,6 @@ import { DebugElement, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By, DomSanitizer } from '@angular/platform-browser';
 import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CmsComponent, CmsParagraphComponent } from '@spartacus/core';
 import { CmsComponentData } from '@spartacus/storefront';
 import { BehaviorSubject } from 'rxjs';
@@ -46,7 +45,6 @@ describe('CmsParagraphComponent in CmsLib', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [MockAnchorPipe, ParagraphComponent],
       providers: [
         {

--- a/projects/storefrontlib/cms-components/content/video/video.component.spec.ts
+++ b/projects/storefrontlib/cms-components/content/video/video.component.spec.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import {
   CmsBannerComponentMedia,
   CmsService,
@@ -81,7 +81,7 @@ describe('VideoComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterModule.forRoot([])],
       declarations: [VideoComponent, MockTranslatePipe],
       providers: [
         { provide: CmsComponentData, useClass: MockCmsVideoComponentData },

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-card.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-card.component.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CustomerCoupon,
   FeaturesConfig,
@@ -91,7 +90,7 @@ describe('CouponCardComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [CouponCardComponent, MyCouponsComponent, MockUrlPipe],
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       providers: [
         { provide: LaunchDialogService, useClass: MockLaunchDialogService },
         {

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CustomerCoupon,
   CustomerCouponSearchResult,
@@ -168,7 +167,7 @@ describe('MyCouponsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule, SpinnerModule],
+      imports: [I18nTestingModule, SpinnerModule],
       declarations: [
         MyCouponsComponent,
         MockedCouponCardComponent,

--- a/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.component.spec.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.component.spec.ts
@@ -10,7 +10,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   GlobalMessageService,
   I18nTestingModule,
@@ -213,7 +212,7 @@ describe('MyInterestsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       providers: [
         { provide: OccConfig, useValue: MockOccModuleConfig },
         { provide: LayoutConfig, useValue: MockLayoutConfig },

--- a/projects/storefrontlib/cms-components/navigation/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/breadcrumb/breadcrumb.component.spec.ts
@@ -1,10 +1,9 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { I18nTestingModule, PageMeta, PageMetaService } from '@spartacus/core';
 import { CmsComponentData } from '@spartacus/storefront';
+import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
 import { Observable, of } from 'rxjs';
 import { BreadcrumbComponent } from './breadcrumb.component';
-import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
 
 class MockPageMetaService {
   getMeta(): Observable<PageMeta> {
@@ -21,7 +20,7 @@ describe('BreadcrumbComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [BreadcrumbComponent, MockFeatureDirective],
       providers: [
         { provide: PageMetaService, useClass: MockPageMetaService },

--- a/projects/storefrontlib/cms-components/navigation/category-navigation/category-navigation.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/category-navigation/category-navigation.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, DebugElement, Input } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CmsNavigationComponent, I18nTestingModule } from '@spartacus/core';
 import { of } from 'rxjs';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
@@ -59,7 +58,7 @@ describe('CategoryNavigationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [CategoryNavigationComponent, MockNavigationComponent],
       providers: [
         {

--- a/projects/storefrontlib/cms-components/navigation/footer-navigation/footer-navigation.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/footer-navigation/footer-navigation.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, DebugElement, Input } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   AnonymousConsentsConfig,
   CmsNavigationComponent,
@@ -72,7 +71,7 @@ describe('FooterNavigationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         FooterNavigationComponent,
         NavigationComponent,

--- a/projects/storefrontlib/cms-components/navigation/navigation/navigation-ui.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/navigation/navigation-ui.component.spec.ts
@@ -6,7 +6,6 @@ import {
   tick,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   FeatureConfigService,
   I18nTestingModule,
@@ -117,7 +116,7 @@ describe('Navigation UI Component', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         NavigationUIComponent,
         MockIconComponent,

--- a/projects/storefrontlib/cms-components/navigation/page-header/page-title.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/page-header/page-title.component.spec.ts
@@ -1,11 +1,10 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { I18nTestingModule, PageMeta, PageMetaService } from '@spartacus/core';
 import { CmsComponentData } from '@spartacus/storefront';
 import { Observable, of } from 'rxjs';
 import { PageTitleComponent } from './page-title.component';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
 
 class MockPageMetaService {
   getMeta(): Observable<PageMeta> {
@@ -23,7 +22,7 @@ describe('PageTitleComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [PageTitleComponent],
       providers: [
         { provide: PageMetaService, useClass: MockPageMetaService },

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel-item/product-carousel-item.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel-item/product-carousel-item.component.spec.ts
@@ -8,7 +8,7 @@ import {
   SimpleChange,
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { By } from '@angular/platform-browser';
 import {
   I18nTestingModule,
   ProductService,
@@ -21,7 +21,6 @@ import {
   ProductListItemContextSource,
 } from '@spartacus/storefront';
 import { ProductCarouselItemComponent } from './product-carousel-item.component';
-import { By } from '@angular/platform-browser';
 
 @Pipe({
   name: 'cxUrl',
@@ -74,7 +73,7 @@ describe('ProductCarouselItemComponent in product-carousel', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule, OutletModule],
+      imports: [I18nTestingModule, OutletModule],
       declarations: [
         ProductCarouselItemComponent,
         MockUrlPipe,

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
@@ -5,17 +5,16 @@ import {
   PipeTransform,
   TemplateRef,
 } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CmsProductCarouselComponent,
-  I18nTestingModule,
   FeatureConfigService,
+  I18nTestingModule,
   Product,
   ProductScope,
-  ProductService,
   ProductSearchByCodeService,
+  ProductService,
 } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
 import { CmsComponentData } from '../../../../cms-structure/page/model/cms-component-data';
@@ -161,7 +160,7 @@ describe('ProductCarouselComponent', () => {
   let productSearchByCodeService: MockProductSearchByCodeService;
 
   const testBedDefaults = {
-    imports: [RouterTestingModule, I18nTestingModule],
+    imports: [I18nTestingModule],
     declarations: [
       ProductCarouselComponent,
       MockProductCarouselItemComponent,

--- a/projects/storefrontlib/cms-components/product/carousel/product-references/product-references.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-references/product-references.component.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CmsProductReferencesComponent,
   Product,
@@ -123,7 +122,6 @@ describe('ProductReferencesComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [
         ProductReferencesComponent,
         MockCarouselComponent,

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-list.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-list.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input, Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { GlobalMessageService, I18nTestingModule } from '@spartacus/core';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { Observable, of } from 'rxjs';
@@ -106,7 +105,6 @@ describe('ProductListComponent', () => {
       imports: [
         ListNavigationModule,
         FormsModule,
-        RouterTestingModule,
         I18nTestingModule,
         InfiniteScrollModule,
         SpinnerModule,

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-scroll/product-scroll.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-scroll/product-scroll.component.spec.ts
@@ -5,9 +5,8 @@ import {
   Pipe,
   PipeTransform,
 } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, ProductSearchPage } from '@spartacus/core';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { ProductGridItemComponent } from '../..';
@@ -172,12 +171,7 @@ describe('ProductScrollComponent', () => {
         MockStyleIconsComponent,
         MockFeatureLevelDirective,
       ],
-      imports: [
-        InfiniteScrollModule,
-        I18nTestingModule,
-        SpinnerModule,
-        RouterTestingModule,
-      ],
+      imports: [InfiniteScrollModule, I18nTestingModule, SpinnerModule],
       providers: [
         {
           provide: ProductListComponentService,

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.spec.ts
@@ -6,7 +6,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { Breadcrumb, I18nTestingModule } from '@spartacus/core';
 import { EMPTY, of } from 'rxjs';
 import { KeyboardFocusModule } from '../../../../../layout/a11y/keyboard-focus/keyboard-focus.module';
@@ -38,7 +37,7 @@ describe('ActiveFacetsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule, KeyboardFocusModule],
+      imports: [I18nTestingModule, KeyboardFocusModule],
       declarations: [ActiveFacetsComponent, MockCxIconComponent],
       providers: [{ provide: FacetService, useClass: MockFacetService }],
     })

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.spec.ts
@@ -8,8 +8,10 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { FeatureConfigService, I18nTestingModule } from '@spartacus/core';
+import { KeyboardFocusService } from '@spartacus/storefront';
+import { TabModule } from 'projects/storefrontlib/cms-components/content/tab/tab.module';
+import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
 import { EMPTY, of } from 'rxjs';
 import { ICON_TYPE } from '../../../../misc/icon/icon.model';
 import {
@@ -19,9 +21,6 @@ import {
 } from '../facet.model';
 import { FacetService } from '../services/facet.service';
 import { FacetListComponent } from './facet-list.component';
-import { KeyboardFocusService } from '@spartacus/storefront';
-import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
-import { TabModule } from 'projects/storefrontlib/cms-components/content/tab/tab.module';
 
 @Component({
   selector: 'cx-icon',
@@ -71,7 +70,7 @@ describe('FacetListComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule, TabModule],
+      imports: [I18nTestingModule, TabModule],
       declarations: [
         FacetListComponent,
         MockIconComponent,

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.spec.ts
@@ -7,7 +7,6 @@ import {
   QueryList,
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   Facet,
   FeatureConfigService,
@@ -68,7 +67,7 @@ describe('FacetComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         FacetComponent,
         MockCxIconComponent,

--- a/projects/storefrontlib/cms-components/product/product-list/product-grid-item/product-grid-item.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-grid-item/product-grid-item.component.spec.ts
@@ -9,7 +9,6 @@ import {
   SimpleChange,
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   ProductService,
@@ -96,7 +95,7 @@ describe('ProductGridItemComponent in product-list', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule, OutletModule],
+      imports: [I18nTestingModule, OutletModule],
       declarations: [
         ProductGridItemComponent,
         MockMediaComponent,

--- a/projects/storefrontlib/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
@@ -9,7 +9,6 @@ import {
   SimpleChange,
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   ProductService,
@@ -96,7 +95,7 @@ describe('ProductListItemComponent in product-list', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule, OutletModule],
+      imports: [I18nTestingModule, OutletModule],
       declarations: [
         ProductListItemComponent,
         MockPictureComponent,

--- a/projects/storefrontlib/cms-components/product/product-summary/product-summary.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-summary/product-summary.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   FeatureConfigService,
   I18nTestingModule,
@@ -25,7 +24,7 @@ describe('ProductSummaryComponent in product', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [ItemCounterModule, I18nTestingModule, RouterTestingModule],
+      imports: [ItemCounterModule, I18nTestingModule],
       declarations: [ProductSummaryComponent, OutletDirective],
       providers: [
         {

--- a/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   I18nTestingModule,
   NotificationPreference,
@@ -50,12 +49,7 @@ describe('StockNotificationDialogComponent', () => {
         FocusDirective,
         MockFeatureDirective,
       ],
-      imports: [
-        I18nTestingModule,
-        RouterTestingModule,
-        SpinnerModule,
-        UrlTestingModule,
-      ],
+      imports: [I18nTestingModule, SpinnerModule, UrlTestingModule],
       providers: [
         { provide: LaunchDialogService, useClass: MockLaunchDialogService },
         { provide: UserInterestsService, useValue: interestsService },

--- a/projects/storefrontlib/cms-components/product/stock-notification/stock-notification.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/stock-notification/stock-notification.component.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   GlobalMessageService,
   I18nTestingModule,
@@ -121,7 +120,7 @@ describe('StockNotificationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [I18nTestingModule, RouterTestingModule, SpinnerModule],
+      imports: [I18nTestingModule, SpinnerModule],
       declarations: [
         StockNotificationComponent,
         StockNotificationDialogComponent,

--- a/projects/storefrontlib/cms-components/user/login-route/login.guard.spec.ts
+++ b/projects/storefrontlib/cms-components/user/login-route/login.guard.spec.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import {
+  ActivatedRouteSnapshot,
+  RouterModule,
+  RouterStateSnapshot,
+} from '@angular/router';
 import {
   AuthConfigService,
   AuthService,
@@ -50,7 +53,7 @@ describe('LoginGuard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
           {
             path: 'login',
             component: MockPageLayoutComponent,

--- a/projects/storefrontlib/cms-components/user/logout/logout.guard.spec.ts
+++ b/projects/storefrontlib/cms-components/user/logout/logout.guard.spec.ts
@@ -1,7 +1,6 @@
 import { Component, NgZone } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, RouterModule } from '@angular/router';
 import {
   AuthService,
   CmsService,
@@ -49,7 +48,7 @@ describe('LogoutGuard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
           {
             path: 'logout',
             component: MockPageLayoutComponent,

--- a/projects/storefrontlib/cms-structure/guards/cms-page-guard.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/guards/cms-page-guard.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterStateSnapshot, UrlTree } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CmsActivatedRouteSnapshot,
   CmsService,
@@ -78,7 +77,6 @@ describe('CmsPageGuardService', () => {
           useClass: MockRoutingService,
         },
       ],
-      imports: [RouterTestingModule],
     });
 
     cms = TestBed.inject(CmsService);

--- a/projects/storefrontlib/cms-structure/guards/cms-page.guard.spec.ts
+++ b/projects/storefrontlib/cms-structure/guards/cms-page.guard.spec.ts
@@ -5,7 +5,6 @@ import {
   RouterStateSnapshot,
   UrlTree,
 } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   CmsService,
   Page,
@@ -72,7 +71,6 @@ describe('CmsPageGuard', () => {
           useClass: MockBeforeCmsPageGuardService,
         },
       ],
-      imports: [RouterTestingModule], //TODO: (CXSPA-8538) consider replacing deprecated `RouterTestingModule`
     });
 
     routingService = TestBed.inject(RoutingService);

--- a/projects/storefrontlib/layout/main/storefront.component.spec.ts
+++ b/projects/storefrontlib/layout/main/storefront.component.spec.ts
@@ -1,6 +1,5 @@
 import { Component, DebugElement, Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { RoutingService } from '@spartacus/core';
 import { EMPTY, Observable, of } from 'rxjs';
 import { OutletDirective } from '../../cms-structure';
@@ -69,7 +68,6 @@ describe('StorefrontComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [
         StorefrontComponent,
         MockHeaderComponent,

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
@@ -1,13 +1,12 @@
 import { Component, Input, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule, LoggerService, Product } from '@spartacus/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { EMPTY, Observable, of } from 'rxjs';
+import { MockFeatureDirective } from '../../test/mock-feature-directive';
 import { CarouselComponent } from './carousel.component';
 import { CarouselService } from './carousel.service';
-import { MockFeatureDirective } from '../../test/mock-feature-directive';
 
 class MockCarouselService {
   getItemsPerSlide(
@@ -51,7 +50,7 @@ describe('Carousel Component', () => {
   let template: TemplateRef<any>;
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [
         CarouselComponent,
         MockCxIconComponent,

--- a/projects/storefrontlib/shared/components/form/form-errors/form-errors.component.spec.ts
+++ b/projects/storefrontlib/shared/components/form/form-errors/form-errors.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { UntypedFormControl } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import {
   FeatureConfigService,
   I18nTestingModule,
@@ -27,7 +26,7 @@ describe('FormErrors', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       providers: [
         FeatureConfigService,
         {

--- a/projects/storefrontlib/shared/components/generic-link/generic-link.component.spec.ts
+++ b/projects/storefrontlib/shared/components/generic-link/generic-link.component.spec.ts
@@ -1,7 +1,6 @@
 import { SimpleChange, SimpleChanges } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { GenericLinkComponent } from './generic-link.component';
 
 /**
@@ -19,7 +18,6 @@ describe('GenericLinkComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
       declarations: [GenericLinkComponent],
     }).compileComponents();
   });

--- a/projects/storefrontlib/shared/components/item-counter/item-counter.component.spec.ts
+++ b/projects/storefrontlib/shared/components/item-counter/item-counter.component.spec.ts
@@ -6,7 +6,6 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { MockKeyboardFocusDirective } from '@spartacus/storefront';
 import { MockFeatureDirective } from '../../test/mock-feature-directive';
@@ -22,7 +21,7 @@ describe('ItemCounterComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, ReactiveFormsModule, I18nTestingModule],
+      imports: [ReactiveFormsModule, I18nTestingModule],
       declarations: [
         ItemCounterComponent,
         MockFeatureDirective,

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.component.spec.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.component.spec.ts
@@ -2,7 +2,6 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute, Params } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { MockFeatureDirective } from 'projects/storefrontlib/shared/test/mock-feature-directive';
 import { PaginationConfig } from './config/pagination.config';
@@ -26,7 +25,7 @@ describe('PaginationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, I18nTestingModule],
+      imports: [I18nTestingModule],
       declarations: [PaginationComponent, MockFeatureDirective],
       providers: [
         {

--- a/projects/storefrontlib/shared/components/popover/popover.component.spec.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.component.spec.ts
@@ -1,7 +1,6 @@
 import { ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
@@ -36,12 +35,7 @@ describe('PopoverComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule,
-        IconModule,
-        KeyboardFocusTestingModule,
-        I18nTestingModule,
-      ],
+      imports: [IconModule, KeyboardFocusTestingModule, I18nTestingModule],
       declarations: [PopoverComponent],
       providers: [
         { provide: PositioningService, useClass: MockPositionService },

--- a/projects/storefrontlib/shared/components/popover/popover.directive.spec.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.directive.spec.ts
@@ -1,7 +1,6 @@
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { PopoverModule } from './popover.module';
 
@@ -45,7 +44,7 @@ describe('PopoverDirective', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, PopoverModule, I18nTestingModule],
+      imports: [PopoverModule, I18nTestingModule],
       declarations: [PopoverTestComponent],
     }).compileComponents();
 

--- a/projects/storefrontlib/shared/components/truncate-text-popover/truncate-text-popover.component.spec.ts
+++ b/projects/storefrontlib/shared/components/truncate-text-popover/truncate-text-popover.component.spec.ts
@@ -1,7 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { I18nTestingModule } from '@spartacus/core';
 import { TruncateTextPopoverComponent } from './truncate-text-popover.component';
 import { TruncateTextPopoverModule } from './truncate-text-popover.module';
@@ -19,11 +18,7 @@ describe('TruncateTextPopoverComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        I18nTestingModule,
-        TruncateTextPopoverModule,
-        RouterTestingModule,
-      ],
+      imports: [I18nTestingModule, TruncateTextPopoverModule],
       declarations: [TruncateTextPopoverComponent],
     }).compileComponents();
   }));


### PR DESCRIPTION
- replace with RouterModule.forRoot([]) where needed
- remove redundant usage of RouterTestingModule