### PR TITLE
refactor(opf): address some review comments - part 12

### DIFF
--- a/integration-libs/opf/base/root/services/opf-resource-loader.service.spec.ts
+++ b/integration-libs/opf/base/root/services/opf-resource-loader.service.spec.ts
@@ -111,35 +111,21 @@ describe('OpfResourceLoaderService', () => {
 
       spyOn<any>(opfResourceLoaderService, 'loadScript').and.callThrough();
       spyOn<any>(opfResourceLoaderService, 'loadStyles').and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'markResourceAsLoaded'
-      ).and.callThrough();
 
       opfResourceLoaderService.loadProviderResources([], [mockStyleResource]);
 
       expect(opfResourceLoaderService['loadScript']).not.toHaveBeenCalled();
       expect(opfResourceLoaderService['loadStyles']).not.toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['markResourceAsLoaded']
-      ).toHaveBeenCalled();
     }));
 
     it('should not load provider resources when no resources are provided', fakeAsync(() => {
       spyOn<any>(opfResourceLoaderService, 'loadScript').and.callThrough();
       spyOn<any>(opfResourceLoaderService, 'loadStyles').and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'markResourceAsLoaded'
-      ).and.callThrough();
 
       opfResourceLoaderService.loadProviderResources();
 
       expect(opfResourceLoaderService['loadScript']).not.toHaveBeenCalled();
       expect(opfResourceLoaderService['loadStyles']).not.toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['markResourceAsLoaded']
-      ).not.toHaveBeenCalled();
     }));
 
     it('should mark resource as loaded when script is successfully loaded', fakeAsync(() => {
@@ -150,10 +136,7 @@ describe('OpfResourceLoaderService', () => {
 
       spyOn<any>(opfResourceLoaderService, 'loadScript').and.callThrough();
       spyOn<any>(opfResourceLoaderService, 'loadStyles').and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'markResourceAsLoaded'
-      ).and.callThrough();
+
       spyOn<any>(ScriptLoader.prototype, 'embedScript').and.callFake(
         (options: any) => {
           options.callback?.();
@@ -165,9 +148,6 @@ describe('OpfResourceLoaderService', () => {
       expect(opfResourceLoaderService['loadStyles']).not.toHaveBeenCalled();
       expect(opfResourceLoaderService['loadScript']).toHaveBeenCalled();
       expect(ScriptLoader.prototype.embedScript).toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['markResourceAsLoaded']
-      ).toHaveBeenCalled();
     }));
 
     it('should handle resource loading error when script is not successfully loaded', fakeAsync(() => {
@@ -178,14 +158,7 @@ describe('OpfResourceLoaderService', () => {
 
       spyOn<any>(opfResourceLoaderService, 'loadScript').and.callThrough();
       spyOn<any>(opfResourceLoaderService, 'loadStyles').and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'markResourceAsLoaded'
-      ).and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'handleLoadingResourceError'
-      ).and.callThrough();
+
       spyOn<any>(ScriptLoader.prototype, 'embedScript').and.callFake(
         (options: any) => {
           options.errorCallback?.();
@@ -196,13 +169,8 @@ describe('OpfResourceLoaderService', () => {
 
       expect(opfResourceLoaderService['loadStyles']).not.toHaveBeenCalled();
       expect(opfResourceLoaderService['loadScript']).toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['markResourceAsLoaded']
-      ).not.toHaveBeenCalled();
+
       expect(ScriptLoader.prototype.embedScript).toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['handleLoadingResourceError']
-      ).toHaveBeenCalled();
     }));
 
     it('should mark resource as loaded when style is successfully loaded', fakeAsync(() => {
@@ -213,10 +181,7 @@ describe('OpfResourceLoaderService', () => {
 
       spyOn<any>(opfResourceLoaderService, 'loadScript').and.callThrough();
       spyOn<any>(opfResourceLoaderService, 'loadStyles').and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'markResourceAsLoaded'
-      ).and.callThrough();
+
       spyOn<any>(opfResourceLoaderService, 'embedStyles').and.callFake(
         (options: any) => {
           options.callback?.(); // Simulate script loading
@@ -227,9 +192,6 @@ describe('OpfResourceLoaderService', () => {
 
       expect(opfResourceLoaderService['loadScript']).not.toHaveBeenCalled();
       expect(opfResourceLoaderService['loadStyles']).toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['markResourceAsLoaded']
-      ).toHaveBeenCalled();
       expect(opfResourceLoaderService['embedStyles']).toHaveBeenCalled();
     }));
 
@@ -241,14 +203,7 @@ describe('OpfResourceLoaderService', () => {
 
       spyOn<any>(opfResourceLoaderService, 'loadScript').and.callThrough();
       spyOn<any>(opfResourceLoaderService, 'loadStyles').and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'markResourceAsLoaded'
-      ).and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'handleLoadingResourceError'
-      ).and.callThrough();
+
       spyOn<any>(opfResourceLoaderService, 'embedStyles').and.callFake(
         (options: any) => {
           options.errorCallback?.(); // Simulate script loading
@@ -258,14 +213,9 @@ describe('OpfResourceLoaderService', () => {
       opfResourceLoaderService.loadProviderResources([], [mockStylesResources]);
 
       expect(opfResourceLoaderService['loadScript']).not.toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['markResourceAsLoaded']
-      ).not.toHaveBeenCalled();
+
       expect(opfResourceLoaderService['loadStyles']).toHaveBeenCalled();
       expect(opfResourceLoaderService['embedStyles']).toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['handleLoadingResourceError']
-      ).toHaveBeenCalled();
     }));
 
     it('should not embed styles if there is no style in the element', fakeAsync(() => {
@@ -275,10 +225,7 @@ describe('OpfResourceLoaderService', () => {
       };
 
       spyOn<any>(opfResourceLoaderService, 'embedStyles').and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'markResourceAsLoaded'
-      ).and.callThrough();
+
       mockDocument.querySelector = jasmine
         .createSpy('querySelector')
         .and.returnValue({} as Element);
@@ -286,9 +233,6 @@ describe('OpfResourceLoaderService', () => {
       opfResourceLoaderService.loadProviderResources([], [mockStyleResource]);
 
       expect(opfResourceLoaderService['embedStyles']).not.toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['markResourceAsLoaded']
-      ).toHaveBeenCalled();
     }));
 
     it('should not embed script if there is no script in the element', fakeAsync(() => {
@@ -298,10 +242,7 @@ describe('OpfResourceLoaderService', () => {
       };
 
       spyOn<any>(opfResourceLoaderService, 'embedScript').and.callThrough();
-      spyOn<any>(
-        opfResourceLoaderService,
-        'markResourceAsLoaded'
-      ).and.callThrough();
+
       mockDocument.querySelector = jasmine
         .createSpy('querySelector')
         .and.returnValue({} as Element);
@@ -309,9 +250,6 @@ describe('OpfResourceLoaderService', () => {
       opfResourceLoaderService.loadProviderResources([mockScriptResource]);
 
       expect(opfResourceLoaderService['embedScript']).not.toHaveBeenCalled();
-      expect(
-        opfResourceLoaderService['markResourceAsLoaded']
-      ).toHaveBeenCalled();
     }));
   });
 

--- a/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
+++ b/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
@@ -26,8 +26,6 @@ export class OpfResourceLoaderService extends ScriptLoader {
 
   protected readonly OPF_RESOURCE_ATTRIBUTE_KEY = 'data-opf-resource';
 
-  protected loadedResources: OpfDynamicScriptResource[] = [];
-
   protected embedStyles(embedOptions: {
     src: string;
     callback?: EventListener;
@@ -60,75 +58,56 @@ export class OpfResourceLoaderService extends ScriptLoader {
     return super.hasScript(src);
   }
 
-  protected handleLoadingResourceError(
-    resolve: (value: void | PromiseLike<void>) => void
-  ) {
-    resolve();
+  /**
+   * Loads a script specified in the resource object.
+   *
+   * The returned Promise is resolved when the script is loaded or already present.
+   * The returned Promise is rejected when a loading error occurs.
+   */
+  protected loadScript(resource: OpfDynamicScriptResource): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const attributes: any = {
+        type: 'text/javascript',
+        [this.OPF_RESOURCE_ATTRIBUTE_KEY]: true,
+      };
+
+      if (resource.attributes) {
+        resource.attributes.forEach((attribute) => {
+          attributes[attribute.key] = attribute.value;
+        });
+      }
+
+      if (resource.url && !this.hasScript(resource.url)) {
+        super.embedScript({
+          src: resource.url,
+          attributes: attributes,
+          callback: () => resolve(),
+          errorCallback: () => reject(),
+        });
+      } else {
+        resolve();
+      }
+    });
   }
 
-  protected isResourceLoadingCompleted(resources: OpfDynamicScriptResource[]) {
-    return resources.length === this.loadedResources.length;
-  }
-
-  protected markResourceAsLoaded(
-    resource: OpfDynamicScriptResource,
-    resources: OpfDynamicScriptResource[],
-    resolve: (value: void | PromiseLike<void>) => void
-  ) {
-    this.loadedResources.push(resource);
-    if (this.isResourceLoadingCompleted(resources)) {
-      resolve();
-    }
-  }
-
-  protected loadScript(
-    resource: OpfDynamicScriptResource,
-    resources: OpfDynamicScriptResource[],
-    resolve: (value: void | PromiseLike<void>) => void
-  ) {
-    const attributes: any = {
-      type: 'text/javascript',
-      [this.OPF_RESOURCE_ATTRIBUTE_KEY]: true,
-    };
-
-    if (resource.attributes) {
-      resource.attributes.forEach((attribute) => {
-        attributes[attribute.key] = attribute.value;
-      });
-    }
-
-    if (resource.url && !this.hasScript(resource.url)) {
-      super.embedScript({
-        src: resource.url,
-        attributes: attributes,
-        callback: () => {
-          this.markResourceAsLoaded(resource, resources, resolve);
-        },
-        errorCallback: () => {
-          this.handleLoadingResourceError(resolve);
-        },
-      });
-    } else {
-      this.markResourceAsLoaded(resource, resources, resolve);
-    }
-  }
-
-  protected loadStyles(
-    resource: OpfDynamicScriptResource,
-    resources: OpfDynamicScriptResource[],
-    resolve: (value: void | PromiseLike<void>) => void
-  ) {
-    if (resource.url && !this.hasStyles(resource.url)) {
-      this.embedStyles({
-        src: resource.url,
-        callback: () => this.markResourceAsLoaded(resource, resources, resolve),
-        errorCallback: () => {
-          this.handleLoadingResourceError(resolve);
-        },
-      });
-    } else {
-      this.markResourceAsLoaded(resource, resources, resolve);
-    }
+  /**
+   * Loads a stylesheet specified in the resource object.
+   *
+   * The returned Promise is resolved when the stylesheet is loaded or already present.
+   * The returned Promise is rejected when a loading error occurs.
+   */
+  protected loadStyles(resource: OpfDynamicScriptResource): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (resource.url && !this.hasStyles(resource.url)) {
+        this.embedStyles({
+          src: resource.url,
+          callback: () => resolve(),
+          errorCallback: () => reject(),
+        });
+      } else {
+        resolve();
+      }
+    });
   }
 
   executeScriptFromHtml(html: string | undefined) {
@@ -153,6 +132,12 @@ export class OpfResourceLoaderService extends ScriptLoader {
       });
   }
 
+  /**
+   * Loads scripts and stylesheets specified in the lists of resource objects (scripts and styles).
+   *
+   * The returned Promise is resolved when all resources are loaded.
+   * The returned Promise is also resolved (not rejected!) immediately when any loading error occurs.
+   */
   loadProviderResources(
     scripts: OpfDynamicScriptResource[] = [],
     styles: OpfDynamicScriptResource[] = []
@@ -172,28 +157,30 @@ export class OpfResourceLoaderService extends ScriptLoader {
         type: OpfDynamicScriptResourceType.STYLES,
       })),
     ];
+
     if (!resources.length) {
       return Promise.resolve();
     }
-    return new Promise((resolve) => {
-      this.loadedResources = [];
 
-      resources.forEach((resource: OpfDynamicScriptResource) => {
+    const resourcesPromises = resources.map(
+      (resource: OpfDynamicScriptResource) => {
         if (!resource.url) {
-          this.markResourceAsLoaded(resource, resources, resolve);
-        } else {
-          switch (resource.type) {
-            case OpfDynamicScriptResourceType.SCRIPT:
-              this.loadScript(resource, resources, resolve);
-              break;
-            case OpfDynamicScriptResourceType.STYLES:
-              this.loadStyles(resource, resources, resolve);
-              break;
-            default:
-              break;
-          }
+          return Promise.resolve();
         }
-      });
-    });
+
+        switch (resource.type) {
+          case OpfDynamicScriptResourceType.SCRIPT:
+            return this.loadScript(resource);
+          case OpfDynamicScriptResourceType.STYLES:
+            return this.loadStyles(resource);
+          default:
+            return Promise.resolve();
+        }
+      }
+    );
+
+    return Promise.all(resourcesPromises)
+      .then(() => {})
+      .catch(() => {});
   }
 }


### PR DESCRIPTION
 Address review comment
 https://github.com/SAP/spartacus/pull/17250#discussion_r1640935216

**How I understood previous behavior:**
The `Promise` returned from `loadProviderResources()`:
- was `resolve`d when all resources were loaded.
- was `resolve`d immediately, when any loading error occurred (for any resource)

**New behavior**
The same as above.

**Concern: should we reject a promise in case of a loading error?**
In case of a loading error, IMHO it would be semantically more correct to `reject` (not `resolve`) the `Promise`.
But I refrained from changing the previous behavior, not to possibly break other consumer classes of the method `loadProviderResources()`.

Anyways, if I understood correctly, due to the previous behavior we had (and still have) a bug - error message not displayed to the user in the payment verification page, when a loading error occur for any resource. See the dependency on the `.catch()` block below:
https://github.com/SAP/spartacus/blob/6a9c76669325222c7178c374694738c4cac2b99a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.service.ts#L242-L253
⬇️
https://github.com/SAP/spartacus/blob/6a9c76669325222c7178c374694738c4cac2b99a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts#L56-L62
⬇️
https://github.com/SAP/spartacus/blob/6a9c76669325222c7178c374694738c4cac2b99a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts#L91-L94


By the way, I've found also places which don't depend on the `.catch()` block and don't bother showing any error message in case of a resources loading error, e.g. see the google pay component below:
https://github.com/SAP/spartacus/blob/6a9c76669325222c7178c374694738c4cac2b99a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.service.ts#L140-L144
⬇️
https://github.com/SAP/spartacus/blob/6a9c76669325222c7178c374694738c4cac2b99a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.component.ts#L37-L48

