### PR TITLE
refactor(opf): rename `callbacksArray` to `callbacks`

### DIFF
--- a/integration-libs/opf/global-functions/core/facade/opf-global-functions.service.ts
+++ b/integration-libs/opf/global-functions/core/facade/opf-global-functions.service.ts
@@ -216,7 +216,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
         if (vcr) {
           overlayedSpinner = this.startLoaderSpinner(vcr);
         }
-        const callbackArray: {
+        const callbacks: {
           onSuccess: OpfPaymentMerchantCallback;
           onPending: OpfPaymentMerchantCallback;
           onFailure: OpfPaymentMerchantCallback;
@@ -231,7 +231,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
             .submitPayment({
               additionalData,
               paymentSessionId,
-              callbackArray,
+              callbacks,
               paymentMethod,
               returnPath: undefined,
             })
@@ -249,7 +249,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
 
   protected runSubmitComplete(
     additionalData: Array<OpfKeyValueMap>,
-    callbackArray: {
+    callbacks: {
       onSuccess: OpfPaymentMerchantCallback;
       onPending: OpfPaymentMerchantCallback;
       onFailure: OpfPaymentMerchantCallback;
@@ -269,7 +269,7 @@ export class OpfGlobalFunctionsService implements OpfGlobalFunctionsFacade {
           .submitCompletePayment({
             additionalData,
             paymentSessionId,
-            callbackArray,
+            callbacks,
             returnPath,
           })
           .pipe(

--- a/integration-libs/opf/payment/core/facade/opf-payment.service.spec.ts
+++ b/integration-libs/opf/payment/core/facade/opf-payment.service.spec.ts
@@ -52,7 +52,7 @@ const mockSubmitCompleteInput: OpfPaymentSubmitCompleteInput = {
   additionalData: [{ key: 'key', value: 'value' }],
   paymentSessionId: 'sessionId',
   returnPath: 'checkout',
-  callbackArray: {
+  callbacks: {
     onSuccess: () => {},
     onPending: () => {},
     onFailure: () => {},

--- a/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.spec.ts
+++ b/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.spec.ts
@@ -80,7 +80,7 @@ describe('OpfPaymentHostedFieldsService', () => {
     additionalData: [{ key: 'key', value: 'value' }],
     paymentSessionId: 'sessionId',
     returnPath: 'checkout',
-    callbackArray: {
+    callbacks: {
       onSuccess: () => {},
       onPending: () => {},
       onFailure: () => {},
@@ -91,7 +91,7 @@ describe('OpfPaymentHostedFieldsService', () => {
     additionalData: [{ key: 'key', value: 'value' }],
     paymentSessionId: 'sessionId',
     returnPath: 'checkout',
-    callbackArray: {
+    callbacks: {
       onSuccess: () => {},
       onPending: () => {},
       onFailure: () => {},

--- a/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.ts
+++ b/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.ts
@@ -87,7 +87,7 @@ export class OpfPaymentHostedFieldsService {
         )
       ),
       concatMap((response: OpfPaymentSubmitResponse) =>
-        this.paymentResponseHandler(response, submitInput.callbackArray)
+        this.paymentResponseHandler(response, submitInput.callbacks)
       ),
       tap((order: Order) => {
         if (order) {
@@ -132,7 +132,7 @@ export class OpfPaymentHostedFieldsService {
         )
       ),
       concatMap((response: OpfPaymentSubmitCompleteResponse) =>
-        this.paymentResponseHandler(response, submitCompleteInput.callbackArray)
+        this.paymentResponseHandler(response, submitCompleteInput.callbacks)
       ),
       tap((order: Order) => {
         if (order) {
@@ -160,7 +160,7 @@ export class OpfPaymentHostedFieldsService {
 
   protected paymentResponseHandler(
     response: OpfPaymentSubmitResponse | OpfPaymentSubmitCompleteResponse,
-    callbackArray: {
+    callbacks: {
       onSuccess: OpfPaymentMerchantCallback;
       onPending: OpfPaymentMerchantCallback;
       onFailure: OpfPaymentMerchantCallback;
@@ -170,15 +170,15 @@ export class OpfPaymentHostedFieldsService {
       response.status === OpfPaymentSubmitStatus.ACCEPTED ||
       response.status === OpfPaymentSubmitStatus.DELAYED
     ) {
-      return from(Promise.resolve(callbackArray.onSuccess(response))).pipe(
+      return from(Promise.resolve(callbacks.onSuccess(response))).pipe(
         concatMap(() => this.orderFacade.placePaymentAuthorizedOrder(true))
       );
     } else if (response.status === OpfPaymentSubmitStatus.PENDING) {
-      return from(Promise.resolve(callbackArray.onPending(response))).pipe(
+      return from(Promise.resolve(callbacks.onPending(response))).pipe(
         concatMap(() => EMPTY)
       );
     } else if (response.status === OpfPaymentSubmitStatus.REJECTED) {
-      return from(Promise.resolve(callbackArray.onFailure(response))).pipe(
+      return from(Promise.resolve(callbacks.onFailure(response))).pipe(
         concatMap(() =>
           throwError({
             ...opfDefaultPaymentError,
@@ -187,7 +187,7 @@ export class OpfPaymentHostedFieldsService {
         )
       );
     } else {
-      return from(Promise.resolve(callbackArray.onFailure(response))).pipe(
+      return from(Promise.resolve(callbacks.onFailure(response))).pipe(
         concatMap(() =>
           throwError({
             ...opfDefaultPaymentError,

--- a/integration-libs/opf/payment/root/model/opf-payment.model.ts
+++ b/integration-libs/opf/payment/root/model/opf-payment.model.ts
@@ -69,7 +69,7 @@ export interface OpfPaymentSubmitRequest {
 export interface OpfPaymentSubmitInput {
   additionalData: Array<OpfKeyValueMap>;
   paymentSessionId?: string;
-  callbackArray: {
+  callbacks: {
     onSuccess: OpfPaymentMerchantCallback;
     onPending: OpfPaymentMerchantCallback;
     onFailure: OpfPaymentMerchantCallback;
@@ -112,7 +112,7 @@ export interface OpfPaymentSubmitCompleteRequest {
 export interface OpfPaymentSubmitCompleteInput {
   additionalData: Array<OpfKeyValueMap>;
   paymentSessionId: string;
-  callbackArray: {
+  callbacks: {
     onSuccess: OpfPaymentMerchantCallback;
     onPending: OpfPaymentMerchantCallback;
     onFailure: OpfPaymentMerchantCallback;

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.service.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.service.ts
@@ -436,7 +436,7 @@ export class ApplePayService {
         return this.opfPaymentFacade.submitPayment({
           additionalData: [],
           paymentSessionId: '',
-          callbackArray: {
+          callbacks: {
             onSuccess: () => {},
             onPending: () => {},
             onFailure: () => {},

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.service.spec.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.service.spec.ts
@@ -641,14 +641,10 @@ describe('OpfGooglePayService', () => {
 
             expect(result).toBeDefined();
             expect(mockPaymentFacade.submitPayment).toHaveBeenCalled();
-            expect(Object.values(submitPaymentArgs.callbackArray).length).toBe(
-              3
-            );
-            Object.values(submitPaymentArgs.callbackArray).forEach(
-              (callback) => {
-                expect(typeof callback).toBe('function');
-              }
-            );
+            expect(Object.values(submitPaymentArgs.callbacks).length).toBe(3);
+            Object.values(submitPaymentArgs.callbacks).forEach((callback) => {
+              expect(typeof callback).toBe('function');
+            });
             expect(submitPaymentArgs.encryptedToken).toBe(encodedMockToken);
             expect(submitPaymentArgs.paymentMethod).toBe(
               OpfQuickBuyProviderType.GOOGLE_PAY

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.service.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.service.ts
@@ -361,7 +361,7 @@ export class OpfGooglePayService {
               return this.opfPaymentFacade.submitPayment({
                 additionalData: [],
                 paymentSessionId: '',
-                callbackArray: {
+                callbacks: {
                   onSuccess: () => {},
                   onPending: () => {},
                   onFailure: () => {},


### PR DESCRIPTION
In a recent PR we changed it from an array to an object, but forgot to change the property name. The leftover `Array` in the name is confusing.