### PR TITLE
refactor(product-availability): rename methods arguments from 'sapCode' to 'unitSapCode'

### DIFF
--- a/projects/core/src/occ/adapters/product/default-occ-product-config.ts
+++ b/projects/core/src/occ/adapters/product/default-occ-product-config.ts
@@ -27,7 +27,7 @@ export const defaultOccProductConfig: OccConfig = {
             'products/${productCode}?fields=code,name,price(formattedValue),images(DEFAULT),baseProduct',
         },
         productAvailabilities:
-          'productAvailabilities?filters=${productCode}:${sapCode}',
+          'productAvailabilities?filters=${productCode}:${unitSapCode}',
         productReviews: 'products/${productCode}/reviews',
         // Uncomment this when occ gets configured
         // productReferences:

--- a/projects/core/src/occ/adapters/product/occ-product-availability-adapter.spec.ts
+++ b/projects/core/src/occ/adapters/product/occ-product-availability-adapter.spec.ts
@@ -3,9 +3,9 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { ProductAvailabilities } from '../../../model/product.model';
 import { OccEndpointsService } from '../../services/occ-endpoints.service';
 import { OccProductAvailabilityAdapter } from './occ-product-availability-adapter';
-import { ProductAvailabilities } from '../../../model/product.model';
 
 describe('OccProductAvailabilityAdapter', () => {
   let adapter: OccProductAvailabilityAdapter;
@@ -13,8 +13,8 @@ describe('OccProductAvailabilityAdapter', () => {
   let occEndpointsService: OccEndpointsService;
 
   const mockProductCode = '12345';
-  const mockSapCode = 'EA';
-  const mockAvailabilityUrl = `https://example.com/productAvailabilities?filters=${mockProductCode}:${mockSapCode}`;
+  const mockUnitSapCode = 'EA';
+  const mockAvailabilityUrl = `https://example.com/productAvailabilities?filters=${mockProductCode}:${mockUnitSapCode}`;
   const mockResponse = {
     availabilityItems: [
       {
@@ -61,7 +61,7 @@ describe('OccProductAvailabilityAdapter', () => {
     let result: ProductAvailabilities | undefined;
 
     adapter
-      .loadRealTimeStock(mockProductCode, mockSapCode)
+      .loadRealTimeStock(mockProductCode, mockUnitSapCode)
       .subscribe((data) => {
         result = data;
       });
@@ -78,7 +78,7 @@ describe('OccProductAvailabilityAdapter', () => {
       {
         urlParams: {
           productCode: mockProductCode,
-          sapCode: mockSapCode,
+          unitSapCode: mockUnitSapCode,
         },
       }
     );
@@ -89,7 +89,7 @@ describe('OccProductAvailabilityAdapter', () => {
     let result: ProductAvailabilities | undefined;
 
     adapter
-      .loadRealTimeStock(mockProductCode, mockSapCode)
+      .loadRealTimeStock(mockProductCode, mockUnitSapCode)
       .subscribe((data) => {
         result = data;
       });

--- a/projects/core/src/occ/adapters/product/occ-product-availability-adapter.ts
+++ b/projects/core/src/occ/adapters/product/occ-product-availability-adapter.ts
@@ -20,14 +20,14 @@ export class OccProductAvailabilityAdapter
 
   loadRealTimeStock(
     productCode: string,
-    sapCode: string
+    unitSapCode: string
   ): Observable<ProductAvailabilities> {
     const availabilityUrl = this.occEndpoints.buildUrl(
       'productAvailabilities',
       {
         urlParams: {
           productCode: productCode,
-          sapCode: sapCode,
+          unitSapCode: unitSapCode,
         },
       }
     );

--- a/projects/core/src/product/connectors/product/prduct-availability.adapter.ts
+++ b/projects/core/src/product/connectors/product/prduct-availability.adapter.ts
@@ -11,12 +11,12 @@ export abstract class ProductAvailabilityAdapter {
   /**
    * Abstract method used to load real time stock data for a product
    * @param productCode
-   * @param sapCode
+   * @param unitSapCode
    * @returns {Observable<ProductAvailabilities>}
    */
 
   abstract loadRealTimeStock(
     productCode: string,
-    sapCode: string
+    unitSapCode: string
   ): Observable<ProductAvailabilities>;
 }

--- a/projects/core/src/product/connectors/product/product-availability.connector.spec.ts
+++ b/projects/core/src/product/connectors/product/product-availability.connector.spec.ts
@@ -9,7 +9,7 @@ describe('ProductAvailabilityConnector', () => {
   let adapter: jasmine.SpyObj<ProductAvailabilityAdapter>;
 
   const mockProductCode = '12345';
-  const mockSapCode = 'SAP001';
+  const mockUnitSapCode = 'SAP001';
   const mockProductAvailabilities: ProductAvailabilities = {
     quantity: '10',
     status: 'inStock',
@@ -41,12 +41,12 @@ describe('ProductAvailabilityConnector', () => {
     adapter.loadRealTimeStock.and.returnValue(of(mockProductAvailabilities));
 
     connector
-      .getRealTimeStock(mockProductCode, mockSapCode)
+      .getRealTimeStock(mockProductCode, mockUnitSapCode)
       .subscribe((data) => {
         expect(data).toEqual(mockProductAvailabilities);
         expect(adapter.loadRealTimeStock).toHaveBeenCalledWith(
           mockProductCode,
-          mockSapCode
+          mockUnitSapCode
         );
         done();
       });
@@ -56,12 +56,12 @@ describe('ProductAvailabilityConnector', () => {
     adapter.loadRealTimeStock.and.returnValue(of(null as any));
 
     connector
-      .getRealTimeStock(mockProductCode, mockSapCode)
+      .getRealTimeStock(mockProductCode, mockUnitSapCode)
       .subscribe((data) => {
         expect(data).toBeNull();
         expect(adapter.loadRealTimeStock).toHaveBeenCalledWith(
           mockProductCode,
-          mockSapCode
+          mockUnitSapCode
         );
         done();
       });

--- a/projects/core/src/product/connectors/product/product-availability.connector.ts
+++ b/projects/core/src/product/connectors/product/product-availability.connector.ts
@@ -17,8 +17,8 @@ export class ProductAvailabilityConnector {
 
   getRealTimeStock(
     productCode: string,
-    sapCode: string
+    unitSapCode: string
   ): Observable<ProductAvailabilities> {
-    return this.adapter.loadRealTimeStock(productCode, sapCode);
+    return this.adapter.loadRealTimeStock(productCode, unitSapCode);
   }
 }

--- a/projects/core/src/product/facade/product-availability.service.spec.ts
+++ b/projects/core/src/product/facade/product-availability.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { Command, CommandService } from '../../../src/util/command-query';
 import { of } from 'rxjs';
+import { Command, CommandService } from '../../../src/util/command-query';
 import { ProductAvailabilities } from '../../model/product.model';
 import { ProductAvailabilityConnector } from '../connectors';
 import { ProductAvailabilityService } from './product-availability.service';
@@ -38,7 +38,7 @@ describe('ProductAvailabilityService', () => {
   describe('getRealTimeStock', () => {
     it('should call getRealTimeStockCommand.execute with correct parameters', () => {
       const productCode = 'testProductCode';
-      const sapCode = 'testSapCode';
+      const unitSapCode = 'testUnitSapCode';
       const expectedStockData: ProductAvailabilities = {
         quantity: '100',
         status: 'IN_STOCK',
@@ -48,18 +48,20 @@ describe('ProductAvailabilityService', () => {
 
       commandSpy.execute.and.returnValue(of(expectedStockData));
 
-      service.getRealTimeStock(productCode, sapCode).subscribe((stockData) => {
-        expect(commandSpy.execute).toHaveBeenCalledWith({
-          productCode,
-          sapCode,
+      service
+        .getRealTimeStock(productCode, unitSapCode)
+        .subscribe((stockData) => {
+          expect(commandSpy.execute).toHaveBeenCalledWith({
+            productCode,
+            unitSapCode,
+          });
+          expect(stockData).toEqual(expectedStockData);
         });
-        expect(stockData).toEqual(expectedStockData);
-      });
     });
 
     it('should return observable of ProductAvailabilities when command executes successfully', () => {
       const productCode = 'testProductCode';
-      const sapCode = 'testSapCode';
+      const unitSapCode = 'testUnitSapCode';
       const mockStockData: ProductAvailabilities = {
         quantity: '100',
         status: 'IN_STOCK',
@@ -68,7 +70,7 @@ describe('ProductAvailabilityService', () => {
       connector.getRealTimeStock.and.returnValue(of(mockStockData));
       commandSpy.execute.and.returnValue(of(mockStockData));
 
-      service.getRealTimeStock(productCode, sapCode).subscribe((result) => {
+      service.getRealTimeStock(productCode, unitSapCode).subscribe((result) => {
         expect(result).toEqual(mockStockData);
       });
     });

--- a/projects/core/src/product/facade/product-availability.service.ts
+++ b/projects/core/src/product/facade/product-availability.service.ts
@@ -5,12 +5,12 @@
  */
 
 import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 import {
   Command,
   CommandService,
   CommandStrategy,
 } from '../../../src/util/command-query';
-import { Observable } from 'rxjs';
 import { ProductAvailabilities } from '../../model/product.model';
 import { ProductAvailabilityConnector } from '../connectors';
 
@@ -31,11 +31,11 @@ export class ProductAvailabilityService {
    * Command to get real-time stock data for a product.
    */
   protected getRealTimeStockCommand: Command<
-    { productCode: string; sapCode: string },
+    { productCode: string; unitSapCode: string },
     ProductAvailabilities
   > = this.command.create(
     (payload) =>
-      this.connector.getRealTimeStock(payload.productCode, payload.sapCode),
+      this.connector.getRealTimeStock(payload.productCode, payload.unitSapCode),
     {
       strategy: CommandStrategy.CancelPrevious,
     }
@@ -45,13 +45,16 @@ export class ProductAvailabilityService {
    * Executes the command to fetch real-time stock data.
    *
    * @param productCode The product code for which to fetch stock data.
-   * @param sapCode The SAP code associated with the product.
+   * @param unitSapCode The SAP code associated with the product.
    * @returns An observable of `ProductAvailabilities`.
    */
   getRealTimeStock(
     productCode: string,
-    sapCode: string
+    unitSapCode: string
   ): Observable<ProductAvailabilities> {
-    return this.getRealTimeStockCommand.execute({ productCode, sapCode });
+    return this.getRealTimeStockCommand.execute({
+      productCode,
+      unitSapCode,
+    });
   }
 }


### PR DESCRIPTION
Rename methods arguments from 'sapCode' to 'unitSapCode'.
However don't rename the original product model properties 'product.sapUnit.sapCode'.