### PR TITLE
fix: (CXSPA-8844) - b2b-order-approval e2e hotfix

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/order-approval/b2b-order-approval.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/order-approval/b2b-order-approval.e2e.cy.ts
@@ -196,7 +196,7 @@ function assertPermissionResults(order) {
   });
 
   order.permissionResults.forEach((permission, index) => {
-    cy.get('cx-order-detail-permission-results tr')
+    cy.get('cx-order-detail-permission-results tbody tr')
       .eq(index)
       .within(() => {
         cy.get('.cx-approval-approverName').should(


### PR DESCRIPTION
Fixes `b2b-order-approval.e2e.cy.ts` be providing a more specific selector. 