### PR TITLE
fix: dynamicScript takes precedence over url on payment option rending

### DIFF
--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.html
@@ -13,7 +13,7 @@
 
 <ng-template #paymentData let-paymentLink="paymentLink">
   <div>
-    <ng-container *ngIf="paymentLink?.destination?.url">
+    <ng-container *ngIf="paymentLink?.destination?.url && !paymentLink?.html">
       <div
         *ngIf="
           paymentLink.renderType === RENDER_PATTERN.FULL_PAGE &&
@@ -67,8 +67,8 @@
         </form>
       </div>
     </ng-container>
-    <ng-container *ngIf="paymentLink.data && !paymentLink?.destination?.url">
-      <div [innerHTML]="bypassSecurityTrustHtml(paymentLink.data)"></div>
+    <ng-container *ngIf="paymentLink?.html">
+      <div [innerHTML]="bypassSecurityTrustHtml(paymentLink.html)"></div>
     </ng-container>
   </div>
 </ng-template>

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.html
@@ -13,7 +13,7 @@
 
 <ng-template #paymentData let-paymentLink="paymentLink">
   <div>
-    <ng-container *ngIf="paymentLink?.destination?.url && !paymentLink?.html">
+    <ng-container *ngIf="paymentLink?.destination?.url">
       <div
         *ngIf="
           paymentLink.renderType === RENDER_PATTERN.FULL_PAGE &&

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.spec.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.spec.ts
@@ -300,7 +300,6 @@ describe('OpfCheckoutPaymentWrapperService', () => {
       isLoading: false,
       isError: false,
       renderType: OpfPaymentRenderPattern.FULL_PAGE,
-      data: mockUrl,
       destination: { url: mockUrl, form: [] },
     });
   });
@@ -349,7 +348,6 @@ describe('OpfCheckoutPaymentWrapperService', () => {
       isLoading: false,
       isError: false,
       renderType: OpfPaymentRenderPattern.IFRAME,
-      data: mockUrl,
       destination: { url: mockUrl, form: mockFormData },
     });
   });
@@ -400,7 +398,7 @@ describe('OpfCheckoutPaymentWrapperService', () => {
         isLoading: false,
         isError: false,
         renderType: OpfPaymentRenderPattern.HOSTED_FIELDS,
-        data: '<html></html>',
+        html: '<html></html>',
       });
       done();
     });

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
@@ -150,17 +150,6 @@ export class OpfCheckoutPaymentWrapperService {
   }
 
   renderPaymentGateway(config: OpfPaymentSessionData) {
-    if (config?.destination) {
-      this.renderPaymentMethodEvent$.next({
-        isLoading: false,
-        isError: false,
-        renderType: config?.pattern,
-        data: config?.destination.url,
-        destination: config?.destination,
-      });
-      return;
-    }
-
     if (config?.dynamicScript) {
       const html = config?.dynamicScript?.html;
 
@@ -174,7 +163,7 @@ export class OpfCheckoutPaymentWrapperService {
             isLoading: false,
             isError: false,
             renderType: config?.pattern,
-            data: html,
+            html,
           });
 
           if (html) {
@@ -186,11 +175,16 @@ export class OpfCheckoutPaymentWrapperService {
         });
       return;
     }
-    this.handlePaymentInitiationError({
-      message: 'Payment Configuration problem',
-    })
-      .pipe(take(1))
-      .subscribe();
+    if (config?.destination) {
+      this.renderPaymentMethodEvent$.next({
+        isLoading: false,
+        isError: false,
+        renderType: config?.pattern,
+        destination: config?.destination,
+      });
+      return;
+    }
+    this.handleGeneralPaymentError().pipe(take(1)).subscribe();
   }
 
   protected handlePaymentInitiationError(

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
@@ -149,6 +149,15 @@ export class OpfCheckoutPaymentWrapperService {
     }
   }
 
+  /**
+   * Render payment option covering the three patterns: IFRAME, FULL_PAGE, HOSTED_FIELDS.
+   * Context to explain this method logic:
+   * All three patterns can contains `dynamicScript` value.
+   * IFRAME and FULL_PAGE patterns can also have `destination` value.
+   * if `dynamicScript` and `destination` are present in same config, dynamicScript takes precendence.
+   * @param config
+   * @returns : none, OpfPaymentRenderMethodEvent gets emitted
+   */
   renderPaymentGateway(config: OpfPaymentSessionData) {
     if (config?.dynamicScript) {
       const html = config?.dynamicScript?.html;

--- a/integration-libs/opf/payment/root/model/opf-payment.model.ts
+++ b/integration-libs/opf/payment/root/model/opf-payment.model.ts
@@ -172,7 +172,7 @@ export interface OpfPaymentRenderMethodEvent {
   isLoading: boolean;
   isError: boolean;
   renderType?: OpfPaymentRenderPattern;
-  data?: string | null;
+  html?: string | null;
   destination?: OpfPaymentDestination;
 }
 


### PR DESCRIPTION
- renamed property 'data' to 'html' as it is only used for html snippet.
- presence of dynamicScript is now checked before destination url.
- in 'renderPaymentMethodEvent$.next()', emitted object never contains 'destination' and 'html' together, thus no need to do additional check it in template.