### PR TITLE
fix: prevent anonymous consent request from being sent for logged in

### DIFF
--- a/projects/storefrontlib/cms-components/navigation/scroll-to-top/scroll-to-top.component.spec.ts
+++ b/projects/storefrontlib/cms-components/navigation/scroll-to-top/scroll-to-top.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import {
   AnonymousConsentsService,
+  AuthService,
   CmsScrollToTopComponent,
   FeatureConfigService,
   I18nTestingModule,
@@ -35,6 +36,12 @@ class MockAnonymousConsentsService {
   }
 }
 
+class MockAuthService {
+  isUserLoggedIn() {
+    return of(false);
+  }
+}
+
 describe('ScrollToTopComponent', () => {
   let component: ScrollToTopComponent;
   let fixture: ComponentFixture<ScrollToTopComponent>;
@@ -58,6 +65,10 @@ describe('ScrollToTopComponent', () => {
         {
           provide: AnonymousConsentsService,
           useClass: MockAnonymousConsentsService,
+        },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
         },
       ],
     }).compileComponents();

--- a/projects/storefrontlib/cms-components/navigation/scroll-to-top/scroll-to-top.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/scroll-to-top/scroll-to-top.component.ts
@@ -22,8 +22,9 @@ import {
   WindowRef,
   AnonymousConsentsService,
   useFeatureStyles,
+  AuthService,
 } from '@spartacus/core';
-import { take, Observable } from 'rxjs';
+import { take, Observable, of, switchMap } from 'rxjs';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 import { SelectFocusUtility } from '../../../layout/a11y/index';
 import { ICON_TYPE } from '../../misc/icon/icon.model';
@@ -58,6 +59,7 @@ export class ScrollToTopComponent implements OnInit {
       optional: true,
     }
   );
+  protected authService = inject(AuthService, { optional: true });
 
   constructor(
     protected winRef: WindowRef,
@@ -70,7 +72,15 @@ export class ScrollToTopComponent implements OnInit {
   ngOnInit(): void {
     this.setConfig();
     if (this.featureConfigService?.isEnabled('a11yScrollToTopPositioning')) {
-      this.elevatedPosition$ = this.anonymousConsentsService?.isBannerVisible();
+      this.elevatedPosition$ = this.authService
+        ?.isUserLoggedIn()
+        .pipe(
+          switchMap((isLoggedIn) =>
+            !isLoggedIn && this.anonymousConsentsService
+              ? this.anonymousConsentsService.isBannerVisible()
+              : of(false)
+          )
+        );
     }
   }
 


### PR DESCRIPTION
After logging in there is an error in console and the banner saying "You are not authorized to perform this action. Please contact your administrator if you think this is a mistake."
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/a815e469-c2cf-4918-b4cf-c27b28b9474c">

This is caused by anonymous consents request being sent when the user is logged in

