### PR TITLE
fix: No default values when installing packages with 'no-interactive' mode

### DIFF
--- a/docs/libs/creating-lib.md
+++ b/docs/libs/creating-lib.md
@@ -402,6 +402,46 @@ There are couple of required changes to make sure schematics will work properly
   - `projects/storefrontapp/tsconfig.server.json`,
   - `projects/storefrontapp/tsconfig.app.prod.json`
 - add new feature lib schema.json elements in schematics folder - `feature-libs\<lib-name>\schematics\add-<lib-name>\schema.json` where the `lib-name` is the name of the new library
+  - if the library includes several features and some of them should be installed by default, add them to the `default` array (for 'no-interactive' mode) and add them `checked: true` flag (for interactive prompt), like in the following example:
+  ```json
+  {
+    "$schema": "http://json-schema.org/schema",
+    "id": "ExampleSchematics",
+    "title": "Example Schematics",
+    "type": "object",
+    "properties": {
+      "features": {
+        "type": "array",
+        "uniqueItems": true,
+        "default": ["Feature1"],
+        "items": {
+          "enum": [
+            "Feature1",
+            "Feature2", 
+          ],
+          "type": "string"
+        },
+        "x-prompt": {
+          "message": "Which features would you like to set up?",
+          "type": "list",
+          "items": [
+            {
+              "value": "Feature1",
+              "label": "Feature 1",
+              "checked": true
+            },
+            {
+              "value": "Feature2", 
+              "label": "Feature 2",
+            },
+          ]
+        }
+      },
+      ...
+    }
+  }
+  ```
+  Values from `x-prompt.items` with `checked: true` should reflect the features that will be installed by default in 'no-interactive' mode (`default` array). 
 - add new feature chain method to 'shouldAddFeature' and function to add it - `feature-libs\<lib-name>\schematics\add-<lib-name>\index.ts` where the `lib-name` is the name of the new library
 - create new feature lib module in - `projects/storefrontapp/src/app/spartacus/features`
 - create your schematics configuration in e.g. `projects/schematics/src/shared/lib-configs/asm-schematics-config.ts` and add it to the `projects/schematics/src/shared/schematics-config-mappings.ts` file.

--- a/docs/libs/creating-lib.md
+++ b/docs/libs/creating-lib.md
@@ -402,7 +402,7 @@ There are couple of required changes to make sure schematics will work properly
   - `projects/storefrontapp/tsconfig.server.json`,
   - `projects/storefrontapp/tsconfig.app.prod.json`
 - add new feature lib schema.json elements in schematics folder - `feature-libs\<lib-name>\schematics\add-<lib-name>\schema.json` where the `lib-name` is the name of the new library
-  - if the library includes several features and some of them should be installed by default, add them to the `default` array (for 'no-interactive' mode) and add them `checked: true` flag (for interactive prompt), like in the following example:
+  - if the library includes several features and some of them should be installed by default, add them to the `default` array (for 'no-interactive' mode) and add them `checked: true` flag (for interactive prompt). Please note the `Feature1` in the following example:
   ```json
   {
     "$schema": "http://json-schema.org/schema",

--- a/feature-libs/cart/schematics/add-cart/schema.json
+++ b/feature-libs/cart/schematics/add-cart/schema.json
@@ -24,6 +24,13 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": [
+        "Cart",
+        "WishList",
+        "Saved-Cart",
+        "Quick-Order",
+        "Import-Export"
+      ],
       "items": {
         "enum": [
           "Cart",

--- a/feature-libs/checkout/schematics/add-checkout/schema.json
+++ b/feature-libs/checkout/schematics/add-checkout/schema.json
@@ -24,6 +24,7 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": ["Checkout"],
       "items": {
         "enum": [
           "Checkout",

--- a/feature-libs/organization/schematics/add-organization/schema.json
+++ b/feature-libs/organization/schematics/add-organization/schema.json
@@ -24,6 +24,13 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": [
+        "Administration",
+        "Order-Approval",
+        "Account-Summary",
+        "Organization-User-Registration",
+        "Unit-Order"
+      ],
       "items": {
         "enum": [
           "Administration",

--- a/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/schema.json
+++ b/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/schema.json
@@ -24,6 +24,10 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": [
+        "Product-Multi-Dimensional-Selector",
+        "Product-Multi-Dimensional-List"
+      ],
       "items": {
         "enum": [
           "Product-Multi-Dimensional-Selector",

--- a/feature-libs/product/schematics/add-product/schema.json
+++ b/feature-libs/product/schematics/add-product/schema.json
@@ -24,6 +24,7 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": ["Product-Variants", "Image-Zoom", "Future-Stock"],
       "items": {
         "enum": [
           "Bulk-Pricing",

--- a/feature-libs/tracking/schematics/add-tracking/schema.json
+++ b/feature-libs/tracking/schematics/add-tracking/schema.json
@@ -24,6 +24,7 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": ["Personalization"],
       "items": {
         "enum": ["Personalization", "TMS-GTM", "TMS-AEPL"],
         "type": "string"

--- a/feature-libs/user/schematics/add-user/schema.json
+++ b/feature-libs/user/schematics/add-user/schema.json
@@ -25,6 +25,7 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": ["User-Account", "User-Profile"],
       "items": {
         "enum": ["User-Account", "User-Profile"],
         "type": "string"

--- a/integration-libs/opf/schematics/add-opf/schema.json
+++ b/integration-libs/opf/schematics/add-opf/schema.json
@@ -24,6 +24,14 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": [
+        "OPF-Checkout",
+        "OPF-Base",
+        "OPF-Payment",
+        "OPF-Cta",
+        "OPF-Global-Functions",
+        "OPF-Quick-Buy"
+      ],
       "items": {
         "enum": [
           "OPF-Checkout",

--- a/integration-libs/s4om/schematics/add-s4om/schema.json
+++ b/integration-libs/s4om/schematics/add-s4om/schema.json
@@ -24,6 +24,7 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": ["S4HANA-Order-Management"],
       "x-prompt": {
         "message": "Which S/4 HANA Order Management features would you like to set up?",
         "type": "list",

--- a/projects/schematics/src/add-spartacus/schema.json
+++ b/projects/schematics/src/add-spartacus/schema.json
@@ -14,6 +14,24 @@
     "features": {
       "type": "array",
       "uniqueItems": true,
+      "default": [
+        "ASM",
+        "ASM-Customer-360",
+        "Cart",
+        "WishList",
+        "Checkout",
+        "Order",
+        "Import-Export",
+        "Saved-Cart",
+        "Quick-Order",
+        "Image-Zoom",
+        "Product-Variants",
+        "SmartEdit",
+        "Store-Finder",
+        "Personalization",
+        "User-Account",
+        "User-Profile"
+      ],
       "items": {
         "enum": [
           "ASM",


### PR DESCRIPTION
This PR contains a revert of the array with default values in `schema.json` files, which, regardless of changes in `x-prompt`, are still required when installing packages with `no-interactive` mode.