### PR TITLE
fix: (CXSPA-9080) - Hide 'Consent Management' button when cookies banner is visible and ensure clear visible focus for accessibility

### DIFF
--- a/projects/assets/src/translations/en/user.json
+++ b/projects/assets/src/translations/en/user.json
@@ -10,7 +10,8 @@
       "title": "This website uses cookies",
       "description": "We use cookies/browser's storage to personalize the content and improve user experience.",
       "allowAll": "Allow All",
-      "viewDetails": "View Details"
+      "viewDetails": "View Details",
+      "consentManagement": "Consent Management"
     }
   },
   "checkoutLogin": {

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -796,10 +796,13 @@ export interface FeatureTogglesInterface {
   a11ySearchableDropdownFirstElementFocus?: boolean;
 
   /**
-   * Aligns the 'Consent Management' button to the center and ensures a strong, clear four-sided visible focus when navigated via keyboard.
-   * Affects: AnonymousConsentOpenDialogComponent
+   * Hides the 'Consent Management' button from the tab order when the cookies banner is visible.
+   * Ensures the button is re-enabled and part of the tab order once consent is given and the banner disappears.
+   * Renames the button from "View Details" to "Consent Management" after consent is given.
+   * Ensures the button is centered in the `AnonymousConsentOpenDialogComponent` and has clear, four-sided visible focus when navigated via keyboard.
+   * Affects: AnonymousConsentOpenDialogComponent, AnonymousConsentManagementBannerComponent
    */
-  a11yAlignConsentManagementButtonCenter?: boolean;
+  a11yHideConsentButtonWhenBannerVisible?: boolean;
 
   /**
    * In OCC cart requests, it puts parameters of a cart name and cart description
@@ -1042,7 +1045,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yQuickOrderSearchBoxRefocusOnClose: false,
   a11yKeyboardFocusInSearchBox: false,
   a11ySearchableDropdownFirstElementFocus: false,
-  a11yAlignConsentManagementButtonCenter: false,
+  a11yHideConsentButtonWhenBannerVisible: false,
   occCartNameAndDescriptionInHttpRequestBody: false,
   cmsBottomHeaderSlotUsingFlexStyles: false,
   useSiteThemeService: false,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -796,6 +796,12 @@ export interface FeatureTogglesInterface {
   a11ySearchableDropdownFirstElementFocus?: boolean;
 
   /**
+   * Aligns the 'Consent Management' button to the center and ensures a strong, clear four-sided visible focus when navigated via keyboard.
+   * Affects: AnonymousConsentOpenDialogComponent
+   */
+  a11yAlignConsentManagementButtonCenter?: boolean;
+
+  /**
    * In OCC cart requests, it puts parameters of a cart name and cart description
    * into a request body, instead of query params.
    * This toggle is used in the following classes: `OccCartAdapter`, `OccSavedCartAdapter`, `SavedCartOccModule`, `CartBaseOccModule`.
@@ -1036,6 +1042,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yQuickOrderSearchBoxRefocusOnClose: false,
   a11yKeyboardFocusInSearchBox: false,
   a11ySearchableDropdownFirstElementFocus: false,
+  a11yAlignConsentManagementButtonCenter: false,
   occCartNameAndDescriptionInHttpRequestBody: false,
   cmsBottomHeaderSlotUsingFlexStyles: false,
   useSiteThemeService: false,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -412,7 +412,7 @@ if (environment.cpq) {
         a11yQuickOrderSearchBoxRefocusOnClose: true,
         a11yKeyboardFocusInSearchBox: true,
         a11ySearchableDropdownFirstElementFocus: true,
-        a11yAlignConsentManagementButtonCenter: true,
+        a11yHideConsentButtonWhenBannerVisible: true,
         cmsBottomHeaderSlotUsingFlexStyles: true,
         useSiteThemeService: false,
         enableConsecutiveCharactersPasswordRequirement: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -412,6 +412,7 @@ if (environment.cpq) {
         a11yQuickOrderSearchBoxRefocusOnClose: true,
         a11yKeyboardFocusInSearchBox: true,
         a11ySearchableDropdownFirstElementFocus: true,
+        a11yAlignConsentManagementButtonCenter: true,
         cmsBottomHeaderSlotUsingFlexStyles: true,
         useSiteThemeService: false,
         enableConsecutiveCharactersPasswordRequirement: true,

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/anonymous-consent-management.module.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/anonymous-consent-management.module.ts
@@ -9,6 +9,7 @@ import { NgModule } from '@angular/core';
 import {
   CmsConfig,
   DeferLoadingStrategy,
+  FeaturesConfigModule,
   I18nModule,
   provideDefaultConfig,
 } from '@spartacus/core';
@@ -18,7 +19,12 @@ import { defaultAnonymousConsentLayoutConfig } from './default-anonymous-consent
 import { AnonymousConsentOpenDialogComponent } from './open-dialog/anonymous-consent-open-dialog.component';
 
 @NgModule({
-  imports: [CommonModule, I18nModule, KeyboardFocusModule],
+  imports: [
+    CommonModule,
+    I18nModule,
+    KeyboardFocusModule,
+    FeaturesConfigModule,
+  ],
   providers: [
     provideDefaultConfig(defaultAnonymousConsentLayoutConfig),
     provideDefaultConfig(<CmsConfig>{

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.html
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.html
@@ -4,7 +4,7 @@
     class="anonymous-consent-banner"
   >
     <div class="container">
-      <div class="row">
+      <div class="row" *cxFeature="'!a11yHideConsentButtonWhenBannerVisible'">
         <div class="col-lg-7 col-xs-12">
           <div class="cx-banner-title">
             {{ 'anonymousConsents.banner.title' | cxTranslate }}
@@ -17,6 +17,29 @@
         <div class="col-lg-5 col-xs-12 cx-banner-buttons">
           <button class="btn btn-secondary" (click)="viewDetails()">
             {{ 'anonymousConsents.banner.viewDetails' | cxTranslate }}
+          </button>
+          <button class="btn btn-primary" (click)="allowAll()">
+            {{ 'anonymousConsents.banner.allowAll' | cxTranslate }}
+          </button>
+        </div>
+      </div>
+      <div class="row" *cxFeature="'a11yHideConsentButtonWhenBannerVisible'">
+        <div class="col-xl-7 col-lg-6 col-xs-12">
+          <div class="cx-banner-title">
+            {{ 'anonymousConsents.banner.title' | cxTranslate }}
+          </div>
+          <div class="cx-banner-description">
+            {{ 'anonymousConsents.banner.description' | cxTranslate }}
+          </div>
+        </div>
+
+        <div class="col-xl-5 col-lg-6 col-xs-12 cx-banner-buttons">
+          <button
+            *cxFeature="'a11yHideConsentButtonWhenBannerVisible'"
+            class="btn btn-secondary"
+            (click)="viewDetails()"
+          >
+            {{ 'anonymousConsents.banner.consentManagement' | cxTranslate }}
           </button>
           <button class="btn btn-primary" (click)="allowAll()">
             {{ 'anonymousConsents.banner.allowAll' | cxTranslate }}

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.html
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.html
@@ -34,11 +34,7 @@
         </div>
 
         <div class="col-xl-5 col-lg-6 col-xs-12 cx-banner-buttons">
-          <button
-            *cxFeature="'a11yHideConsentButtonWhenBannerVisible'"
-            class="btn btn-secondary"
-            (click)="viewDetails()"
-          >
+          <button class="btn btn-secondary" (click)="viewDetails()">
             {{ 'anonymousConsents.banner.consentManagement' | cxTranslate }}
           </button>
           <button class="btn btn-primary" (click)="allowAll()">

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.html
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.html
@@ -1,3 +1,13 @@
-<button #open class="btn btn-link" (click)="openDialog()">
-  {{ 'anonymousConsents.dialog.title' | cxTranslate }}
-</button>
+<ng-container *cxFeature="'!a11yHideConsentButtonWhenBannerVisible'">
+  <button #open class="btn btn-link" (click)="openDialog()">
+    {{ 'anonymousConsents.dialog.title' | cxTranslate }}
+  </button>
+</ng-container>
+
+<ng-container *cxFeature="'a11yHideConsentButtonWhenBannerVisible'">
+  <ng-container *ngIf="!(bannerVisible$ | async)">
+    <button #open class="btn btn-link" (click)="openDialog()">
+      {{ 'anonymousConsents.dialog.title' | cxTranslate }}
+    </button>
+  </ng-container>
+</ng-container>

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.html
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.html
@@ -5,9 +5,12 @@
 </ng-container>
 
 <ng-container *cxFeature="'a11yHideConsentButtonWhenBannerVisible'">
-  <ng-container *ngIf="!(bannerVisible$ | async)">
-    <button #open class="btn btn-link" (click)="openDialog()">
-      {{ 'anonymousConsents.dialog.title' | cxTranslate }}
-    </button>
-  </ng-container>
+  <button
+    *ngIf="!(bannerVisible$ | async)"
+    #open
+    class="btn btn-link"
+    (click)="openDialog()"
+  >
+    {{ 'anonymousConsents.dialog.title' | cxTranslate }}
+  </button>
 </ng-container>

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.ts
@@ -10,7 +10,8 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
-import { useFeatureStyles } from '@spartacus/core';
+import { AnonymousConsentsService, useFeatureStyles } from '@spartacus/core';
+import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { LAUNCH_CALLER } from '../../../layout/launch-dialog/config/launch-config';
 import { LaunchDialogService } from '../../../layout/launch-dialog/services/launch-dialog.service';
@@ -21,12 +22,15 @@ import { LaunchDialogService } from '../../../layout/launch-dialog/services/laun
 })
 export class AnonymousConsentOpenDialogComponent {
   @ViewChild('open') openElement: ElementRef;
+  bannerVisible$: Observable<boolean> =
+    this.anonymousConsentsService.isBannerVisible();
 
   constructor(
     protected vcr: ViewContainerRef,
+    protected anonymousConsentsService: AnonymousConsentsService,
     protected launchDialogService: LaunchDialogService
   ) {
-    useFeatureStyles('a11yAlignConsentManagementButtonCenter');
+    useFeatureStyles('a11yHideConsentButtonWhenBannerVisible');
   }
 
   openDialog(): void {

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.ts
@@ -10,9 +10,10 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
-import { LaunchDialogService } from '../../../layout/launch-dialog/services/launch-dialog.service';
-import { LAUNCH_CALLER } from '../../../layout/launch-dialog/config/launch-config';
+import { useFeatureStyles } from '@spartacus/core';
 import { take } from 'rxjs/operators';
+import { LAUNCH_CALLER } from '../../../layout/launch-dialog/config/launch-config';
+import { LaunchDialogService } from '../../../layout/launch-dialog/services/launch-dialog.service';
 
 @Component({
   selector: 'cx-anonymous-consent-open-dialog',
@@ -24,7 +25,9 @@ export class AnonymousConsentOpenDialogComponent {
   constructor(
     protected vcr: ViewContainerRef,
     protected launchDialogService: LaunchDialogService
-  ) {}
+  ) {
+    useFeatureStyles('a11yAlignConsentManagementButtonCenter');
+  }
 
   openDialog(): void {
     const dialog = this.launchDialogService.openDialog(

--- a/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-open-dialog.scss
+++ b/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-open-dialog.scss
@@ -3,14 +3,17 @@
   justify-content: center;
   margin: 0 3vw 3vw 3vw;
 
-  @include forFeature('a11yAlignConsentManagementButtonCenter') {
-    margin: 1.5vw 3vw;
+  @include forFeature('a11yHideConsentButtonWhenBannerVisible') {
+    margin: 0;
   }
 
   @include media-breakpoint-down(sm) {
     justify-content: flex-start;
   }
   .btn-link {
+    @include forFeature('a11yHideConsentButtonWhenBannerVisible') {
+      margin: 1.5vw 3vw;
+    }
     padding: 0;
     color: var(--cx-color-inverse);
     font-size: 0.875rem;

--- a/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-open-dialog.scss
+++ b/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-open-dialog.scss
@@ -3,6 +3,10 @@
   justify-content: center;
   margin: 0 3vw 3vw 3vw;
 
+  @include forFeature('a11yAlignConsentManagementButtonCenter') {
+    margin: 1.5vw 3vw;
+  }
+
   @include media-breakpoint-down(sm) {
     justify-content: flex-start;
   }


### PR DESCRIPTION
Ticket: [CXSPA-9080](https://jira.tools.sap/browse/CXSPA-9080)

Hide the 'Consent Management' button when the cookies banner is visible: The button is removed from the tab order (via tabindex="-1" or display: none) to prevent interaction until the user interacts with the cookies banner.
Re-enable the button after consent is given: Once the user gives consent and the cookies banner disappears, the 'Consent Management' button is made visible and becomes part of the tab order again.
Button name change: The 'View Details' button inside the cookies banner is renamed to 'Consent Management' after the user provides consent.
Clear, visible focus: Ensures the button and other interactive elements have a strong, clear, four-sided visible focus when navigated via keyboard, improving accessibility.
Affects: AnonymousConsentOpenDialogComponent, AnonymousConsentManagementBannerComponent