### PR TITLE
Fix code scanning alert no. 50: Prototype-polluting function

### DIFF
--- a/.github/api-extractor-action/src/api-extractor.ts
+++ b/.github/api-extractor-action/src/api-extractor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/.github/api-extractor-action/src/comment.ts
+++ b/.github/api-extractor-action/src/comment.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/.github/api-extractor-action/src/const.ts
+++ b/.github/api-extractor-action/src/const.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/.github/api-extractor-action/src/index.ts
+++ b/.github/api-extractor-action/src/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/.github/api-extractor-action/src/setup.ts
+++ b/.github/api-extractor-action/src/setup.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/.github/cache-builded-libs/index.ts
+++ b/.github/cache-builded-libs/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/public_api.ts
+++ b/core-libs/setup/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/recipes/b2b/config/default-b2b-occ-config.ts
+++ b/core-libs/setup/recipes/b2b/config/default-b2b-occ-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/recipes/b2b/config/index.ts
+++ b/core-libs/setup/recipes/b2b/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/recipes/b2b/index.ts
+++ b/core-libs/setup/recipes/b2b/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/recipes/index.ts
+++ b/core-libs/setup/recipes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/setup-jest.ts
+++ b/core-libs/setup/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/engine-decorator/index.ts
+++ b/core-libs/setup/ssr/engine-decorator/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
+++ b/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/engine/cx-common-engine.ts
+++ b/core-libs/setup/ssr/engine/cx-common-engine.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/engine/ng-express-engine.ts
+++ b/core-libs/setup/ssr/engine/ng-express-engine.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/error-handling/error-response/index.ts
+++ b/core-libs/setup/ssr/error-handling/error-response/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/error-handling/error-response/propagate-error-to-server.ts
+++ b/core-libs/setup/ssr/error-handling/error-response/propagate-error-to-server.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/error-handling/express-error-handlers/express-error-handlers.ts
+++ b/core-libs/setup/ssr/error-handling/express-error-handlers/express-error-handlers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/error-handling/express-error-handlers/index.ts
+++ b/core-libs/setup/ssr/error-handling/express-error-handlers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/error-handling/index.ts
+++ b/core-libs/setup/ssr/error-handling/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/error-handling/multi-error-handlers/index.ts
+++ b/core-libs/setup/ssr/error-handling/multi-error-handlers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/error-handling/multi-error-handlers/propagating-to-server-error-handler.ts
+++ b/core-libs/setup/ssr/error-handling/multi-error-handlers/propagating-to-server-error-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/express-utils/express-request-origin.ts
+++ b/core-libs/setup/ssr/express-utils/express-request-origin.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/express-utils/express-request-url.ts
+++ b/core-libs/setup/ssr/express-utils/express-request-url.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/get-logger-inspect-options.ts
+++ b/core-libs/setup/ssr/logger/get-logger-inspect-options.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/index.ts
+++ b/core-libs/setup/ssr/logger/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/loggers/default-express-server-logger.ts
+++ b/core-libs/setup/ssr/logger/loggers/default-express-server-logger.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/loggers/express-server-logger.ts
+++ b/core-libs/setup/ssr/logger/loggers/express-server-logger.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/loggers/index.ts
+++ b/core-libs/setup/ssr/logger/loggers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/loggers/w3c-trace-context/errors/invalid-traceparent-format-error.ts
+++ b/core-libs/setup/ssr/logger/loggers/w3c-trace-context/errors/invalid-traceparent-format-error.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/loggers/w3c-trace-context/errors/invalid-traceparent-length-error.ts
+++ b/core-libs/setup/ssr/logger/loggers/w3c-trace-context/errors/invalid-traceparent-length-error.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/loggers/w3c-trace-context/parse-traceparent.ts
+++ b/core-libs/setup/ssr/logger/loggers/w3c-trace-context/parse-traceparent.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/loggers/w3c-trace-context/w3c-trace-context.model.ts
+++ b/core-libs/setup/ssr/logger/loggers/w3c-trace-context/w3c-trace-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/services/express-logger.service.ts
+++ b/core-libs/setup/ssr/logger/services/express-logger.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/services/index.ts
+++ b/core-libs/setup/ssr/logger/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/services/prerendering-logger.service.ts
+++ b/core-libs/setup/ssr/logger/services/prerendering-logger.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/logger/services/server-logger-service-factory.ts
+++ b/core-libs/setup/ssr/logger/services/server-logger-service-factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/optimized-engine/get-loggable-ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/get-loggable-ssr-optimization-options.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/optimized-engine/index.ts
+++ b/core-libs/setup/ssr/optimized-engine/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/optimized-engine/rendering-cache.model.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/optimized-engine/rendering-cache.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/optimized-engine/rendering-strategy-resolver-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-strategy-resolver-options.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/optimized-engine/rendering-strategy-resolver.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-strategy-resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/optimized-engine/request-context.ts
+++ b/core-libs/setup/ssr/optimized-engine/request-context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/providers/index.ts
+++ b/core-libs/setup/ssr/providers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/providers/model.ts
+++ b/core-libs/setup/ssr/providers/model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/providers/server-request-origin.ts
+++ b/core-libs/setup/ssr/providers/server-request-origin.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/providers/server-request-url.ts
+++ b/core-libs/setup/ssr/providers/server-request-url.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/providers/ssr-providers.ts
+++ b/core-libs/setup/ssr/providers/ssr-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/public_api.ts
+++ b/core-libs/setup/ssr/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/testing/index.ts
+++ b/core-libs/setup/ssr/testing/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/testing/test-config-server.module.ts
+++ b/core-libs/setup/ssr/testing/test-config-server.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/core-libs/setup/ssr/tokens/express.tokens.ts
+++ b/core-libs/setup/ssr/tokens/express.tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/asm.module.ts
+++ b/feature-libs/asm/asm.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/assets/public_api.ts
+++ b/feature-libs/asm/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/assets/translations/en/index.ts
+++ b/feature-libs/asm/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/assets/translations/translations.ts
+++ b/feature-libs/asm/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-bind-cart-dialog/asm-bind-cart-dialog.component.ts
+++ b/feature-libs/asm/components/asm-bind-cart-dialog/asm-bind-cart-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-bind-cart/asm-bind-cart.component.ts
+++ b/feature-libs/asm/components/asm-bind-cart/asm-bind-cart.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-components.module.ts
+++ b/feature-libs/asm/components/asm-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.component.ts
+++ b/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.model.ts
+++ b/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-create-customer-form/default-asm-create-customer-form-layout.config.ts
+++ b/feature-libs/asm/components/asm-create-customer-form/default-asm-create-customer-form-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-main-ui/asm-main-ui.component.ts
+++ b/feature-libs/asm/components/asm-main-ui/asm-main-ui.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-save-cart-dialog/asm-save-cart-dialog.component.ts
+++ b/feature-libs/asm/components/asm-save-cart-dialog/asm-save-cart-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-session-timer/asm-session-timer.component.ts
+++ b/feature-libs/asm/components/asm-session-timer/asm-session-timer.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-session-timer/format-timer.pipe.ts
+++ b/feature-libs/asm/components/asm-session-timer/format-timer.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-switch-customer-dialog/asm-switch-customer-dialog.component.ts
+++ b/feature-libs/asm/components/asm-switch-customer-dialog/asm-switch-customer-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/asm-toggle-ui/asm-toggle-ui.component.ts
+++ b/feature-libs/asm/components/asm-toggle-ui/asm-toggle-ui.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/csagent-login-form/csagent-login-form.component.ts
+++ b/feature-libs/asm/components/csagent-login-form/csagent-login-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/customer-emulation/customer-emulation.component.ts
+++ b/feature-libs/asm/components/customer-emulation/customer-emulation.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/customer-list/customer-list.component.ts
+++ b/feature-libs/asm/components/customer-list/customer-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/customer-list/customer-list.model.ts
+++ b/feature-libs/asm/components/customer-list/customer-list.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/customer-list/default-customer-list-layout.config.ts
+++ b/feature-libs/asm/components/customer-list/default-customer-list-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/customer-selection/customer-selection.component.ts
+++ b/feature-libs/asm/components/customer-selection/customer-selection.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/default-asm-layout.config.ts
+++ b/feature-libs/asm/components/default-asm-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/default-asm-pagination.config.ts
+++ b/feature-libs/asm/components/default-asm-pagination.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/default-bind-cart-layout.config.ts
+++ b/feature-libs/asm/components/default-bind-cart-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/default-save-cart-layout.config.ts
+++ b/feature-libs/asm/components/default-save-cart-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/default-switch-customer-layout.config.ts
+++ b/feature-libs/asm/components/default-switch-customer-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/dot-spinner/dot-spinner.component.ts
+++ b/feature-libs/asm/components/dot-spinner/dot-spinner.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/public_api.ts
+++ b/feature-libs/asm/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/services/asm-component.service.ts
+++ b/feature-libs/asm/components/services/asm-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/components/services/index.ts
+++ b/feature-libs/asm/components/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/asm-core.module.ts
+++ b/feature-libs/asm/core/asm-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/connectors/asm.adapter.ts
+++ b/feature-libs/asm/core/connectors/asm.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/connectors/asm.connector.ts
+++ b/feature-libs/asm/core/connectors/asm.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/connectors/converters.ts
+++ b/feature-libs/asm/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/connectors/index.ts
+++ b/feature-libs/asm/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/facade/asm-bind-cart.service.ts
+++ b/feature-libs/asm/core/facade/asm-bind-cart.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/facade/asm-create-customer.service.ts
+++ b/feature-libs/asm/core/facade/asm-create-customer.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/facade/asm-customer-list.service.ts
+++ b/feature-libs/asm/core/facade/asm-customer-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/facade/asm.service.ts
+++ b/feature-libs/asm/core/facade/asm.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/facade/facade-providers.ts
+++ b/feature-libs/asm/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/facade/index.ts
+++ b/feature-libs/asm/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/public_api.ts
+++ b/feature-libs/asm/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/services/asm-state-persistence.service.ts
+++ b/feature-libs/asm/core/services/asm-state-persistence.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/services/index.ts
+++ b/feature-libs/asm/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/actions/asm-ui.action.ts
+++ b/feature-libs/asm/core/store/actions/asm-ui.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/actions/customer-group.actions.ts
+++ b/feature-libs/asm/core/store/actions/customer-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/actions/customer.action.ts
+++ b/feature-libs/asm/core/store/actions/customer.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/actions/index.ts
+++ b/feature-libs/asm/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/actions/logout-agent.action.ts
+++ b/feature-libs/asm/core/store/actions/logout-agent.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/asm-state.ts
+++ b/feature-libs/asm/core/store/asm-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/asm-store.module.ts
+++ b/feature-libs/asm/core/store/asm-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/effects/customer.effect.ts
+++ b/feature-libs/asm/core/store/effects/customer.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/effects/index.ts
+++ b/feature-libs/asm/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/index.ts
+++ b/feature-libs/asm/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/reducers/asm-ui.reducer.ts
+++ b/feature-libs/asm/core/store/reducers/asm-ui.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/reducers/index.ts
+++ b/feature-libs/asm/core/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/selectors/asm-group.selectors.ts
+++ b/feature-libs/asm/core/store/selectors/asm-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/selectors/asm-ui.selectors.ts
+++ b/feature-libs/asm/core/store/selectors/asm-ui.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/selectors/customer-search.selectors.ts
+++ b/feature-libs/asm/core/store/selectors/customer-search.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/selectors/feature.selector.ts
+++ b/feature-libs/asm/core/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/store/selectors/index.ts
+++ b/feature-libs/asm/core/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/args/args.module.ts
+++ b/feature-libs/asm/core/utils/args/args.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/args/args.pipe.ts
+++ b/feature-libs/asm/core/utils/args/args.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/args/index.ts
+++ b/feature-libs/asm/core/utils/args/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/by-boolean.function.ts
+++ b/feature-libs/asm/core/utils/sort/by-boolean.function.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/by-comparison.function.ts
+++ b/feature-libs/asm/core/utils/sort/by-comparison.function.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/by-nullish.function.ts
+++ b/feature-libs/asm/core/utils/sort/by-nullish.function.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/by-number.function.ts
+++ b/feature-libs/asm/core/utils/sort/by-number.function.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/by-string.function.ts
+++ b/feature-libs/asm/core/utils/sort/by-string.function.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/index.ts
+++ b/feature-libs/asm/core/utils/sort/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/items-with.function.ts
+++ b/feature-libs/asm/core/utils/sort/items-with.function.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/property.function.ts
+++ b/feature-libs/asm/core/utils/sort/property.function.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/sort.helper.function.ts
+++ b/feature-libs/asm/core/utils/sort/sort.helper.function.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/sort.model.ts
+++ b/feature-libs/asm/core/utils/sort/sort.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/core/utils/sort/when-type.function.ts
+++ b/feature-libs/asm/core/utils/sort/when-type.function.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/asm-customer-360.module.ts
+++ b/feature-libs/asm/customer-360/asm-customer-360.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/assets/public_api.ts
+++ b/feature-libs/asm/customer-360/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/assets/translations/en/asm-customer-360.ts
+++ b/feature-libs/asm/customer-360/assets/translations/en/asm-customer-360.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/assets/translations/en/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/assets/translations/translations.ts
+++ b/feature-libs/asm/customer-360/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-components.module.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-product-item/asm-customer-360-product-item.component.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-product-item/asm-customer-360-product-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-product-item/asm-customer-360-product-item.module.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-product-item/asm-customer-360-product-item.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/asm-customer-360-product-listing.component.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/asm-customer-360-product-listing.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/asm-customer-360-product-listing.module.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/asm-customer-360-product-listing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/product-item.model.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/product-item.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.component.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.model.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.module.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.component.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.model.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.module.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/asm-customer-360/asm-customer-360.component.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360/asm-customer-360.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/config/asm-customer-360-config.ts
+++ b/feature-libs/asm/customer-360/components/config/asm-customer-360-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/config/default-asm-customer-360-config.ts
+++ b/feature-libs/asm/customer-360/components/config/default-asm-customer-360-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/config/index.ts
+++ b/feature-libs/asm/customer-360/components/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/default-asm-customer-360-layout.config.ts
+++ b/feature-libs/asm/customer-360/components/default-asm-customer-360-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/public_api.ts
+++ b/feature-libs/asm/customer-360/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-active-cart/asm-customer-360-active-cart.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-active-cart/asm-customer-360-active-cart.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-active-cart/asm-customer-360-active-cart.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-active-cart/asm-customer-360-active-cart.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-activity/asm-customer-360-activity.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-activity/asm-customer-360-activity.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-activity/asm-customer-360-activity.model.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-activity/asm-customer-360-activity.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-activity/asm-customer-360-activity.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-activity/asm-customer-360-activity.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-coupon/asm-customer-360-coupon.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-coupon/asm-customer-360-coupon.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-coupon/asm-customer-360-coupon.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-coupon/asm-customer-360-coupon.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.model.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-map/asm-customer-360-map.component.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-map/asm-customer-360-map.component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-map/asm-customer-360-map.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-map/asm-customer-360-map.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-interests/asm-customer-360-product-interests.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-interests/asm-customer-360-product-interests.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-interests/asm-customer-360-product-interests.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-interests/asm-customer-360-product-interests.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-reviews/asm-customer-360-product-reviews.component.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-reviews/asm-customer-360-product-reviews.component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-reviews/asm-customer-360-product-reviews.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-reviews/asm-customer-360-product-reviews.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-reviews/asm-customer-360-product-reviews.model.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-reviews/asm-customer-360-product-reviews.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-profile/asm-customer-360-profile.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-profile/asm-customer-360-profile.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-profile/asm-customer-360-profile.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-profile/asm-customer-360-profile.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-promotion/asm-customer-360-promotion.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-promotion/asm-customer-360-promotion.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-promotion/asm-customer-360-promotion.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-promotion/asm-customer-360-promotion.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-saved-cart/asm-customer-360-saved-cart.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-saved-cart/asm-customer-360-saved-cart.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-saved-cart/asm-customer-360-saved-cart.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-saved-cart/asm-customer-360-saved-cart.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-section-context-source.model.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-section-context-source.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-section-context.model.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-section-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-section/asm-customer-360-section.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-section/asm-customer-360-section.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-support-tickets/asm-customer-360-support-tickets.component.module.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-support-tickets/asm-customer-360-support-tickets.component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-support-tickets/asm-customer-360-support-tickets.component.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-support-tickets/asm-customer-360-support-tickets.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-support-tickets/asm-customer-360-support-tickets.model.ts
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-support-tickets/asm-customer-360-support-tickets.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/components/sections/index.ts
+++ b/feature-libs/asm/customer-360/components/sections/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/asm-customer-360-core.module.ts
+++ b/feature-libs/asm/customer-360/core/asm-customer-360-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/connectors/asm-customer-360.adapter.ts
+++ b/feature-libs/asm/customer-360/core/connectors/asm-customer-360.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/connectors/asm-customer-360.connector.ts
+++ b/feature-libs/asm/customer-360/core/connectors/asm-customer-360.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/connectors/converters.ts
+++ b/feature-libs/asm/customer-360/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/connectors/index.ts
+++ b/feature-libs/asm/customer-360/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/facade/facade-providers.ts
+++ b/feature-libs/asm/customer-360/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/public_api.ts
+++ b/feature-libs/asm/customer-360/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/services/asm-customer-360.service.ts
+++ b/feature-libs/asm/customer-360/core/services/asm-customer-360.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/services/index.ts
+++ b/feature-libs/asm/customer-360/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/core/utils.ts
+++ b/feature-libs/asm/customer-360/core/utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/occ/adapters/default-occ-asm-customer-360-config.ts
+++ b/feature-libs/asm/customer-360/occ/adapters/default-occ-asm-customer-360-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/occ/adapters/index.ts
+++ b/feature-libs/asm/customer-360/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/occ/adapters/occ-asm-customer-360.adapter.ts
+++ b/feature-libs/asm/customer-360/occ/adapters/occ-asm-customer-360.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/occ/asm-customer-360-occ.module.ts
+++ b/feature-libs/asm/customer-360/occ/asm-customer-360-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/occ/model/index.ts
+++ b/feature-libs/asm/customer-360/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/occ/model/occ-asm-customer-360-endpoints.model.ts
+++ b/feature-libs/asm/customer-360/occ/model/occ-asm-customer-360-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/occ/public_api.ts
+++ b/feature-libs/asm/customer-360/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/public_api.ts
+++ b/feature-libs/asm/customer-360/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/asm-customer-360-root.module.ts
+++ b/feature-libs/asm/customer-360/root/asm-customer-360-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/facade/asm-customer-360.facade.ts
+++ b/feature-libs/asm/customer-360/root/facade/asm-customer-360.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/facade/index.ts
+++ b/feature-libs/asm/customer-360/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/feature-name.ts
+++ b/feature-libs/asm/customer-360/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/interceptors/site-context.interceptor.ts
+++ b/feature-libs/asm/customer-360/root/interceptors/site-context.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/model/asm-customer-360-section-config.ts
+++ b/feature-libs/asm/customer-360/root/model/asm-customer-360-section-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/model/asm-customer-360-section-data.ts
+++ b/feature-libs/asm/customer-360/root/model/asm-customer-360-section-data.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/model/asm-customer-360-tab-config.ts
+++ b/feature-libs/asm/customer-360/root/model/asm-customer-360-tab-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/model/asm-customer-360-tabs-config.ts
+++ b/feature-libs/asm/customer-360/root/model/asm-customer-360-tabs-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/model/asm-customer-360.model.ts
+++ b/feature-libs/asm/customer-360/root/model/asm-customer-360.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/model/augmented-core.model.ts
+++ b/feature-libs/asm/customer-360/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/model/index.ts
+++ b/feature-libs/asm/customer-360/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/customer-360/root/public_api.ts
+++ b/feature-libs/asm/customer-360/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/occ/adapters/default-occ-asm-config.ts
+++ b/feature-libs/asm/occ/adapters/default-occ-asm-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/occ/adapters/index.ts
+++ b/feature-libs/asm/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/occ/adapters/occ-asm.adapter.ts
+++ b/feature-libs/asm/occ/adapters/occ-asm.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/occ/asm-occ.module.ts
+++ b/feature-libs/asm/occ/asm-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/occ/model/index.ts
+++ b/feature-libs/asm/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/occ/model/occ-asm-endpoints.model.ts
+++ b/feature-libs/asm/occ/model/occ-asm-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/occ/public_api.ts
+++ b/feature-libs/asm/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/public_api.ts
+++ b/feature-libs/asm/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/asm-constants.ts
+++ b/feature-libs/asm/root/asm-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/asm-loader.module.ts
+++ b/feature-libs/asm/root/asm-loader.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/asm-root.module.ts
+++ b/feature-libs/asm/root/asm-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/config/asm-config.ts
+++ b/feature-libs/asm/root/config/asm-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/config/default-asm-config.ts
+++ b/feature-libs/asm/root/config/default-asm-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/facade/asm-bind-cart.facade.ts
+++ b/feature-libs/asm/root/facade/asm-bind-cart.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/facade/asm-create-customer.facade.ts
+++ b/feature-libs/asm/root/facade/asm-create-customer.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/facade/asm-customer-list.facade.ts
+++ b/feature-libs/asm/root/facade/asm-customer-list.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/facade/index.ts
+++ b/feature-libs/asm/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/feature-name.ts
+++ b/feature-libs/asm/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/interceptors/user-id-http-header.interceptor.ts
+++ b/feature-libs/asm/root/interceptors/user-id-http-header.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/model/asm.models.ts
+++ b/feature-libs/asm/root/model/asm.models.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/model/augmented-core.model.ts
+++ b/feature-libs/asm/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/model/cart-binding.models.ts
+++ b/feature-libs/asm/root/model/cart-binding.models.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/model/create-customer.model.ts
+++ b/feature-libs/asm/root/model/create-customer.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/model/customer-list.model.ts
+++ b/feature-libs/asm/root/model/customer-list.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/model/index.ts
+++ b/feature-libs/asm/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/public_api.ts
+++ b/feature-libs/asm/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/services/asm-auth-http-header.service.ts
+++ b/feature-libs/asm/root/services/asm-auth-http-header.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/services/asm-auth-storage.service.ts
+++ b/feature-libs/asm/root/services/asm-auth-storage.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/services/asm-auth.service.ts
+++ b/feature-libs/asm/root/services/asm-auth.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/services/asm-deep-link.service.ts
+++ b/feature-libs/asm/root/services/asm-deep-link.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/services/asm-enabler.service.ts
+++ b/feature-libs/asm/root/services/asm-enabler.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/services/csagent-auth.service.ts
+++ b/feature-libs/asm/root/services/csagent-auth.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/root/services/index.ts
+++ b/feature-libs/asm/root/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/schematics/add-asm/index.ts
+++ b/feature-libs/asm/schematics/add-asm/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/setup-jest.ts
+++ b/feature-libs/asm/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/asm/test.ts
+++ b/feature-libs/asm/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/assets/public_api.ts
+++ b/feature-libs/cart/base/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/assets/translations/en/index.ts
+++ b/feature-libs/cart/base/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/assets/translations/translations.ts
+++ b/feature-libs/cart/base/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/cart-base.module.ts
+++ b/feature-libs/cart/base/cart-base.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/abstract-order-context/abstract-order-context-source.model.ts
+++ b/feature-libs/cart/base/components/abstract-order-context/abstract-order-context-source.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/abstract-order-context/abstract-order-context.directive.ts
+++ b/feature-libs/cart/base/components/abstract-order-context/abstract-order-context.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/abstract-order-context/abstract-order-context.model.ts
+++ b/feature-libs/cart/base/components/abstract-order-context/abstract-order-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/abstract-order-context/abstract-order-context.module.ts
+++ b/feature-libs/cart/base/components/abstract-order-context/abstract-order-context.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/abstract-order-context/index.ts
+++ b/feature-libs/cart/base/components/abstract-order-context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.ts
+++ b/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/add-to-cart/add-to-cart.module.ts
+++ b/feature-libs/cart/base/components/add-to-cart/add-to-cart.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/add-to-cart/public_api.ts
+++ b/feature-libs/cart/base/components/add-to-cart/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog-event.listener.ts
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.ts
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.module.ts
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/added-to-cart-dialog/default-added-to-cart-layout.config.ts
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/default-added-to-cart-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/added-to-cart-dialog/index.ts
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-base-components.module.ts
+++ b/feature-libs/cart/base/components/cart-base-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.ts
+++ b/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-coupon/cart-coupon.component.ts
+++ b/feature-libs/cart/base/components/cart-coupon/cart-coupon.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-coupon/cart-coupon.module.ts
+++ b/feature-libs/cart/base/components/cart-coupon/cart-coupon.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-coupon/index.ts
+++ b/feature-libs/cart/base/components/cart-coupon/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-details/cart-details.component.ts
+++ b/feature-libs/cart/base/components/cart-details/cart-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-details/cart-details.module.ts
+++ b/feature-libs/cart/base/components/cart-details/cart-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-page-layout-handler.ts
+++ b/feature-libs/cart/base/components/cart-page-layout-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.component.ts
+++ b/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.module.ts
+++ b/feature-libs/cart/base/components/cart-proceed-to-checkout/cart-proceed-to-checkout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.service.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list-row/index.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list-row/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/cart-item/index.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/cart-item/model/cart-item-context-source.model.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item/model/cart-item-context-source.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/cart-item/model/index.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/cart-shared.module.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-shared.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/index.ts
+++ b/feature-libs/cart/base/components/cart-shared/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-shared/order-summary/order-summary.component.ts
+++ b/feature-libs/cart/base/components/cart-shared/order-summary/order-summary.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-totals/cart-totals.component.ts
+++ b/feature-libs/cart/base/components/cart-totals/cart-totals.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/cart-totals/cart-totals.module.ts
+++ b/feature-libs/cart/base/components/cart-totals/cart-totals.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-button/clear-cart.component.ts
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-button/clear-cart.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-button/clear-cart.module.ts
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-button/clear-cart.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-button/index.ts
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-button/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog-component.service.ts
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog.component.ts
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog.module.ts
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/default-clear-cart-layout.config.ts
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/default-clear-cart-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/index.ts
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/clear-cart/index.ts
+++ b/feature-libs/cart/base/components/clear-cart/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/mini-cart/mini-cart-component.service.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/mini-cart/mini-cart.component.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/mini-cart/mini-cart.module.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/mini-cart/public_api.ts
+++ b/feature-libs/cart/base/components/mini-cart/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/page-context/active-cart-order-entries.context.ts
+++ b/feature-libs/cart/base/components/page-context/active-cart-order-entries.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/page-context/index.ts
+++ b/feature-libs/cart/base/components/page-context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/public_api.ts
+++ b/feature-libs/cart/base/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/save-for-later/save-for-later.component.ts
+++ b/feature-libs/cart/base/components/save-for-later/save-for-later.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/save-for-later/save-for-later.module.ts
+++ b/feature-libs/cart/base/components/save-for-later/save-for-later.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.component.ts
+++ b/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.module.ts
+++ b/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/validation/cart-validation-components.module.ts
+++ b/feature-libs/cart/base/components/validation/cart-validation-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.component.ts
+++ b/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.module.ts
+++ b/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/cart-base-core.module.ts
+++ b/feature-libs/cart/base/core/cart-base-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/cart-persistence.module.ts
+++ b/feature-libs/cart/base/core/cart-persistence.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/access-code/cart-access-code.adapter.ts
+++ b/feature-libs/cart/base/core/connectors/access-code/cart-access-code.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/access-code/cart-access-code.connector.ts
+++ b/feature-libs/cart/base/core/connectors/access-code/cart-access-code.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/access-code/converters.ts
+++ b/feature-libs/cart/base/core/connectors/access-code/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/access-code/index.ts
+++ b/feature-libs/cart/base/core/connectors/access-code/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/cart/cart.adapter.ts
+++ b/feature-libs/cart/base/core/connectors/cart/cart.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/cart/cart.connector.ts
+++ b/feature-libs/cart/base/core/connectors/cart/cart.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/cart/index.ts
+++ b/feature-libs/cart/base/core/connectors/cart/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/entry/cart-entry.adapter.ts
+++ b/feature-libs/cart/base/core/connectors/entry/cart-entry.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/entry/cart-entry.connector.ts
+++ b/feature-libs/cart/base/core/connectors/entry/cart-entry.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/entry/index.ts
+++ b/feature-libs/cart/base/core/connectors/entry/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/guest-user/cart-guest-user.adapter.ts
+++ b/feature-libs/cart/base/core/connectors/guest-user/cart-guest-user.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/guest-user/cart-guest-user.connector.ts
+++ b/feature-libs/cart/base/core/connectors/guest-user/cart-guest-user.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/guest-user/converters.ts
+++ b/feature-libs/cart/base/core/connectors/guest-user/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/guest-user/index.ts
+++ b/feature-libs/cart/base/core/connectors/guest-user/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/index.ts
+++ b/feature-libs/cart/base/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/validation/cart-validation.adapter.ts
+++ b/feature-libs/cart/base/core/connectors/validation/cart-validation.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/validation/cart-validation.connector.ts
+++ b/feature-libs/cart/base/core/connectors/validation/cart-validation.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/validation/converters.ts
+++ b/feature-libs/cart/base/core/connectors/validation/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/validation/index.ts
+++ b/feature-libs/cart/base/core/connectors/validation/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/voucher/cart-voucher.adapter.ts
+++ b/feature-libs/cart/base/core/connectors/voucher/cart-voucher.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/voucher/cart-voucher.connector.ts
+++ b/feature-libs/cart/base/core/connectors/voucher/cart-voucher.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/connectors/voucher/index.ts
+++ b/feature-libs/cart/base/core/connectors/voucher/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/event/cart-event.builder.ts
+++ b/feature-libs/cart/base/core/event/cart-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/event/cart-event.module.ts
+++ b/feature-libs/cart/base/core/event/cart-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/event/cart-page-event.builder.ts
+++ b/feature-libs/cart/base/core/event/cart-page-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/event/cart-page-event.module.ts
+++ b/feature-libs/cart/base/core/event/cart-page-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/event/index.ts
+++ b/feature-libs/cart/base/core/event/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/facade/active-cart.service.ts
+++ b/feature-libs/cart/base/core/facade/active-cart.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/facade/cart-access-code.service.ts
+++ b/feature-libs/cart/base/core/facade/cart-access-code.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/facade/cart-guest-user.service.ts
+++ b/feature-libs/cart/base/core/facade/cart-guest-user.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/facade/cart-validation.service.ts
+++ b/feature-libs/cart/base/core/facade/cart-validation.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/facade/cart-voucher.service.ts
+++ b/feature-libs/cart/base/core/facade/cart-voucher.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/facade/facade-providers.ts
+++ b/feature-libs/cart/base/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/facade/index.ts
+++ b/feature-libs/cart/base/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/facade/multi-cart.service.ts
+++ b/feature-libs/cart/base/core/facade/multi-cart.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/facade/selective-cart.service.ts
+++ b/feature-libs/cart/base/core/facade/selective-cart.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/guards/cart-validation.guard.ts
+++ b/feature-libs/cart/base/core/guards/cart-validation.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/guards/index.ts
+++ b/feature-libs/cart/base/core/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/http-interceptors/handlers/bad-cart-request.handler.ts
+++ b/feature-libs/cart/base/core/http-interceptors/handlers/bad-cart-request.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/http-interceptors/handlers/bad-voucher-request.handler.ts
+++ b/feature-libs/cart/base/core/http-interceptors/handlers/bad-voucher-request.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/public_api.ts
+++ b/feature-libs/cart/base/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/services/cart-config.service.ts
+++ b/feature-libs/cart/base/core/services/cart-config.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/services/cart-validation-state.service.ts
+++ b/feature-libs/cart/base/core/services/cart-validation-state.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/services/index.ts
+++ b/feature-libs/cart/base/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/services/multi-cart-state-persistence.service.ts
+++ b/feature-libs/cart/base/core/services/multi-cart-state-persistence.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/services/product-import-info.service.ts
+++ b/feature-libs/cart/base/core/services/product-import-info.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/actions/cart-entry.action.ts
+++ b/feature-libs/cart/base/core/store/actions/cart-entry.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/actions/cart-group.actions.ts
+++ b/feature-libs/cart/base/core/store/actions/cart-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/actions/cart-voucher.action.ts
+++ b/feature-libs/cart/base/core/store/actions/cart-voucher.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/actions/cart.action.ts
+++ b/feature-libs/cart/base/core/store/actions/cart.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/actions/index.ts
+++ b/feature-libs/cart/base/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/actions/multi-cart.action.ts
+++ b/feature-libs/cart/base/core/store/actions/multi-cart.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/effects/cart-entry.effect.ts
+++ b/feature-libs/cart/base/core/store/effects/cart-entry.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/effects/cart-voucher.effect.ts
+++ b/feature-libs/cart/base/core/store/effects/cart-voucher.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/effects/cart.effect.ts
+++ b/feature-libs/cart/base/core/store/effects/cart.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/effects/index.ts
+++ b/feature-libs/cart/base/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/effects/multi-cart-effect.service.ts
+++ b/feature-libs/cart/base/core/store/effects/multi-cart-effect.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/effects/multi-cart.effect.ts
+++ b/feature-libs/cart/base/core/store/effects/multi-cart.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/index.ts
+++ b/feature-libs/cart/base/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/multi-cart-state.ts
+++ b/feature-libs/cart/base/core/store/multi-cart-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/multi-cart-store.module.ts
+++ b/feature-libs/cart/base/core/store/multi-cart-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/reducers/index.ts
+++ b/feature-libs/cart/base/core/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/reducers/multi-cart.reducer.ts
+++ b/feature-libs/cart/base/core/store/reducers/multi-cart.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/selectors/index.ts
+++ b/feature-libs/cart/base/core/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/selectors/multi-cart-group.selectors.ts
+++ b/feature-libs/cart/base/core/store/selectors/multi-cart-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/store/selectors/multi-cart.selector.ts
+++ b/feature-libs/cart/base/core/store/selectors/multi-cart.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/core/utils/utils.ts
+++ b/feature-libs/cart/base/core/utils/utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/converters/index.ts
+++ b/feature-libs/cart/base/occ/adapters/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/converters/occ-cart-normalizer.ts
+++ b/feature-libs/cart/base/occ/adapters/converters/occ-cart-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/converters/order-entry-promotions-normalizer.ts
+++ b/feature-libs/cart/base/occ/adapters/converters/order-entry-promotions-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/index.ts
+++ b/feature-libs/cart/base/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/occ-cart-access-code.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-access-code.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/occ-cart-entry.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-entry.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/occ-cart-guest-user.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-guest-user.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/occ-cart-validation.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-validation.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/occ-cart-voucher.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart-voucher.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/adapters/occ-cart.adapter.ts
+++ b/feature-libs/cart/base/occ/adapters/occ-cart.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/cart-base-occ.module.ts
+++ b/feature-libs/cart/base/occ/cart-base-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/config/default-occ-cart-config-factory.ts
+++ b/feature-libs/cart/base/occ/config/default-occ-cart-config-factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/model/index.ts
+++ b/feature-libs/cart/base/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/model/occ-cart-endpoints.model.ts
+++ b/feature-libs/cart/base/occ/model/occ-cart-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/occ/public_api.ts
+++ b/feature-libs/cart/base/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/public_api.ts
+++ b/feature-libs/cart/base/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/cart-base-root.module.ts
+++ b/feature-libs/cart/base/root/cart-base-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/config/cart-config.ts
+++ b/feature-libs/cart/base/root/config/cart-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/config/default-cart-config.ts
+++ b/feature-libs/cart/base/root/config/default-cart-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/config/default-cart-routing-config.ts
+++ b/feature-libs/cart/base/root/config/default-cart-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/context/add-order-entries.context.ts
+++ b/feature-libs/cart/base/root/context/add-order-entries.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/context/get-order-entries.context.ts
+++ b/feature-libs/cart/base/root/context/get-order-entries.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/context/index.ts
+++ b/feature-libs/cart/base/root/context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/context/order-entires.context.ts
+++ b/feature-libs/cart/base/root/context/order-entires.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/events/cart-base-event.module.ts
+++ b/feature-libs/cart/base/root/events/cart-base-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/events/cart-page.events.ts
+++ b/feature-libs/cart/base/root/events/cart-page.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/events/cart.events.ts
+++ b/feature-libs/cart/base/root/events/cart.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/events/index.ts
+++ b/feature-libs/cart/base/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/events/multi-cart-event.listener.ts
+++ b/feature-libs/cart/base/root/events/multi-cart-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/facade/active-cart.facade.ts
+++ b/feature-libs/cart/base/root/facade/active-cart.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/facade/cart-access-code.facade.ts
+++ b/feature-libs/cart/base/root/facade/cart-access-code.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/facade/cart-guest-user.facade.ts
+++ b/feature-libs/cart/base/root/facade/cart-guest-user.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/facade/cart-validation.facade.ts
+++ b/feature-libs/cart/base/root/facade/cart-validation.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/facade/cart-voucher.facade.ts
+++ b/feature-libs/cart/base/root/facade/cart-voucher.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/facade/index.ts
+++ b/feature-libs/cart/base/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/facade/multi-cart.facade.ts
+++ b/feature-libs/cart/base/root/facade/multi-cart.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/facade/selective-cart.facade.ts
+++ b/feature-libs/cart/base/root/facade/selective-cart.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/feature-name.ts
+++ b/feature-libs/cart/base/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/models/augmented.model.ts
+++ b/feature-libs/cart/base/root/models/augmented.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/models/cart-guest-user.model.ts
+++ b/feature-libs/cart/base/root/models/cart-guest-user.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/models/cart-item-context.model.ts
+++ b/feature-libs/cart/base/root/models/cart-item-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/models/cart-outlets.model.ts
+++ b/feature-libs/cart/base/root/models/cart-outlets.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/models/cart.model.ts
+++ b/feature-libs/cart/base/root/models/cart.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/models/import-export.model.ts
+++ b/feature-libs/cart/base/root/models/import-export.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/models/import-to-cart.model.ts
+++ b/feature-libs/cart/base/root/models/import-to-cart.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/models/index.ts
+++ b/feature-libs/cart/base/root/models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/public_api.ts
+++ b/feature-libs/cart/base/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/tokens/context.ts
+++ b/feature-libs/cart/base/root/tokens/context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/tokens/converters.ts
+++ b/feature-libs/cart/base/root/tokens/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/base/root/tokens/index.ts
+++ b/feature-libs/cart/base/root/tokens/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/assets/public_api.ts
+++ b/feature-libs/cart/import-export/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/assets/translations/en/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/assets/translations/translations.ts
+++ b/feature-libs/cart/import-export/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/export-entries/export-order-entries-to-csv.service.ts
+++ b/feature-libs/cart/import-export/components/export-entries/export-order-entries-to-csv.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/export-entries/export-order-entries.component.ts
+++ b/feature-libs/cart/import-export/components/export-entries/export-order-entries.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/export-entries/export-order-entries.module.ts
+++ b/feature-libs/cart/import-export/components/export-entries/export-order-entries.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/export-entries/index.ts
+++ b/feature-libs/cart/import-export/components/export-entries/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-export/import-export-order-entries.component.ts
+++ b/feature-libs/cart/import-export/components/import-export/import-export-order-entries.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-export/import-export-order-entries.module.ts
+++ b/feature-libs/cart/import-export/components/import-export/import-export-order-entries.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-export/index.ts
+++ b/feature-libs/cart/import-export/components/import-export/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-to-cart/default-import-entries-layout.config.ts
+++ b/feature-libs/cart/import-export/components/import-to-cart/default-import-entries-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-dialog.component.ts
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-form/import-entries-form.component.ts
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-form/import-entries-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-summary/import-entries-summary.component.ts
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-summary/import-entries-summary.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-to-new-saved-cart-form/import-to-new-saved-cart-form.component.ts
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-to-new-saved-cart-form/import-to-new-saved-cart-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries/import-order-entries.component.ts
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries/import-order-entries.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-to-cart/import-order-entries.module.ts
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-order-entries.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-to-cart/import-products-from-csv.service.ts
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-products-from-csv.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/import-to-cart/index.ts
+++ b/feature-libs/cart/import-export/components/import-to-cart/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/components/public_api.ts
+++ b/feature-libs/cart/import-export/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/core/config/default-import-export-config.ts
+++ b/feature-libs/cart/import-export/core/config/default-import-export-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/core/config/import-export-config.ts
+++ b/feature-libs/cart/import-export/core/config/import-export-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/core/config/index.ts
+++ b/feature-libs/cart/import-export/core/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/core/import-export-core.module.ts
+++ b/feature-libs/cart/import-export/core/import-export-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/core/model/augmented-core.model.ts
+++ b/feature-libs/cart/import-export/core/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/core/model/export-entries.model.ts
+++ b/feature-libs/cart/import-export/core/model/export-entries.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/core/model/import-entries.config.ts
+++ b/feature-libs/cart/import-export/core/model/import-entries.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/core/model/index.ts
+++ b/feature-libs/cart/import-export/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/core/public_api.ts
+++ b/feature-libs/cart/import-export/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/import-export.module.ts
+++ b/feature-libs/cart/import-export/import-export.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/public_api.ts
+++ b/feature-libs/cart/import-export/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/root/feature-name.ts
+++ b/feature-libs/cart/import-export/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/root/import-export-root.module.ts
+++ b/feature-libs/cart/import-export/root/import-export-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/import-export/root/public_api.ts
+++ b/feature-libs/cart/import-export/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/public_api.ts
+++ b/feature-libs/cart/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/assets/public_api.ts
+++ b/feature-libs/cart/quick-order/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/assets/translations/en/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/assets/translations/translations.ts
+++ b/feature-libs/cart/quick-order/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/cart-quick-order-form/cart-quick-order-form.component.ts
+++ b/feature-libs/cart/quick-order/components/cart-quick-order-form/cart-quick-order-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/cart-quick-order-form/cart-quick-order-form.module.ts
+++ b/feature-libs/cart/quick-order/components/cart-quick-order-form/cart-quick-order-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/cart-quick-order-form/index.ts
+++ b/feature-libs/cart/quick-order/components/cart-quick-order-form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/page-context/index.ts
+++ b/feature-libs/cart/quick-order/components/page-context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/page-context/quick-order-order-entries.context.ts
+++ b/feature-libs/cart/quick-order/components/page-context/quick-order-order-entries.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/public_api.ts
+++ b/feature-libs/cart/quick-order/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/quick-order-components.module.ts
+++ b/feature-libs/cart/quick-order/components/quick-order-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/quick-order/index.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/quick-order/quick-order-list.module.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/quick-order-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/quick-order/quick-order.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/quick-order.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/quick-order/table/item/quick-order-item.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/table/item/quick-order-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/components/quick-order/table/quick-order-table.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/table/quick-order-table.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/core/facade/facade-providers.ts
+++ b/feature-libs/cart/quick-order/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/core/models/cms.model.ts
+++ b/feature-libs/cart/quick-order/core/models/cms.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/core/models/index.ts
+++ b/feature-libs/cart/quick-order/core/models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/core/public_api.ts
+++ b/feature-libs/cart/quick-order/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/core/quick-order-core.module.ts
+++ b/feature-libs/cart/quick-order/core/quick-order-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/core/services/index.ts
+++ b/feature-libs/cart/quick-order/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/core/services/quick-order-state-persistance.service.ts
+++ b/feature-libs/cart/quick-order/core/services/quick-order-state-persistance.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/core/services/quick-order.service.ts
+++ b/feature-libs/cart/quick-order/core/services/quick-order.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/public_api.ts
+++ b/feature-libs/cart/quick-order/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/quick-order.module.ts
+++ b/feature-libs/cart/quick-order/quick-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/config/default-quick-order.config.ts
+++ b/feature-libs/cart/quick-order/root/config/default-quick-order.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/config/index.ts
+++ b/feature-libs/cart/quick-order/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/config/quick-order-config.ts
+++ b/feature-libs/cart/quick-order/root/config/quick-order-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/facade/index.ts
+++ b/feature-libs/cart/quick-order/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/facade/quick-order.facade.ts
+++ b/feature-libs/cart/quick-order/root/facade/quick-order.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/feature-name.ts
+++ b/feature-libs/cart/quick-order/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/models/index.ts
+++ b/feature-libs/cart/quick-order/root/models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/models/quick-order.model.ts
+++ b/feature-libs/cart/quick-order/root/models/quick-order.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/public_api.ts
+++ b/feature-libs/cart/quick-order/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/quick-order-root.module.ts
+++ b/feature-libs/cart/quick-order/root/quick-order-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/tokens/context.ts
+++ b/feature-libs/cart/quick-order/root/tokens/context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/quick-order/root/tokens/index.ts
+++ b/feature-libs/cart/quick-order/root/tokens/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/assets/public_api.ts
+++ b/feature-libs/cart/saved-cart/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/assets/translations/en/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/assets/translations/translations.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/add-to-saved-cart/add-to-saved-cart.component.ts
+++ b/feature-libs/cart/saved-cart/components/add-to-saved-cart/add-to-saved-cart.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/add-to-saved-cart/add-to-saved-cart.module.ts
+++ b/feature-libs/cart/saved-cart/components/add-to-saved-cart/add-to-saved-cart.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/add-to-saved-cart/index.ts
+++ b/feature-libs/cart/saved-cart/components/add-to-saved-cart/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/details/index.ts
+++ b/feature-libs/cart/saved-cart/components/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details-action/saved-cart-details-action.component.ts
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details-action/saved-cart-details-action.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details-items/saved-cart-details-items.component.ts
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details-items/saved-cart-details-items.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details-overview/saved-cart-details-overview.component.ts
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details-overview/saved-cart-details-overview.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details.module.ts
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details.service.ts
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/list/index.ts
+++ b/feature-libs/cart/saved-cart/components/list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.ts
+++ b/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/list/saved-cart-list.module.ts
+++ b/feature-libs/cart/saved-cart/components/list/saved-cart-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/page-context/index.ts
+++ b/feature-libs/cart/saved-cart/components/page-context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/page-context/saved-cart-details-page/saved-cart-order-entries.context.ts
+++ b/feature-libs/cart/saved-cart/components/page-context/saved-cart-details-page/saved-cart-order-entries.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/page-context/saved-carts-page/new-saved-cart-order-entries.context.ts
+++ b/feature-libs/cart/saved-cart/components/page-context/saved-carts-page/new-saved-cart-order-entries.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/public_api.ts
+++ b/feature-libs/cart/saved-cart/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/saved-cart-components.module.ts
+++ b/feature-libs/cart/saved-cart/components/saved-cart-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/default-saved-cart-form-layout.config.ts
+++ b/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/default-saved-cart-form-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/index.ts
+++ b/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.component.ts
+++ b/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.module.ts
+++ b/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/connectors/index.ts
+++ b/feature-libs/cart/saved-cart/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/connectors/saved-cart.adapter.ts
+++ b/feature-libs/cart/saved-cart/core/connectors/saved-cart.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/connectors/saved-cart.connector.ts
+++ b/feature-libs/cart/saved-cart/core/connectors/saved-cart.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/events/index.ts
+++ b/feature-libs/cart/saved-cart/core/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/events/saved-cart-event.builder.ts
+++ b/feature-libs/cart/saved-cart/core/events/saved-cart-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/events/saved-cart-events.module.ts
+++ b/feature-libs/cart/saved-cart/core/events/saved-cart-events.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/facade/facade-providers.ts
+++ b/feature-libs/cart/saved-cart/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/facade/index.ts
+++ b/feature-libs/cart/saved-cart/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/facade/saved-cart.service.ts
+++ b/feature-libs/cart/saved-cart/core/facade/saved-cart.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/public_api.ts
+++ b/feature-libs/cart/saved-cart/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/saved-cart-core.module.ts
+++ b/feature-libs/cart/saved-cart/core/saved-cart-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/store/actions/index.ts
+++ b/feature-libs/cart/saved-cart/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/store/actions/saved-cart.action.ts
+++ b/feature-libs/cart/saved-cart/core/store/actions/saved-cart.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/store/effects/index.ts
+++ b/feature-libs/cart/saved-cart/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/store/effects/saved-cart.effect.ts
+++ b/feature-libs/cart/saved-cart/core/store/effects/saved-cart.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/store/index.ts
+++ b/feature-libs/cart/saved-cart/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/store/saved-cart-constants.ts
+++ b/feature-libs/cart/saved-cart/core/store/saved-cart-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/core/store/saved-cart-store.module.ts
+++ b/feature-libs/cart/saved-cart/core/store/saved-cart-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/occ/adapters/index.ts
+++ b/feature-libs/cart/saved-cart/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/occ/adapters/occ-saved-cart.adapter.ts
+++ b/feature-libs/cart/saved-cart/occ/adapters/occ-saved-cart.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/occ/config/default-occ-saved-cart-config-factory.ts
+++ b/feature-libs/cart/saved-cart/occ/config/default-occ-saved-cart-config-factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/occ/model/index.ts
+++ b/feature-libs/cart/saved-cart/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/occ/model/occ-saved-cart-endpoints.model.ts
+++ b/feature-libs/cart/saved-cart/occ/model/occ-saved-cart-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/occ/public_api.ts
+++ b/feature-libs/cart/saved-cart/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/occ/saved-cart-occ.module.ts
+++ b/feature-libs/cart/saved-cart/occ/saved-cart-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/public_api.ts
+++ b/feature-libs/cart/saved-cart/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/events/index.ts
+++ b/feature-libs/cart/saved-cart/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/events/saved-cart.events.ts
+++ b/feature-libs/cart/saved-cart/root/events/saved-cart.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/facade/index.ts
+++ b/feature-libs/cart/saved-cart/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/facade/saved-cart.facade.ts
+++ b/feature-libs/cart/saved-cart/root/facade/saved-cart.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/feature-name.ts
+++ b/feature-libs/cart/saved-cart/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/model/augmented-core.model.ts
+++ b/feature-libs/cart/saved-cart/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/model/index.ts
+++ b/feature-libs/cart/saved-cart/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/model/saved-cart.model.ts
+++ b/feature-libs/cart/saved-cart/root/model/saved-cart.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/public_api.ts
+++ b/feature-libs/cart/saved-cart/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/saved-cart-root.module.ts
+++ b/feature-libs/cart/saved-cart/root/saved-cart-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/tokens/context.ts
+++ b/feature-libs/cart/saved-cart/root/tokens/context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/root/tokens/index.ts
+++ b/feature-libs/cart/saved-cart/root/tokens/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/saved-cart/saved-cart.module.ts
+++ b/feature-libs/cart/saved-cart/saved-cart.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/schematics/add-cart/index.ts
+++ b/feature-libs/cart/schematics/add-cart/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/setup-jest.ts
+++ b/feature-libs/cart/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/test.ts
+++ b/feature-libs/cart/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/assets/public_api.ts
+++ b/feature-libs/cart/wish-list/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/assets/translations/en/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/assets/translations/translations.ts
+++ b/feature-libs/cart/wish-list/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.ts
+++ b/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.module.ts
+++ b/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/components/add-to-wishlist/public_api.ts
+++ b/feature-libs/cart/wish-list/components/add-to-wishlist/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/components/public_api.ts
+++ b/feature-libs/cart/wish-list/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/components/wish-list-components.module.ts
+++ b/feature-libs/cart/wish-list/components/wish-list-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.ts
+++ b/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/components/wish-list/wish-list.component.ts
+++ b/feature-libs/cart/wish-list/components/wish-list/wish-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/facade/facade-providers.ts
+++ b/feature-libs/cart/wish-list/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/facade/index.ts
+++ b/feature-libs/cart/wish-list/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/facade/wish-list.service.ts
+++ b/feature-libs/cart/wish-list/core/facade/wish-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/public_api.ts
+++ b/feature-libs/cart/wish-list/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/store/actions/index.ts
+++ b/feature-libs/cart/wish-list/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/store/actions/wish-list.action.ts
+++ b/feature-libs/cart/wish-list/core/store/actions/wish-list.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/store/effects/index.ts
+++ b/feature-libs/cart/wish-list/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/store/effects/wish-list.effect.ts
+++ b/feature-libs/cart/wish-list/core/store/effects/wish-list.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/store/index.ts
+++ b/feature-libs/cart/wish-list/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/store/wish-list-store.module.ts
+++ b/feature-libs/cart/wish-list/core/store/wish-list-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/utils/utils.ts
+++ b/feature-libs/cart/wish-list/core/utils/utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/core/wish-list-core.module.ts
+++ b/feature-libs/cart/wish-list/core/wish-list-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/public_api.ts
+++ b/feature-libs/cart/wish-list/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/root/facade/index.ts
+++ b/feature-libs/cart/wish-list/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/root/facade/wish-list.facade.ts
+++ b/feature-libs/cart/wish-list/root/facade/wish-list.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/root/feature-name.ts
+++ b/feature-libs/cart/wish-list/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/root/public_api.ts
+++ b/feature-libs/cart/wish-list/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/root/wish-list-root.module.ts
+++ b/feature-libs/cart/wish-list/root/wish-list-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/cart/wish-list/wish-list.module.ts
+++ b/feature-libs/cart/wish-list/wish-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/assets/public_api.ts
+++ b/feature-libs/checkout/b2b/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/assets/translations/en/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/assets/translations/translations.ts
+++ b/feature-libs/checkout/b2b/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/checkout-b2b.module.ts
+++ b/feature-libs/checkout/b2b/checkout-b2b.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/checkout-b2b-components.module.ts
+++ b/feature-libs/checkout/b2b/components/checkout-b2b-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/checkout-cost-center/checkout-cost-center.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-cost-center/checkout-cost-center.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/checkout-cost-center/checkout-cost-center.module.ts
+++ b/feature-libs/checkout/b2b/components/checkout-cost-center/checkout-cost-center.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.module.ts
+++ b/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.module.ts
+++ b/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.ts
+++ b/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.module.ts
+++ b/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.ts
+++ b/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/guards/checkout-b2b-steps-set.guard.ts
+++ b/feature-libs/checkout/b2b/components/guards/checkout-b2b-steps-set.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/guards/index.ts
+++ b/feature-libs/checkout/b2b/components/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/components/public_api.ts
+++ b/feature-libs/checkout/b2b/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/checkout-b2b-core.module.ts
+++ b/feature-libs/checkout/b2b/core/checkout-b2b-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/connectors/checkout-cost-center/checkout-cost-center.adapter.ts
+++ b/feature-libs/checkout/b2b/core/connectors/checkout-cost-center/checkout-cost-center.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/connectors/checkout-cost-center/checkout-cost-center.connector.ts
+++ b/feature-libs/checkout/b2b/core/connectors/checkout-cost-center/checkout-cost-center.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/connectors/checkout-cost-center/index.ts
+++ b/feature-libs/checkout/b2b/core/connectors/checkout-cost-center/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/connectors/checkout-payment-type/checkout-payment-type.adapter.ts
+++ b/feature-libs/checkout/b2b/core/connectors/checkout-payment-type/checkout-payment-type.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/connectors/checkout-payment-type/checkout-payment-type.connector.ts
+++ b/feature-libs/checkout/b2b/core/connectors/checkout-payment-type/checkout-payment-type.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/connectors/checkout-payment-type/converters.ts
+++ b/feature-libs/checkout/b2b/core/connectors/checkout-payment-type/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/connectors/checkout-payment-type/index.ts
+++ b/feature-libs/checkout/b2b/core/connectors/checkout-payment-type/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/connectors/index.ts
+++ b/feature-libs/checkout/b2b/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/facade/checkout-cost-center.service.ts
+++ b/feature-libs/checkout/b2b/core/facade/checkout-cost-center.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/facade/checkout-payment-type.service.ts
+++ b/feature-libs/checkout/b2b/core/facade/checkout-payment-type.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/facade/facade-providers.ts
+++ b/feature-libs/checkout/b2b/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/facade/index.ts
+++ b/feature-libs/checkout/b2b/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/http-interceptors/bad-request/bad-cost-center-request.handler.ts
+++ b/feature-libs/checkout/b2b/core/http-interceptors/bad-request/bad-cost-center-request.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/http-interceptors/bad-request/bad-cost-center-request.model.ts
+++ b/feature-libs/checkout/b2b/core/http-interceptors/bad-request/bad-cost-center-request.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/core/public_api.ts
+++ b/feature-libs/checkout/b2b/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/occ/adapters/index.ts
+++ b/feature-libs/checkout/b2b/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/occ/adapters/occ-checkout-cost-center.adapter.ts
+++ b/feature-libs/checkout/b2b/occ/adapters/occ-checkout-cost-center.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/occ/adapters/occ-checkout-payment-type.adapter.ts
+++ b/feature-libs/checkout/b2b/occ/adapters/occ-checkout-payment-type.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/occ/checkout-b2b-occ.module.ts
+++ b/feature-libs/checkout/b2b/occ/checkout-b2b-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/occ/config/default-occ-checkout-b2b-config.ts
+++ b/feature-libs/checkout/b2b/occ/config/default-occ-checkout-b2b-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/occ/model/index.ts
+++ b/feature-libs/checkout/b2b/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/occ/model/occ-checkout-b2b-endpoints.model.ts
+++ b/feature-libs/checkout/b2b/occ/model/occ-checkout-b2b-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/occ/public_api.ts
+++ b/feature-libs/checkout/b2b/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/public_api.ts
+++ b/feature-libs/checkout/b2b/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
+++ b/feature-libs/checkout/b2b/root/checkout-b2b-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/config/default-b2b-checkout-config.ts
+++ b/feature-libs/checkout/b2b/root/config/default-b2b-checkout-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/config/default-checkout-b2b-routing-config.ts
+++ b/feature-libs/checkout/b2b/root/config/default-checkout-b2b-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/config/index.ts
+++ b/feature-libs/checkout/b2b/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/events/checkout-b2b-event.module.ts
+++ b/feature-libs/checkout/b2b/root/events/checkout-b2b-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/events/checkout-b2b.events.ts
+++ b/feature-libs/checkout/b2b/root/events/checkout-b2b.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/events/checkout-cost-center-event.listener.ts
+++ b/feature-libs/checkout/b2b/root/events/checkout-cost-center-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/events/checkout-payment-type-event.listener.ts
+++ b/feature-libs/checkout/b2b/root/events/checkout-payment-type-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/events/index.ts
+++ b/feature-libs/checkout/b2b/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/facade/checkout-cost-center.facade.ts
+++ b/feature-libs/checkout/b2b/root/facade/checkout-cost-center.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/facade/checkout-payment-type.facade.ts
+++ b/feature-libs/checkout/b2b/root/facade/checkout-payment-type.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/facade/index.ts
+++ b/feature-libs/checkout/b2b/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/model/augmented-types.ts
+++ b/feature-libs/checkout/b2b/root/model/augmented-types.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/model/index.ts
+++ b/feature-libs/checkout/b2b/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/model/payment-type.model.ts
+++ b/feature-libs/checkout/b2b/root/model/payment-type.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/b2b/root/public_api.ts
+++ b/feature-libs/checkout/b2b/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/assets/public_api.ts
+++ b/feature-libs/checkout/base/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/assets/translations/en/index.ts
+++ b/feature-libs/checkout/base/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/assets/translations/translations.ts
+++ b/feature-libs/checkout/base/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/checkout.module.ts
+++ b/feature-libs/checkout/base/checkout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.component.ts
+++ b/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.module.ts
+++ b/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.service.ts
+++ b/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-billing-address/index.ts
+++ b/feature-libs/checkout/base/components/checkout-billing-address/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-components.module.ts
+++ b/feature-libs/checkout/base/components/checkout-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.module.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.module.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-login/checkout-login.component.ts
+++ b/feature-libs/checkout/base/components/checkout-login/checkout-login.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-login/checkout-login.module.ts
+++ b/feature-libs/checkout/base/components/checkout-login/checkout-login.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-orchestrator/checkout-orchestrator.component.ts
+++ b/feature-libs/checkout/base/components/checkout-orchestrator/checkout-orchestrator.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-orchestrator/checkout-orchestrator.module.ts
+++ b/feature-libs/checkout/base/components/checkout-orchestrator/checkout-orchestrator.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-order-summary/checkout-order-summary.component.ts
+++ b/feature-libs/checkout/base/components/checkout-order-summary/checkout-order-summary.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-order-summary/checkout-order-summary.module.ts
+++ b/feature-libs/checkout/base/components/checkout-order-summary/checkout-order-summary.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.module.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.module.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.ts
+++ b/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.module.ts
+++ b/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-place-order/default-place-order-spinner-layout.config.ts
+++ b/feature-libs/checkout/base/components/checkout-place-order/default-place-order-spinner-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-bottom/checkout-progress-mobile-bottom.component.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-bottom/checkout-progress-mobile-bottom.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-bottom/checkout-progress-mobile-bottom.module.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-bottom/checkout-progress-mobile-bottom.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.component.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.module.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress-mobile-top/checkout-progress-mobile-top.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress.component.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-progress/checkout-progress.module.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/checkout-progress.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-progress/multiline-titles.pipe.ts
+++ b/feature-libs/checkout/base/components/checkout-progress/multiline-titles.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.ts
+++ b/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.module.ts
+++ b/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-overview/checkout-review-overview.component.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-overview/checkout-review-overview.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-overview/checkout-review-overview.module.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-overview/checkout-review-overview.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.module.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.component.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.module.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/guards/cart-not-empty.guard.ts
+++ b/feature-libs/checkout/base/components/guards/cart-not-empty.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/guards/checkout-auth.guard.ts
+++ b/feature-libs/checkout/base/components/guards/checkout-auth.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/guards/checkout-steps-set.guard.ts
+++ b/feature-libs/checkout/base/components/guards/checkout-steps-set.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/guards/checkout.guard.ts
+++ b/feature-libs/checkout/base/components/guards/checkout.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/guards/index.ts
+++ b/feature-libs/checkout/base/components/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/guards/not-checkout-auth.guard.ts
+++ b/feature-libs/checkout/base/components/guards/not-checkout-auth.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/public_api.ts
+++ b/feature-libs/checkout/base/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/services/checkout-config.service.ts
+++ b/feature-libs/checkout/base/components/services/checkout-config.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/services/checkout-flow-orchestrator.service.ts
+++ b/feature-libs/checkout/base/components/services/checkout-flow-orchestrator.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/services/checkout-step.service.ts
+++ b/feature-libs/checkout/base/components/services/checkout-step.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/services/express-checkout.service.ts
+++ b/feature-libs/checkout/base/components/services/express-checkout.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/components/services/index.ts
+++ b/feature-libs/checkout/base/components/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/checkout-core.module.ts
+++ b/feature-libs/checkout/base/core/checkout-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-billing-address/checkout-billing-address.adapter.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-billing-address/checkout-billing-address.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-billing-address/checkout-billing-address.connector.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-billing-address/checkout-billing-address.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-billing-address/index.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-billing-address/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-delivery-address/checkout-delivery-address.adapter.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-delivery-address/checkout-delivery-address.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-delivery-address/checkout-delivery-address.connector.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-delivery-address/checkout-delivery-address.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-delivery-address/index.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-delivery-address/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-delivery-modes/checkout-delivery-modes.adapter.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-delivery-modes/checkout-delivery-modes.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-delivery-modes/checkout-delivery-modes.connector.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-delivery-modes/checkout-delivery-modes.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-delivery-modes/converters.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-delivery-modes/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-delivery-modes/index.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-delivery-modes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-payment/checkout-payment.adapter.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-payment/checkout-payment.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-payment/checkout-payment.connector.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-payment/checkout-payment.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-payment/converters.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-payment/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout-payment/index.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout-payment/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout/checkout.adapter.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout/checkout.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout/checkout.connector.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout/checkout.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout/converters.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/checkout/index.ts
+++ b/feature-libs/checkout/base/core/connectors/checkout/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/connectors/index.ts
+++ b/feature-libs/checkout/base/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/facade/checkout-billing-address.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-billing-address.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-delivery-address.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/facade/checkout-delivery-modes.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-delivery-modes.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/facade/checkout-payment.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-payment.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/facade/checkout-query.service.ts
+++ b/feature-libs/checkout/base/core/facade/checkout-query.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/facade/facade-providers.ts
+++ b/feature-libs/checkout/base/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/facade/index.ts
+++ b/feature-libs/checkout/base/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/public_api.ts
+++ b/feature-libs/checkout/base/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/services/checkout-page-meta.resolver.ts
+++ b/feature-libs/checkout/base/core/services/checkout-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/core/services/index.ts
+++ b/feature-libs/checkout/base/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/adapters/index.ts
+++ b/feature-libs/checkout/base/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-billing-address.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-billing-address.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-address.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-address.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-modes.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-delivery-modes.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout-payment.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/adapters/occ-checkout.adapter.ts
+++ b/feature-libs/checkout/base/occ/adapters/occ-checkout.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/checkout-occ.module.ts
+++ b/feature-libs/checkout/base/occ/checkout-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/config/default-occ-checkout-config.ts
+++ b/feature-libs/checkout/base/occ/config/default-occ-checkout-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/model/index.ts
+++ b/feature-libs/checkout/base/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/model/occ-checkout-endpoints.model.ts
+++ b/feature-libs/checkout/base/occ/model/occ-checkout-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/occ/public_api.ts
+++ b/feature-libs/checkout/base/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/public_api.ts
+++ b/feature-libs/checkout/base/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/checkout-root.module.ts
+++ b/feature-libs/checkout/base/root/checkout-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/config/checkout-config.ts
+++ b/feature-libs/checkout/base/root/config/checkout-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/config/default-checkout-config.ts
+++ b/feature-libs/checkout/base/root/config/default-checkout-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/config/default-checkout-routing-config.ts
+++ b/feature-libs/checkout/base/root/config/default-checkout-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/config/index.ts
+++ b/feature-libs/checkout/base/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/events/checkout-delivery-address-event.listener.ts
+++ b/feature-libs/checkout/base/root/events/checkout-delivery-address-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/events/checkout-delivery-mode-event.listener.ts
+++ b/feature-libs/checkout/base/root/events/checkout-delivery-mode-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/events/checkout-event.module.ts
+++ b/feature-libs/checkout/base/root/events/checkout-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/events/checkout-legacy-store-event.listener.ts
+++ b/feature-libs/checkout/base/root/events/checkout-legacy-store-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/events/checkout-payment-event.listener.ts
+++ b/feature-libs/checkout/base/root/events/checkout-payment-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/events/checkout-place-order-event.listener.ts
+++ b/feature-libs/checkout/base/root/events/checkout-place-order-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/events/checkout-query-event.listener.ts
+++ b/feature-libs/checkout/base/root/events/checkout-query-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/events/checkout.events.ts
+++ b/feature-libs/checkout/base/root/events/checkout.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/events/index.ts
+++ b/feature-libs/checkout/base/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/facade/checkout-billing-address.facade.ts
+++ b/feature-libs/checkout/base/root/facade/checkout-billing-address.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/facade/checkout-delivery-address.facade.ts
+++ b/feature-libs/checkout/base/root/facade/checkout-delivery-address.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/facade/checkout-delivery-modes.facade.ts
+++ b/feature-libs/checkout/base/root/facade/checkout-delivery-modes.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/facade/checkout-payment.facade.ts
+++ b/feature-libs/checkout/base/root/facade/checkout-payment.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/facade/checkout-query.facade.ts
+++ b/feature-libs/checkout/base/root/facade/checkout-query.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/facade/index.ts
+++ b/feature-libs/checkout/base/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/feature-name.ts
+++ b/feature-libs/checkout/base/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/http-interceptors/checkout-cart.interceptor.ts
+++ b/feature-libs/checkout/base/root/http-interceptors/checkout-cart.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/http-interceptors/index.ts
+++ b/feature-libs/checkout/base/root/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/model/checkout-flow.model.ts
+++ b/feature-libs/checkout/base/root/model/checkout-flow.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/model/checkout-state.model.ts
+++ b/feature-libs/checkout/base/root/model/checkout-state.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/model/checkout-step.model.ts
+++ b/feature-libs/checkout/base/root/model/checkout-step.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/model/index.ts
+++ b/feature-libs/checkout/base/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/base/root/public_api.ts
+++ b/feature-libs/checkout/base/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/public_api.ts
+++ b/feature-libs/checkout/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/assets/public_api.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/en/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/translations.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/checkout-scheduled-replenishment.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/checkout-scheduled-replenishment.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-place-order/checkout-place-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-scheduled-replenishment-components.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-scheduled-replenishment-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/components/public_api.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/components/services/checkout-replenishment-form.service.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/services/checkout-replenishment-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/components/services/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/components/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/public_api.ts
+++ b/feature-libs/checkout/scheduled-replenishment/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/root/checkout-scheduled-replenishment-root.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/root/checkout-scheduled-replenishment-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/root/events/checkout-scheduled-replenishment-event.listener.ts
+++ b/feature-libs/checkout/scheduled-replenishment/root/events/checkout-scheduled-replenishment-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/root/events/checkout-scheduled-replenishment-event.module.ts
+++ b/feature-libs/checkout/scheduled-replenishment/root/events/checkout-scheduled-replenishment-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/root/events/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/scheduled-replenishment/root/public_api.ts
+++ b/feature-libs/checkout/scheduled-replenishment/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/schematics/add-checkout/index.ts
+++ b/feature-libs/checkout/schematics/add-checkout/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/setup-jest.ts
+++ b/feature-libs/checkout/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/checkout/test.ts
+++ b/feature-libs/checkout/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/assets/public_api.ts
+++ b/feature-libs/customer-ticketing/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/assets/translations/en/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/assets/translations/translations.ts
+++ b/feature-libs/customer-ticketing/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/customer-ticketing-components.module.ts
+++ b/feature-libs/customer-ticketing/components/customer-ticketing-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close-component.service.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close-dialog/customer-ticketing-close-dialog.component.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close-dialog/customer-ticketing-close-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close.component.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close.module.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-close/index.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-close/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.module.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-details/index.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/customer-ticketing-messages-component.service.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/customer-ticketing-messages-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/customer-ticketing-messages.component.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/customer-ticketing-messages.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/customer-ticketing-messages.module.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/customer-ticketing-messages.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/index.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen-component.service.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen-dialog/customer-ticketing-reopen-dialog.component.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen-dialog/customer-ticketing-reopen-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen.component.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen.module.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/index.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/details/index.ts
+++ b/feature-libs/customer-ticketing/components/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create-dialog/customer-ticketing-create-dialog.component.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create-dialog/customer-ticketing-create-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create.component.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create.module.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-create/index.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-create/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.module.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-list/index.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/list/index.ts
+++ b/feature-libs/customer-ticketing/components/list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/my-account-v2/index.ts
+++ b/feature-libs/customer-ticketing/components/my-account-v2/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.component.ts
+++ b/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.module.ts
+++ b/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/public_api.ts
+++ b/feature-libs/customer-ticketing/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/shared/customer-ticketing-dialog/customer-ticketing-dialog.component.ts
+++ b/feature-libs/customer-ticketing/components/shared/customer-ticketing-dialog/customer-ticketing-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/shared/customer-ticketing-dialog/default-customer-ticketing-form-layout.config.ts
+++ b/feature-libs/customer-ticketing/components/shared/customer-ticketing-dialog/default-customer-ticketing-form-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/shared/customer-ticketing-dialog/index.ts
+++ b/feature-libs/customer-ticketing/components/shared/customer-ticketing-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/components/shared/index.ts
+++ b/feature-libs/customer-ticketing/components/shared/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/connectors/converters.ts
+++ b/feature-libs/customer-ticketing/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/connectors/customer-ticketing.adapter.ts
+++ b/feature-libs/customer-ticketing/core/connectors/customer-ticketing.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/connectors/customer-ticketing.connector.ts
+++ b/feature-libs/customer-ticketing/core/connectors/customer-ticketing.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/connectors/index.ts
+++ b/feature-libs/customer-ticketing/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/customer-ticketing-core.module.ts
+++ b/feature-libs/customer-ticketing/core/customer-ticketing-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/facade/customer-ticketing.service.ts
+++ b/feature-libs/customer-ticketing/core/facade/customer-ticketing.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/facade/facade-providers.ts
+++ b/feature-libs/customer-ticketing/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/facade/index.ts
+++ b/feature-libs/customer-ticketing/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/http-interceptors/handlers/not-found-ticket-request.handler.ts
+++ b/feature-libs/customer-ticketing/core/http-interceptors/handlers/not-found-ticket-request.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/public_api.ts
+++ b/feature-libs/customer-ticketing/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/services/customer-ticketing-page-meta.resolver.ts
+++ b/feature-libs/customer-ticketing/core/services/customer-ticketing-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/services/index.ts
+++ b/feature-libs/customer-ticketing/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/core/utils/utils.ts
+++ b/feature-libs/customer-ticketing/core/utils/utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/customer-ticketing.module.ts
+++ b/feature-libs/customer-ticketing/customer-ticketing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/occ/adapters/index.ts
+++ b/feature-libs/customer-ticketing/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/occ/adapters/occ-customer-ticketing.adapter.ts
+++ b/feature-libs/customer-ticketing/occ/adapters/occ-customer-ticketing.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/occ/config/default-occ-customer-ticketing-config.ts
+++ b/feature-libs/customer-ticketing/occ/config/default-occ-customer-ticketing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/occ/customer-ticketing-occ.module.ts
+++ b/feature-libs/customer-ticketing/occ/customer-ticketing-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/occ/model/index.ts
+++ b/feature-libs/customer-ticketing/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/occ/model/occ-customer-ticketing-endpoints.model.ts
+++ b/feature-libs/customer-ticketing/occ/model/occ-customer-ticketing-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/occ/public_api.ts
+++ b/feature-libs/customer-ticketing/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/public_api.ts
+++ b/feature-libs/customer-ticketing/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/config/customer-ticketing-config.ts
+++ b/feature-libs/customer-ticketing/root/config/customer-ticketing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/config/default-customer-ticketing-config.ts
+++ b/feature-libs/customer-ticketing/root/config/default-customer-ticketing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/config/default-customer-ticketing-routing-config.ts
+++ b/feature-libs/customer-ticketing/root/config/default-customer-ticketing-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/config/index.ts
+++ b/feature-libs/customer-ticketing/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/customer-ticketing-constants.ts
+++ b/feature-libs/customer-ticketing/root/customer-ticketing-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/customer-ticketing-root.module.ts
+++ b/feature-libs/customer-ticketing/root/customer-ticketing-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/events/customer-ticketing-event.listener.ts
+++ b/feature-libs/customer-ticketing/root/events/customer-ticketing-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/events/customer-ticketing-event.module.ts
+++ b/feature-libs/customer-ticketing/root/events/customer-ticketing-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/events/customer-ticketing.events.ts
+++ b/feature-libs/customer-ticketing/root/events/customer-ticketing.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/events/index.ts
+++ b/feature-libs/customer-ticketing/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/facade/customer-ticketing.facade.ts
+++ b/feature-libs/customer-ticketing/root/facade/customer-ticketing.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/facade/index.ts
+++ b/feature-libs/customer-ticketing/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/feature-name.ts
+++ b/feature-libs/customer-ticketing/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/model/augmented-core.model.ts
+++ b/feature-libs/customer-ticketing/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/model/customer-ticketing.model.ts
+++ b/feature-libs/customer-ticketing/root/model/customer-ticketing.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/model/index.ts
+++ b/feature-libs/customer-ticketing/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/root/public_api.ts
+++ b/feature-libs/customer-ticketing/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/schematics/add-customer-ticketing/index.ts
+++ b/feature-libs/customer-ticketing/schematics/add-customer-ticketing/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/setup-jest.ts
+++ b/feature-libs/customer-ticketing/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/customer-ticketing/test.ts
+++ b/feature-libs/customer-ticketing/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/assets/public_api.ts
+++ b/feature-libs/estimated-delivery-date/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/assets/translations/en/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/assets/translations/translations.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/estimated-delivery-date.module.ts
+++ b/feature-libs/estimated-delivery-date/estimated-delivery-date.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/public_api.ts
+++ b/feature-libs/estimated-delivery-date/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/root/estimated-delivery-date-root.module.ts
+++ b/feature-libs/estimated-delivery-date/root/estimated-delivery-date-root.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/root/feature-name.ts
+++ b/feature-libs/estimated-delivery-date/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/root/model/augmented-core.model.ts
+++ b/feature-libs/estimated-delivery-date/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/root/model/estimated-delivery-date.model.ts
+++ b/feature-libs/estimated-delivery-date/root/model/estimated-delivery-date.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/root/model/index.ts
+++ b/feature-libs/estimated-delivery-date/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/root/public_api.ts
+++ b/feature-libs/estimated-delivery-date/root/public_api.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/index.ts
+++ b/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/setup-jest.ts
+++ b/feature-libs/estimated-delivery-date/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/show-estimated-delivery-date/components/estimated-delivery-date.component.ts
+++ b/feature-libs/estimated-delivery-date/show-estimated-delivery-date/components/estimated-delivery-date.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/show-estimated-delivery-date/config/default-occ-cart-with-edd.config.ts
+++ b/feature-libs/estimated-delivery-date/show-estimated-delivery-date/config/default-occ-cart-with-edd.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/show-estimated-delivery-date/public_api.ts
+++ b/feature-libs/estimated-delivery-date/show-estimated-delivery-date/public_api.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/show-estimated-delivery-date/show-estimated-delivery-date.module.ts
+++ b/feature-libs/estimated-delivery-date/show-estimated-delivery-date/show-estimated-delivery-date.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/estimated-delivery-date/test.ts
+++ b/feature-libs/estimated-delivery-date/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/assets/public_api.ts
+++ b/feature-libs/order/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/assets/translations/en/index.ts
+++ b/feature-libs/order/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/assets/translations/translations.ts
+++ b/feature-libs/order/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/amend-order-actions/amend-order-actions.component.ts
+++ b/feature-libs/order/components/amend-order/amend-order-actions/amend-order-actions.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/amend-order-actions/amend-order-actions.module.ts
+++ b/feature-libs/order/components/amend-order/amend-order-actions/amend-order-actions.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/amend-order-items/amend-order-items.component.ts
+++ b/feature-libs/order/components/amend-order/amend-order-items/amend-order-items.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/amend-order-items/amend-order-items.module.ts
+++ b/feature-libs/order/components/amend-order/amend-order-items/amend-order-items.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/amend-order.model.ts
+++ b/feature-libs/order/components/amend-order/amend-order.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/amend-order.module.ts
+++ b/feature-libs/order/components/amend-order/amend-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/amend-order.service.ts
+++ b/feature-libs/order/components/amend-order/amend-order.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.component.ts
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.module.ts
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.component.ts
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.module.ts
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/cancellations/index.ts
+++ b/feature-libs/order/components/amend-order/cancellations/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/cancellations/order-cancellation.guard.ts
+++ b/feature-libs/order/components/amend-order/cancellations/order-cancellation.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/cancellations/order-cancellation.module.ts
+++ b/feature-libs/order/components/amend-order/cancellations/order-cancellation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/cancellations/order-cancellation.service.ts
+++ b/feature-libs/order/components/amend-order/cancellations/order-cancellation.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/index.ts
+++ b/feature-libs/order/components/amend-order/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/returns/index.ts
+++ b/feature-libs/order/components/amend-order/returns/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/returns/order-return.guard.ts
+++ b/feature-libs/order/components/amend-order/returns/order-return.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/returns/order-return.module.ts
+++ b/feature-libs/order/components/amend-order/returns/order-return.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/returns/order-return.service.ts
+++ b/feature-libs/order/components/amend-order/returns/order-return.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.component.ts
+++ b/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.module.ts
+++ b/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/returns/return-order/return-order.component.ts
+++ b/feature-libs/order/components/amend-order/returns/return-order/return-order.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/amend-order/returns/return-order/return-order.module.ts
+++ b/feature-libs/order/components/amend-order/returns/return-order/return-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/guards/index.ts
+++ b/feature-libs/order/components/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/guards/order-confirmation.guard.ts
+++ b/feature-libs/order/components/guards/order-confirmation.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/my-account-v2/index.ts
+++ b/feature-libs/order/components/my-account-v2/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.ts
+++ b/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/my-account-v2/my-account-v2-orders.module.ts
+++ b/feature-libs/order/components/my-account-v2/my-account-v2-orders.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-components.module.ts
+++ b/feature-libs/order/components/order-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-confirmation/index.ts
+++ b/feature-libs/order/components/order-confirmation/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-confirmation/order-confirmation-items/order-confirmation-items.component.ts
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-items/order-confirmation-items.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-confirmation/order-confirmation-shipping/order-confirmation-shipping.component.ts
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-shipping/order-confirmation-shipping.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-confirmation/order-confirmation-thank-you-message/order-confirmation-thank-you-message.component.ts
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-thank-you-message/order-confirmation-thank-you-message.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-confirmation/order-confirmation-totals/order-confirmation-totals.component.ts
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-totals/order-confirmation-totals.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-confirmation/order-confirmation.module.ts
+++ b/feature-libs/order/components/order-confirmation/order-confirmation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.ts
+++ b/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/index.ts
+++ b/feature-libs/order/components/order-details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/my-account-v2-order-consignments.service.ts
+++ b/feature-libs/order/components/order-details/my-account-v2-order-consignments.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/my-account-v2/consignment-tracking/my-account-v2-consignment-tracking.component.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/consignment-tracking/my-account-v2-consignment-tracking.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/my-account-v2/download-invoices/default-my-account-v2-download-invoices-layout.config.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/download-invoices/default-my-account-v2-download-invoices-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/my-account-v2/download-invoices/index.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/download-invoices/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices-event.listener.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices.component.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices.module.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/my-account-v2/index.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/my-account-v2/order-details-actions/my-account-v2-order-details-actions.component.ts
+++ b/feature-libs/order/components/order-details/my-account-v2/order-details-actions/my-account-v2-order-details-actions.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-actions/order-detail-actions.component.ts
+++ b/feature-libs/order/components/order-details/order-detail-actions/order-detail-actions.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-billing/order-detail-billing.component.ts
+++ b/feature-libs/order/components/order-details/order-detail-billing/order-detail-billing.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/consignment-tracking.component.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/consignment-tracking.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/tracking-events/tracking-events.component.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/tracking-events/tracking-events.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-items/default-consignment-tracking-layout.config.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/default-consignment-tracking-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-items/index.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.component.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.model.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-items/order-detail-items.component.ts
+++ b/feature-libs/order/components/order-details/order-detail-items/order-detail-items.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-reorder/index.ts
+++ b/feature-libs/order/components/order-details/order-detail-reorder/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-reorder/order-detail-reorder.component.ts
+++ b/feature-libs/order/components/order-details/order-detail-reorder/order-detail-reorder.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.ts
+++ b/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-detail-totals/order-detail-totals.component.ts
+++ b/feature-libs/order/components/order-details/order-detail-totals/order-detail-totals.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-details.module.ts
+++ b/feature-libs/order/components/order-details/order-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-details.service.ts
+++ b/feature-libs/order/components/order-details/order-details.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-overview/order-overview-component.service.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-details/reoder-layout.config.ts
+++ b/feature-libs/order/components/order-details/reoder-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-history/index.ts
+++ b/feature-libs/order/components/order-history/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-history/my-account-v2/consignment-entries/my-account-v2-consignment-entries.component.ts
+++ b/feature-libs/order/components/order-history/my-account-v2/consignment-entries/my-account-v2-consignment-entries.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-history/my-account-v2/consolidated-information/my-account-v2-order-consolidated-information.component.ts
+++ b/feature-libs/order/components/order-history/my-account-v2/consolidated-information/my-account-v2-order-consolidated-information.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-history/my-account-v2/index.ts
+++ b/feature-libs/order/components/order-history/my-account-v2/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.component.ts
+++ b/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.model.ts
+++ b/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-history/order-history.component.ts
+++ b/feature-libs/order/components/order-history/order-history.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/order-history/order-history.module.ts
+++ b/feature-libs/order/components/order-history/order-history.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/page-context/index.ts
+++ b/feature-libs/order/components/page-context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/page-context/order-confirmation-order-entries.context.ts
+++ b/feature-libs/order/components/page-context/order-confirmation-order-entries.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/page-context/order-details-order-entries.context.ts
+++ b/feature-libs/order/components/page-context/order-details-order-entries.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/public_api.ts
+++ b/feature-libs/order/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-cancellation-dialog/index.ts
+++ b/feature-libs/order/components/replenishment-order-cancellation-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.ts
+++ b/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.module.ts
+++ b/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-details/default-replenishment-order-cancellation-layout.config.ts
+++ b/feature-libs/order/components/replenishment-order-details/default-replenishment-order-cancellation-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-details/index.ts
+++ b/feature-libs/order/components/replenishment-order-details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-details/replenishment-order-cancellation/replenishment-order-cancellation.component.ts
+++ b/feature-libs/order/components/replenishment-order-details/replenishment-order-cancellation/replenishment-order-cancellation.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-details/replenishment-order-details.module.ts
+++ b/feature-libs/order/components/replenishment-order-details/replenishment-order-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-details/replenishment-order-details.service.ts
+++ b/feature-libs/order/components/replenishment-order-details/replenishment-order-details.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-history/index.ts
+++ b/feature-libs/order/components/replenishment-order-history/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.ts
+++ b/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/replenishment-order-history/replenishment-order-history.module.ts
+++ b/feature-libs/order/components/replenishment-order-history/replenishment-order-history.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/return-request-detail/index.ts
+++ b/feature-libs/order/components/return-request-detail/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/return-request-detail/return-request-detail.module.ts
+++ b/feature-libs/order/components/return-request-detail/return-request-detail.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/return-request-detail/return-request-items/return-request-items.component.ts
+++ b/feature-libs/order/components/return-request-detail/return-request-items/return-request-items.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/return-request-detail/return-request-overview/return-request-overview.component.ts
+++ b/feature-libs/order/components/return-request-detail/return-request-overview/return-request-overview.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/return-request-detail/return-request-totals/return-request-totals.component.ts
+++ b/feature-libs/order/components/return-request-detail/return-request-totals/return-request-totals.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/return-request-detail/return-request.service.ts
+++ b/feature-libs/order/components/return-request-detail/return-request.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/return-request-list/order-return-request-list.component.ts
+++ b/feature-libs/order/components/return-request-list/order-return-request-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/components/return-request-list/order-return-request-list.module.ts
+++ b/feature-libs/order/components/return-request-list/order-return-request-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/index.ts
+++ b/feature-libs/order/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/order-history.adapter.ts
+++ b/feature-libs/order/core/connectors/order-history.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/order-history.connector.ts
+++ b/feature-libs/order/core/connectors/order-history.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/order.adapter.ts
+++ b/feature-libs/order/core/connectors/order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/order.connector.ts
+++ b/feature-libs/order/core/connectors/order.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/reorder-order.adapter.ts
+++ b/feature-libs/order/core/connectors/reorder-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/reorder-order.connector.ts
+++ b/feature-libs/order/core/connectors/reorder-order.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/replenishment-order-history.adapter.ts
+++ b/feature-libs/order/core/connectors/replenishment-order-history.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/replenishment-order-history.connector.ts
+++ b/feature-libs/order/core/connectors/replenishment-order-history.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/scheduled-replenishment-order.adapter.ts
+++ b/feature-libs/order/core/connectors/scheduled-replenishment-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/connectors/scheduled-replenishment-order.connector.ts
+++ b/feature-libs/order/core/connectors/scheduled-replenishment-order.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/facade/facade-providers.ts
+++ b/feature-libs/order/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/facade/index.ts
+++ b/feature-libs/order/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/facade/my-account-v2-order-history.service.ts
+++ b/feature-libs/order/core/facade/my-account-v2-order-history.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/facade/order-history.service.ts
+++ b/feature-libs/order/core/facade/order-history.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/facade/order-return-request.service.ts
+++ b/feature-libs/order/core/facade/order-return-request.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/facade/order.service.ts
+++ b/feature-libs/order/core/facade/order.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/facade/reorder-order.service.ts
+++ b/feature-libs/order/core/facade/reorder-order.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/facade/replenishment-order-history.service.ts
+++ b/feature-libs/order/core/facade/replenishment-order-history.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/facade/scheduled-replenishment-order.service.ts
+++ b/feature-libs/order/core/facade/scheduled-replenishment-order.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/order-core.module.ts
+++ b/feature-libs/order/core/order-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/public_api.ts
+++ b/feature-libs/order/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/consignment-tracking-by-id.action.ts
+++ b/feature-libs/order/core/store/actions/consignment-tracking-by-id.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/consignment-tracking.action.ts
+++ b/feature-libs/order/core/store/actions/consignment-tracking.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/index.ts
+++ b/feature-libs/order/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/order-by-id.action.ts
+++ b/feature-libs/order/core/store/actions/order-by-id.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/order-details.action.ts
+++ b/feature-libs/order/core/store/actions/order-details.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/order-group.actions.ts
+++ b/feature-libs/order/core/store/actions/order-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/order-return-request.action.ts
+++ b/feature-libs/order/core/store/actions/order-return-request.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/orders.action.ts
+++ b/feature-libs/order/core/store/actions/orders.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/replenishment-order-details.action.ts
+++ b/feature-libs/order/core/store/actions/replenishment-order-details.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/actions/replenishment-orders.action.ts
+++ b/feature-libs/order/core/store/actions/replenishment-orders.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/effects/consignment-tracking-by-id.effect.ts
+++ b/feature-libs/order/core/store/effects/consignment-tracking-by-id.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/effects/consignment-tracking.effect.ts
+++ b/feature-libs/order/core/store/effects/consignment-tracking.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/effects/index.ts
+++ b/feature-libs/order/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/effects/order-by-id.effect.ts
+++ b/feature-libs/order/core/store/effects/order-by-id.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/effects/order-details.effect.ts
+++ b/feature-libs/order/core/store/effects/order-details.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/effects/order-return-request.effect.ts
+++ b/feature-libs/order/core/store/effects/order-return-request.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/effects/orders.effect.ts
+++ b/feature-libs/order/core/store/effects/orders.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/effects/replenishment-order-details.effect.ts
+++ b/feature-libs/order/core/store/effects/replenishment-order-details.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/effects/replenishment-orders.effect.ts
+++ b/feature-libs/order/core/store/effects/replenishment-orders.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/index.ts
+++ b/feature-libs/order/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/order-state.ts
+++ b/feature-libs/order/core/store/order-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/order-store.module.ts
+++ b/feature-libs/order/core/store/order-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/reducers/consignment-tracking-by-id.reducer.ts
+++ b/feature-libs/order/core/store/reducers/consignment-tracking-by-id.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/reducers/consignment-tracking.reducer.ts
+++ b/feature-libs/order/core/store/reducers/consignment-tracking.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/reducers/index.ts
+++ b/feature-libs/order/core/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/reducers/order-by-id.reducer.ts
+++ b/feature-libs/order/core/store/reducers/order-by-id.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/reducers/order-details.reducer.ts
+++ b/feature-libs/order/core/store/reducers/order-details.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/reducers/order-return-request.reducer.ts
+++ b/feature-libs/order/core/store/reducers/order-return-request.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/reducers/orders.reducer.ts
+++ b/feature-libs/order/core/store/reducers/orders.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/reducers/replenishment-order-details.reducer.ts
+++ b/feature-libs/order/core/store/reducers/replenishment-order-details.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/reducers/replenishment-orders.reducer.ts
+++ b/feature-libs/order/core/store/reducers/replenishment-orders.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/consignment-tracking-by-id.selector.ts
+++ b/feature-libs/order/core/store/selectors/consignment-tracking-by-id.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/consignment-tracking.selectors.ts
+++ b/feature-libs/order/core/store/selectors/consignment-tracking.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/feature.selector.ts
+++ b/feature-libs/order/core/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/index.ts
+++ b/feature-libs/order/core/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/order-by-id.selector.ts
+++ b/feature-libs/order/core/store/selectors/order-by-id.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/order-details.selectors.ts
+++ b/feature-libs/order/core/store/selectors/order-details.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/order-group.selectors.ts
+++ b/feature-libs/order/core/store/selectors/order-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/order-return-request.selectors.ts
+++ b/feature-libs/order/core/store/selectors/order-return-request.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/orders.selectors.ts
+++ b/feature-libs/order/core/store/selectors/orders.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/replenishment-order-details.selectors.ts
+++ b/feature-libs/order/core/store/selectors/replenishment-order-details.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/core/store/selectors/replenishment-orders.selectors.ts
+++ b/feature-libs/order/core/store/selectors/replenishment-orders.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/converters/index.ts
+++ b/feature-libs/order/occ/adapters/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/converters/occ-order-normalizer.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-order-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/converters/occ-reorder-order-normalizer.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-reorder-order-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/converters/occ-replenishment-order-normalizer.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-replenishment-order-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/converters/occ-return-request-normalizer.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-return-request-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/converters/occ-scheduled-replenishment-order-form-serializer.ts
+++ b/feature-libs/order/occ/adapters/converters/occ-scheduled-replenishment-order-form-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/index.ts
+++ b/feature-libs/order/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/occ-order-history.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-order-history.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/occ-order.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/occ-reorder-order.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-reorder-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/occ-replenishment-order-history.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-replenishment-order-history.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.ts
+++ b/feature-libs/order/occ/adapters/occ-scheduled-replenishment-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/config/default-occ-order-config.ts
+++ b/feature-libs/order/occ/config/default-occ-order-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/model/index.ts
+++ b/feature-libs/order/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/model/occ-order-endpoints.model.ts
+++ b/feature-libs/order/occ/model/occ-order-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/order-occ.module.ts
+++ b/feature-libs/order/occ/order-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/occ/public_api.ts
+++ b/feature-libs/order/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/order.module.ts
+++ b/feature-libs/order/order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/public_api.ts
+++ b/feature-libs/order/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/config/default-order-routing-config.ts
+++ b/feature-libs/order/root/config/default-order-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/events/index.ts
+++ b/feature-libs/order/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/events/order.events.ts
+++ b/feature-libs/order/root/events/order.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/facade/index.ts
+++ b/feature-libs/order/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/facade/order-history.facade.ts
+++ b/feature-libs/order/root/facade/order-history.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/facade/order-return-request.facade.ts
+++ b/feature-libs/order/root/facade/order-return-request.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/facade/order.facade.ts
+++ b/feature-libs/order/root/facade/order.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/facade/reorder-order.facade.ts
+++ b/feature-libs/order/root/facade/reorder-order.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/facade/replenishment-order-history.facade.ts
+++ b/feature-libs/order/root/facade/replenishment-order-history.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/facade/scheduled-replenishment-order.facade.ts
+++ b/feature-libs/order/root/facade/scheduled-replenishment-order.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/feature-name.ts
+++ b/feature-libs/order/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/model/augmented.model.ts
+++ b/feature-libs/order/root/model/augmented.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/model/consignment-tracking.model.ts
+++ b/feature-libs/order/root/model/consignment-tracking.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/model/index.ts
+++ b/feature-libs/order/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/model/order-outlets.model.ts
+++ b/feature-libs/order/root/model/order-outlets.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/model/order-view.model.ts
+++ b/feature-libs/order/root/model/order-view.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/model/order.model.ts
+++ b/feature-libs/order/root/model/order.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/model/replenishment-order.model.ts
+++ b/feature-libs/order/root/model/replenishment-order.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/model/scheduled-replenishment.model.ts
+++ b/feature-libs/order/root/model/scheduled-replenishment.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/order-root.module.ts
+++ b/feature-libs/order/root/order-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/public_api.ts
+++ b/feature-libs/order/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/tokens/context.ts
+++ b/feature-libs/order/root/tokens/context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/tokens/converters.ts
+++ b/feature-libs/order/root/tokens/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/tokens/index.ts
+++ b/feature-libs/order/root/tokens/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/utils/index.ts
+++ b/feature-libs/order/root/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/root/utils/order-card-utils.ts
+++ b/feature-libs/order/root/utils/order-card-utils.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/schematics/add-order/index.ts
+++ b/feature-libs/order/schematics/add-order/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/setup-jest.ts
+++ b/feature-libs/order/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/order/test.ts
+++ b/feature-libs/order/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/account-summary.module.ts
+++ b/feature-libs/organization/account-summary/account-summary.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/assets/public_api.ts
+++ b/feature-libs/organization/account-summary/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/assets/translations/en/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/assets/translations/translations.ts
+++ b/feature-libs/organization/account-summary/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/account-summary-components.module.ts
+++ b/feature-libs/organization/account-summary/components/account-summary-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/account-summary-mock-data.ts
+++ b/feature-libs/organization/account-summary/components/details/account-summary-mock-data.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/document/account-summary-document.component.ts
+++ b/feature-libs/organization/account-summary/components/details/document/account-summary-document.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/document/account-summary-document.module.ts
+++ b/feature-libs/organization/account-summary/components/details/document/account-summary-document.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/document/filter/account-summary-document-filter.component.ts
+++ b/feature-libs/organization/account-summary/components/details/document/filter/account-summary-document-filter.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/document/filter/account-summary-document-filter.module.ts
+++ b/feature-libs/organization/account-summary/components/details/document/filter/account-summary-document-filter.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/document/filter/index.ts
+++ b/feature-libs/organization/account-summary/components/details/document/filter/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/document/index.ts
+++ b/feature-libs/organization/account-summary/components/details/document/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/header/account-summary-header.component.ts
+++ b/feature-libs/organization/account-summary/components/details/header/account-summary-header.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/header/account-summary-header.module.ts
+++ b/feature-libs/organization/account-summary/components/details/header/account-summary-header.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/details/header/index.ts
+++ b/feature-libs/organization/account-summary/components/details/header/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/list/account-summary-list.component.ts
+++ b/feature-libs/organization/account-summary/components/list/account-summary-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/list/account-summary-list.config.ts
+++ b/feature-libs/organization/account-summary/components/list/account-summary-list.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/list/account-summary-list.module.ts
+++ b/feature-libs/organization/account-summary/components/list/account-summary-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/list/index.ts
+++ b/feature-libs/organization/account-summary/components/list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/model/augmented.model.ts
+++ b/feature-libs/organization/account-summary/components/model/augmented.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/model/index.ts
+++ b/feature-libs/organization/account-summary/components/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/public_api.ts
+++ b/feature-libs/organization/account-summary/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/services/account-summary-item.service.ts
+++ b/feature-libs/organization/account-summary/components/services/account-summary-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/services/account-summary-unit-list.service.ts
+++ b/feature-libs/organization/account-summary/components/services/account-summary-unit-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/components/services/index.ts
+++ b/feature-libs/organization/account-summary/components/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/core/account-summary-core.module.ts
+++ b/feature-libs/organization/account-summary/core/account-summary-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/core/account-summary-page-meta.resolver.ts
+++ b/feature-libs/organization/account-summary/core/account-summary-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/core/connectors/account-summary.adapter.ts
+++ b/feature-libs/organization/account-summary/core/connectors/account-summary.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/core/connectors/account-summary.connector.ts
+++ b/feature-libs/organization/account-summary/core/connectors/account-summary.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/core/connectors/converters.ts
+++ b/feature-libs/organization/account-summary/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/core/connectors/index.ts
+++ b/feature-libs/organization/account-summary/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/core/facade/account-summary.service.ts
+++ b/feature-libs/organization/account-summary/core/facade/account-summary.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/core/facade/facade-providers.ts
+++ b/feature-libs/organization/account-summary/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/core/public_api.ts
+++ b/feature-libs/organization/account-summary/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/occ/account-summary-occ.module.ts
+++ b/feature-libs/organization/account-summary/occ/account-summary-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/occ/adapters/index.ts
+++ b/feature-libs/organization/account-summary/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/occ/adapters/occ-account-summary.adapter.ts
+++ b/feature-libs/organization/account-summary/occ/adapters/occ-account-summary.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/occ/config/default-occ-account-summary-config.ts
+++ b/feature-libs/organization/account-summary/occ/config/default-occ-account-summary-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/occ/model/index.ts
+++ b/feature-libs/organization/account-summary/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/occ/model/occ-account-summary-endpoints.model.ts
+++ b/feature-libs/organization/account-summary/occ/model/occ-account-summary-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/occ/public_api.ts
+++ b/feature-libs/organization/account-summary/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/public_api.ts
+++ b/feature-libs/organization/account-summary/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/account-summary-root.module.ts
+++ b/feature-libs/organization/account-summary/root/account-summary-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/config/default-account-summary-routing.config.ts
+++ b/feature-libs/organization/account-summary/root/config/default-account-summary-routing.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/config/index.ts
+++ b/feature-libs/organization/account-summary/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/facade/account-summary.facade.ts
+++ b/feature-libs/organization/account-summary/root/facade/account-summary.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/facade/index.ts
+++ b/feature-libs/organization/account-summary/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/feature-name.ts
+++ b/feature-libs/organization/account-summary/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/http-interceptors/blob-error.interceptor.ts
+++ b/feature-libs/organization/account-summary/root/http-interceptors/blob-error.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/http-interceptors/index.ts
+++ b/feature-libs/organization/account-summary/root/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/model/account-summary.model.ts
+++ b/feature-libs/organization/account-summary/root/model/account-summary.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/model/index.ts
+++ b/feature-libs/organization/account-summary/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/account-summary/root/public_api.ts
+++ b/feature-libs/organization/account-summary/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/administration.module.ts
+++ b/feature-libs/organization/administration/administration.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/assets/public_api.ts
+++ b/feature-libs/organization/administration/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/assets/translations/en/index.ts
+++ b/feature-libs/organization/administration/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/assets/translations/translations.ts
+++ b/feature-libs/organization/administration/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/administration-components.module.ts
+++ b/feature-libs/organization/administration/components/administration-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/budget-components.module.ts
+++ b/feature-libs/organization/administration/components/budget/budget-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/budget.config.ts
+++ b/feature-libs/organization/administration/components/budget/budget.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.component.ts
+++ b/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.module.ts
+++ b/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.service.ts
+++ b/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/cost-centers/index.ts
+++ b/feature-libs/organization/administration/components/budget/cost-centers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/details-cell/budget-details-cell.component.ts
+++ b/feature-libs/organization/administration/components/budget/details-cell/budget-details-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/details-cell/budget-details-cell.module.ts
+++ b/feature-libs/organization/administration/components/budget/details-cell/budget-details-cell.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/details-cell/index.ts
+++ b/feature-libs/organization/administration/components/budget/details-cell/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/details/budget-details.component.ts
+++ b/feature-libs/organization/administration/components/budget/details/budget-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/details/budget-details.module.ts
+++ b/feature-libs/organization/administration/components/budget/details/budget-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/details/index.ts
+++ b/feature-libs/organization/administration/components/budget/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/form/budget-form.component.ts
+++ b/feature-libs/organization/administration/components/budget/form/budget-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/form/budget-form.module.ts
+++ b/feature-libs/organization/administration/components/budget/form/budget-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/form/budget-form.service.ts
+++ b/feature-libs/organization/administration/components/budget/form/budget-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/form/index.ts
+++ b/feature-libs/organization/administration/components/budget/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/index.ts
+++ b/feature-libs/organization/administration/components/budget/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/services/budget-item.service.ts
+++ b/feature-libs/organization/administration/components/budget/services/budget-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/services/budget-list.service.ts
+++ b/feature-libs/organization/administration/components/budget/services/budget-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/services/budget-route-page-meta.resolver.ts
+++ b/feature-libs/organization/administration/components/budget/services/budget-route-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/services/current-budget.service.ts
+++ b/feature-libs/organization/administration/components/budget/services/current-budget.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/budget/services/index.ts
+++ b/feature-libs/organization/administration/components/budget/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/constants.ts
+++ b/feature-libs/organization/administration/components/constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/budgets/assigned/cost-center-assigned-budget-list.component.ts
+++ b/feature-libs/organization/administration/components/cost-center/budgets/assigned/cost-center-assigned-budget-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/budgets/assigned/cost-center-assigned-budget-list.service.ts
+++ b/feature-libs/organization/administration/components/cost-center/budgets/assigned/cost-center-assigned-budget-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/budgets/assigned/index.ts
+++ b/feature-libs/organization/administration/components/cost-center/budgets/assigned/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/budgets/cost-center-budget-list.component.ts
+++ b/feature-libs/organization/administration/components/cost-center/budgets/cost-center-budget-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/budgets/cost-center-budget-list.module.ts
+++ b/feature-libs/organization/administration/components/cost-center/budgets/cost-center-budget-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/budgets/cost-center-budget-list.service.ts
+++ b/feature-libs/organization/administration/components/cost-center/budgets/cost-center-budget-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/budgets/index.ts
+++ b/feature-libs/organization/administration/components/cost-center/budgets/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/cost-center-components.module.ts
+++ b/feature-libs/organization/administration/components/cost-center/cost-center-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/cost-center.config.ts
+++ b/feature-libs/organization/administration/components/cost-center/cost-center.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/details-cell/cost-center-details-cell.component.ts
+++ b/feature-libs/organization/administration/components/cost-center/details-cell/cost-center-details-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/details-cell/cost-center-details-cell.module.ts
+++ b/feature-libs/organization/administration/components/cost-center/details-cell/cost-center-details-cell.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/details-cell/index.ts
+++ b/feature-libs/organization/administration/components/cost-center/details-cell/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/details/cost-center-details.component.ts
+++ b/feature-libs/organization/administration/components/cost-center/details/cost-center-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/details/cost-center-details.module.ts
+++ b/feature-libs/organization/administration/components/cost-center/details/cost-center-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/details/index.ts
+++ b/feature-libs/organization/administration/components/cost-center/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/form/cost-center-form.component.ts
+++ b/feature-libs/organization/administration/components/cost-center/form/cost-center-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/form/cost-center-form.module.ts
+++ b/feature-libs/organization/administration/components/cost-center/form/cost-center-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/form/cost-center-form.service.ts
+++ b/feature-libs/organization/administration/components/cost-center/form/cost-center-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/form/index.ts
+++ b/feature-libs/organization/administration/components/cost-center/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/index.ts
+++ b/feature-libs/organization/administration/components/cost-center/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/services/cost-center-item.service.ts
+++ b/feature-libs/organization/administration/components/cost-center/services/cost-center-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/services/cost-center-list.service.ts
+++ b/feature-libs/organization/administration/components/cost-center/services/cost-center-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/services/cost-center-route-page-meta.resolver.ts
+++ b/feature-libs/organization/administration/components/cost-center/services/cost-center-route-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/services/current-cost-center.service.ts
+++ b/feature-libs/organization/administration/components/cost-center/services/current-cost-center.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/cost-center/services/index.ts
+++ b/feature-libs/organization/administration/components/cost-center/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/details-cell/index.ts
+++ b/feature-libs/organization/administration/components/permission/details-cell/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/details-cell/permission-details-cell.component.ts
+++ b/feature-libs/organization/administration/components/permission/details-cell/permission-details-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/details-cell/permission-details-cell.module.ts
+++ b/feature-libs/organization/administration/components/permission/details-cell/permission-details-cell.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/details/index.ts
+++ b/feature-libs/organization/administration/components/permission/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/details/permission-details.component.ts
+++ b/feature-libs/organization/administration/components/permission/details/permission-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/details/permission-details.module.ts
+++ b/feature-libs/organization/administration/components/permission/details/permission-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/form/index.ts
+++ b/feature-libs/organization/administration/components/permission/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/form/permission-form.component.ts
+++ b/feature-libs/organization/administration/components/permission/form/permission-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/form/permission-form.module.ts
+++ b/feature-libs/organization/administration/components/permission/form/permission-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/form/permission-form.service.ts
+++ b/feature-libs/organization/administration/components/permission/form/permission-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/index.ts
+++ b/feature-libs/organization/administration/components/permission/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/permission-components.module.ts
+++ b/feature-libs/organization/administration/components/permission/permission-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/permission.config.ts
+++ b/feature-libs/organization/administration/components/permission/permission.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/services/current-permission.service.ts
+++ b/feature-libs/organization/administration/components/permission/services/current-permission.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/services/index.ts
+++ b/feature-libs/organization/administration/components/permission/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/services/permission-item.service.ts
+++ b/feature-libs/organization/administration/components/permission/services/permission-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/services/permission-list.service.ts
+++ b/feature-libs/organization/administration/components/permission/services/permission-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/permission/services/permission-route-page-meta.resolver.ts
+++ b/feature-libs/organization/administration/components/permission/services/permission-route-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/public_api.ts
+++ b/feature-libs/organization/administration/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/card/card.component.ts
+++ b/feature-libs/organization/administration/components/shared/card/card.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/card/card.module.ts
+++ b/feature-libs/organization/administration/components/shared/card/card.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/card/card.testing.module.ts
+++ b/feature-libs/organization/administration/components/shared/card/card.testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/card/index.ts
+++ b/feature-libs/organization/administration/components/shared/card/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/current-item.service.ts
+++ b/feature-libs/organization/administration/components/shared/current-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/delete-item-action/delete-item.component.ts
+++ b/feature-libs/organization/administration/components/shared/detail/delete-item-action/delete-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/delete-item-action/delete-item.module.ts
+++ b/feature-libs/organization/administration/components/shared/detail/delete-item-action/delete-item.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/delete-item-action/index.ts
+++ b/feature-libs/organization/administration/components/shared/detail/delete-item-action/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/disable-info/disable-info.component.ts
+++ b/feature-libs/organization/administration/components/shared/detail/disable-info/disable-info.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/disable-info/disable-info.module.ts
+++ b/feature-libs/organization/administration/components/shared/detail/disable-info/disable-info.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/disable-info/disable-info.service.ts
+++ b/feature-libs/organization/administration/components/shared/detail/disable-info/disable-info.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/disable-info/index.ts
+++ b/feature-libs/organization/administration/components/shared/detail/disable-info/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/index.ts
+++ b/feature-libs/organization/administration/components/shared/detail/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/toggle-status-action/index.ts
+++ b/feature-libs/organization/administration/components/shared/detail/toggle-status-action/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/toggle-status-action/toggle-status.component.ts
+++ b/feature-libs/organization/administration/components/shared/detail/toggle-status-action/toggle-status.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/detail/toggle-status-action/toggle-status.module.ts
+++ b/feature-libs/organization/administration/components/shared/detail/toggle-status-action/toggle-status.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/form/form.component.ts
+++ b/feature-libs/organization/administration/components/shared/form/form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/form/form.module.ts
+++ b/feature-libs/organization/administration/components/shared/form/form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/form/form.service.ts
+++ b/feature-libs/organization/administration/components/shared/form/form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/form/form.testing.module.ts
+++ b/feature-libs/organization/administration/components/shared/form/form.testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/form/index.ts
+++ b/feature-libs/organization/administration/components/shared/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/index.ts
+++ b/feature-libs/organization/administration/components/shared/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/item-active.directive.ts
+++ b/feature-libs/organization/administration/components/shared/item-active.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/item-active.module.ts
+++ b/feature-libs/organization/administration/components/shared/item-active.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/item-exists.directive.ts
+++ b/feature-libs/organization/administration/components/shared/item-exists.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/item-exists.module.ts
+++ b/feature-libs/organization/administration/components/shared/item-exists.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/item.service.ts
+++ b/feature-libs/organization/administration/components/shared/item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/list/index.ts
+++ b/feature-libs/organization/administration/components/shared/list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/list/list.component.ts
+++ b/feature-libs/organization/administration/components/shared/list/list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/list/list.module.ts
+++ b/feature-libs/organization/administration/components/shared/list/list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/list/list.service.ts
+++ b/feature-libs/organization/administration/components/shared/list/list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/base-message.component.ts
+++ b/feature-libs/organization/administration/components/shared/message/base-message.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.component.ts
+++ b/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.model.ts
+++ b/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.module.ts
+++ b/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/confirmation/index.ts
+++ b/feature-libs/organization/administration/components/shared/message/confirmation/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/index.ts
+++ b/feature-libs/organization/administration/components/shared/message/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/message.component.ts
+++ b/feature-libs/organization/administration/components/shared/message/message.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/message.model.ts
+++ b/feature-libs/organization/administration/components/shared/message/message.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/message.module.ts
+++ b/feature-libs/organization/administration/components/shared/message/message.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/message.testing.module.ts
+++ b/feature-libs/organization/administration/components/shared/message/message.testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/notification/index.ts
+++ b/feature-libs/organization/administration/components/shared/message/notification/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.module.ts
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/services/index.ts
+++ b/feature-libs/organization/administration/components/shared/message/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/services/message-render.service.ts
+++ b/feature-libs/organization/administration/components/shared/message/services/message-render.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/message/services/message.service.ts
+++ b/feature-libs/organization/administration/components/shared/message/services/message.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/organization.model.ts
+++ b/feature-libs/organization/administration/components/shared/organization.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/shared-organization.module.ts
+++ b/feature-libs/organization/administration/components/shared/shared-organization.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/sub-list/assign-cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/sub-list/assign-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/sub-list/index.ts
+++ b/feature-libs/organization/administration/components/shared/sub-list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/sub-list/sub-list.component.ts
+++ b/feature-libs/organization/administration/components/shared/sub-list/sub-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/sub-list/sub-list.module.ts
+++ b/feature-libs/organization/administration/components/shared/sub-list/sub-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/sub-list/sub-list.service.ts
+++ b/feature-libs/organization/administration/components/shared/sub-list/sub-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/sub-list/sub-list.testing.module.ts
+++ b/feature-libs/organization/administration/components/shared/sub-list/sub-list.testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/active-link/active-link-cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/active-link/active-link-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/amount/amount-cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/amount/amount-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/cell.module.ts
+++ b/feature-libs/organization/administration/components/shared/table/cell.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/date-range/date-range-cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/date-range/date-range-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/index.ts
+++ b/feature-libs/organization/administration/components/shared/table/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/limit/limit-cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/limit/limit-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/roles/roles-cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/roles/roles-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/status/status-cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/status/status-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/table/unit/unit-cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/unit/unit-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/shared/utility/entity-code.ts
+++ b/feature-libs/organization/administration/components/shared/utility/entity-code.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/details-cell/index.ts
+++ b/feature-libs/organization/administration/components/unit/details-cell/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/details-cell/unit-details-cell.component.ts
+++ b/feature-libs/organization/administration/components/unit/details-cell/unit-details-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/details-cell/unit-details-cell.module.ts
+++ b/feature-libs/organization/administration/components/unit/details-cell/unit-details-cell.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/details/index.ts
+++ b/feature-libs/organization/administration/components/unit/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/details/unit-details.module.ts
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/form/index.ts
+++ b/feature-libs/organization/administration/components/unit/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/form/unit-form.component.ts
+++ b/feature-libs/organization/administration/components/unit/form/unit-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/form/unit-form.module.ts
+++ b/feature-libs/organization/administration/components/unit/form/unit-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/form/unit-form.service.ts
+++ b/feature-libs/organization/administration/components/unit/form/unit-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/index.ts
+++ b/feature-libs/organization/administration/components/unit/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/details/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/details/unit-address-details.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/details/unit-address-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/details/unit-address-details.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/details/unit-address-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/form/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/list/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/list/link-cell.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/list/link-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/list/unit-address-list.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/list/unit-address-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/list/unit-address-list.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/list/unit-address-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/list/unit-address-list.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/list/unit-address-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/services/current-unit-address.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/services/current-unit-address.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/services/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/services/unit-address-item.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/services/unit-address-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/addresses/unit-address.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/unit-address.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/approvers/assigned/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/approvers/assigned/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/approvers/assigned/unit-assigned-approver-list.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/approvers/assigned/unit-assigned-approver-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/approvers/assigned/unit-assigned-approver-list.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/approvers/assigned/unit-assigned-approver-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/approvers/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/approvers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/approvers/unit-approver-list.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/approvers/unit-approver-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/approvers/unit-approver-list.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/approvers/unit-approver-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/approvers/unit-approver-list.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/approvers/unit-approver-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/children/create/current-unit-child.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/create/current-unit-child.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/children/create/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/create/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/children/create/unit-child-create.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/create/unit-child-create.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/children/create/unit-child-create.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/create/unit-child-create.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/children/create/unit-child-item.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/create/unit-child-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/children/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/children/unit-children.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/unit-children.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/children/unit-children.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/unit-children.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/children/unit-children.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/children/unit-children.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/create/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/create/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/create/unit-cost-center-create.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/create/unit-cost-center-create.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/create/unit-cost-center-create.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/create/unit-cost-center-create.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/create/unit-cost-center-item.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/create/unit-cost-center-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/create/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/create/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/create/unit-user-create.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/create/unit-user-create.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/create/unit-user-create.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/create/unit-user-create.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/create/unit-user-item.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/create/unit-user-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/list/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/list/unit-user-link-cell.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/list/unit-user-link-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/list/unit-user-list.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/list/unit-user-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/list/unit-user-list.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/list/unit-user-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/roles/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/roles/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/roles/unit-user-roles-form.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/roles/unit-user-roles-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/roles/unit-user-roles-item.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/roles/unit-user-roles-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/roles/unit-user-roles.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/roles/unit-user-roles.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/roles/unit-user-roles.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/roles/unit-user-roles.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/services/current-unit-user.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/services/current-unit-user.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/services/index.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/services/unit-user-list.service.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/services/unit-user-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/links/users/unit-user-list.module.ts
+++ b/feature-libs/organization/administration/components/unit/links/users/unit-user-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/list/index.ts
+++ b/feature-libs/organization/administration/components/unit/list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.ts
+++ b/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/list/unit-list.component.ts
+++ b/feature-libs/organization/administration/components/unit/list/unit-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/list/unit-list.module.ts
+++ b/feature-libs/organization/administration/components/unit/list/unit-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/services/current-unit.service.ts
+++ b/feature-libs/organization/administration/components/unit/services/current-unit.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/services/index.ts
+++ b/feature-libs/organization/administration/components/unit/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/services/unit-address-route-page-meta.resolver.ts
+++ b/feature-libs/organization/administration/components/unit/services/unit-address-route-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/services/unit-item.service.ts
+++ b/feature-libs/organization/administration/components/unit/services/unit-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/services/unit-list.service.ts
+++ b/feature-libs/organization/administration/components/unit/services/unit-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/services/unit-route-page-meta.resolver.ts
+++ b/feature-libs/organization/administration/components/unit/services/unit-route-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/services/unit-tree.model.ts
+++ b/feature-libs/organization/administration/components/unit/services/unit-tree.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/services/unit-tree.service.ts
+++ b/feature-libs/organization/administration/components/unit/services/unit-tree.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/units-components.module.ts
+++ b/feature-libs/organization/administration/components/unit/units-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/unit/units.config.ts
+++ b/feature-libs/organization/administration/components/unit/units.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/details-cell/index.ts
+++ b/feature-libs/organization/administration/components/user-group/details-cell/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/details-cell/user-group-details-cell.component.ts
+++ b/feature-libs/organization/administration/components/user-group/details-cell/user-group-details-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/details-cell/user-group-details-cell.module.ts
+++ b/feature-libs/organization/administration/components/user-group/details-cell/user-group-details-cell.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/details/index.ts
+++ b/feature-libs/organization/administration/components/user-group/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/details/user-group-details.component.ts
+++ b/feature-libs/organization/administration/components/user-group/details/user-group-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/details/user-group-details.module.ts
+++ b/feature-libs/organization/administration/components/user-group/details/user-group-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/form/index.ts
+++ b/feature-libs/organization/administration/components/user-group/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/form/user-group-form.component.ts
+++ b/feature-libs/organization/administration/components/user-group/form/user-group-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/form/user-group-form.module.ts
+++ b/feature-libs/organization/administration/components/user-group/form/user-group-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/form/user-group-form.service.ts
+++ b/feature-libs/organization/administration/components/user-group/form/user-group-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/index.ts
+++ b/feature-libs/organization/administration/components/user-group/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/permissions/assigned/index.ts
+++ b/feature-libs/organization/administration/components/user-group/permissions/assigned/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/permissions/assigned/user-group-assigned-permission-list.component.ts
+++ b/feature-libs/organization/administration/components/user-group/permissions/assigned/user-group-assigned-permission-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/permissions/assigned/user-group-assigned-permission-list.service.ts
+++ b/feature-libs/organization/administration/components/user-group/permissions/assigned/user-group-assigned-permission-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/permissions/index.ts
+++ b/feature-libs/organization/administration/components/user-group/permissions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/permissions/user-group-permission-list.component.ts
+++ b/feature-libs/organization/administration/components/user-group/permissions/user-group-permission-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/permissions/user-group-permission-list.module.ts
+++ b/feature-libs/organization/administration/components/user-group/permissions/user-group-permission-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/permissions/user-group-permission-list.service.ts
+++ b/feature-libs/organization/administration/components/user-group/permissions/user-group-permission-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/services/current-user-group.service.ts
+++ b/feature-libs/organization/administration/components/user-group/services/current-user-group.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/services/index.ts
+++ b/feature-libs/organization/administration/components/user-group/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/services/user-group-item.service.ts
+++ b/feature-libs/organization/administration/components/user-group/services/user-group-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/services/user-group-list.service.ts
+++ b/feature-libs/organization/administration/components/user-group/services/user-group-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/services/user-group-route-page-meta.resolver.ts
+++ b/feature-libs/organization/administration/components/user-group/services/user-group-route-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/user-group-components.module.ts
+++ b/feature-libs/organization/administration/components/user-group/user-group-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/user-group.config.ts
+++ b/feature-libs/organization/administration/components/user-group/user-group.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/users/assigned/index.ts
+++ b/feature-libs/organization/administration/components/user-group/users/assigned/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/users/assigned/user-group-assigned-user-list.component.ts
+++ b/feature-libs/organization/administration/components/user-group/users/assigned/user-group-assigned-user-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/users/assigned/user-group-assigned-user-list.service.ts
+++ b/feature-libs/organization/administration/components/user-group/users/assigned/user-group-assigned-user-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/users/index.ts
+++ b/feature-libs/organization/administration/components/user-group/users/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/users/user-group-user-list.component.ts
+++ b/feature-libs/organization/administration/components/user-group/users/user-group-user-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/users/user-group-user-list.module.ts
+++ b/feature-libs/organization/administration/components/user-group/users/user-group-user-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user-group/users/user-group-user-list.service.ts
+++ b/feature-libs/organization/administration/components/user-group/users/user-group-user-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/approvers/assigned/index.ts
+++ b/feature-libs/organization/administration/components/user/approvers/assigned/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/approvers/assigned/user-assigned-approver-list.component.ts
+++ b/feature-libs/organization/administration/components/user/approvers/assigned/user-assigned-approver-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/approvers/assigned/user-assigned-approver-list.service.ts
+++ b/feature-libs/organization/administration/components/user/approvers/assigned/user-assigned-approver-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/approvers/index.ts
+++ b/feature-libs/organization/administration/components/user/approvers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/approvers/user-approver-list.component.ts
+++ b/feature-libs/organization/administration/components/user/approvers/user-approver-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/approvers/user-approver-list.module.ts
+++ b/feature-libs/organization/administration/components/user/approvers/user-approver-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/approvers/user-approver-list.service.ts
+++ b/feature-libs/organization/administration/components/user/approvers/user-approver-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/change-password-form/index.ts
+++ b/feature-libs/organization/administration/components/user/change-password-form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/change-password-form/user-change-password-form.component.ts
+++ b/feature-libs/organization/administration/components/user/change-password-form/user-change-password-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/change-password-form/user-change-password-form.module.ts
+++ b/feature-libs/organization/administration/components/user/change-password-form/user-change-password-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/change-password-form/user-change-password-form.service.ts
+++ b/feature-libs/organization/administration/components/user/change-password-form/user-change-password-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/details-cell/index.ts
+++ b/feature-libs/organization/administration/components/user/details-cell/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/details-cell/user-details-cell.component.ts
+++ b/feature-libs/organization/administration/components/user/details-cell/user-details-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/details-cell/user-details-cell.module.ts
+++ b/feature-libs/organization/administration/components/user/details-cell/user-details-cell.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/details/index.ts
+++ b/feature-libs/organization/administration/components/user/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/details/user-details.component.ts
+++ b/feature-libs/organization/administration/components/user/details/user-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/details/user-details.module.ts
+++ b/feature-libs/organization/administration/components/user/details/user-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/form/index.ts
+++ b/feature-libs/organization/administration/components/user/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/form/user-form.component.ts
+++ b/feature-libs/organization/administration/components/user/form/user-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/form/user-form.module.ts
+++ b/feature-libs/organization/administration/components/user/form/user-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/form/user-form.service.ts
+++ b/feature-libs/organization/administration/components/user/form/user-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/index.ts
+++ b/feature-libs/organization/administration/components/user/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/permissions/assigned/index.ts
+++ b/feature-libs/organization/administration/components/user/permissions/assigned/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/permissions/assigned/user-assigned-permission-list.component.ts
+++ b/feature-libs/organization/administration/components/user/permissions/assigned/user-assigned-permission-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/permissions/assigned/user-assigned-permission-list.service.ts
+++ b/feature-libs/organization/administration/components/user/permissions/assigned/user-assigned-permission-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/permissions/index.ts
+++ b/feature-libs/organization/administration/components/user/permissions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/permissions/user-permission-list.component.ts
+++ b/feature-libs/organization/administration/components/user/permissions/user-permission-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/permissions/user-permission-list.module.ts
+++ b/feature-libs/organization/administration/components/user/permissions/user-permission-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/permissions/user-permission-list.service.ts
+++ b/feature-libs/organization/administration/components/user/permissions/user-permission-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/services/current-user.service.ts
+++ b/feature-libs/organization/administration/components/user/services/current-user.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/services/index.ts
+++ b/feature-libs/organization/administration/components/user/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/services/user-item.service.ts
+++ b/feature-libs/organization/administration/components/user/services/user-item.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/services/user-list.service.ts
+++ b/feature-libs/organization/administration/components/user/services/user-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/services/user-route-page-meta.resolver.ts
+++ b/feature-libs/organization/administration/components/user/services/user-route-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/user-components.module.ts
+++ b/feature-libs/organization/administration/components/user/user-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/user-groups/assigned/index.ts
+++ b/feature-libs/organization/administration/components/user/user-groups/assigned/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/user-groups/assigned/user-assigned-user-group-list.component.ts
+++ b/feature-libs/organization/administration/components/user/user-groups/assigned/user-assigned-user-group-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/user-groups/assigned/user-assigned-user-group-list.service.ts
+++ b/feature-libs/organization/administration/components/user/user-groups/assigned/user-assigned-user-group-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/user-groups/index.ts
+++ b/feature-libs/organization/administration/components/user/user-groups/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/user-groups/user-user-group-list.component.ts
+++ b/feature-libs/organization/administration/components/user/user-groups/user-user-group-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/user-groups/user-user-group-list.module.ts
+++ b/feature-libs/organization/administration/components/user/user-groups/user-user-group-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/user-groups/user-user-group-list.service.ts
+++ b/feature-libs/organization/administration/components/user/user-groups/user-user-group-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/components/user/user.config.ts
+++ b/feature-libs/organization/administration/components/user/user.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/administration-core.module.ts
+++ b/feature-libs/organization/administration/core/administration-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/b2b-user/b2b-user.adapter.ts
+++ b/feature-libs/organization/administration/core/connectors/b2b-user/b2b-user.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/b2b-user/b2b-user.connector.ts
+++ b/feature-libs/organization/administration/core/connectors/b2b-user/b2b-user.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/b2b-user/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/b2b-user/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/b2b-user/index.ts
+++ b/feature-libs/organization/administration/core/connectors/b2b-user/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/budget/budget.adapter.ts
+++ b/feature-libs/organization/administration/core/connectors/budget/budget.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/budget/budget.connector.ts
+++ b/feature-libs/organization/administration/core/connectors/budget/budget.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/budget/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/budget/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/budget/index.ts
+++ b/feature-libs/organization/administration/core/connectors/budget/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/cost-center/cost-center.adapter.ts
+++ b/feature-libs/organization/administration/core/connectors/cost-center/cost-center.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/cost-center/cost-center.connector.ts
+++ b/feature-libs/organization/administration/core/connectors/cost-center/cost-center.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/cost-center/index.ts
+++ b/feature-libs/organization/administration/core/connectors/cost-center/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/index.ts
+++ b/feature-libs/organization/administration/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/org-unit/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/org-unit/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/org-unit/index.ts
+++ b/feature-libs/organization/administration/core/connectors/org-unit/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/org-unit/org-unit.adapter.ts
+++ b/feature-libs/organization/administration/core/connectors/org-unit/org-unit.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/org-unit/org-unit.connector.ts
+++ b/feature-libs/organization/administration/core/connectors/org-unit/org-unit.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/permission/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/permission/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/permission/index.ts
+++ b/feature-libs/organization/administration/core/connectors/permission/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/permission/permission.adapter.ts
+++ b/feature-libs/organization/administration/core/connectors/permission/permission.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/permission/permission.connector.ts
+++ b/feature-libs/organization/administration/core/connectors/permission/permission.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/user-group/converters.ts
+++ b/feature-libs/organization/administration/core/connectors/user-group/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/user-group/index.ts
+++ b/feature-libs/organization/administration/core/connectors/user-group/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/user-group/user-group.adapter.ts
+++ b/feature-libs/organization/administration/core/connectors/user-group/user-group.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/connectors/user-group/user-group.connector.ts
+++ b/feature-libs/organization/administration/core/connectors/user-group/user-group.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/guards/admin.guard.ts
+++ b/feature-libs/organization/administration/core/guards/admin.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/guards/index.ts
+++ b/feature-libs/organization/administration/core/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/guards/org-unit.guard.ts
+++ b/feature-libs/organization/administration/core/guards/org-unit.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/guards/organization-guards.module.ts
+++ b/feature-libs/organization/administration/core/guards/organization-guards.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/guards/user.guard.ts
+++ b/feature-libs/organization/administration/core/guards/user.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/http-interceptors/bad-request/bad-request.handler.ts
+++ b/feature-libs/organization/administration/core/http-interceptors/bad-request/bad-request.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/http-interceptors/conflict/conflict.handler.ts
+++ b/feature-libs/organization/administration/core/http-interceptors/conflict/conflict.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/http-interceptors/index.ts
+++ b/feature-libs/organization/administration/core/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/model/augmented-core.model.ts
+++ b/feature-libs/organization/administration/core/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/model/budget.model.ts
+++ b/feature-libs/organization/administration/core/model/budget.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/model/index.ts
+++ b/feature-libs/organization/administration/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/model/organization-item-status.ts
+++ b/feature-libs/organization/administration/core/model/organization-item-status.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/model/permission.model.ts
+++ b/feature-libs/organization/administration/core/model/permission.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/model/unit-node.model.ts
+++ b/feature-libs/organization/administration/core/model/unit-node.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/model/user-group.model.ts
+++ b/feature-libs/organization/administration/core/model/user-group.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/public_api.ts
+++ b/feature-libs/organization/administration/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/services/b2b-user.service.ts
+++ b/feature-libs/organization/administration/core/services/b2b-user.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/services/budget.service.ts
+++ b/feature-libs/organization/administration/core/services/budget.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/services/cost-center.service.ts
+++ b/feature-libs/organization/administration/core/services/cost-center.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/services/index.ts
+++ b/feature-libs/organization/administration/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/services/org-unit.service.ts
+++ b/feature-libs/organization/administration/core/services/org-unit.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/services/organization-page-meta.module.ts
+++ b/feature-libs/organization/administration/core/services/organization-page-meta.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/services/organization-page-meta.resolver.ts
+++ b/feature-libs/organization/administration/core/services/organization-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/services/permission.service.ts
+++ b/feature-libs/organization/administration/core/services/permission.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/services/user-group.service.ts
+++ b/feature-libs/organization/administration/core/services/user-group.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/actions/b2b-user.action.ts
+++ b/feature-libs/organization/administration/core/store/actions/b2b-user.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/actions/budget.action.ts
+++ b/feature-libs/organization/administration/core/store/actions/budget.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/actions/cost-center.action.ts
+++ b/feature-libs/organization/administration/core/store/actions/cost-center.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/actions/index.ts
+++ b/feature-libs/organization/administration/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/actions/org-unit.action.ts
+++ b/feature-libs/organization/administration/core/store/actions/org-unit.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/actions/organization.action.ts
+++ b/feature-libs/organization/administration/core/store/actions/organization.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/actions/permission.action.ts
+++ b/feature-libs/organization/administration/core/store/actions/permission.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/actions/user-group.action.ts
+++ b/feature-libs/organization/administration/core/store/actions/user-group.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/effects/b2b-user.effect.ts
+++ b/feature-libs/organization/administration/core/store/effects/b2b-user.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/effects/budget.effect.ts
+++ b/feature-libs/organization/administration/core/store/effects/budget.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/effects/cost-center.effect.ts
+++ b/feature-libs/organization/administration/core/store/effects/cost-center.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/effects/index.ts
+++ b/feature-libs/organization/administration/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/effects/org-unit.effect.ts
+++ b/feature-libs/organization/administration/core/store/effects/org-unit.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/effects/permission.effect.ts
+++ b/feature-libs/organization/administration/core/store/effects/permission.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/effects/user-group.effect.ts
+++ b/feature-libs/organization/administration/core/store/effects/user-group.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/index.ts
+++ b/feature-libs/organization/administration/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/organization-state.ts
+++ b/feature-libs/organization/administration/core/store/organization-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/organization-store.module.ts
+++ b/feature-libs/organization/administration/core/store/organization-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/reducers/b2b-user.reducer.ts
+++ b/feature-libs/organization/administration/core/store/reducers/b2b-user.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/reducers/budget.reducer.ts
+++ b/feature-libs/organization/administration/core/store/reducers/budget.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/reducers/cost-center.reducer.ts
+++ b/feature-libs/organization/administration/core/store/reducers/cost-center.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/reducers/index.ts
+++ b/feature-libs/organization/administration/core/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/reducers/org-unit.reducer.ts
+++ b/feature-libs/organization/administration/core/store/reducers/org-unit.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/reducers/permission.reducer.ts
+++ b/feature-libs/organization/administration/core/store/reducers/permission.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/reducers/user-group.reducer.ts
+++ b/feature-libs/organization/administration/core/store/reducers/user-group.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/selectors/b2b-user.selector.ts
+++ b/feature-libs/organization/administration/core/store/selectors/b2b-user.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/selectors/budget.selector.ts
+++ b/feature-libs/organization/administration/core/store/selectors/budget.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/selectors/cost-center.selector.ts
+++ b/feature-libs/organization/administration/core/store/selectors/cost-center.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/selectors/feature.selector.ts
+++ b/feature-libs/organization/administration/core/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/selectors/index.ts
+++ b/feature-libs/organization/administration/core/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/selectors/org-unit.selector.ts
+++ b/feature-libs/organization/administration/core/store/selectors/org-unit.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/selectors/permission.selector.ts
+++ b/feature-libs/organization/administration/core/store/selectors/permission.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/store/selectors/user-group.selector.ts
+++ b/feature-libs/organization/administration/core/store/selectors/user-group.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/core/utils/get-item-status.ts
+++ b/feature-libs/organization/administration/core/utils/get-item-status.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/adapters/index.ts
+++ b/feature-libs/organization/administration/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/adapters/occ-b2b-users.adapter.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-b2b-users.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/adapters/occ-budget.adapter.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-budget.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/adapters/occ-cost-center.adapter.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-cost-center.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/adapters/occ-org-unit.adapter.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-org-unit.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/adapters/occ-permission.adapter.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-permission.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/adapters/occ-user-group.adapter.ts
+++ b/feature-libs/organization/administration/occ/adapters/occ-user-group.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/administration-occ.module.ts
+++ b/feature-libs/organization/administration/occ/administration-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/config/default-occ-organization-config.ts
+++ b/feature-libs/organization/administration/occ/config/default-occ-organization-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/index.ts
+++ b/feature-libs/organization/administration/occ/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-b2b-user-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-b2b-user-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-b2b-user-serializer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-b2b-user-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-budget-list-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-budget-list-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-budget-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-budget-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-budget-serializer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-budget-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-org-unit-approval-processes-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-org-unit-approval-processes-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-org-unit-node-list-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-org-unit-node-list-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-org-unit-node-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-org-unit-node-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-org-unit-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-org-unit-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-permission-list-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-permission-list-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-permission-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-permission-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-permission-type-list.normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-permission-type-list.normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-permission-type-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-permission-type-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-user-group-list-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-user-group-list-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-user-group-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-user-group-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/converters/occ-user-list-normalizer.ts
+++ b/feature-libs/organization/administration/occ/converters/occ-user-list-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/model/index.ts
+++ b/feature-libs/organization/administration/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/model/occ-administration-endpoints.model.ts
+++ b/feature-libs/organization/administration/occ/model/occ-administration-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/occ/public_api.ts
+++ b/feature-libs/organization/administration/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/public_api.ts
+++ b/feature-libs/organization/administration/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/administration-root.module.ts
+++ b/feature-libs/organization/administration/root/administration-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/config/default-budget-routing.config.ts
+++ b/feature-libs/organization/administration/root/config/default-budget-routing.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/config/default-cost-center-routing.config.ts
+++ b/feature-libs/organization/administration/root/config/default-cost-center-routing.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/config/default-organization-layout.config.ts
+++ b/feature-libs/organization/administration/root/config/default-organization-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/config/default-permission-routing.config.ts
+++ b/feature-libs/organization/administration/root/config/default-permission-routing.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/config/default-units-routing.config.ts
+++ b/feature-libs/organization/administration/root/config/default-units-routing.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/config/default-user-group-routing.config.ts
+++ b/feature-libs/organization/administration/root/config/default-user-group-routing.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/config/default-user-routing.config.ts
+++ b/feature-libs/organization/administration/root/config/default-user-routing.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/config/index.ts
+++ b/feature-libs/organization/administration/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/feature-name.ts
+++ b/feature-libs/organization/administration/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/public_api.ts
+++ b/feature-libs/organization/administration/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/administration/root/route-params.ts
+++ b/feature-libs/organization/administration/root/route-params.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/assets/public_api.ts
+++ b/feature-libs/organization/order-approval/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/assets/translations/en/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/assets/translations/translations.ts
+++ b/feature-libs/organization/order-approval/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/details/index.ts
+++ b/feature-libs/organization/order-approval/components/details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/details/order-approval-detail-form/order-approval-detail-form.component.ts
+++ b/feature-libs/organization/order-approval/components/details/order-approval-detail-form/order-approval-detail-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/details/order-approval-detail.service.ts
+++ b/feature-libs/organization/order-approval/components/details/order-approval-detail.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/details/order-approval-details.module.ts
+++ b/feature-libs/organization/order-approval/components/details/order-approval-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/details/order-detail-permission-results/order-detail-permission-results.component.ts
+++ b/feature-libs/organization/order-approval/components/details/order-detail-permission-results/order-detail-permission-results.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/index.ts
+++ b/feature-libs/organization/order-approval/components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/list/index.ts
+++ b/feature-libs/organization/order-approval/components/list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/list/order-approval-list.component.ts
+++ b/feature-libs/organization/order-approval/components/list/order-approval-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/list/order-approval-list.module.ts
+++ b/feature-libs/organization/order-approval/components/list/order-approval-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/components/order-approval-components.module.ts
+++ b/feature-libs/organization/order-approval/components/order-approval-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/connectors/converters.ts
+++ b/feature-libs/organization/order-approval/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/connectors/index.ts
+++ b/feature-libs/organization/order-approval/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/connectors/order-approval.adapter.ts
+++ b/feature-libs/organization/order-approval/core/connectors/order-approval.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/connectors/order-approval.connector.ts
+++ b/feature-libs/organization/order-approval/core/connectors/order-approval.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/guards/approver.guard.ts
+++ b/feature-libs/organization/order-approval/core/guards/approver.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/guards/index.ts
+++ b/feature-libs/organization/order-approval/core/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/model/augmented-core.model.ts
+++ b/feature-libs/organization/order-approval/core/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/model/index.ts
+++ b/feature-libs/organization/order-approval/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/model/order-approval.model.ts
+++ b/feature-libs/organization/order-approval/core/model/order-approval.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/order-approval-core.module.ts
+++ b/feature-libs/organization/order-approval/core/order-approval-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/services/index.ts
+++ b/feature-libs/organization/order-approval/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/services/order-approval.service.ts
+++ b/feature-libs/organization/order-approval/core/services/order-approval.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/actions/index.ts
+++ b/feature-libs/organization/order-approval/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/actions/order-approval.action.ts
+++ b/feature-libs/organization/order-approval/core/store/actions/order-approval.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/effects/index.ts
+++ b/feature-libs/organization/order-approval/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/effects/order-approval.effect.ts
+++ b/feature-libs/organization/order-approval/core/store/effects/order-approval.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/index.ts
+++ b/feature-libs/organization/order-approval/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/order-approval-state.ts
+++ b/feature-libs/organization/order-approval/core/store/order-approval-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/order-approval-store.module.ts
+++ b/feature-libs/organization/order-approval/core/store/order-approval-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/reducers/index.ts
+++ b/feature-libs/organization/order-approval/core/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/reducers/order-approval.reducer.ts
+++ b/feature-libs/organization/order-approval/core/store/reducers/order-approval.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/selectors/index.ts
+++ b/feature-libs/organization/order-approval/core/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/core/store/selectors/order-approval.selector.ts
+++ b/feature-libs/organization/order-approval/core/store/selectors/order-approval.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/adapters/index.ts
+++ b/feature-libs/organization/order-approval/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/adapters/occ-order-approval.adapter.ts
+++ b/feature-libs/organization/order-approval/occ/adapters/occ-order-approval.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/config/default-occ-organization-config.ts
+++ b/feature-libs/organization/order-approval/occ/config/default-occ-organization-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/converters/index.ts
+++ b/feature-libs/organization/order-approval/occ/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/converters/occ-order-approval-decision-normalizer.ts
+++ b/feature-libs/organization/order-approval/occ/converters/occ-order-approval-decision-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/converters/occ-order-approval-list-normalizer.ts
+++ b/feature-libs/organization/order-approval/occ/converters/occ-order-approval-list-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/converters/occ-order-approval-normalizer.ts
+++ b/feature-libs/organization/order-approval/occ/converters/occ-order-approval-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/index.ts
+++ b/feature-libs/organization/order-approval/occ/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/model/index.ts
+++ b/feature-libs/organization/order-approval/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/model/occ-order-approval-endpoints.model.ts
+++ b/feature-libs/organization/order-approval/occ/model/occ-order-approval-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/occ/order-approval-occ.module.ts
+++ b/feature-libs/organization/order-approval/occ/order-approval-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/order-approval.module.ts
+++ b/feature-libs/organization/order-approval/order-approval.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/public_api.ts
+++ b/feature-libs/organization/order-approval/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/root/feature-name.ts
+++ b/feature-libs/organization/order-approval/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/root/order-approval-root.module.ts
+++ b/feature-libs/organization/order-approval/root/order-approval-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/order-approval/root/public_api.ts
+++ b/feature-libs/organization/order-approval/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/public_api.ts
+++ b/feature-libs/organization/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/schematics/add-organization/index.ts
+++ b/feature-libs/organization/schematics/add-organization/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/setup-jest.ts
+++ b/feature-libs/organization/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/test.ts
+++ b/feature-libs/organization/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/assets/public_api.ts
+++ b/feature-libs/organization/unit-order/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/assets/translations/en/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/assets/translations/translations.ts
+++ b/feature-libs/organization/unit-order/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/page-context/index.ts
+++ b/feature-libs/organization/unit-order/components/page-context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/page-context/unit-order-details-order-entries.context.ts
+++ b/feature-libs/organization/unit-order/components/page-context/unit-order-details-order-entries.context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/public_api.ts
+++ b/feature-libs/organization/unit-order/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-detail/index.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-detail/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-detail.module.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-detail.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-detail.service.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-detail.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/index.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/unit-level-order-overview.component.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/unit-level-order-overview.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/unit-level-order-overview.module.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/unit-level-order-overview.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/filter/unit-level-order-history-filter.component.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/filter/unit-level-order-history-filter.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/filter/unit-level-order-history-filter.module.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/filter/unit-level-order-history-filter.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/index.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.module.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/components/unit-order-components.module.ts
+++ b/feature-libs/organization/unit-order/components/unit-order-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/connectors/index.ts
+++ b/feature-libs/organization/unit-order/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/connectors/unit-order.adapter.ts
+++ b/feature-libs/organization/unit-order/core/connectors/unit-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/connectors/unit-order.connector.ts
+++ b/feature-libs/organization/unit-order/core/connectors/unit-order.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/guards/index.ts
+++ b/feature-libs/organization/unit-order/core/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/guards/unit-level-orders-viewer.guard.ts
+++ b/feature-libs/organization/unit-order/core/guards/unit-level-orders-viewer.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/model/augmented-core.model.ts
+++ b/feature-libs/organization/unit-order/core/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/model/index.ts
+++ b/feature-libs/organization/unit-order/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/model/unit-order.model.ts
+++ b/feature-libs/organization/unit-order/core/model/unit-order.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/public_api.ts
+++ b/feature-libs/organization/unit-order/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/services/index.ts
+++ b/feature-libs/organization/unit-order/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/services/unit-order.service.ts
+++ b/feature-libs/organization/unit-order/core/services/unit-order.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/actions/index.ts
+++ b/feature-libs/organization/unit-order/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/actions/unit-order-group.actions.ts
+++ b/feature-libs/organization/unit-order/core/store/actions/unit-order-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/actions/unit-order.action.ts
+++ b/feature-libs/organization/unit-order/core/store/actions/unit-order.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/effects/index.ts
+++ b/feature-libs/organization/unit-order/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/effects/unit-order.effect.ts
+++ b/feature-libs/organization/unit-order/core/store/effects/unit-order.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/index.ts
+++ b/feature-libs/organization/unit-order/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/reducers/index.ts
+++ b/feature-libs/organization/unit-order/core/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/reducers/unit-order.reducer.ts
+++ b/feature-libs/organization/unit-order/core/store/reducers/unit-order.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/selectors/feature.selector.ts
+++ b/feature-libs/organization/unit-order/core/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/selectors/index.ts
+++ b/feature-libs/organization/unit-order/core/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/selectors/unit-order-group.selectors.ts
+++ b/feature-libs/organization/unit-order/core/store/selectors/unit-order-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/selectors/unit-order.selector.ts
+++ b/feature-libs/organization/unit-order/core/store/selectors/unit-order.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/unit-order-state.ts
+++ b/feature-libs/organization/unit-order/core/store/unit-order-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/store/unit-order-store.module.ts
+++ b/feature-libs/organization/unit-order/core/store/unit-order-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/core/unit-order-core.module.ts
+++ b/feature-libs/organization/unit-order/core/unit-order-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/occ/adapters/index.ts
+++ b/feature-libs/organization/unit-order/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/occ/adapters/occ-unit-order.adapter.ts
+++ b/feature-libs/organization/unit-order/occ/adapters/occ-unit-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/occ/config/default-occ-organization-config.ts
+++ b/feature-libs/organization/unit-order/occ/config/default-occ-organization-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/occ/model/index.ts
+++ b/feature-libs/organization/unit-order/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/occ/model/occ-unit-order-endpoints.model.ts
+++ b/feature-libs/organization/unit-order/occ/model/occ-unit-order-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/occ/public_api.ts
+++ b/feature-libs/organization/unit-order/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/occ/unit-order-occ.module.ts
+++ b/feature-libs/organization/unit-order/occ/unit-order-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/public_api.ts
+++ b/feature-libs/organization/unit-order/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/root/context/context.ts
+++ b/feature-libs/organization/unit-order/root/context/context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/root/context/index.ts
+++ b/feature-libs/organization/unit-order/root/context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/root/facade/index.ts
+++ b/feature-libs/organization/unit-order/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/root/facade/unit-order.facade.ts
+++ b/feature-libs/organization/unit-order/root/facade/unit-order.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/root/feature-name.ts
+++ b/feature-libs/organization/unit-order/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/root/public_api.ts
+++ b/feature-libs/organization/unit-order/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/root/unit-order-root.module.ts
+++ b/feature-libs/organization/unit-order/root/unit-order-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/unit-order/unit-order.module.ts
+++ b/feature-libs/organization/unit-order/unit-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/assets/public_api.ts
+++ b/feature-libs/organization/user-registration/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/assets/translations/en/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/assets/translations/translations.ts
+++ b/feature-libs/organization/user-registration/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/components/form/index.ts
+++ b/feature-libs/organization/user-registration/components/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/components/form/user-registration-form.component.ts
+++ b/feature-libs/organization/user-registration/components/form/user-registration-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/components/form/user-registration-form.module.ts
+++ b/feature-libs/organization/user-registration/components/form/user-registration-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/components/form/user-registration-form.service.ts
+++ b/feature-libs/organization/user-registration/components/form/user-registration-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/components/public_api.ts
+++ b/feature-libs/organization/user-registration/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/components/user-registration-components.module.ts
+++ b/feature-libs/organization/user-registration/components/user-registration-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/connectors/converters.ts
+++ b/feature-libs/organization/user-registration/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/connectors/index.ts
+++ b/feature-libs/organization/user-registration/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/connectors/user-registration.adapter.ts
+++ b/feature-libs/organization/user-registration/core/connectors/user-registration.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/connectors/user-registration.connector.ts
+++ b/feature-libs/organization/user-registration/core/connectors/user-registration.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/facade/facade-providers.ts
+++ b/feature-libs/organization/user-registration/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/facade/index.ts
+++ b/feature-libs/organization/user-registration/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/facade/user-registration.service.ts
+++ b/feature-libs/organization/user-registration/core/facade/user-registration.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/http-interceptors/conflict/conflict.handler.ts
+++ b/feature-libs/organization/user-registration/core/http-interceptors/conflict/conflict.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/http-interceptors/index.ts
+++ b/feature-libs/organization/user-registration/core/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/public_api.ts
+++ b/feature-libs/organization/user-registration/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/core/user-registration-core.module.ts
+++ b/feature-libs/organization/user-registration/core/user-registration-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/occ/adapters/index.ts
+++ b/feature-libs/organization/user-registration/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/occ/adapters/occ-user-registration.adapter.ts
+++ b/feature-libs/organization/user-registration/occ/adapters/occ-user-registration.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/occ/config/default-occ-organization-config.ts
+++ b/feature-libs/organization/user-registration/occ/config/default-occ-organization-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/occ/model/index.ts
+++ b/feature-libs/organization/user-registration/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/occ/model/occ-user-registration-endpoints.model.ts
+++ b/feature-libs/organization/user-registration/occ/model/occ-user-registration-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/occ/public_api.ts
+++ b/feature-libs/organization/user-registration/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/occ/user-registration-occ.module.ts
+++ b/feature-libs/organization/user-registration/occ/user-registration-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/public_api.ts
+++ b/feature-libs/organization/user-registration/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/root/facade/index.ts
+++ b/feature-libs/organization/user-registration/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/root/facade/user-registration.facade.ts
+++ b/feature-libs/organization/user-registration/root/facade/user-registration.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/root/feature-name.ts
+++ b/feature-libs/organization/user-registration/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/root/model/index.ts
+++ b/feature-libs/organization/user-registration/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/root/model/user-registration.model.ts
+++ b/feature-libs/organization/user-registration/root/model/user-registration.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/root/public_api.ts
+++ b/feature-libs/organization/user-registration/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/root/user-registration-root.module.ts
+++ b/feature-libs/organization/user-registration/root/user-registration-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/organization/user-registration/user-registration.module.ts
+++ b/feature-libs/organization/user-registration/user-registration.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/assets/public_api.ts
+++ b/feature-libs/pdf-invoices/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/assets/translations/en/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/assets/translations/translations.ts
+++ b/feature-libs/pdf-invoices/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/components/index.ts
+++ b/feature-libs/pdf-invoices/components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/components/invoices-list/invoices-list.component.ts
+++ b/feature-libs/pdf-invoices/components/invoices-list/invoices-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/components/pdf-invoices-components.module.ts
+++ b/feature-libs/pdf-invoices/components/pdf-invoices-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/components/public_api.ts
+++ b/feature-libs/pdf-invoices/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/connectors/converters.ts
+++ b/feature-libs/pdf-invoices/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/connectors/index.ts
+++ b/feature-libs/pdf-invoices/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/connectors/pdf-invoices.adapter.ts
+++ b/feature-libs/pdf-invoices/core/connectors/pdf-invoices.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/connectors/pdf-invoices.connector.ts
+++ b/feature-libs/pdf-invoices/core/connectors/pdf-invoices.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/http-interceptors/bad-request/pdf-invoices-badrequest.handler.ts
+++ b/feature-libs/pdf-invoices/core/http-interceptors/bad-request/pdf-invoices-badrequest.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/http-interceptors/index.ts
+++ b/feature-libs/pdf-invoices/core/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/pdf-invoices-core.module.ts
+++ b/feature-libs/pdf-invoices/core/pdf-invoices-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/public_api.ts
+++ b/feature-libs/pdf-invoices/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/services/index.ts
+++ b/feature-libs/pdf-invoices/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/core/services/pdf-invoices.service.ts
+++ b/feature-libs/pdf-invoices/core/services/pdf-invoices.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/occ/adapters/index.ts
+++ b/feature-libs/pdf-invoices/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/occ/adapters/occ-pdf-invoices.adapter.ts
+++ b/feature-libs/pdf-invoices/occ/adapters/occ-pdf-invoices.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/occ/config/default-occ-pdf-invoices-config.ts
+++ b/feature-libs/pdf-invoices/occ/config/default-occ-pdf-invoices-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/occ/model/index.ts
+++ b/feature-libs/pdf-invoices/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/occ/model/occ-pdf-invoices.model.ts
+++ b/feature-libs/pdf-invoices/occ/model/occ-pdf-invoices.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/occ/pdf-invoices-occ.module.ts
+++ b/feature-libs/pdf-invoices/occ/pdf-invoices-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/occ/public_api.ts
+++ b/feature-libs/pdf-invoices/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/pdf-invoices.module.ts
+++ b/feature-libs/pdf-invoices/pdf-invoices.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/public_api.ts
+++ b/feature-libs/pdf-invoices/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/root/facade/index.ts
+++ b/feature-libs/pdf-invoices/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/root/facade/pdf-invoices.facade.ts
+++ b/feature-libs/pdf-invoices/root/facade/pdf-invoices.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/root/feature-name.ts
+++ b/feature-libs/pdf-invoices/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/root/model/index.ts
+++ b/feature-libs/pdf-invoices/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/root/model/pdf-invoices.model.ts
+++ b/feature-libs/pdf-invoices/root/model/pdf-invoices.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/root/pdf-invoices-root.module.ts
+++ b/feature-libs/pdf-invoices/root/pdf-invoices-root.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/root/public_api.ts
+++ b/feature-libs/pdf-invoices/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/schematics/add-pdf-invoices/index.ts
+++ b/feature-libs/pdf-invoices/schematics/add-pdf-invoices/index.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/setup-jest.ts
+++ b/feature-libs/pdf-invoices/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pdf-invoices/test.ts
+++ b/feature-libs/pdf-invoices/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/assets/public_api.ts
+++ b/feature-libs/pickup-in-store/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/assets/translations/en/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/assets/translations/translations.ts
+++ b/feature-libs/pickup-in-store/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.module.ts
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/index.ts
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/index.ts
+++ b/feature-libs/pickup-in-store/components/container/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/my-preferred-store/index.ts
+++ b/feature-libs/pickup-in-store/components/container/my-preferred-store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/my-preferred-store/my-preferred-store.component.ts
+++ b/feature-libs/pickup-in-store/components/container/my-preferred-store/my-preferred-store.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/my-preferred-store/my-preferred-store.module.ts
+++ b/feature-libs/pickup-in-store/components/container/my-preferred-store/my-preferred-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/index.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.module.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-in-store-order-consignment/index.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-in-store-order-consignment/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-in-store-order-consignment/pickup-in-store-order-consignment-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-in-store-order-consignment/pickup-in-store-order-consignment-container.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-in-store-order-consignment/pickup-in-store-order-consignment-container.module.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-in-store-order-consignment/pickup-in-store-order-consignment-container.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-info-container/index.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-info-container/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-info-container/pickup-info-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-info-container/pickup-info-container.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-info-container/pickup-info-container.module.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-info-container/pickup-info-container.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-items-details/index.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-items-details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-items-details/pickup-items-details.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-items-details/pickup-items-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-items-details/pickup-items-details.module.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-items-details/pickup-items-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/index.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog-layout.config.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.module.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.ts
+++ b/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.module.ts
+++ b/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/store-list/index.ts
+++ b/feature-libs/pickup-in-store/components/container/store-list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/store-list/store-list.component.ts
+++ b/feature-libs/pickup-in-store/components/container/store-list/store-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/store-list/store-list.module.ts
+++ b/feature-libs/pickup-in-store/components/container/store-list/store-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/store-search/index.ts
+++ b/feature-libs/pickup-in-store/components/container/store-search/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/store-search/store-search.component.ts
+++ b/feature-libs/pickup-in-store/components/container/store-search/store-search.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/container/store-search/store-search.module.ts
+++ b/feature-libs/pickup-in-store/components/container/store-search/store-search.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/pickup-in-store-components.module.ts
+++ b/feature-libs/pickup-in-store/components/pickup-in-store-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/pickup-info/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-info/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/pickup-info/pickup-info.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-info/pickup-info.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/pickup-info/pickup-info.module.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-info/pickup-info.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.model.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.module.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/store/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/store/store-address/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store-address/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/store/store-address/store-address.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store-address/store-address.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/store/store-schedule/index.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store-schedule/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/store/store-schedule/store-schedule.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store-schedule/store-schedule.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/store/store.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/presentational/store/store.module.ts
+++ b/feature-libs/pickup-in-store/components/presentational/store/store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/public_api.ts
+++ b/feature-libs/pickup-in-store/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/services/current-location.service.ts
+++ b/feature-libs/pickup-in-store/components/services/current-location.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/components/services/delivery-points.service.ts
+++ b/feature-libs/pickup-in-store/components/services/delivery-points.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/config/default-pickup-in-store-config.ts
+++ b/feature-libs/pickup-in-store/core/config/default-pickup-in-store-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/config/index.ts
+++ b/feature-libs/pickup-in-store/core/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/config/pickup-in-store-config.ts
+++ b/feature-libs/pickup-in-store/core/config/pickup-in-store-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/connectors/index.ts
+++ b/feature-libs/pickup-in-store/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/connectors/pickup-location.adapter.ts
+++ b/feature-libs/pickup-in-store/core/connectors/pickup-location.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/connectors/pickup-location.connector.ts
+++ b/feature-libs/pickup-in-store/core/connectors/pickup-location.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/connectors/stock.adapter.ts
+++ b/feature-libs/pickup-in-store/core/connectors/stock.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/connectors/stock.connector.ts
+++ b/feature-libs/pickup-in-store/core/connectors/stock.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/facade/facade-providers.ts
+++ b/feature-libs/pickup-in-store/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/facade/index.ts
+++ b/feature-libs/pickup-in-store/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/facade/intended-pickup-location.service.ts
+++ b/feature-libs/pickup-in-store/core/facade/intended-pickup-location.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/facade/pickup-locations-search.service.ts
+++ b/feature-libs/pickup-in-store/core/facade/pickup-locations-search.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/facade/pickup-option.service.ts
+++ b/feature-libs/pickup-in-store/core/facade/pickup-option.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/pickup-in-store-core.module.ts
+++ b/feature-libs/pickup-in-store/core/pickup-in-store-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/public_api.ts
+++ b/feature-libs/pickup-in-store/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/services/index.ts
+++ b/feature-libs/pickup-in-store/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/services/preferred-store.service.ts
+++ b/feature-libs/pickup-in-store/core/services/preferred-store.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/actions/browser-location.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/browser-location.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/actions/default-point-of-service-name.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/default-point-of-service-name.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/actions/hide-out-of-stock.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/hide-out-of-stock.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/actions/index.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/actions/pickup-location.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/pickup-location.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/actions/pickup-option.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/pickup-option.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/actions/stock.action.ts
+++ b/feature-libs/pickup-in-store/core/store/actions/stock.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/effects/default-point-of-service-name.effect.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/default-point-of-service-name.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/effects/index.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/effects/pickup-location.effect.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/pickup-location.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/effects/stock.effect.ts
+++ b/feature-libs/pickup-in-store/core/store/effects/stock.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/index.ts
+++ b/feature-libs/pickup-in-store/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/pickup-in-store-store.module.ts
+++ b/feature-libs/pickup-in-store/core/store/pickup-in-store-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/pickup-location-state.ts
+++ b/feature-libs/pickup-in-store/core/store/pickup-location-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/pickup-option-state.ts
+++ b/feature-libs/pickup-in-store/core/store/pickup-option-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/index.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/default-point-of-service-name.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/default-point-of-service-name.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/index.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/pickup-locations.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/pickup-locations.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/store-details.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-locations/store-details.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-option/index.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-option/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-option/page-context.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-option/page-context.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/pickup-option/pickup-option.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/pickup-option/pickup-option.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/stock/browser-location.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/stock/browser-location.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/stock/hide-out-of-stock.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/stock/hide-out-of-stock.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/stock/index.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/stock/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/reducers/stock/stock-level.reducer.ts
+++ b/feature-libs/pickup-in-store/core/store/reducers/stock/stock-level.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/selectors/default-point-of-service-name.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/default-point-of-service-name.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/selectors/feature.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/feature.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/selectors/hide-out-of-stock.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/hide-out-of-stock.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/selectors/index.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/selectors/pickup-locations.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/pickup-locations.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/selectors/pickup-option.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/pickup-option.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/selectors/stock.selectors.ts
+++ b/feature-libs/pickup-in-store/core/store/selectors/stock.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/store/stock-state.ts
+++ b/feature-libs/pickup-in-store/core/store/stock-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/utils/index.ts
+++ b/feature-libs/pickup-in-store/core/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/core/utils/utils.ts
+++ b/feature-libs/pickup-in-store/core/utils/utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/adapters/default-occ-pickup-location-config.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/default-occ-pickup-location-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/adapters/default-occ-stock-config.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/default-occ-stock-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/adapters/index.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-pickup-location.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
+++ b/feature-libs/pickup-in-store/occ/adapters/occ-stock.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/model/index.ts
+++ b/feature-libs/pickup-in-store/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/model/occ-pickup-location-endpoints.model.ts
+++ b/feature-libs/pickup-in-store/occ/model/occ-pickup-location-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/model/occ-stock-endpoints.model.ts
+++ b/feature-libs/pickup-in-store/occ/model/occ-stock-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/pickup-in-store-occ.module.ts
+++ b/feature-libs/pickup-in-store/occ/pickup-in-store-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/occ/public_api.ts
+++ b/feature-libs/pickup-in-store/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/pickup-in-store.module.ts
+++ b/feature-libs/pickup-in-store/pickup-in-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/public_api.ts
+++ b/feature-libs/pickup-in-store/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/facade/index.ts
+++ b/feature-libs/pickup-in-store/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/facade/intended-pickup-location.facade.ts
+++ b/feature-libs/pickup-in-store/root/facade/intended-pickup-location.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/facade/pickup-locations-search.facade.ts
+++ b/feature-libs/pickup-in-store/root/facade/pickup-locations-search.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/facade/pickup-option.facade.ts
+++ b/feature-libs/pickup-in-store/root/facade/pickup-option.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/facade/preferred-store.facade.ts
+++ b/feature-libs/pickup-in-store/root/facade/preferred-store.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/feature-name.ts
+++ b/feature-libs/pickup-in-store/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/model/augmented-core.model.ts
+++ b/feature-libs/pickup-in-store/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/model/delivery-points.model.ts
+++ b/feature-libs/pickup-in-store/root/model/delivery-points.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/model/index.ts
+++ b/feature-libs/pickup-in-store/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/model/pickup-option.model.ts
+++ b/feature-libs/pickup-in-store/root/model/pickup-option.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/model/point-of-service-names.model.ts
+++ b/feature-libs/pickup-in-store/root/model/point-of-service-names.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/model/stock-location-search-params.model.ts
+++ b/feature-libs/pickup-in-store/root/model/stock-location-search-params.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/pickup-in-store-constants.ts
+++ b/feature-libs/pickup-in-store/root/pickup-in-store-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/pickup-in-store-root.module.ts
+++ b/feature-libs/pickup-in-store/root/pickup-in-store-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/public_api.ts
+++ b/feature-libs/pickup-in-store/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/utils/index.ts
+++ b/feature-libs/pickup-in-store/root/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/utils/type-utils.ts
+++ b/feature-libs/pickup-in-store/root/utils/type-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/root/utils/utils.ts
+++ b/feature-libs/pickup-in-store/root/utils/utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index.ts
+++ b/feature-libs/pickup-in-store/schematics/add-pickup-in-store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/setup-jest.ts
+++ b/feature-libs/pickup-in-store/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/pickup-in-store/test.ts
+++ b/feature-libs/pickup-in-store/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/assets/public_api.ts
+++ b/feature-libs/product-configurator/common/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/assets/translations/en/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/assets/translations/translations.ts
+++ b/feature-libs/product-configurator/common/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/common-configurator.module.ts
+++ b/feature-libs/product-configurator/common/common-configurator.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/common-configurator-components.module.ts
+++ b/feature-libs/product-configurator/common/components/common-configurator-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.model.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.module.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.service.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/index.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.module.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-info/index.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-info/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.module.ts
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/index.ts
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.ts
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.module.ts
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/index.ts
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configure-product/configure-product.component.ts
+++ b/feature-libs/product-configurator/common/components/configure-product/configure-product.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configure-product/configure-product.module.ts
+++ b/feature-libs/product-configurator/common/components/configure-product/configure-product.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/configure-product/index.ts
+++ b/feature-libs/product-configurator/common/components/configure-product/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/index.ts
+++ b/feature-libs/product-configurator/common/components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/service/configurator-router-data.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-data.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/components/service/index.ts
+++ b/feature-libs/product-configurator/common/components/service/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/core/model/augmented-core.model.ts
+++ b/feature-libs/product-configurator/common/core/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/core/model/common-configurator.model.ts
+++ b/feature-libs/product-configurator/common/core/model/common-configurator.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/core/model/configurator-product-scope.ts
+++ b/feature-libs/product-configurator/common/core/model/configurator-product-scope.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/core/model/index.ts
+++ b/feature-libs/product-configurator/common/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/core/model/product-configurator.config.ts
+++ b/feature-libs/product-configurator/common/core/model/product-configurator.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/occ/common-configurator-occ.module.ts
+++ b/feature-libs/product-configurator/common/occ/common-configurator-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/occ/default-occ-configurator-product-config.ts
+++ b/feature-libs/product-configurator/common/occ/default-occ-configurator-product-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/occ/index.ts
+++ b/feature-libs/product-configurator/common/occ/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/public_api.ts
+++ b/feature-libs/product-configurator/common/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/shared/index.ts
+++ b/feature-libs/product-configurator/common/shared/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/shared/utils/common-configurator-utils.service.ts
+++ b/feature-libs/product-configurator/common/shared/utils/common-configurator-utils.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/shared/utils/configurator-model-utils.ts
+++ b/feature-libs/product-configurator/common/shared/utils/configurator-model-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/shared/utils/index.ts
+++ b/feature-libs/product-configurator/common/shared/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/common/testing/common-configurator-test-utils.service.ts
+++ b/feature-libs/product-configurator/common/testing/common-configurator-test-utils.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/public_api.ts
+++ b/feature-libs/product-configurator/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/composition/configurator-attribute-composition.config.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/composition/configurator-attribute-composition.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/composition/configurator-attribute-composition.directive.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/composition/configurator-attribute-composition.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/composition/configurator-attribute-composition.model.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/composition/configurator-attribute-composition.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/composition/configurator-attribute-composition.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/composition/configurator-attribute-composition.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/composition/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/composition/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/footer/configurator-attribute-footer.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/footer/configurator-attribute-footer.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/footer/configurator-attribute-footer.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/footer/configurator-attribute-footer.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/footer/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/footer/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/header/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/header/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/price-change/configurator-attribute-price-change.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/price-change/configurator-attribute-price-change.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/price-change/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/price-change/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/quantity/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/quantity/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-base.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-base.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-multi-selection-base.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-multi-selection-base.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/configurator-attribute-input-field.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/input-field/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/not-supported/configurator-attribute-not-supported.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/not-supported/configurator-attribute-not-supported.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/not-supported/configurator-attribute-not-supported.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/not-supported/configurator-attribute-not-supported.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/not-supported/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/not-supported/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/config/augmented-config.model.ts
+++ b/feature-libs/product-configurator/rulebased/components/config/augmented-config.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/config/configurator-message.config.ts
+++ b/feature-libs/product-configurator/rulebased/components/config/configurator-message.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/config/configurator-ui-settings.config.ts
+++ b/feature-libs/product-configurator/rulebased/components/config/configurator-ui-settings.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/config/default-configurator-message.config.ts
+++ b/feature-libs/product-configurator/rulebased/components/config/default-configurator-message.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/config/default-configurator-ui-settings.config.ts
+++ b/feature-libs/product-configurator/rulebased/components/config/default-configurator-ui-settings.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/config/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/configurator-conflict-and-error-messages.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/configurator-conflict-and-error-messages.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/configurator-conflict-and-error-messages.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/configurator-conflict-and-error-messages.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-description/configurator-conflict-description.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-description/configurator-conflict-description.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-description/configurator-conflict-description.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-description/configurator-conflict-description.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-description/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-description/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog-launcher.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog-launcher.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/default-configurator-conflict-solver-layout.config.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/default-configurator-conflict-solver-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-suggestion/configurator-conflict-suggestion.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-suggestion/configurator-conflict-suggestion.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-suggestion/configurator-conflict-suggestion.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-suggestion/configurator-conflict-suggestion.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/conflict-suggestion/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/conflict-suggestion/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/exit-button/configurator-exit-button.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/exit-button/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/exit-button/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.event.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.event.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/form/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.component.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group-menu/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-menu/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group-title/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/group-title/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group/configurator-group.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/group/configurator-group.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group/configurator-group.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/group/configurator-group.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/group/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/group/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-attribute/configurator-overview-attribute.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-attribute/configurator-overview-attribute.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-attribute/configurator-overview-attribute.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-attribute/configurator-overview-attribute.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-attribute/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-attribute/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/configurator-overview-bundle-attribute.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/configurator-overview-bundle-attribute.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/configurator-overview-bundle-attribute.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/configurator-overview-bundle-attribute.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-bar/configurator-overview-filter-bar.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-bar/configurator-overview-filter-bar.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-bar/configurator-overview-filter-bar.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-bar/configurator-overview-filter-bar.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-bar/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-bar/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-button/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-button/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/default-configurator-overview-filer-dialog-layout.config.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/default-configurator-overview-filer-dialog-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-filter/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-form/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-menu/configurator-overview-menu.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-menu/configurator-overview-menu.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-menu/configurator-overview-menu.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-menu/configurator-overview-menu.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-menu/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-menu/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-sidebar/configurator-overview-sidebar.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-sidebar/configurator-overview-sidebar.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-sidebar/configurator-overview-sidebar.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-sidebar/configurator-overview-sidebar.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/overview-sidebar/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-sidebar/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/previous-next-buttons/configurator-previous-next-buttons.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/previous-next-buttons/configurator-previous-next-buttons.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/previous-next-buttons/configurator-previous-next-buttons.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/previous-next-buttons/configurator-previous-next-buttons.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/previous-next-buttons/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/previous-next-buttons/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/price-summary/configurator-price-summary.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/price-summary/configurator-price-summary.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/price-summary/configurator-price-summary.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/price-summary/configurator-price-summary.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/price-summary/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/price-summary/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/price/configurator-price.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/price/configurator-price.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/price/configurator-price.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/price/configurator-price.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/price/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/price/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/product-title/configurator-product-title.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/product-title/configurator-product-title.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/product-title/configurator-product-title.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/product-title/configurator-product-title.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/product-title/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/product-title/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/restart-dialog/configurator-restart-dialog.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/restart-dialog/configurator-restart-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/restart-dialog/configurator-restart-dialog.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/restart-dialog/configurator-restart-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/restart-dialog/default-configurator-restart-dialog-layout.config.ts
+++ b/feature-libs/product-configurator/rulebased/components/restart-dialog/default-configurator-restart-dialog-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/restart-dialog/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/restart-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/rulebased-configurator-components.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/rulebased-configurator-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/service/configurator-storefront-utils.service.ts
+++ b/feature-libs/product-configurator/rulebased/components/service/configurator-storefront-utils.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/service/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/service/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/show-more/configurator-show-more.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/show-more/configurator-show-more.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/show-more/configurator-show-more.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/show-more/configurator-show-more.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/show-more/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/show-more/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/configurator-tab-bar.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/tab-bar/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/tab-bar/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/update-message/configurator-update-message.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/update-message/configurator-update-message.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/update-message/configurator-update-message.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/update-message/configurator-update-message.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/update-message/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/update-message/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/variant-carousel/configurator-variant-carousel.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/variant-carousel/configurator-variant-carousel.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/variant-carousel/configurator-variant-carousel.module.ts
+++ b/feature-libs/product-configurator/rulebased/components/variant-carousel/configurator-variant-carousel.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/components/variant-carousel/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/variant-carousel/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/config/configurator-core.config.ts
+++ b/feature-libs/product-configurator/rulebased/core/config/configurator-core.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/config/default-configurator-core.config.ts
+++ b/feature-libs/product-configurator/rulebased/core/config/default-configurator-core.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/config/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/connectors/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/connectors/rulebased-configurator.adapter.ts
+++ b/feature-libs/product-configurator/rulebased/core/connectors/rulebased-configurator.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/connectors/rulebased-configurator.connector.ts
+++ b/feature-libs/product-configurator/rulebased/core/connectors/rulebased-configurator.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/events/configurator-logout-event.listener.ts
+++ b/feature-libs/product-configurator/rulebased/core/events/configurator-logout-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/events/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-cart.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-cart.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-commons.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-commons.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-group-status.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-group-status.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/configurator-groups.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/configurator-groups.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/routing/configurator-router.listener.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/routing/configurator-router.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/routing/configurator-router.module.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/routing/configurator-router.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/routing/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/routing/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/utils/configurator-utils.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/utils/configurator-utils.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/facade/utils/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/facade/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
+++ b/feature-libs/product-configurator/rulebased/core/model/configurator.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/rulebased-configurator-core.module.ts
+++ b/feature-libs/product-configurator/rulebased/core/rulebased-configurator-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/services/configurator-expert-mode.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/services/configurator-expert-mode.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/services/configurator-quantity.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/services/configurator-quantity.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/services/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/actions/configurator-cart.action.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/actions/configurator-cart.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/actions/configurator-group.actions.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/actions/configurator-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/actions/configurator-variant.action.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/actions/configurator-variant.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/actions/configurator.action.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/actions/configurator.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/actions/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/configurator-state-utils.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/configurator-state-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/configurator-state.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/configurator-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-basic-effect.service.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-basic-effect.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-basic.effect.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-basic.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-cart.effect.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-cart.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/effects/configurator-variant.effect.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/configurator-variant.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/effects/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/reducers/configurator.reducer.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/reducers/configurator.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/reducers/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/rulebased-configurator-state.module.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/rulebased-configurator-state.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/selectors/configurator-group.selectors.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/selectors/configurator-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/selectors/configurator.selector.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/selectors/configurator.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/core/state/selectors/index.ts
+++ b/feature-libs/product-configurator/rulebased/core/state/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-normalizer-utils.service.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-normalizer-utils.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-value-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-value-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator.converters.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator.converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/index.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/cpq-configurator-common.module.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/cpq-configurator-common.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/cpq.models.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/cpq.models.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/common/index.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/converters/cpq-configurator-occ.converters.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/converters/cpq-configurator-occ.converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/converters/index.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/converters/occ-configurator-cpq-add-to-cart-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/converters/occ-configurator-cpq-add-to-cart-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/converters/occ-configurator-cpq-update-cart-entry-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/converters/occ-configurator-cpq-update-cart-entry-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/cpq-configurator-occ.adapter.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/cpq-configurator-occ.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/cpq-configurator-occ.models.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/cpq-configurator-occ.models.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/cpq-configurator-occ.module.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/cpq-configurator-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/cpq-configurator-occ.service.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/cpq-configurator-occ.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/default-occ-configurator-cpq-config.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/default-occ-configurator-cpq-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/index.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/model/index.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/occ/model/occ-cpq-configurator-endpoints.model.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/occ/model/occ-cpq-configurator-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/public_api.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-endpoint.config.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-endpoint.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-endpoint.service.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-endpoint.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-rest.adapter.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-rest.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-rest.module.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-rest.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-rest.service.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-rest.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-utils.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/cpq-configurator-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/rest/default-cpq-configurator-endpoint.config.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/default-cpq-configurator-endpoint.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/rest/index.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rest/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/cpq/rulebased-cpq-configurator.module.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/rulebased-cpq-configurator.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/index.ts
+++ b/feature-libs/product-configurator/rulebased/occ/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/model/index.ts
+++ b/feature-libs/product-configurator/rulebased/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/model/occ-variant-configurator-endpoints.model.ts
+++ b/feature-libs/product-configurator/rulebased/occ/model/occ-variant-configurator-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/index.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-add-to-cart-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-add-to-cart-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-overview-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-price-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-price-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-price-summary-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-price-summary-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-update-cart-entry-serializer.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/converters/occ-configurator-variant-update-cart-entry-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/default-occ-configurator-variant-config.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/default-occ-configurator-variant-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/index.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.adapter.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.converters.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.models.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.models.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.module.ts
+++ b/feature-libs/product-configurator/rulebased/occ/variant/variant-configurator-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/public_api.ts
+++ b/feature-libs/product-configurator/rulebased/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-interactive.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-interactive.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-layout.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-layout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-overview.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-overview.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-page-layout-handler.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-page-layout-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-root.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/cpq-configurator-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/default-cpq-interactive-routing-config.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/default-cpq-interactive-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/default-cpq-overview-routing-config.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/default-cpq-overview-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/index.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-access-data.models.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-access-data.models.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-access-loader.service.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-access-loader.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-access-storage.service.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-access-storage.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-auth.config.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-auth.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-interceptor.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-interceptor.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-rest.interceptor.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/cpq-configurator-rest.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/default-cpq-configurator-auth.config.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/default-cpq-configurator-auth.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/cpq/interceptor/index.ts
+++ b/feature-libs/product-configurator/rulebased/root/cpq/interceptor/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/default-rulebased-routing-config.ts
+++ b/feature-libs/product-configurator/rulebased/root/default-rulebased-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/feature-name.ts
+++ b/feature-libs/product-configurator/rulebased/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/http-interceptors/configurator-bad-request.handler.ts
+++ b/feature-libs/product-configurator/rulebased/root/http-interceptors/configurator-bad-request.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/http-interceptors/index.ts
+++ b/feature-libs/product-configurator/rulebased/root/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/public_api.ts
+++ b/feature-libs/product-configurator/rulebased/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/rulebased-configurator-root-feature.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/rulebased-configurator-root-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/rulebased-configurator-root.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/rulebased-configurator-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/rulebased-configurator-routing.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/rulebased-configurator-routing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/variant/index.ts
+++ b/feature-libs/product-configurator/rulebased/root/variant/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-interactive-layout.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-interactive-layout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-interactive.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-interactive.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-overview-layout.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-overview-layout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-overview.module.ts
+++ b/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-overview.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-page-layout-handler.ts
+++ b/feature-libs/product-configurator/rulebased/root/variant/variant-configurator-page-layout-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/rulebased-configurator.module.ts
+++ b/feature-libs/product-configurator/rulebased/rulebased-configurator.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/testing/configurator-test-data.ts
+++ b/feature-libs/product-configurator/rulebased/testing/configurator-test-data.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/testing/configurator-test-utils.ts
+++ b/feature-libs/product-configurator/rulebased/testing/configurator-test-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/rulebased/testing/occ-configurator-test-utils.ts
+++ b/feature-libs/product-configurator/rulebased/testing/occ-configurator-test-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/schematics/add-product-configurator/index.ts
+++ b/feature-libs/product-configurator/schematics/add-product-configurator/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/setup-jest.ts
+++ b/feature-libs/product-configurator/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/test.ts
+++ b/feature-libs/product-configurator/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/components/add-to-cart-button/configurator-textfield-add-to-cart-button.component.ts
+++ b/feature-libs/product-configurator/textfield/components/add-to-cart-button/configurator-textfield-add-to-cart-button.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/components/form/configurator-textfield-form.component.ts
+++ b/feature-libs/product-configurator/textfield/components/form/configurator-textfield-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/components/index.ts
+++ b/feature-libs/product-configurator/textfield/components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/components/input-field-readonly/configurator-textfield-input-field-readonly.component.ts
+++ b/feature-libs/product-configurator/textfield/components/input-field-readonly/configurator-textfield-input-field-readonly.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/components/input-field/configurator-textfield-input-field.component.ts
+++ b/feature-libs/product-configurator/textfield/components/input-field/configurator-textfield-input-field.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/components/textfield-configurator-components.module.ts
+++ b/feature-libs/product-configurator/textfield/components/textfield-configurator-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/connectors/configurator-textfield.adapter.ts
+++ b/feature-libs/product-configurator/textfield/core/connectors/configurator-textfield.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/connectors/configurator-textfield.connector.ts
+++ b/feature-libs/product-configurator/textfield/core/connectors/configurator-textfield.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/connectors/converters.ts
+++ b/feature-libs/product-configurator/textfield/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/connectors/index.ts
+++ b/feature-libs/product-configurator/textfield/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/facade/configurator-textfield.service.ts
+++ b/feature-libs/product-configurator/textfield/core/facade/configurator-textfield.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/facade/index.ts
+++ b/feature-libs/product-configurator/textfield/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/index.ts
+++ b/feature-libs/product-configurator/textfield/core/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/model/configurator-textfield.model.ts
+++ b/feature-libs/product-configurator/textfield/core/model/configurator-textfield.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/actions/configurator-textfield-group.actions.ts
+++ b/feature-libs/product-configurator/textfield/core/state/actions/configurator-textfield-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/actions/configurator-textfield.action.ts
+++ b/feature-libs/product-configurator/textfield/core/state/actions/configurator-textfield.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/actions/index.ts
+++ b/feature-libs/product-configurator/textfield/core/state/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/configuration-textfield-state.ts
+++ b/feature-libs/product-configurator/textfield/core/state/configuration-textfield-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/configurator-textfield-store.module.ts
+++ b/feature-libs/product-configurator/textfield/core/state/configurator-textfield-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/effects/configurator-textfield.effect.ts
+++ b/feature-libs/product-configurator/textfield/core/state/effects/configurator-textfield.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/effects/index.ts
+++ b/feature-libs/product-configurator/textfield/core/state/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/index.ts
+++ b/feature-libs/product-configurator/textfield/core/state/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/reducers/configurator-textfield.reducer.ts
+++ b/feature-libs/product-configurator/textfield/core/state/reducers/configurator-textfield.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/reducers/index.ts
+++ b/feature-libs/product-configurator/textfield/core/state/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/selectors/configurator-textfield-group.selectors.ts
+++ b/feature-libs/product-configurator/textfield/core/state/selectors/configurator-textfield-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/selectors/configurator-textfield.selector.ts
+++ b/feature-libs/product-configurator/textfield/core/state/selectors/configurator-textfield.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/state/selectors/index.ts
+++ b/feature-libs/product-configurator/textfield/core/state/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/core/textfield-configurator-core.module.ts
+++ b/feature-libs/product-configurator/textfield/core/textfield-configurator-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/converters/index.ts
+++ b/feature-libs/product-configurator/textfield/occ/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/converters/occ-configurator-textfield-add-to-cart-serializer.ts
+++ b/feature-libs/product-configurator/textfield/occ/converters/occ-configurator-textfield-add-to-cart-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/converters/occ-configurator-textfield-normalizer.ts
+++ b/feature-libs/product-configurator/textfield/occ/converters/occ-configurator-textfield-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/converters/occ-configurator-textfield-update-cart-entry-serializer.ts
+++ b/feature-libs/product-configurator/textfield/occ/converters/occ-configurator-textfield-update-cart-entry-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/default-occ-configurator-textfield-config.ts
+++ b/feature-libs/product-configurator/textfield/occ/default-occ-configurator-textfield-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/index.ts
+++ b/feature-libs/product-configurator/textfield/occ/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/occ-configurator-textfield-endpoints.model.ts
+++ b/feature-libs/product-configurator/textfield/occ/occ-configurator-textfield-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/occ-configurator-textfield.adapter.ts
+++ b/feature-libs/product-configurator/textfield/occ/occ-configurator-textfield.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/occ-configurator-textfield.models.ts
+++ b/feature-libs/product-configurator/textfield/occ/occ-configurator-textfield.models.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/occ/textfield-configurator-occ.module.ts
+++ b/feature-libs/product-configurator/textfield/occ/textfield-configurator-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/public_api.ts
+++ b/feature-libs/product-configurator/textfield/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/root/default-textfield-routing-config.ts
+++ b/feature-libs/product-configurator/textfield/root/default-textfield-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/root/feature-name.ts
+++ b/feature-libs/product-configurator/textfield/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/root/public_api.ts
+++ b/feature-libs/product-configurator/textfield/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/root/textfield-configurator-root-feature.module.ts
+++ b/feature-libs/product-configurator/textfield/root/textfield-configurator-root-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/root/textfield-configurator-root.module.ts
+++ b/feature-libs/product-configurator/textfield/root/textfield-configurator-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/root/textfield-configurator-routing.module.ts
+++ b/feature-libs/product-configurator/textfield/root/textfield-configurator-routing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-configurator/textfield/textfield-configurator.module.ts
+++ b/feature-libs/product-configurator/textfield/textfield-configurator.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/list/public_api.ts
+++ b/feature-libs/product-multi-dimensional/list/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/list/root/components/product-item-details/product-multi-dimensional-list-item-details.component.ts
+++ b/feature-libs/product-multi-dimensional/list/root/components/product-item-details/product-multi-dimensional-list-item-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/list/root/components/product-item-details/product-multi-dimensional-list-item-details.module.ts
+++ b/feature-libs/product-multi-dimensional/list/root/components/product-item-details/product-multi-dimensional-list-item-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/list/root/feature-name.ts
+++ b/feature-libs/product-multi-dimensional/list/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/list/root/product-multi-dimensional-list-root.module.ts
+++ b/feature-libs/product-multi-dimensional/list/root/product-multi-dimensional-list-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/list/root/public_api.ts
+++ b/feature-libs/product-multi-dimensional/list/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/public_api.ts
+++ b/feature-libs/product-multi-dimensional/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/index.ts
+++ b/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/assets/public_api.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/en/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/translations.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/components/guards/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/components/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/components/guards/product-multi-dimensional-selector.guard.ts
+++ b/feature-libs/product-multi-dimensional/selector/components/guards/product-multi-dimensional-selector.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/components/product-multi-dimensional-selector-components.module.ts
+++ b/feature-libs/product-multi-dimensional/selector/components/product-multi-dimensional-selector-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/components/public_api.ts
+++ b/feature-libs/product-multi-dimensional/selector/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/components/selector/product-multi-dimensional-selector-component.module.ts
+++ b/feature-libs/product-multi-dimensional/selector/components/selector/product-multi-dimensional-selector-component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/components/selector/product-multi-dimensional-selector.component.ts
+++ b/feature-libs/product-multi-dimensional/selector/components/selector/product-multi-dimensional-selector.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/core/model/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/core/model/variant-category.model.ts
+++ b/feature-libs/product-multi-dimensional/selector/core/model/variant-category.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/core/public_api.ts
+++ b/feature-libs/product-multi-dimensional/selector/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/core/services/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/core/services/product-multi-dimensional-selector-images.service.ts
+++ b/feature-libs/product-multi-dimensional/selector/core/services/product-multi-dimensional-selector-images.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/core/services/product-multi-dimensional-selector.service.ts
+++ b/feature-libs/product-multi-dimensional/selector/core/services/product-multi-dimensional-selector.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/occ/config/default-occ-product-multi-dimensional-selector-config.ts
+++ b/feature-libs/product-multi-dimensional/selector/occ/config/default-occ-product-multi-dimensional-selector-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/occ/product-multi-dimensional-selector-occ.module.ts
+++ b/feature-libs/product-multi-dimensional/selector/occ/product-multi-dimensional-selector-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/occ/public_api.ts
+++ b/feature-libs/product-multi-dimensional/selector/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/product-multi-dimensional-selector.module.ts
+++ b/feature-libs/product-multi-dimensional/selector/product-multi-dimensional-selector.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/public_api.ts
+++ b/feature-libs/product-multi-dimensional/selector/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/root/config/default-product-multi-dimensional-config.ts
+++ b/feature-libs/product-multi-dimensional/selector/root/config/default-product-multi-dimensional-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/root/config/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/root/config/product-multi-dimensional-config.ts
+++ b/feature-libs/product-multi-dimensional/selector/root/config/product-multi-dimensional-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/root/feature-name.ts
+++ b/feature-libs/product-multi-dimensional/selector/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/root/product-multi-dimensional-selector-root.module.ts
+++ b/feature-libs/product-multi-dimensional/selector/root/product-multi-dimensional-selector-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/selector/root/public_api.ts
+++ b/feature-libs/product-multi-dimensional/selector/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/setup-jest.ts
+++ b/feature-libs/product-multi-dimensional/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product-multi-dimensional/test.ts
+++ b/feature-libs/product-multi-dimensional/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/assets/public_api.ts
+++ b/feature-libs/product/bulk-pricing/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/assets/translations/en/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/assets/translations/translations.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/bulk-pricing.module.ts
+++ b/feature-libs/product/bulk-pricing/bulk-pricing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/components/bulk-pricing-table/bulk-pricing-table.component.ts
+++ b/feature-libs/product/bulk-pricing/components/bulk-pricing-table/bulk-pricing-table.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/components/bulk-pricing-table/bulk-pricing-table.module.ts
+++ b/feature-libs/product/bulk-pricing/components/bulk-pricing-table/bulk-pricing-table.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/components/bulk-pricing-table/index.ts
+++ b/feature-libs/product/bulk-pricing/components/bulk-pricing-table/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/components/public_api.ts
+++ b/feature-libs/product/bulk-pricing/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/core/model/augmented-core.model.ts
+++ b/feature-libs/product/bulk-pricing/core/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/core/model/bulk-price.model.ts
+++ b/feature-libs/product/bulk-pricing/core/model/bulk-price.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/core/model/index.ts
+++ b/feature-libs/product/bulk-pricing/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/core/public_api.ts
+++ b/feature-libs/product/bulk-pricing/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/core/services/bulk-pricing.service.ts
+++ b/feature-libs/product/bulk-pricing/core/services/bulk-pricing.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/core/services/index.ts
+++ b/feature-libs/product/bulk-pricing/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/occ/bulk-pricing-occ.module.ts
+++ b/feature-libs/product/bulk-pricing/occ/bulk-pricing-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/occ/config/default-occ-bulk-pricing-config.ts
+++ b/feature-libs/product/bulk-pricing/occ/config/default-occ-bulk-pricing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/occ/public_api.ts
+++ b/feature-libs/product/bulk-pricing/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/public_api.ts
+++ b/feature-libs/product/bulk-pricing/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/root/bulk-pricing-root.module.ts
+++ b/feature-libs/product/bulk-pricing/root/bulk-pricing-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/root/feature-name.ts
+++ b/feature-libs/product/bulk-pricing/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/bulk-pricing/root/public_api.ts
+++ b/feature-libs/product/bulk-pricing/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/assets/public_api.ts
+++ b/feature-libs/product/future-stock/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/assets/translations/en/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/assets/translations/translations.ts
+++ b/feature-libs/product/future-stock/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.component.ts
+++ b/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.module.ts
+++ b/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/components/future-stock-accordion/index.ts
+++ b/feature-libs/product/future-stock/components/future-stock-accordion/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/components/future-stock-components.module.ts
+++ b/feature-libs/product/future-stock/components/future-stock-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/components/public_api.ts
+++ b/feature-libs/product/future-stock/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/connectors/converters.ts
+++ b/feature-libs/product/future-stock/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/connectors/future-stock.adapter.ts
+++ b/feature-libs/product/future-stock/core/connectors/future-stock.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/connectors/future-stock.connector.ts
+++ b/feature-libs/product/future-stock/core/connectors/future-stock.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/connectors/index.ts
+++ b/feature-libs/product/future-stock/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/facade/facade-providers.ts
+++ b/feature-libs/product/future-stock/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/future-stock-core.module.ts
+++ b/feature-libs/product/future-stock/core/future-stock-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/model/future-stock.model.ts
+++ b/feature-libs/product/future-stock/core/model/future-stock.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/model/index.ts
+++ b/feature-libs/product/future-stock/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/public_api.ts
+++ b/feature-libs/product/future-stock/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/services/future-stock.service.ts
+++ b/feature-libs/product/future-stock/core/services/future-stock.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/core/services/index.ts
+++ b/feature-libs/product/future-stock/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/future-stock.module.ts
+++ b/feature-libs/product/future-stock/future-stock.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/occ/adapters/index.ts
+++ b/feature-libs/product/future-stock/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/occ/adapters/occ-future-stock.adapter.ts
+++ b/feature-libs/product/future-stock/occ/adapters/occ-future-stock.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/occ/config/default-occ-future-stock.config.ts
+++ b/feature-libs/product/future-stock/occ/config/default-occ-future-stock.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/occ/future-stock-occ.module.ts
+++ b/feature-libs/product/future-stock/occ/future-stock-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/occ/model/index.ts
+++ b/feature-libs/product/future-stock/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/occ/model/occ-future-stock-endpoints.model.ts
+++ b/feature-libs/product/future-stock/occ/model/occ-future-stock-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/occ/public_api.ts
+++ b/feature-libs/product/future-stock/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/public_api.ts
+++ b/feature-libs/product/future-stock/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/root/facade/future-stock.facade.ts
+++ b/feature-libs/product/future-stock/root/facade/future-stock.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/root/facade/index.ts
+++ b/feature-libs/product/future-stock/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/root/feature-name.ts
+++ b/feature-libs/product/future-stock/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/root/future-stock-root.module.ts
+++ b/feature-libs/product/future-stock/root/future-stock-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/future-stock/root/public_api.ts
+++ b/feature-libs/product/future-stock/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/assets/public_api.ts
+++ b/feature-libs/product/image-zoom/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/assets/translations/en/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/assets/translations/translations.ts
+++ b/feature-libs/product/image-zoom/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/product-image-zoom-components.module.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/product-image-zoom/default-product-image-zoom-layout.config.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/default-product-image-zoom-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/product-image-zoom/index.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-dialog/product-image-zoom-dialog.component.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-dialog/product-image-zoom-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-trigger/product-image-zoom-trigger.component.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-trigger/product-image-zoom-trigger.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom.module.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/components/public_api.ts
+++ b/feature-libs/product/image-zoom/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/product-image-zoom.module.ts
+++ b/feature-libs/product/image-zoom/product-image-zoom.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/public_api.ts
+++ b/feature-libs/product/image-zoom/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/root/feature-name.ts
+++ b/feature-libs/product/image-zoom/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/root/models/augmented-core.model.ts
+++ b/feature-libs/product/image-zoom/root/models/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/root/models/index.ts
+++ b/feature-libs/product/image-zoom/root/models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/root/models/product-image-zoom-thumbnails.model.ts
+++ b/feature-libs/product/image-zoom/root/models/product-image-zoom-thumbnails.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/root/product-image-zoom-root.module.ts
+++ b/feature-libs/product/image-zoom/root/product-image-zoom-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/image-zoom/root/public_api.ts
+++ b/feature-libs/product/image-zoom/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/public_api.ts
+++ b/feature-libs/product/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/schematics/add-product/index.ts
+++ b/feature-libs/product/schematics/add-product/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/setup-jest.ts
+++ b/feature-libs/product/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/test.ts
+++ b/feature-libs/product/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/assets/public_api.ts
+++ b/feature-libs/product/variants/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/assets/translations/en/index.ts
+++ b/feature-libs/product/variants/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/assets/translations/translations.ts
+++ b/feature-libs/product/variants/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/guards/index.ts
+++ b/feature-libs/product/variants/components/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/guards/product-variants.guard.ts
+++ b/feature-libs/product/variants/components/guards/product-variants.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/product-variants-components.module.ts
+++ b/feature-libs/product/variants/components/product-variants-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/product-variants-container/product-variants-container.component.ts
+++ b/feature-libs/product/variants/components/product-variants-container/product-variants-container.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/product-variants-container/product-variants-container.module.ts
+++ b/feature-libs/product/variants/components/product-variants-container/product-variants-container.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/public_api.ts
+++ b/feature-libs/product/variants/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/variant-color-selector/product-variant-color-selector.component.ts
+++ b/feature-libs/product/variants/components/variant-color-selector/product-variant-color-selector.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/variant-color-selector/product-variant-color-selector.module.ts
+++ b/feature-libs/product/variants/components/variant-color-selector/product-variant-color-selector.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/variant-size-selector/product-variant-size-selector.component.ts
+++ b/feature-libs/product/variants/components/variant-size-selector/product-variant-size-selector.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/variant-size-selector/product-variant-size-selector.module.ts
+++ b/feature-libs/product/variants/components/variant-size-selector/product-variant-size-selector.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/variant-style-selector/product-variant-style-selector.component.ts
+++ b/feature-libs/product/variants/components/variant-style-selector/product-variant-style-selector.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/components/variant-style-selector/product-variant-style-selector.module.ts
+++ b/feature-libs/product/variants/components/variant-style-selector/product-variant-style-selector.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/occ/config/default-occ-product-variants-config.ts
+++ b/feature-libs/product/variants/occ/config/default-occ-product-variants-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/occ/product-variants-occ.module.ts
+++ b/feature-libs/product/variants/occ/product-variants-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/occ/public_api.ts
+++ b/feature-libs/product/variants/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/product-variants.module.ts
+++ b/feature-libs/product/variants/product-variants.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/public_api.ts
+++ b/feature-libs/product/variants/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/root/components/variant-style-icons/product-variant-style-icons.component.ts
+++ b/feature-libs/product/variants/root/components/variant-style-icons/product-variant-style-icons.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/root/components/variant-style-icons/product-variant-style-icons.module.ts
+++ b/feature-libs/product/variants/root/components/variant-style-icons/product-variant-style-icons.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/root/feature-name.ts
+++ b/feature-libs/product/variants/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/root/product-variants-root.module.ts
+++ b/feature-libs/product/variants/root/product-variants-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/product/variants/root/public_api.ts
+++ b/feature-libs/product/variants/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/components/public_api.ts
+++ b/feature-libs/qualtrics/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/components/qualtrics-components.module.ts
+++ b/feature-libs/qualtrics/components/qualtrics-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/components/qualtrics-embedded-feedback/qualtrics-embedded-feedback.component.ts
+++ b/feature-libs/qualtrics/components/qualtrics-embedded-feedback/qualtrics-embedded-feedback.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/components/qualtrics-loader/config/default-qualtrics-config.ts
+++ b/feature-libs/qualtrics/components/qualtrics-loader/config/default-qualtrics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/components/qualtrics-loader/config/qualtrics-config.ts
+++ b/feature-libs/qualtrics/components/qualtrics-loader/config/qualtrics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/components/qualtrics-loader/index.ts
+++ b/feature-libs/qualtrics/components/qualtrics-loader/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/components/qualtrics-loader/qualtrics-loader.service.ts
+++ b/feature-libs/qualtrics/components/qualtrics-loader/qualtrics-loader.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/components/qualtrics-loader/qualtrics.component.ts
+++ b/feature-libs/qualtrics/components/qualtrics-loader/qualtrics.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/public_api.ts
+++ b/feature-libs/qualtrics/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/qualtrics.module.ts
+++ b/feature-libs/qualtrics/qualtrics.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/root/feature-name.ts
+++ b/feature-libs/qualtrics/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/root/public_api.ts
+++ b/feature-libs/qualtrics/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/root/qualtrics-root.module.ts
+++ b/feature-libs/qualtrics/root/qualtrics-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/schematics/add-qualtrics/index.ts
+++ b/feature-libs/qualtrics/schematics/add-qualtrics/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/setup-jest.ts
+++ b/feature-libs/qualtrics/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/qualtrics/test.ts
+++ b/feature-libs/qualtrics/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/assets/public_api.ts
+++ b/feature-libs/quote/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/assets/translations/en/index.ts
+++ b/feature-libs/quote/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/assets/translations/translations.ts
+++ b/feature-libs/quote/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/cart-guard/public_api.ts
+++ b/feature-libs/quote/components/cart-guard/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/cart-guard/quote-cart-guard.component.module.ts
+++ b/feature-libs/quote/components/cart-guard/quote-cart-guard.component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/cart-guard/quote-cart-guard.component.ts
+++ b/feature-libs/quote/components/cart-guard/quote-cart-guard.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/cart-guard/quote-cart.guard.ts
+++ b/feature-libs/quote/components/cart-guard/quote-cart.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/comments/index.ts
+++ b/feature-libs/quote/components/comments/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/comments/quote-comments.component.ts
+++ b/feature-libs/quote/components/comments/quote-comments.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/comments/quote-comments.module.ts
+++ b/feature-libs/quote/components/comments/quote-comments.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/config/default-quote-ui.config.ts
+++ b/feature-libs/quote/components/config/default-quote-ui.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/config/index.ts
+++ b/feature-libs/quote/components/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/config/quote-ui.config.ts
+++ b/feature-libs/quote/components/config/quote-ui.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/confirm-dialog/default-quote-confirm-dialog.config.ts
+++ b/feature-libs/quote/components/confirm-dialog/default-quote-confirm-dialog.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/confirm-dialog/index.ts
+++ b/feature-libs/quote/components/confirm-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.component.ts
+++ b/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.model.ts
+++ b/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.module.ts
+++ b/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/header/buyer-edit/index.ts
+++ b/feature-libs/quote/components/header/buyer-edit/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/header/buyer-edit/quote-header-buyer-edit.component.ts
+++ b/feature-libs/quote/components/header/buyer-edit/quote-header-buyer-edit.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/header/buyer-edit/quote-header-buyer-edit.module.ts
+++ b/feature-libs/quote/components/header/buyer-edit/quote-header-buyer-edit.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/header/index.ts
+++ b/feature-libs/quote/components/header/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/header/overview/index.ts
+++ b/feature-libs/quote/components/header/overview/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/header/overview/quote-header-overview.component.ts
+++ b/feature-libs/quote/components/header/overview/quote-header-overview.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/header/overview/quote-header-overview.module.ts
+++ b/feature-libs/quote/components/header/overview/quote-header-overview.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/items/index.ts
+++ b/feature-libs/quote/components/items/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/items/quote-items.component.service.ts
+++ b/feature-libs/quote/components/items/quote-items.component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/items/quote-items.component.ts
+++ b/feature-libs/quote/components/items/quote-items.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/items/quote-items.module.ts
+++ b/feature-libs/quote/components/items/quote-items.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/links/index.ts
+++ b/feature-libs/quote/components/links/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/links/quote-links.component.ts
+++ b/feature-libs/quote/components/links/quote-links.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/links/quote-links.module.ts
+++ b/feature-libs/quote/components/links/quote-links.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/list/index.ts
+++ b/feature-libs/quote/components/list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/list/quote-list-component.service.ts
+++ b/feature-libs/quote/components/list/quote-list-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/list/quote-list.component.ts
+++ b/feature-libs/quote/components/list/quote-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/list/quote-list.module.ts
+++ b/feature-libs/quote/components/list/quote-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/public_api.ts
+++ b/feature-libs/quote/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/quote-components.module.ts
+++ b/feature-libs/quote/components/quote-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/request-button/public_api.ts
+++ b/feature-libs/quote/components/request-button/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/request-button/quote-request-button.component.ts
+++ b/feature-libs/quote/components/request-button/quote-request-button.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/request-button/quote-request-button.module.ts
+++ b/feature-libs/quote/components/request-button/quote-request-button.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/actions/index.ts
+++ b/feature-libs/quote/components/summary/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/actions/quote-summary-actions.component.ts
+++ b/feature-libs/quote/components/summary/actions/quote-summary-actions.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/actions/quote-summary-actions.module.ts
+++ b/feature-libs/quote/components/summary/actions/quote-summary-actions.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/index.ts
+++ b/feature-libs/quote/components/summary/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/prices/index.ts
+++ b/feature-libs/quote/components/summary/prices/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/prices/quote-summary-prices.component.ts
+++ b/feature-libs/quote/components/summary/prices/quote-summary-prices.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/prices/quote-summary-prices.module.ts
+++ b/feature-libs/quote/components/summary/prices/quote-summary-prices.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/quote-summary.component.ts
+++ b/feature-libs/quote/components/summary/quote-summary.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/quote-summary.module.ts
+++ b/feature-libs/quote/components/summary/quote-summary.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/seller-edit/index.ts
+++ b/feature-libs/quote/components/summary/seller-edit/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/seller-edit/quote-summary-seller-edit.component.service.ts
+++ b/feature-libs/quote/components/summary/seller-edit/quote-summary-seller-edit.component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/seller-edit/quote-summary-seller-edit.component.ts
+++ b/feature-libs/quote/components/summary/seller-edit/quote-summary-seller-edit.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/summary/seller-edit/quote-summary-seller-edit.module.ts
+++ b/feature-libs/quote/components/summary/seller-edit/quote-summary-seller-edit.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/components/testing/common-quote-test-utils.service.ts
+++ b/feature-libs/quote/components/testing/common-quote-test-utils.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/config/default-quote.core.config.ts
+++ b/feature-libs/quote/core/config/default-quote.core.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/config/index.ts
+++ b/feature-libs/quote/core/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/config/quote-core.config.ts
+++ b/feature-libs/quote/core/config/quote-core.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/connectors/converters.ts
+++ b/feature-libs/quote/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/connectors/index.ts
+++ b/feature-libs/quote/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/connectors/quote.adapter.ts
+++ b/feature-libs/quote/core/connectors/quote.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/connectors/quote.connector.ts
+++ b/feature-libs/quote/core/connectors/quote.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/event/index.ts
+++ b/feature-libs/quote/core/event/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/event/quote-cart-event.listener.ts
+++ b/feature-libs/quote/core/event/quote-cart-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/event/quote.events.ts
+++ b/feature-libs/quote/core/event/quote.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/facade/facade-providers.ts
+++ b/feature-libs/quote/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/facade/index.ts
+++ b/feature-libs/quote/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/facade/quote.service.ts
+++ b/feature-libs/quote/core/facade/quote.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/public_api.ts
+++ b/feature-libs/quote/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/quote-core.module.ts
+++ b/feature-libs/quote/core/quote-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/services/cart-utils.service.ts
+++ b/feature-libs/quote/core/services/cart-utils.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/services/index.ts
+++ b/feature-libs/quote/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/services/quote-cart.service.ts
+++ b/feature-libs/quote/core/services/quote-cart.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/services/quote-storefront-utils.service.ts
+++ b/feature-libs/quote/core/services/quote-storefront-utils.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/core/testing/quote-test-utils.ts
+++ b/feature-libs/quote/core/testing/quote-test-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/occ/adapters/index.ts
+++ b/feature-libs/quote/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/occ/adapters/occ-quote.adapter.ts
+++ b/feature-libs/quote/occ/adapters/occ-quote.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/occ/config/default-occ-quote-config.ts
+++ b/feature-libs/quote/occ/config/default-occ-quote-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/occ/converters/occ-quote-action-normalizer.ts
+++ b/feature-libs/quote/occ/converters/occ-quote-action-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/occ/converters/occ-quote-entry-normalizer.ts
+++ b/feature-libs/quote/occ/converters/occ-quote-entry-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/occ/model/index.ts
+++ b/feature-libs/quote/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/occ/model/occ-quote-endpoints.model.ts
+++ b/feature-libs/quote/occ/model/occ-quote-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/occ/public_api.ts
+++ b/feature-libs/quote/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/occ/quote-occ.module.ts
+++ b/feature-libs/quote/occ/quote-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/public_api.ts
+++ b/feature-libs/quote/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/quote.module.ts
+++ b/feature-libs/quote/quote.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/config/index.ts
+++ b/feature-libs/quote/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/config/quote.config.ts
+++ b/feature-libs/quote/root/config/quote.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/facade/index.ts
+++ b/feature-libs/quote/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/facade/quote.facade.ts
+++ b/feature-libs/quote/root/facade/quote.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/feature-name.ts
+++ b/feature-libs/quote/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/http-interceptors/index.ts
+++ b/feature-libs/quote/root/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/http-interceptors/quote-bad-request.handler.ts
+++ b/feature-libs/quote/root/http-interceptors/quote-bad-request.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/http-interceptors/quote-not-found.handler.ts
+++ b/feature-libs/quote/root/http-interceptors/quote-not-found.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/model/augmented-types.ts
+++ b/feature-libs/quote/root/model/augmented-types.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/model/index.ts
+++ b/feature-libs/quote/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/model/quote.model.ts
+++ b/feature-libs/quote/root/model/quote.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/public_api.ts
+++ b/feature-libs/quote/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/root/quote-root.module.ts
+++ b/feature-libs/quote/root/quote-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/schematics/add-quote/index.ts
+++ b/feature-libs/quote/schematics/add-quote/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/schematics/constants.ts
+++ b/feature-libs/quote/schematics/constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/setup-jest.ts
+++ b/feature-libs/quote/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/quote/test.ts
+++ b/feature-libs/quote/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/assets/public_api.ts
+++ b/feature-libs/requested-delivery-date/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/assets/translations/en/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/assets/translations/translations.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/core/connectors/index.ts
+++ b/feature-libs/requested-delivery-date/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/core/connectors/requested-delivery-date.adapter.ts
+++ b/feature-libs/requested-delivery-date/core/connectors/requested-delivery-date.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/core/connectors/requested-delivery-date.connector.ts
+++ b/feature-libs/requested-delivery-date/core/connectors/requested-delivery-date.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/core/http-interceptors/bad-request/requested-delivery-date-badrequest.handler.ts
+++ b/feature-libs/requested-delivery-date/core/http-interceptors/bad-request/requested-delivery-date-badrequest.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/core/http-interceptors/index.ts
+++ b/feature-libs/requested-delivery-date/core/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/core/public_api.ts
+++ b/feature-libs/requested-delivery-date/core/public_api.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/core/requested-delivery-date-core.module.ts
+++ b/feature-libs/requested-delivery-date/core/requested-delivery-date-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/core/services/index.ts
+++ b/feature-libs/requested-delivery-date/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/core/services/requested-delivery-date.service.ts
+++ b/feature-libs/requested-delivery-date/core/services/requested-delivery-date.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/occ/adapters/index.ts
+++ b/feature-libs/requested-delivery-date/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/occ/adapters/occ-requested-delivery-date.adapter.ts
+++ b/feature-libs/requested-delivery-date/occ/adapters/occ-requested-delivery-date.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/occ/config/default-occ-requested-delivery-date-config.ts
+++ b/feature-libs/requested-delivery-date/occ/config/default-occ-requested-delivery-date-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/occ/model/index.ts
+++ b/feature-libs/requested-delivery-date/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/occ/model/occ-requested-delivery-date-endpoints.model.ts
+++ b/feature-libs/requested-delivery-date/occ/model/occ-requested-delivery-date-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/occ/public_api.ts
+++ b/feature-libs/requested-delivery-date/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/occ/requested-delivery-date-occ.module.ts
+++ b/feature-libs/requested-delivery-date/occ/requested-delivery-date-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/public_api.ts
+++ b/feature-libs/requested-delivery-date/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/requested-delivery-date.module.ts
+++ b/feature-libs/requested-delivery-date/requested-delivery-date.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.ts
+++ b/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/components/index.ts
+++ b/feature-libs/requested-delivery-date/root/components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/components/order-overview-delivery-date/order-overview-delivery-date.component.ts
+++ b/feature-libs/requested-delivery-date/root/components/order-overview-delivery-date/order-overview-delivery-date.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/components/requested-delivery-date-components.module.ts
+++ b/feature-libs/requested-delivery-date/root/components/requested-delivery-date-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
+++ b/feature-libs/requested-delivery-date/root/components/shared/date-validation.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/facade/index.ts
+++ b/feature-libs/requested-delivery-date/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/facade/requested-delivery-date.facade.ts
+++ b/feature-libs/requested-delivery-date/root/facade/requested-delivery-date.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/feature-name.ts
+++ b/feature-libs/requested-delivery-date/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/model/augmented-core.model.ts
+++ b/feature-libs/requested-delivery-date/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/model/index.ts
+++ b/feature-libs/requested-delivery-date/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/public_api.ts
+++ b/feature-libs/requested-delivery-date/root/public_api.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/root/requested-delivery-date-root.module.ts
+++ b/feature-libs/requested-delivery-date/root/requested-delivery-date-root.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/index.ts
+++ b/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/index.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/setup-jest.ts
+++ b/feature-libs/requested-delivery-date/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/requested-delivery-date/test.ts
+++ b/feature-libs/requested-delivery-date/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/core/decorators/index.ts
+++ b/feature-libs/smartedit/core/decorators/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/core/decorators/smart-edit-component-decorator.ts
+++ b/feature-libs/smartedit/core/decorators/smart-edit-component-decorator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/core/decorators/smart-edit-slot-decorator.ts
+++ b/feature-libs/smartedit/core/decorators/smart-edit-slot-decorator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/core/public_api.ts
+++ b/feature-libs/smartedit/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/core/services/smart-edit.service.ts
+++ b/feature-libs/smartedit/core/services/smart-edit.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/core/smart-edit-core.module.ts
+++ b/feature-libs/smartedit/core/smart-edit-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/public_api.ts
+++ b/feature-libs/smartedit/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/root/config/default-smart-edit-config.ts
+++ b/feature-libs/smartedit/root/config/default-smart-edit-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/root/config/smart-edit-config.ts
+++ b/feature-libs/smartedit/root/config/smart-edit-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/root/feature-name.ts
+++ b/feature-libs/smartedit/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/root/http-interceptors/cms-ticket.interceptor.ts
+++ b/feature-libs/smartedit/root/http-interceptors/cms-ticket.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/root/http-interceptors/index.ts
+++ b/feature-libs/smartedit/root/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/root/public_api.ts
+++ b/feature-libs/smartedit/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/root/services/smart-edit-launcher.service.ts
+++ b/feature-libs/smartedit/root/services/smart-edit-launcher.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/root/smart-edit-root.module.ts
+++ b/feature-libs/smartedit/root/smart-edit-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/schematics/add-smartedit/index.ts
+++ b/feature-libs/smartedit/schematics/add-smartedit/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/setup-jest.ts
+++ b/feature-libs/smartedit/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/smart-edit.module.ts
+++ b/feature-libs/smartedit/smart-edit.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/smartedit/test.ts
+++ b/feature-libs/smartedit/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/assets/public_api.ts
+++ b/feature-libs/storefinder/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/assets/translations/en/index.ts
+++ b/feature-libs/storefinder/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/assets/translations/translations.ts
+++ b/feature-libs/storefinder/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/abstract-store-item/abstract-store-item.component.ts
+++ b/feature-libs/storefinder/components/abstract-store-item/abstract-store-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/public_api.ts
+++ b/feature-libs/storefinder/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/schedule-component/schedule.component.ts
+++ b/feature-libs/storefinder/components/schedule-component/schedule.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-components.module.ts
+++ b/feature-libs/storefinder/components/store-finder-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.ts
+++ b/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-header/store-finder-header.component.ts
+++ b/feature-libs/storefinder/components/store-finder-header/store-finder-header.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.ts
+++ b/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-map/store-finder-map.component.ts
+++ b/feature-libs/storefinder/components/store-finder-map/store-finder-map.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-pagination-details/store-finder-pagination-details.component.ts
+++ b/feature-libs/storefinder/components/store-finder-pagination-details/store-finder-pagination-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.model.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-search-result.component.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-search-result.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-search/store-finder-search.component.ts
+++ b/feature-libs/storefinder/components/store-finder-search/store-finder-search.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.ts
+++ b/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.ts
+++ b/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.ts
+++ b/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/components/store-finder/store-finder.component.ts
+++ b/feature-libs/storefinder/components/store-finder/store-finder.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/config/default-store-finder-config.ts
+++ b/feature-libs/storefinder/core/config/default-store-finder-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/config/store-finder-config.ts
+++ b/feature-libs/storefinder/core/config/store-finder-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/connectors/converters.ts
+++ b/feature-libs/storefinder/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/connectors/index.ts
+++ b/feature-libs/storefinder/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/connectors/store-finder.adapter.ts
+++ b/feature-libs/storefinder/core/connectors/store-finder.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/connectors/store-finder.connector.ts
+++ b/feature-libs/storefinder/core/connectors/store-finder.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/facade/index.ts
+++ b/feature-libs/storefinder/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/facade/store-finder.service.ts
+++ b/feature-libs/storefinder/core/facade/store-finder.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/model/index.ts
+++ b/feature-libs/storefinder/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/model/search-query.ts
+++ b/feature-libs/storefinder/core/model/search-query.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/model/store-finder.model.ts
+++ b/feature-libs/storefinder/core/model/store-finder.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/public_api.ts
+++ b/feature-libs/storefinder/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/service/google-map-renderer.service.ts
+++ b/feature-libs/storefinder/core/service/google-map-renderer.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/service/index.ts
+++ b/feature-libs/storefinder/core/service/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store-finder-core.module.ts
+++ b/feature-libs/storefinder/core/store-finder-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/actions/find-stores.action.ts
+++ b/feature-libs/storefinder/core/store/actions/find-stores.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/actions/index.ts
+++ b/feature-libs/storefinder/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/actions/store-finder-group.actions.ts
+++ b/feature-libs/storefinder/core/store/actions/store-finder-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/actions/view-all-stores.action.ts
+++ b/feature-libs/storefinder/core/store/actions/view-all-stores.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/effects/find-stores.effect.ts
+++ b/feature-libs/storefinder/core/store/effects/find-stores.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/effects/index.ts
+++ b/feature-libs/storefinder/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/effects/view-all-stores.effect.ts
+++ b/feature-libs/storefinder/core/store/effects/view-all-stores.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/index.ts
+++ b/feature-libs/storefinder/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/reducers/find-stores.reducer.ts
+++ b/feature-libs/storefinder/core/store/reducers/find-stores.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/reducers/index.ts
+++ b/feature-libs/storefinder/core/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/reducers/view-all-stores.reducer.ts
+++ b/feature-libs/storefinder/core/store/reducers/view-all-stores.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/selectors/feature.selector.ts
+++ b/feature-libs/storefinder/core/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/selectors/find-stores.selectors.ts
+++ b/feature-libs/storefinder/core/store/selectors/find-stores.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/selectors/index.ts
+++ b/feature-libs/storefinder/core/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/selectors/store-finder-group.selectors.ts
+++ b/feature-libs/storefinder/core/store/selectors/store-finder-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/selectors/view-all-stores.selectors.ts
+++ b/feature-libs/storefinder/core/store/selectors/view-all-stores.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/store-finder-state.ts
+++ b/feature-libs/storefinder/core/store/store-finder-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/core/store/store-finder-store.module.ts
+++ b/feature-libs/storefinder/core/store/store-finder-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/occ/adapters/default-occ-store-finder-config.ts
+++ b/feature-libs/storefinder/occ/adapters/default-occ-store-finder-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/occ/adapters/index.ts
+++ b/feature-libs/storefinder/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/occ/adapters/occ-store-finder.adapter.ts
+++ b/feature-libs/storefinder/occ/adapters/occ-store-finder.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/occ/model/index.ts
+++ b/feature-libs/storefinder/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/occ/model/occ-storefinder-endpoints.model.ts
+++ b/feature-libs/storefinder/occ/model/occ-storefinder-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/occ/public_api.ts
+++ b/feature-libs/storefinder/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/occ/store-finder-occ.module.ts
+++ b/feature-libs/storefinder/occ/store-finder-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/public_api.ts
+++ b/feature-libs/storefinder/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/config/constants.ts
+++ b/feature-libs/storefinder/root/config/constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/config/default-store-finder-layout-config.ts
+++ b/feature-libs/storefinder/root/config/default-store-finder-layout-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/config/index.ts
+++ b/feature-libs/storefinder/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/facade/index.ts
+++ b/feature-libs/storefinder/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/facade/store-finder.facade.ts
+++ b/feature-libs/storefinder/root/facade/store-finder.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/feature-name.ts
+++ b/feature-libs/storefinder/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/model/index.ts
+++ b/feature-libs/storefinder/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/model/store-entities.model.ts
+++ b/feature-libs/storefinder/root/model/store-entities.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/public_api.ts
+++ b/feature-libs/storefinder/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/root/store-finder-root.module.ts
+++ b/feature-libs/storefinder/root/store-finder-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/schematics/add-storefinder/index.ts
+++ b/feature-libs/storefinder/schematics/add-storefinder/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/setup-jest.ts
+++ b/feature-libs/storefinder/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/store-finder.module.ts
+++ b/feature-libs/storefinder/store-finder.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/storefinder/test.ts
+++ b/feature-libs/storefinder/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/core/model/personalization-context.model.ts
+++ b/feature-libs/tracking/personalization/core/model/personalization-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/core/personalization-core.module.ts
+++ b/feature-libs/tracking/personalization/core/personalization-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/core/public_api.ts
+++ b/feature-libs/tracking/personalization/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/core/services/personalization-context.service.ts
+++ b/feature-libs/tracking/personalization/core/services/personalization-context.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/personalization.module.ts
+++ b/feature-libs/tracking/personalization/personalization.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/public_api.ts
+++ b/feature-libs/tracking/personalization/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/root/config/default-personalization-config.ts
+++ b/feature-libs/tracking/personalization/root/config/default-personalization-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/root/config/personalization-config.ts
+++ b/feature-libs/tracking/personalization/root/config/personalization-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/root/feature-name.ts
+++ b/feature-libs/tracking/personalization/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/root/http-interceptors/index.ts
+++ b/feature-libs/tracking/personalization/root/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/root/http-interceptors/occ-personalization-id.interceptor.ts
+++ b/feature-libs/tracking/personalization/root/http-interceptors/occ-personalization-id.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/root/http-interceptors/occ-personalization-time.interceptor.ts
+++ b/feature-libs/tracking/personalization/root/http-interceptors/occ-personalization-time.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/root/personalization-root.module.ts
+++ b/feature-libs/tracking/personalization/root/personalization-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/personalization/root/public_api.ts
+++ b/feature-libs/tracking/personalization/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/public_api.ts
+++ b/feature-libs/tracking/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/schematics/add-tracking/index.ts
+++ b/feature-libs/tracking/schematics/add-tracking/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/setup-jest.ts
+++ b/feature-libs/tracking/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/test.ts
+++ b/feature-libs/tracking/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/aep/aep.module.ts
+++ b/feature-libs/tracking/tms/aep/aep.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/aep/config/default-aep.config.ts
+++ b/feature-libs/tracking/tms/aep/config/default-aep.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/aep/public_api.ts
+++ b/feature-libs/tracking/tms/aep/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/aep/services/aep-collector.service.ts
+++ b/feature-libs/tracking/tms/aep/services/aep-collector.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/aep/services/index.ts
+++ b/feature-libs/tracking/tms/aep/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/core/base-tms.module.ts
+++ b/feature-libs/tracking/tms/core/base-tms.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/core/config/index.ts
+++ b/feature-libs/tracking/tms/core/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/core/config/tms-config.ts
+++ b/feature-libs/tracking/tms/core/config/tms-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/core/model/index.ts
+++ b/feature-libs/tracking/tms/core/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/core/model/tms.model.ts
+++ b/feature-libs/tracking/tms/core/model/tms.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/core/public_api.ts
+++ b/feature-libs/tracking/tms/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/core/services/index.ts
+++ b/feature-libs/tracking/tms/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/core/services/tms.service.ts
+++ b/feature-libs/tracking/tms/core/services/tms.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/gtm/config/default-gtm.config.ts
+++ b/feature-libs/tracking/tms/gtm/config/default-gtm.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/gtm/gtm.module.ts
+++ b/feature-libs/tracking/tms/gtm/gtm.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/gtm/public_api.ts
+++ b/feature-libs/tracking/tms/gtm/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/gtm/services/gtm-collector.service.ts
+++ b/feature-libs/tracking/tms/gtm/services/gtm-collector.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/gtm/services/index.ts
+++ b/feature-libs/tracking/tms/gtm/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/tracking/tms/public_api.ts
+++ b/feature-libs/tracking/tms/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/assets/public_api.ts
+++ b/feature-libs/user/account/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/assets/translations/en/index.ts
+++ b/feature-libs/user/account/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/assets/translations/translations.ts
+++ b/feature-libs/user/account/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login-form/index.ts
+++ b/feature-libs/user/account/components/login-form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login-form/login-form-component.service.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login-form/login-form.component.ts
+++ b/feature-libs/user/account/components/login-form/login-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login-form/login-form.module.ts
+++ b/feature-libs/user/account/components/login-form/login-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login-register/index.ts
+++ b/feature-libs/user/account/components/login-register/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login-register/login-register.component.ts
+++ b/feature-libs/user/account/components/login-register/login-register.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login-register/login-register.module.ts
+++ b/feature-libs/user/account/components/login-register/login-register.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login/index.ts
+++ b/feature-libs/user/account/components/login/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login/login.component.ts
+++ b/feature-libs/user/account/components/login/login.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/login/login.module.ts
+++ b/feature-libs/user/account/components/login/login.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/my-account-v2-user/index.ts
+++ b/feature-libs/user/account/components/my-account-v2-user/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/my-account-v2-user/my-account-v2-user.component.ts
+++ b/feature-libs/user/account/components/my-account-v2-user/my-account-v2-user.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/my-account-v2-user/my-account-v2-user.module.ts
+++ b/feature-libs/user/account/components/my-account-v2-user/my-account-v2-user.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/otp-login-form/index.ts
+++ b/feature-libs/user/account/components/otp-login-form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/otp-login-form/otp-login-form.component.ts
+++ b/feature-libs/user/account/components/otp-login-form/otp-login-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/otp-login-form/otp-login-form.module.ts
+++ b/feature-libs/user/account/components/otp-login-form/otp-login-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/public_api.ts
+++ b/feature-libs/user/account/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/user-account-component.module.ts
+++ b/feature-libs/user/account/components/user-account-component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/user-account-constants.ts
+++ b/feature-libs/user/account/components/user-account-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/verification-token-form/default-verification-token-layout.config.ts
+++ b/feature-libs/user/account/components/verification-token-form/default-verification-token-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/verification-token-form/index.ts
+++ b/feature-libs/user/account/components/verification-token-form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/verification-token-form/verification-token-dialog.component.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form.component.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form.module.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/connectors/converters.ts
+++ b/feature-libs/user/account/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/connectors/index.ts
+++ b/feature-libs/user/account/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/connectors/user-account.adapter.ts
+++ b/feature-libs/user/account/core/connectors/user-account.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/connectors/user-account.connector.ts
+++ b/feature-libs/user/account/core/connectors/user-account.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/facade/facade-providers.ts
+++ b/feature-libs/user/account/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/facade/index.ts
+++ b/feature-libs/user/account/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/facade/user-account.service.ts
+++ b/feature-libs/user/account/core/facade/user-account.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/facade/verification-token.service.ts
+++ b/feature-libs/user/account/core/facade/verification-token.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/public_api.ts
+++ b/feature-libs/user/account/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/core/user-account-core.module.ts
+++ b/feature-libs/user/account/core/user-account-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/occ/adapters/config/default-occ-user-account-endpoint.config.ts
+++ b/feature-libs/user/account/occ/adapters/config/default-occ-user-account-endpoint.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/occ/adapters/config/index.ts
+++ b/feature-libs/user/account/occ/adapters/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/occ/adapters/config/occ-user-account-endpoint.model.ts
+++ b/feature-libs/user/account/occ/adapters/config/occ-user-account-endpoint.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/occ/adapters/index.ts
+++ b/feature-libs/user/account/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/occ/adapters/occ-user-account.adapter.ts
+++ b/feature-libs/user/account/occ/adapters/occ-user-account.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/occ/public_api.ts
+++ b/feature-libs/user/account/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/occ/user-account-occ.module.ts
+++ b/feature-libs/user/account/occ/user-account-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/public_api.ts
+++ b/feature-libs/user/account/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/events/index.ts
+++ b/feature-libs/user/account/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/events/user-account-event.listener.ts
+++ b/feature-libs/user/account/root/events/user-account-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/events/user-account-event.module.ts
+++ b/feature-libs/user/account/root/events/user-account-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/events/user-account.events.ts
+++ b/feature-libs/user/account/root/events/user-account.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/facade/index.ts
+++ b/feature-libs/user/account/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/facade/user-account.facade.ts
+++ b/feature-libs/user/account/root/facade/user-account.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/facade/verification-token.facade.ts
+++ b/feature-libs/user/account/root/facade/verification-token.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/feature-name.ts
+++ b/feature-libs/user/account/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/model/augmented.model.ts
+++ b/feature-libs/user/account/root/model/augmented.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/model/index.ts
+++ b/feature-libs/user/account/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/model/otp-login.model.ts
+++ b/feature-libs/user/account/root/model/otp-login.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/model/user.model.ts
+++ b/feature-libs/user/account/root/model/user.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/public_api.ts
+++ b/feature-libs/user/account/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/root/user-account-root.module.ts
+++ b/feature-libs/user/account/root/user-account-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/account/user-account.module.ts
+++ b/feature-libs/user/account/user-account.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/assets/public_api.ts
+++ b/feature-libs/user/profile/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/assets/translations/en/index.ts
+++ b/feature-libs/user/profile/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/assets/translations/en/my-account-v2-email.18n.ts
+++ b/feature-libs/user/profile/assets/translations/en/my-account-v2-email.18n.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/assets/translations/en/my-account-v2-password.i18n.ts
+++ b/feature-libs/user/profile/assets/translations/en/my-account-v2-password.i18n.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/assets/translations/en/my-account-v2-user-profile.18n.ts
+++ b/feature-libs/user/profile/assets/translations/en/my-account-v2-user-profile.18n.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/assets/translations/translations.ts
+++ b/feature-libs/user/profile/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/address-book/address-book.component.service.ts
+++ b/feature-libs/user/profile/components/address-book/address-book.component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/address-book/address-book.component.ts
+++ b/feature-libs/user/profile/components/address-book/address-book.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/address-book/address-book.module.ts
+++ b/feature-libs/user/profile/components/address-book/address-book.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.module.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/default-suggested-addresses-dialog-layout.config.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/default-suggested-addresses-dialog-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/suggested-addresses-dialog.component.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/suggested-addresses-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/address-book/index.ts
+++ b/feature-libs/user/profile/components/address-book/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/close-account/close-account.module.ts
+++ b/feature-libs/user/profile/components/close-account/close-account.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.ts
+++ b/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/close-account/components/close-account-modal/default-close-account-modal-layout.config.ts
+++ b/feature-libs/user/profile/components/close-account/components/close-account-modal/default-close-account-modal-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/close-account/components/close-account/close-account.component.ts
+++ b/feature-libs/user/profile/components/close-account/components/close-account/close-account.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/close-account/index.ts
+++ b/feature-libs/user/profile/components/close-account/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/forgot-password/forgot-password-component.service.ts
+++ b/feature-libs/user/profile/components/forgot-password/forgot-password-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/forgot-password/forgot-password.component.ts
+++ b/feature-libs/user/profile/components/forgot-password/forgot-password.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/forgot-password/forgot-password.module.ts
+++ b/feature-libs/user/profile/components/forgot-password/forgot-password.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/forgot-password/index.ts
+++ b/feature-libs/user/profile/components/forgot-password/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/public_api.ts
+++ b/feature-libs/user/profile/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/register/index.ts
+++ b/feature-libs/user/profile/components/register/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/register/register-component.service.ts
+++ b/feature-libs/user/profile/components/register/register-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/register/register.component.ts
+++ b/feature-libs/user/profile/components/register/register.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/register/register.module.ts
+++ b/feature-libs/user/profile/components/register/register.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/reset-password/index.ts
+++ b/feature-libs/user/profile/components/reset-password/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/reset-password/reset-password-component.service.ts
+++ b/feature-libs/user/profile/components/reset-password/reset-password-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/reset-password/reset-password.component.ts
+++ b/feature-libs/user/profile/components/reset-password/reset-password.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/reset-password/reset-password.module.ts
+++ b/feature-libs/user/profile/components/reset-password/reset-password.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-email/index.ts
+++ b/feature-libs/user/profile/components/update-email/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-email/my-account-v2-email.component.ts
+++ b/feature-libs/user/profile/components/update-email/my-account-v2-email.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-email/update-email-component.service.ts
+++ b/feature-libs/user/profile/components/update-email/update-email-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-email/update-email.component.ts
+++ b/feature-libs/user/profile/components/update-email/update-email.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-email/update-email.module.ts
+++ b/feature-libs/user/profile/components/update-email/update-email.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-email/use-my-account-v2-email.ts.ts
+++ b/feature-libs/user/profile/components/update-email/use-my-account-v2-email.ts.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-password/index.ts
+++ b/feature-libs/user/profile/components/update-password/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-password/my-account-v2-password.component.ts
+++ b/feature-libs/user/profile/components/update-password/my-account-v2-password.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-password/update-password-component.service.ts
+++ b/feature-libs/user/profile/components/update-password/update-password-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-password/update-password.component.ts
+++ b/feature-libs/user/profile/components/update-password/update-password.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-password/update-password.module.ts
+++ b/feature-libs/user/profile/components/update-password/update-password.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-password/use-my-account-v2-password.ts
+++ b/feature-libs/user/profile/components/update-password/use-my-account-v2-password.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-profile/index.ts
+++ b/feature-libs/user/profile/components/update-profile/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.ts
+++ b/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-profile/update-profile-component.service.ts
+++ b/feature-libs/user/profile/components/update-profile/update-profile-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-profile/update-profile.component.ts
+++ b/feature-libs/user/profile/components/update-profile/update-profile.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-profile/update-profile.module.ts
+++ b/feature-libs/user/profile/components/update-profile/update-profile.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/update-profile/use-my-account-v2-profile.ts
+++ b/feature-libs/user/profile/components/update-profile/use-my-account-v2-profile.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/components/user-profile-components.module.ts
+++ b/feature-libs/user/profile/components/user-profile-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/connectors/converters.ts
+++ b/feature-libs/user/profile/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/connectors/index.ts
+++ b/feature-libs/user/profile/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/connectors/user-profile.adapter.ts
+++ b/feature-libs/user/profile/core/connectors/user-profile.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/connectors/user-profile.connector.ts
+++ b/feature-libs/user/profile/core/connectors/user-profile.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/facade/facade-providers.ts
+++ b/feature-libs/user/profile/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/facade/index.ts
+++ b/feature-libs/user/profile/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/facade/user-email.service.ts
+++ b/feature-libs/user/profile/core/facade/user-email.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/facade/user-password.service.ts
+++ b/feature-libs/user/profile/core/facade/user-password.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/facade/user-profile.service.ts
+++ b/feature-libs/user/profile/core/facade/user-profile.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/facade/user-register.service.ts
+++ b/feature-libs/user/profile/core/facade/user-register.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/public_api.ts
+++ b/feature-libs/user/profile/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/core/user-profile-core.module.ts
+++ b/feature-libs/user/profile/core/user-profile-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/occ/adapters/config/default-occ-user-profile-endpoint.config.ts
+++ b/feature-libs/user/profile/occ/adapters/config/default-occ-user-profile-endpoint.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/occ/adapters/config/index.ts
+++ b/feature-libs/user/profile/occ/adapters/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/occ/adapters/config/occ-user-profile-endpoint.model.ts
+++ b/feature-libs/user/profile/occ/adapters/config/occ-user-profile-endpoint.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/occ/adapters/index.ts
+++ b/feature-libs/user/profile/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/occ/adapters/occ-user-profile.adapter.ts
+++ b/feature-libs/user/profile/occ/adapters/occ-user-profile.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/occ/public_api.ts
+++ b/feature-libs/user/profile/occ/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/occ/user-profile-occ.module.ts
+++ b/feature-libs/user/profile/occ/user-profile-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/public_api.ts
+++ b/feature-libs/user/profile/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/facade/index.ts
+++ b/feature-libs/user/profile/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/facade/user-email.facade.ts
+++ b/feature-libs/user/profile/root/facade/user-email.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/facade/user-password.facade.ts
+++ b/feature-libs/user/profile/root/facade/user-password.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/facade/user-profile.facade.ts
+++ b/feature-libs/user/profile/root/facade/user-profile.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/facade/user-register.facade.ts
+++ b/feature-libs/user/profile/root/facade/user-register.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/feature-name.ts
+++ b/feature-libs/user/profile/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/model/augmented.model.ts
+++ b/feature-libs/user/profile/root/model/augmented.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/model/index.ts
+++ b/feature-libs/user/profile/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/model/user-profile.model.ts
+++ b/feature-libs/user/profile/root/model/user-profile.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/public_api.ts
+++ b/feature-libs/user/profile/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/root/user-profile-root.module.ts
+++ b/feature-libs/user/profile/root/user-profile-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/profile/user-profile.module.ts
+++ b/feature-libs/user/profile/user-profile.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/public_api.ts
+++ b/feature-libs/user/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/schematics/add-user/index.ts
+++ b/feature-libs/user/schematics/add-user/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/setup-jest.ts
+++ b/feature-libs/user/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/feature-libs/user/test.ts
+++ b/feature-libs/user/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/assets/public_api.ts
+++ b/integration-libs/cdc/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/assets/translations/en/index.ts
+++ b/integration-libs/cdc/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/assets/translations/translations.ts
+++ b/integration-libs/cdc/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/cdc.module.ts
+++ b/integration-libs/cdc/cdc.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/components/cdc-components.module.ts
+++ b/integration-libs/cdc/components/cdc-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/components/gigya-raas/gigya-raas.component.ts
+++ b/integration-libs/cdc/components/gigya-raas/gigya-raas.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/components/gigya-raas/gigya-raas.guard.ts
+++ b/integration-libs/cdc/components/gigya-raas/gigya-raas.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/components/gigya-raas/gigya-raas.module.ts
+++ b/integration-libs/cdc/components/gigya-raas/gigya-raas.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/components/gigya-raas/index.ts
+++ b/integration-libs/cdc/components/gigya-raas/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/components/public_api.ts
+++ b/integration-libs/cdc/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/auth/cdc-auth.module.ts
+++ b/integration-libs/cdc/core/auth/cdc-auth.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/auth/facade/cdc-auth.service.ts
+++ b/integration-libs/cdc/core/auth/facade/cdc-auth.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/auth/facade/facade-providers.ts
+++ b/integration-libs/cdc/core/auth/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/auth/facade/index.ts
+++ b/integration-libs/cdc/core/auth/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/auth/index.ts
+++ b/integration-libs/cdc/core/auth/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/auth/services/index.ts
+++ b/integration-libs/cdc/core/auth/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/auth/services/user-authentication/cdc-user-authentication-token.service.ts
+++ b/integration-libs/cdc/core/auth/services/user-authentication/cdc-user-authentication-token.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/auth/services/user-authentication/index.ts
+++ b/integration-libs/cdc/core/auth/services/user-authentication/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/cdc-core.module.ts
+++ b/integration-libs/cdc/core/cdc-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/events/cdc-event.builder.ts
+++ b/integration-libs/cdc/core/events/cdc-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/events/cdc-event.module.ts
+++ b/integration-libs/cdc/core/events/cdc-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/events/index.ts
+++ b/integration-libs/cdc/core/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/models/cms.model.ts
+++ b/integration-libs/cdc/core/models/cms.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/public_api.ts
+++ b/integration-libs/cdc/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/store/actions/cdc-user-token.action.ts
+++ b/integration-libs/cdc/core/store/actions/cdc-user-token.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/store/actions/index.ts
+++ b/integration-libs/cdc/core/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/store/cdc-store.module.ts
+++ b/integration-libs/cdc/core/store/cdc-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/store/effects/cdc-user-addresses.effect.ts
+++ b/integration-libs/cdc/core/store/effects/cdc-user-addresses.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/store/effects/cdc-user-token.effect.ts
+++ b/integration-libs/cdc/core/store/effects/cdc-user-token.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/store/effects/index.ts
+++ b/integration-libs/cdc/core/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/core/store/index.ts
+++ b/integration-libs/cdc/core/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/organization/administration/cdc-administration.module.ts
+++ b/integration-libs/cdc/organization/administration/cdc-administration.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/organization/administration/cdc-b2b-user.service.ts
+++ b/integration-libs/cdc/organization/administration/cdc-b2b-user.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/organization/administration/cdc-org-unit.service.ts
+++ b/integration-libs/cdc/organization/administration/cdc-org-unit.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/organization/administration/cdc-user-list.service.ts
+++ b/integration-libs/cdc/organization/administration/cdc-user-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/organization/administration/public_api.ts
+++ b/integration-libs/cdc/organization/administration/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/organization/user-registration/cdc-b2b-register-component.service.ts
+++ b/integration-libs/cdc/organization/user-registration/cdc-b2b-register-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/organization/user-registration/cdc-b2b-register.module.ts
+++ b/integration-libs/cdc/organization/user-registration/cdc-b2b-register.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/organization/user-registration/public_api.ts
+++ b/integration-libs/cdc/organization/user-registration/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/public_api.ts
+++ b/integration-libs/cdc/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/cdc-root.module.ts
+++ b/integration-libs/cdc/root/cdc-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/config/cdc-config.ts
+++ b/integration-libs/cdc/root/config/cdc-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/config/default-cdc-routing-config.ts
+++ b/integration-libs/cdc/root/config/default-cdc-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/config/index.ts
+++ b/integration-libs/cdc/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/cdc-consent.module.ts
+++ b/integration-libs/cdc/root/consent-management/cdc-consent.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/cdc-user-consent.adapter.ts
+++ b/integration-libs/cdc/root/consent-management/cdc-user-consent.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/converters/cdc-user-preference.serializer.ts
+++ b/integration-libs/cdc/root/consent-management/converters/cdc-user-preference.serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/converters/cdc-user-preference.serializer.ts
+++ b/integration-libs/cdc/root/consent-management/converters/cdc-user-preference.serializer.ts
@@ -46,12 +46,18 @@ export class CdcUserPreferenceSerializer
     const len = list.length;
     for (let i = 0; i < len - 1; i++) {
       const elem = list[i];
+      if (elem === '__proto__' || elem === 'constructor') {
+        continue;
+      }
       if (!consentCode[elem]) {
         consentCode[elem] = {};
       }
       consentCode = consentCode[elem];
     }
-    consentCode[list[len - 1]] = value;
+    const lastElem = list[len - 1];
+    if (lastElem !== '__proto__' && lastElem !== 'constructor') {
+      consentCode[lastElem] = value;
+    }
     return target;
   }
 }

--- a/integration-libs/cdc/root/consent-management/converters/converter.ts
+++ b/integration-libs/cdc/root/consent-management/converters/converter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/converters/index.ts
+++ b/integration-libs/cdc/root/consent-management/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/index.ts
+++ b/integration-libs/cdc/root/consent-management/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/model/cdc-consent-management.model.ts
+++ b/integration-libs/cdc/root/consent-management/model/cdc-consent-management.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/model/index.ts
+++ b/integration-libs/cdc/root/consent-management/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/services/cdc-consent-management-component.service.ts
+++ b/integration-libs/cdc/root/consent-management/services/cdc-consent-management-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/services/cdc-consents-local-storage.service.ts
+++ b/integration-libs/cdc/root/consent-management/services/cdc-consents-local-storage.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/services/cdc-user-consent.service.ts
+++ b/integration-libs/cdc/root/consent-management/services/cdc-user-consent.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/consent-management/services/index.ts
+++ b/integration-libs/cdc/root/consent-management/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/events/cdc-event.ts
+++ b/integration-libs/cdc/root/events/cdc-event.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/events/index.ts
+++ b/integration-libs/cdc/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/facade/cdc-auth.facade.ts
+++ b/integration-libs/cdc/root/facade/cdc-auth.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/facade/index.ts
+++ b/integration-libs/cdc/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/feature-name.ts
+++ b/integration-libs/cdc/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/guards/cdc-logout.guard.ts
+++ b/integration-libs/cdc/root/guards/cdc-logout.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/guards/index.ts
+++ b/integration-libs/cdc/root/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/public_api.ts
+++ b/integration-libs/cdc/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/service/cdc-js.service.ts
+++ b/integration-libs/cdc/root/service/cdc-js.service.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/root/service/index.ts
+++ b/integration-libs/cdc/root/service/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/schematics/add-cdc/index.ts
+++ b/integration-libs/cdc/schematics/add-cdc/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/setup-jest.ts
+++ b/integration-libs/cdc/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/test.ts
+++ b/integration-libs/cdc/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/cdc-user-account.module.ts
+++ b/integration-libs/cdc/user-account/cdc-user-account.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.ts
+++ b/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/login-form/cdc-login-form.module.ts
+++ b/integration-libs/cdc/user-account/login-form/cdc-login-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/login-form/index.ts
+++ b/integration-libs/cdc/user-account/login-form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent-component.service.ts
+++ b/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent-dialogue-event.listener.ts
+++ b/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent-dialogue-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent.component.ts
+++ b/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent.module.ts
+++ b/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/login-form/reconsent/default-cdc-reconsent-layout.config.ts
+++ b/integration-libs/cdc/user-account/login-form/reconsent/default-cdc-reconsent-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/login-form/reconsent/index.ts
+++ b/integration-libs/cdc/user-account/login-form/reconsent/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-account/public_api.ts
+++ b/integration-libs/cdc/user-account/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/cdc-user-profile.module.ts
+++ b/integration-libs/cdc/user-profile/cdc-user-profile.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.ts
+++ b/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password.module.ts
+++ b/integration-libs/cdc/user-profile/forgot-password/cdc-forgot-password.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/forgot-password/index.ts
+++ b/integration-libs/cdc/user-profile/forgot-password/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/public_api.ts
+++ b/integration-libs/cdc/user-profile/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/register/cdc-register-component.service.ts
+++ b/integration-libs/cdc/user-profile/register/cdc-register-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/register/cdc-register.module.ts
+++ b/integration-libs/cdc/user-profile/register/cdc-register.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/register/index.ts
+++ b/integration-libs/cdc/user-profile/register/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/update-email/cdc-update-email-component.service.ts
+++ b/integration-libs/cdc/user-profile/update-email/cdc-update-email-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/update-email/cdc-update-email.module.ts
+++ b/integration-libs/cdc/user-profile/update-email/cdc-update-email.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/update-password/cdc-update-password-component.service.ts
+++ b/integration-libs/cdc/user-profile/update-password/cdc-update-password-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/update-password/cdc-update-password.module.ts
+++ b/integration-libs/cdc/user-profile/update-password/cdc-update-password.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/update-profile/cdc-update-profile-component.service.ts
+++ b/integration-libs/cdc/user-profile/update-profile/cdc-update-profile-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdc/user-profile/update-profile/cdc-update-profile.module.ts
+++ b/integration-libs/cdc/user-profile/update-profile/cdc-update-profile.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdp/customer-ticketing/cdp-customer-ticketing-close-component.service.ts
+++ b/integration-libs/cdp/customer-ticketing/cdp-customer-ticketing-close-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdp/customer-ticketing/cdp-customer-ticketing-messages-component.service.ts
+++ b/integration-libs/cdp/customer-ticketing/cdp-customer-ticketing-messages-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdp/customer-ticketing/cdp-customer-ticketing-reopen-component.service.ts
+++ b/integration-libs/cdp/customer-ticketing/cdp-customer-ticketing-reopen-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdp/customer-ticketing/cdp-customer-ticketing.module.ts
+++ b/integration-libs/cdp/customer-ticketing/cdp-customer-ticketing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdp/customer-ticketing/public_api.ts
+++ b/integration-libs/cdp/customer-ticketing/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdp/public_api.ts
+++ b/integration-libs/cdp/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdp/schematics/add-cdp/index.ts
+++ b/integration-libs/cdp/schematics/add-cdp/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdp/setup-jest.ts
+++ b/integration-libs/cdp/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cdp/test.ts
+++ b/integration-libs/cdp/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/assets/public_api.ts
+++ b/integration-libs/cds/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/assets/translations/en/index.ts
+++ b/integration-libs/cds/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/assets/translations/translations.ts
+++ b/integration-libs/cds/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/public_api.ts
+++ b/integration-libs/cds/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/setup-jest.ts
+++ b/integration-libs/cds/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/assets/index.ts
+++ b/integration-libs/cds/src/assets/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/cds-models/cds-endpoints.model.ts
+++ b/integration-libs/cds/src/cds-models/cds-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/cds-models/cds-strategy-request.model.ts
+++ b/integration-libs/cds/src/cds-models/cds-strategy-request.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/cds-models/cms.model.ts
+++ b/integration-libs/cds/src/cds-models/cms.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/cds-models/index.ts
+++ b/integration-libs/cds/src/cds-models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/cds.module.ts
+++ b/integration-libs/cds/src/cds.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/config/cds-config-validator.ts
+++ b/integration-libs/cds/src/config/cds-config-validator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/config/cds-config.ts
+++ b/integration-libs/cds/src/config/cds-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/config/default-cds-config.ts
+++ b/integration-libs/cds/src/config/default-cds-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/config/index.ts
+++ b/integration-libs/cds/src/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/config/merchandising.config.ts
+++ b/integration-libs/cds/src/config/merchandising.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/config/profile-tag.config.ts
+++ b/integration-libs/cds/src/config/profile-tag.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/adapters/index.ts
+++ b/integration-libs/cds/src/merchandising/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/adapters/strategy/cds-merchandising-strategy.adapter.ts
+++ b/integration-libs/cds/src/merchandising/adapters/strategy/cds-merchandising-strategy.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/adapters/strategy/index.ts
+++ b/integration-libs/cds/src/merchandising/adapters/strategy/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/directives/attributes/attributes.directive.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/directives/attributes/attributes.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/directives/attributes/attributes.module.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/directives/attributes/attributes.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/directives/attributes/index.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/directives/attributes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/directives/index.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/directives/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/index.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel-cms.module.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel-cms.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/index.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.service.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/model/index.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/model/merchandising-carousel-events.model.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/model/merchandising-carousel-events.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/model/merchandising-carousel.model.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/model/merchandising-carousel.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/connectors/index.ts
+++ b/integration-libs/cds/src/merchandising/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/connectors/strategy/index.ts
+++ b/integration-libs/cds/src/merchandising/connectors/strategy/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/connectors/strategy/merchandising-strategy.adapter.ts
+++ b/integration-libs/cds/src/merchandising/connectors/strategy/merchandising-strategy.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/connectors/strategy/merchandising-strategy.connector.ts
+++ b/integration-libs/cds/src/merchandising/connectors/strategy/merchandising-strategy.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/facade/cds-merchandising-product.service.ts
+++ b/integration-libs/cds/src/merchandising/facade/cds-merchandising-product.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/facade/cds-merchandising-site-context.service.ts
+++ b/integration-libs/cds/src/merchandising/facade/cds-merchandising-site-context.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/facade/cds-merchandising-user-context.service.ts
+++ b/integration-libs/cds/src/merchandising/facade/cds-merchandising-user-context.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/facade/index.ts
+++ b/integration-libs/cds/src/merchandising/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/index.ts
+++ b/integration-libs/cds/src/merchandising/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/merchandising.module.ts
+++ b/integration-libs/cds/src/merchandising/merchandising.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/model/index.ts
+++ b/integration-libs/cds/src/merchandising/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/model/merchandising-facet.model.ts
+++ b/integration-libs/cds/src/merchandising/model/merchandising-facet.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/model/merchandising-metadata.model.ts
+++ b/integration-libs/cds/src/merchandising/model/merchandising-metadata.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/model/merchandising-products.model.ts
+++ b/integration-libs/cds/src/merchandising/model/merchandising-products.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/model/merchandising-site-context.model.ts
+++ b/integration-libs/cds/src/merchandising/model/merchandising-site-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/model/merchandising-user-context.model.ts
+++ b/integration-libs/cds/src/merchandising/model/merchandising-user-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/merchandising/model/strategy-products.model.ts
+++ b/integration-libs/cds/src/merchandising/model/strategy-products.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/adapters/cds-backend-notification-adapter.ts
+++ b/integration-libs/cds/src/profiletag/adapters/cds-backend-notification-adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/adapters/index.ts
+++ b/integration-libs/cds/src/profiletag/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/adapters/occ-backend-notification-adapter.ts
+++ b/integration-libs/cds/src/profiletag/adapters/occ-backend-notification-adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/cms-components/index.ts
+++ b/integration-libs/cds/src/profiletag/cms-components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/cms-components/profile-tag-cms.module.ts
+++ b/integration-libs/cds/src/profiletag/cms-components/profile-tag-cms.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/cms-components/profile-tag.component.ts
+++ b/integration-libs/cds/src/profiletag/cms-components/profile-tag.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/connectors/cds-backend-connector.ts
+++ b/integration-libs/cds/src/profiletag/connectors/cds-backend-connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/connectors/index.ts
+++ b/integration-libs/cds/src/profiletag/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/http-interceptors/consent-reference-interceptor.ts
+++ b/integration-libs/cds/src/profiletag/http-interceptors/consent-reference-interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/http-interceptors/debug-interceptor.ts
+++ b/integration-libs/cds/src/profiletag/http-interceptors/debug-interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/http-interceptors/index.ts
+++ b/integration-libs/cds/src/profiletag/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/index.ts
+++ b/integration-libs/cds/src/profiletag/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/model/index.ts
+++ b/integration-libs/cds/src/profiletag/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/model/profile-tag.model.ts
+++ b/integration-libs/cds/src/profiletag/model/profile-tag.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/profile-tag.module.ts
+++ b/integration-libs/cds/src/profiletag/profile-tag.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/services/index.ts
+++ b/integration-libs/cds/src/profiletag/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/services/profile-tag-lifecycle.service.ts
+++ b/integration-libs/cds/src/profiletag/services/profile-tag-lifecycle.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/services/profile-tag-push-events.service.ts
+++ b/integration-libs/cds/src/profiletag/services/profile-tag-push-events.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/services/profile-tag.injector.service.ts
+++ b/integration-libs/cds/src/profiletag/services/profile-tag.injector.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/services/profiletag-event.service.ts
+++ b/integration-libs/cds/src/profiletag/services/profiletag-event.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/tracking/index.ts
+++ b/integration-libs/cds/src/profiletag/tracking/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/tracking/tracking.module.ts
+++ b/integration-libs/cds/src/profiletag/tracking/tracking.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/profiletag/tracking/tracking.service.ts
+++ b/integration-libs/cds/src/profiletag/tracking/tracking.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/recent-searches/recent-searches.component.ts
+++ b/integration-libs/cds/src/recent-searches/recent-searches.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/recent-searches/recent-searches.module.ts
+++ b/integration-libs/cds/src/recent-searches/recent-searches.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/recent-searches/recent-searches.service.ts
+++ b/integration-libs/cds/src/recent-searches/recent-searches.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/schematics/add-cds/index.ts
+++ b/integration-libs/cds/src/schematics/add-cds/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/services/cds-endpoints.service.ts
+++ b/integration-libs/cds/src/services/cds-endpoints.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/services/index.ts
+++ b/integration-libs/cds/src/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/test.ts
+++ b/integration-libs/cds/src/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/trending-searches/model/index.ts
+++ b/integration-libs/cds/src/trending-searches/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/trending-searches/model/trending-searches.model.ts
+++ b/integration-libs/cds/src/trending-searches/model/trending-searches.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/trending-searches/trending-searches.component.ts
+++ b/integration-libs/cds/src/trending-searches/trending-searches.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/trending-searches/trending-searches.module.ts
+++ b/integration-libs/cds/src/trending-searches/trending-searches.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/trending-searches/trending-searches.service.ts
+++ b/integration-libs/cds/src/trending-searches/trending-searches.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cds/src/utils/dynamic-template.ts
+++ b/integration-libs/cds/src/utils/dynamic-template.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/assets/public_api.ts
+++ b/integration-libs/cpq-quote/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/assets/translations/en/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/assets/translations/translations.ts
+++ b/integration-libs/cpq-quote/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/cpq-quote-discount/components/cpq-quote-discount-tbody/cpq-quote.component.ts
+++ b/integration-libs/cpq-quote/cpq-quote-discount/components/cpq-quote-discount-tbody/cpq-quote.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/cpq-quote-discount/components/cpq-quote-heading/cpq-quote-heading.component.ts
+++ b/integration-libs/cpq-quote/cpq-quote-discount/components/cpq-quote-heading/cpq-quote-heading.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/cpq-quote-discount/components/cpq-quote/cpq-quote-offer.component.ts
+++ b/integration-libs/cpq-quote/cpq-quote-discount/components/cpq-quote/cpq-quote-offer.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/cpq-quote-discount/cpq-discount.module.ts
+++ b/integration-libs/cpq-quote/cpq-quote-discount/cpq-discount.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/cpq-quote-discount/cpq-qute-shared.service.ts
+++ b/integration-libs/cpq-quote/cpq-quote-discount/cpq-qute-shared.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/cpq-quote-discount/cpq-qute.service.ts
+++ b/integration-libs/cpq-quote/cpq-quote-discount/cpq-qute.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/cpq-quote-discount/public_api.ts
+++ b/integration-libs/cpq-quote/cpq-quote-discount/public_api.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/cpq-quote.module.ts
+++ b/integration-libs/cpq-quote/cpq-quote.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/public_api.ts
+++ b/integration-libs/cpq-quote/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/root/cpq-quote-root.module.ts
+++ b/integration-libs/cpq-quote/root/cpq-quote-root.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/root/feature-name.ts
+++ b/integration-libs/cpq-quote/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/root/model/augmented-core.model.ts
+++ b/integration-libs/cpq-quote/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/root/model/cpqDiscounts.model.ts
+++ b/integration-libs/cpq-quote/root/model/cpqDiscounts.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/root/model/index.ts
+++ b/integration-libs/cpq-quote/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/root/public_api.ts
+++ b/integration-libs/cpq-quote/root/public_api.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/schematics/add-cpq-quote/index.ts
+++ b/integration-libs/cpq-quote/schematics/add-cpq-quote/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/setup-jest.ts
+++ b/integration-libs/cpq-quote/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/cpq-quote/test.ts
+++ b/integration-libs/cpq-quote/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/assets/public_api.ts
+++ b/integration-libs/digital-payments/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/assets/translations/en/index.ts
+++ b/integration-libs/digital-payments/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/assets/translations/translations.ts
+++ b/integration-libs/digital-payments/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/public_api.ts
+++ b/integration-libs/digital-payments/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/schematics/add-digital-payments/index.ts
+++ b/integration-libs/digital-payments/schematics/add-digital-payments/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/setup-jest.ts
+++ b/integration-libs/digital-payments/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/config/default-digital-payments-endpoint.config.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/config/default-digital-payments-endpoint.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/config/index.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/config/occ-digital-payments-endpoint.config.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/config/occ-digital-payments-endpoint.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/config/occ-digital-payments-endpoint.model.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/config/occ-digital-payments-endpoint.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/converters.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/digital-payments.adapter.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/digital-payments.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/occ-digital-payment-details.normalizer.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/occ-digital-payment-details.normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/occ-digital-payment-request.normalizer.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/occ-digital-payment-request.normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/occ-digital-payments.adapter.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/occ-digital-payments.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/adapters/occ.models.ts
+++ b/integration-libs/digital-payments/src/checkout/adapters/occ.models.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/default-dp-confirmation-dialog.config.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/default-dp-confirmation-dialog.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/dp-confirmation-dialog.component.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/dp-confirmation-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/dp-confirmation-dialog.module.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/dp-confirmation-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-callback/dp-payment-callback.component.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-callback/dp-payment-callback.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-callback/dp-payment-callback.module.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-callback/dp-payment-callback.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-form/dp-payment-form.component.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-form/dp-payment-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-form/dp-payment-form.module.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-form/dp-payment-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-method.component.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-method.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-method.module.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-method.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/cms-components/index.ts
+++ b/integration-libs/digital-payments/src/checkout/cms-components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/dp-checkout.module.ts
+++ b/integration-libs/digital-payments/src/checkout/dp-checkout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/facade/dp-checkout-payment.service.ts
+++ b/integration-libs/digital-payments/src/checkout/facade/dp-checkout-payment.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/facade/dp-local-storage.service.ts
+++ b/integration-libs/digital-payments/src/checkout/facade/dp-local-storage.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/facade/index.ts
+++ b/integration-libs/digital-payments/src/checkout/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/index.ts
+++ b/integration-libs/digital-payments/src/checkout/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/models/augmented.model.ts
+++ b/integration-libs/digital-payments/src/checkout/models/augmented.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/models/dp-checkout.model.ts
+++ b/integration-libs/digital-payments/src/checkout/models/dp-checkout.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/checkout/models/index.ts
+++ b/integration-libs/digital-payments/src/checkout/models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/digital-payments.module.ts
+++ b/integration-libs/digital-payments/src/digital-payments.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/test.ts
+++ b/integration-libs/digital-payments/src/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/digital-payments/src/utils/dp-constants.ts
+++ b/integration-libs/digital-payments/src/utils/dp-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/assets/public_api.ts
+++ b/integration-libs/epd-visualization/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/assets/translations/en/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/assets/translations/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/assets/translations/translations.ts
+++ b/integration-libs/epd-visualization/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/epd-visualization-components.module.ts
+++ b/integration-libs/epd-visualization/components/epd-visualization-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/public_api.ts
+++ b/integration-libs/epd-visualization/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/model/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/model/visual-picking-product-list-item.model.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/model/visual-picking-product-list-item.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/index.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/index.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/models/index.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/models/navigation-mode.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/navigation-mode.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/models/node-content-type.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/node-content-type.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/models/scene-load-info.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/scene-load-info.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/models/scene-load-state.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/scene-load-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/models/selection-display-mode.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/selection-display-mode.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/models/selection-mode.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/selection-mode.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/models/visualization-load-info.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/visualization-load-info.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/models/zoom-to.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/zoom-to.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/index.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/index.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.component.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.module.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.service.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/index.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.component.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.module.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.module.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.service.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/index.ts
+++ b/integration-libs/epd-visualization/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/scene/converters.ts
+++ b/integration-libs/epd-visualization/core/connectors/scene/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/scene/index.ts
+++ b/integration-libs/epd-visualization/core/connectors/scene/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/scene/nodes-response.ts
+++ b/integration-libs/epd-visualization/core/connectors/scene/nodes-response.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/scene/scene.adapter.ts
+++ b/integration-libs/epd-visualization/core/connectors/scene/scene.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/scene/scene.connector.ts
+++ b/integration-libs/epd-visualization/core/connectors/scene/scene.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/visualization/converters.ts
+++ b/integration-libs/epd-visualization/core/connectors/visualization/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/visualization/index.ts
+++ b/integration-libs/epd-visualization/core/connectors/visualization/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/visualization/lookup-visualizations-response.ts
+++ b/integration-libs/epd-visualization/core/connectors/visualization/lookup-visualizations-response.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/visualization/visualization.adapter.ts
+++ b/integration-libs/epd-visualization/core/connectors/visualization/visualization.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/connectors/visualization/visualization.connector.ts
+++ b/integration-libs/epd-visualization/core/connectors/visualization/visualization.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/epd-visualization-core.module.ts
+++ b/integration-libs/epd-visualization/core/epd-visualization-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/public_api.ts
+++ b/integration-libs/epd-visualization/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/services/index.ts
+++ b/integration-libs/epd-visualization/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/index.ts
+++ b/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/scene-node-to-product-lookup.service.ts
+++ b/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/scene-node-to-product-lookup.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/services/visualization-lookup/index.ts
+++ b/integration-libs/epd-visualization/core/services/visualization-lookup/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/core/services/visualization-lookup/visualization-lookup.service.ts
+++ b/integration-libs/epd-visualization/core/services/visualization-lookup/visualization-lookup.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/epd-visualization-api/epd-visualization-api.module.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/epd-visualization-api.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/epd-visualization-api/public_api.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/epd-visualization.module.ts
+++ b/integration-libs/epd-visualization/epd-visualization.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/public_api.ts
+++ b/integration-libs/epd-visualization/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/config/epd-visualization-config-validator.ts
+++ b/integration-libs/epd-visualization/root/config/epd-visualization-config-validator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/config/epd-visualization-config.ts
+++ b/integration-libs/epd-visualization/root/config/epd-visualization-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/config/epd-visualization-default-config.ts
+++ b/integration-libs/epd-visualization/root/config/epd-visualization-default-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/config/index.ts
+++ b/integration-libs/epd-visualization/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/epd-visualization-root.module.ts
+++ b/integration-libs/epd-visualization/root/epd-visualization-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/feature-name.ts
+++ b/integration-libs/epd-visualization/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/models/index.ts
+++ b/integration-libs/epd-visualization/root/models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/models/usage-ids/index.ts
+++ b/integration-libs/epd-visualization/root/models/usage-ids/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/models/usage-ids/usage-id-definition.ts
+++ b/integration-libs/epd-visualization/root/models/usage-ids/usage-id-definition.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/models/usage-ids/usage-id.ts
+++ b/integration-libs/epd-visualization/root/models/usage-ids/usage-id.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/models/visualizations/content-type.ts
+++ b/integration-libs/epd-visualization/root/models/visualizations/content-type.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/models/visualizations/index.ts
+++ b/integration-libs/epd-visualization/root/models/visualizations/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/models/visualizations/visualization-info.ts
+++ b/integration-libs/epd-visualization/root/models/visualizations/visualization-info.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/public_api.ts
+++ b/integration-libs/epd-visualization/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
+++ b/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/util/event-listener-utils.ts
+++ b/integration-libs/epd-visualization/root/util/event-listener-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/util/index.ts
+++ b/integration-libs/epd-visualization/root/util/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/root/util/url-utils.ts
+++ b/integration-libs/epd-visualization/root/util/url-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/index.ts
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/setup-jest.ts
+++ b/integration-libs/epd-visualization/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/epd-visualization/test.ts
+++ b/integration-libs/epd-visualization/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/order/config/default-omf-config.ts
+++ b/integration-libs/omf/order/config/default-omf-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/order/config/omf-config.ts
+++ b/integration-libs/omf/order/config/omf-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/order/occ-omf-order-history.adapter.ts
+++ b/integration-libs/omf/order/occ-omf-order-history.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/order/omf-order-history.service.ts
+++ b/integration-libs/omf/order/omf-order-history.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/order/omf-order.module.ts
+++ b/integration-libs/omf/order/omf-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/order/public_api.ts
+++ b/integration-libs/omf/order/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/public_api.ts
+++ b/integration-libs/omf/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/root/feature-name.ts
+++ b/integration-libs/omf/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/root/model/index.ts
+++ b/integration-libs/omf/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/root/model/omf-configuration.ts
+++ b/integration-libs/omf/root/model/omf-configuration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/root/omf-root.module.ts
+++ b/integration-libs/omf/root/omf-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/root/public_api.ts
+++ b/integration-libs/omf/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/schematics/add-omf/index.ts
+++ b/integration-libs/omf/schematics/add-omf/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/setup-jest.ts
+++ b/integration-libs/omf/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/omf/test.ts
+++ b/integration-libs/omf/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/components/opf-base-components.module.ts
+++ b/integration-libs/opf/base/components/opf-base-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/components/opf-error-modal/default-opf-error-modal.layout.config.ts
+++ b/integration-libs/opf/base/components/opf-error-modal/default-opf-error-modal.layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/components/opf-error-modal/index.ts
+++ b/integration-libs/opf/base/components/opf-error-modal/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.component.ts
+++ b/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.module.ts
+++ b/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.service.ts
+++ b/integration-libs/opf/base/components/opf-error-modal/opf-error-modal.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/components/public_api.ts
+++ b/integration-libs/opf/base/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/connectors/index.ts
+++ b/integration-libs/opf/base/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/connectors/opf-base.adapter.ts
+++ b/integration-libs/opf/base/core/connectors/opf-base.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/connectors/opf-base.connector.ts
+++ b/integration-libs/opf/base/core/connectors/opf-base.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/facade/facade-providers.ts
+++ b/integration-libs/opf/base/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/facade/index.ts
+++ b/integration-libs/opf/base/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/facade/opf-base.service.ts
+++ b/integration-libs/opf/base/core/facade/opf-base.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/opf-base-core.module.ts
+++ b/integration-libs/opf/base/core/opf-base-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/public_api.ts
+++ b/integration-libs/opf/base/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/services/index.ts
+++ b/integration-libs/opf/base/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/services/opf-endpoints.service.ts
+++ b/integration-libs/opf/base/core/services/opf-endpoints.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/tokens/index.ts
+++ b/integration-libs/opf/base/core/tokens/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/core/tokens/tokens.ts
+++ b/integration-libs/opf/base/core/tokens/tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/opf-api/adapters/index.ts
+++ b/integration-libs/opf/base/opf-api/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
+++ b/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/opf-api/config/default-opf-api-base-config.ts
+++ b/integration-libs/opf/base/opf-api/config/default-opf-api-base-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/opf-api/model/index.ts
+++ b/integration-libs/opf/base/opf-api/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/opf-api/model/opf-api-base-endpoints.model.ts
+++ b/integration-libs/opf/base/opf-api/model/opf-api-base-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/opf-api/opf-api-base.module.ts
+++ b/integration-libs/opf/base/opf-api/opf-api-base.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/opf-api/public_api.ts
+++ b/integration-libs/opf/base/opf-api/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/opf-base.module.ts
+++ b/integration-libs/opf/base/opf-base.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/public_api.ts
+++ b/integration-libs/opf/base/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/config/constants.ts
+++ b/integration-libs/opf/base/root/config/constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/config/default-opf-config.ts
+++ b/integration-libs/opf/base/root/config/default-opf-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/config/index.ts
+++ b/integration-libs/opf/base/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/config/opf-api-config.ts
+++ b/integration-libs/opf/base/root/config/opf-api-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/config/opf-config.ts
+++ b/integration-libs/opf/base/root/config/opf-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/events/index.ts
+++ b/integration-libs/opf/base/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/events/opf-event.listener.ts
+++ b/integration-libs/opf/base/root/events/opf-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/events/opf-event.module.ts
+++ b/integration-libs/opf/base/root/events/opf-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/facade/index.ts
+++ b/integration-libs/opf/base/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/facade/opf-base.facade.ts
+++ b/integration-libs/opf/base/root/facade/opf-base.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/feature-name.ts
+++ b/integration-libs/opf/base/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/model/augmented-core.model.ts
+++ b/integration-libs/opf/base/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/model/index.ts
+++ b/integration-libs/opf/base/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/model/opf-api-backend-config.model.ts
+++ b/integration-libs/opf/base/root/model/opf-api-backend-config.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/model/opf-api-endpoint.model.ts
+++ b/integration-libs/opf/base/root/model/opf-api-endpoint.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/model/opf-api-endpoints.model.ts
+++ b/integration-libs/opf/base/root/model/opf-api-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/model/opf-base.model.ts
+++ b/integration-libs/opf/base/root/model/opf-base.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/model/opf-error-dialog.model.ts
+++ b/integration-libs/opf/base/root/model/opf-error-dialog.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/model/opf-metadata-store.model.ts
+++ b/integration-libs/opf/base/root/model/opf-metadata-store.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/opf-base-root.module.ts
+++ b/integration-libs/opf/base/root/opf-base-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/public_api.ts
+++ b/integration-libs/opf/base/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/services/index.ts
+++ b/integration-libs/opf/base/root/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/services/opf-global-message.service.ts
+++ b/integration-libs/opf/base/root/services/opf-global-message.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/services/opf-metadata-state-persistence.service.ts
+++ b/integration-libs/opf/base/root/services/opf-metadata-state-persistence.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/services/opf-metadata-store.service.ts
+++ b/integration-libs/opf/base/root/services/opf-metadata-store.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
+++ b/integration-libs/opf/base/root/services/opf-resource-loader.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/assets/public_api.ts
+++ b/integration-libs/opf/checkout/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/assets/translations/en/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/assets/translations/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/assets/translations/translations.ts
+++ b/integration-libs/opf/checkout/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/get-address-card-content.pipe.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/get-address-card-content.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.module.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-components.module.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/index.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.module.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/index.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.module.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payments/index.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payments/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.module.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/index.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/opf-checkout-terms-and-conditions-alert.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/opf-checkout-terms-and-conditions-alert.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/opf-checkout-terms-and-conditions-alert.module.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/opf-checkout-terms-and-conditions-alert.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/components/public_api.ts
+++ b/integration-libs/opf/checkout/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/opf-checkout.module.ts
+++ b/integration-libs/opf/checkout/opf-checkout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/public_api.ts
+++ b/integration-libs/opf/checkout/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/root/config/default-opf-checkout-b2b-config.ts
+++ b/integration-libs/opf/checkout/root/config/default-opf-checkout-b2b-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/root/config/default-opf-checkout-config.ts
+++ b/integration-libs/opf/checkout/root/config/default-opf-checkout-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/root/config/default-opf-checkout-routing-config.ts
+++ b/integration-libs/opf/checkout/root/config/default-opf-checkout-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/root/config/index.ts
+++ b/integration-libs/opf/checkout/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/root/feature-name.ts
+++ b/integration-libs/opf/checkout/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/root/model/index.ts
+++ b/integration-libs/opf/checkout/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/root/model/opf-checkout.model.ts
+++ b/integration-libs/opf/checkout/root/model/opf-checkout.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/root/opf-checkout-root.module.ts
+++ b/integration-libs/opf/checkout/root/opf-checkout-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/checkout/root/public_api.ts
+++ b/integration-libs/opf/checkout/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/components/opf-cta-components.module.ts
+++ b/integration-libs/opf/cta/components/opf-cta-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/components/opf-cta-element/index.ts
+++ b/integration-libs/opf/cta/components/opf-cta-element/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/components/opf-cta-element/opf-cta-element.component.ts
+++ b/integration-libs/opf/cta/components/opf-cta-element/opf-cta-element.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/components/opf-cta-element/opf-cta-element.module.ts
+++ b/integration-libs/opf/cta/components/opf-cta-element/opf-cta-element.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/components/opf-cta-scripts/index.ts
+++ b/integration-libs/opf/cta/components/opf-cta-scripts/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/components/opf-cta-scripts/opf-cta-scripts.component.ts
+++ b/integration-libs/opf/cta/components/opf-cta-scripts/opf-cta-scripts.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/components/opf-cta-scripts/opf-cta-scripts.module.ts
+++ b/integration-libs/opf/cta/components/opf-cta-scripts/opf-cta-scripts.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/components/opf-cta-scripts/opf-cta-scripts.service.ts
+++ b/integration-libs/opf/cta/components/opf-cta-scripts/opf-cta-scripts.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/components/public_api.ts
+++ b/integration-libs/opf/cta/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/connectors/index.ts
+++ b/integration-libs/opf/cta/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/connectors/opf-cta.adapter.ts
+++ b/integration-libs/opf/cta/core/connectors/opf-cta.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/connectors/opf-cta.connector.ts
+++ b/integration-libs/opf/cta/core/connectors/opf-cta.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/facade/facade-providers.ts
+++ b/integration-libs/opf/cta/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/facade/index.ts
+++ b/integration-libs/opf/cta/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/facade/opf-cta.service.ts
+++ b/integration-libs/opf/cta/core/facade/opf-cta.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/opf-cta-core.module.ts
+++ b/integration-libs/opf/cta/core/opf-cta-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/public_api.ts
+++ b/integration-libs/opf/cta/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/services/index.ts
+++ b/integration-libs/opf/cta/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/services/opf-dynamic-cta.service.ts
+++ b/integration-libs/opf/cta/core/services/opf-dynamic-cta.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/services/opf-static-cta.service.ts
+++ b/integration-libs/opf/cta/core/services/opf-static-cta.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/tokens/index.ts
+++ b/integration-libs/opf/cta/core/tokens/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/core/tokens/tokens.ts
+++ b/integration-libs/opf/cta/core/tokens/tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/opf-api/adapters/index.ts
+++ b/integration-libs/opf/cta/opf-api/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/opf-api/adapters/opf-api-cta.adapter.ts
+++ b/integration-libs/opf/cta/opf-api/adapters/opf-api-cta.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/opf-api/config/default-opf-api-cta-config.ts
+++ b/integration-libs/opf/cta/opf-api/config/default-opf-api-cta-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/opf-api/model/index.ts
+++ b/integration-libs/opf/cta/opf-api/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/opf-api/model/opf-api-cta-endpoints.model.ts
+++ b/integration-libs/opf/cta/opf-api/model/opf-api-cta-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/opf-api/opf-api-cta.module.ts
+++ b/integration-libs/opf/cta/opf-api/opf-api-cta.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/opf-api/public_api.ts
+++ b/integration-libs/opf/cta/opf-api/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/opf-cta.module.ts
+++ b/integration-libs/opf/cta/opf-cta.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/public_api.ts
+++ b/integration-libs/opf/cta/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/root/facade/index.ts
+++ b/integration-libs/opf/cta/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/root/facade/opf-cta.facade.ts
+++ b/integration-libs/opf/cta/root/facade/opf-cta.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/root/feature-name.ts
+++ b/integration-libs/opf/cta/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/root/model/index.ts
+++ b/integration-libs/opf/cta/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/root/model/opf-cta.model.ts
+++ b/integration-libs/opf/cta/root/model/opf-cta.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/root/opf-cta-root.module.ts
+++ b/integration-libs/opf/cta/root/opf-cta-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/cta/root/public_api.ts
+++ b/integration-libs/opf/cta/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/core/facade/facade-providers.ts
+++ b/integration-libs/opf/global-functions/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/core/facade/index.ts
+++ b/integration-libs/opf/global-functions/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/core/facade/opf-global-functions.service.ts
+++ b/integration-libs/opf/global-functions/core/facade/opf-global-functions.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/core/opf-global-functions-core.module.ts
+++ b/integration-libs/opf/global-functions/core/opf-global-functions-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/core/public_api.ts
+++ b/integration-libs/opf/global-functions/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/opf-global-functions.module.ts
+++ b/integration-libs/opf/global-functions/opf-global-functions.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/public_api.ts
+++ b/integration-libs/opf/global-functions/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/root/facade/index.ts
+++ b/integration-libs/opf/global-functions/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/root/facade/opf-global-functions.facade.ts
+++ b/integration-libs/opf/global-functions/root/facade/opf-global-functions.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/root/feature-name.ts
+++ b/integration-libs/opf/global-functions/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/root/model/index.ts
+++ b/integration-libs/opf/global-functions/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/root/model/opf-global-functions.model.ts
+++ b/integration-libs/opf/global-functions/root/model/opf-global-functions.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/root/opf-global-functions-root.module.ts
+++ b/integration-libs/opf/global-functions/root/opf-global-functions-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/global-functions/root/public_api.ts
+++ b/integration-libs/opf/global-functions/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/order/model/index.ts
+++ b/integration-libs/opf/order/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/order/model/opf-order.model.ts
+++ b/integration-libs/opf/order/model/opf-order.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/order/opf-occ-order-normalizer.ts
+++ b/integration-libs/opf/order/opf-occ-order-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/order/opf-order.module.ts
+++ b/integration-libs/opf/order/opf-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/order/public_api.ts
+++ b/integration-libs/opf/order/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/assets/public_api.ts
+++ b/integration-libs/opf/payment/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/assets/translations/en/index.ts
+++ b/integration-libs/opf/payment/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/assets/translations/index.ts
+++ b/integration-libs/opf/payment/assets/translations/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/assets/translations/translations.ts
+++ b/integration-libs/opf/payment/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/connectors/converters.ts
+++ b/integration-libs/opf/payment/core/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/connectors/index.ts
+++ b/integration-libs/opf/payment/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/connectors/opf-payment.adapter.ts
+++ b/integration-libs/opf/payment/core/connectors/opf-payment.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/connectors/opf-payment.connector.ts
+++ b/integration-libs/opf/payment/core/connectors/opf-payment.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/facade/facade-providers.ts
+++ b/integration-libs/opf/payment/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/facade/index.ts
+++ b/integration-libs/opf/payment/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/facade/opf-payment.service.ts
+++ b/integration-libs/opf/payment/core/facade/opf-payment.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/opf-payment-core.module.ts
+++ b/integration-libs/opf/payment/core/opf-payment-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/public_api.ts
+++ b/integration-libs/opf/payment/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/services/index.ts
+++ b/integration-libs/opf/payment/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/services/opf-payment-error-handler.service.ts
+++ b/integration-libs/opf/payment/core/services/opf-payment-error-handler.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.ts
+++ b/integration-libs/opf/payment/core/services/opf-payment-hosted-fields.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/tokens/index.ts
+++ b/integration-libs/opf/payment/core/tokens/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/tokens/tokens.ts
+++ b/integration-libs/opf/payment/core/tokens/tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/utils/index.ts
+++ b/integration-libs/opf/payment/core/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/core/utils/opf-payment-utils.ts
+++ b/integration-libs/opf/payment/core/utils/opf-payment-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/opf-api/adapters/index.ts
+++ b/integration-libs/opf/payment/opf-api/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/opf-api/adapters/opf-api-payment.adapter.ts
+++ b/integration-libs/opf/payment/opf-api/adapters/opf-api-payment.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/opf-api/config/default-opf-api-payment-config.ts
+++ b/integration-libs/opf/payment/opf-api/config/default-opf-api-payment-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/opf-api/model/index.ts
+++ b/integration-libs/opf/payment/opf-api/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/opf-api/model/opf-api-payment-endpoints.model.ts
+++ b/integration-libs/opf/payment/opf-api/model/opf-api-payment-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/opf-api/opf-api-payment.module.ts
+++ b/integration-libs/opf/payment/opf-api/opf-api-payment.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/opf-api/public_api.ts
+++ b/integration-libs/opf/payment/opf-api/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/opf-payment.module.ts
+++ b/integration-libs/opf/payment/opf-payment.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/public_api.ts
+++ b/integration-libs/opf/payment/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/components/opf-payment-method-details/index.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-method-details/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/components/opf-payment-method-details/opf-payment-method-details.component.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-method-details/opf-payment-method-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/components/opf-payment-method-details/opf-payment-method-details.module.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-method-details/opf-payment-method-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/index.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.module.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.service.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/config/default-opf-payment-routing-config.ts
+++ b/integration-libs/opf/payment/root/config/default-opf-payment-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/config/index.ts
+++ b/integration-libs/opf/payment/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/facade/index.ts
+++ b/integration-libs/opf/payment/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/facade/opf-payment.facade.ts
+++ b/integration-libs/opf/payment/root/facade/opf-payment.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/feature-name.ts
+++ b/integration-libs/opf/payment/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/model/augmented-core.model.ts
+++ b/integration-libs/opf/payment/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/model/index.ts
+++ b/integration-libs/opf/payment/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/model/opf-payment-error.model.ts
+++ b/integration-libs/opf/payment/root/model/opf-payment-error.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/model/opf-payment-verification.model.ts
+++ b/integration-libs/opf/payment/root/model/opf-payment-verification.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/model/opf-payment.model.ts
+++ b/integration-libs/opf/payment/root/model/opf-payment.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/opf-payment-root.module.ts
+++ b/integration-libs/opf/payment/root/opf-payment-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/payment/root/public_api.ts
+++ b/integration-libs/opf/payment/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/public_api.ts
+++ b/integration-libs/opf/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay-session/apple-pay-session-wrapper.service.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay-session/apple-pay-session-wrapper.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay-session/apple-pay-session.orchestrator.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay-session/apple-pay-session.orchestrator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay-session/index.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay-session/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.component.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.module.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.service.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/apple-pay.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/index.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/apple-pay/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.component.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.module.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.service.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/google-pay.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/index.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/google-pay/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/index.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/opf-quick-buy-buttons.component.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/opf-quick-buy-buttons.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/opf-quick-buy-buttons.module.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/opf-quick-buy-buttons.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/opf-quick-buy-buttons.service.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/opf-quick-buy-buttons.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-components.module.ts
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/components/public_api.ts
+++ b/integration-libs/opf/quick-buy/components/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/connectors/index.ts
+++ b/integration-libs/opf/quick-buy/core/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/connectors/opf-quick-buy.adapter.ts
+++ b/integration-libs/opf/quick-buy/core/connectors/opf-quick-buy.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/connectors/opf-quick-buy.connector.ts
+++ b/integration-libs/opf/quick-buy/core/connectors/opf-quick-buy.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/facade/facade-providers.ts
+++ b/integration-libs/opf/quick-buy/core/facade/facade-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/facade/index.ts
+++ b/integration-libs/opf/quick-buy/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/facade/opf-quick-buy.service.ts
+++ b/integration-libs/opf/quick-buy/core/facade/opf-quick-buy.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/opf-quick-buy-core.module.ts
+++ b/integration-libs/opf/quick-buy/core/opf-quick-buy-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/public_api.ts
+++ b/integration-libs/opf/quick-buy/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/services/index.ts
+++ b/integration-libs/opf/quick-buy/core/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/services/opf-quick-buy-transaction.service.ts
+++ b/integration-libs/opf/quick-buy/core/services/opf-quick-buy-transaction.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/tokens/index.ts
+++ b/integration-libs/opf/quick-buy/core/tokens/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/core/tokens/tokens.ts
+++ b/integration-libs/opf/quick-buy/core/tokens/tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/opf-api/adapters/index.ts
+++ b/integration-libs/opf/quick-buy/opf-api/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/opf-api/adapters/opf-api-quick-buy.adapter.ts
+++ b/integration-libs/opf/quick-buy/opf-api/adapters/opf-api-quick-buy.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/opf-api/config/default-opf-api-quick-buy-config.ts
+++ b/integration-libs/opf/quick-buy/opf-api/config/default-opf-api-quick-buy-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/opf-api/model/index.ts
+++ b/integration-libs/opf/quick-buy/opf-api/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/opf-api/model/opf-api-quick-buy-endpoints.model.ts
+++ b/integration-libs/opf/quick-buy/opf-api/model/opf-api-quick-buy-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/opf-api/opf-api-quick-buy.module.ts
+++ b/integration-libs/opf/quick-buy/opf-api/opf-api-quick-buy.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/opf-api/public_api.ts
+++ b/integration-libs/opf/quick-buy/opf-api/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/opf-quick-buy.module.ts
+++ b/integration-libs/opf/quick-buy/opf-quick-buy.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/public_api.ts
+++ b/integration-libs/opf/quick-buy/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/config/default-opf-quick-buy-config.ts
+++ b/integration-libs/opf/quick-buy/root/config/default-opf-quick-buy-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/config/index.ts
+++ b/integration-libs/opf/quick-buy/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/config/opf-quick-buy-config.ts
+++ b/integration-libs/opf/quick-buy/root/config/opf-quick-buy-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/facade/index.ts
+++ b/integration-libs/opf/quick-buy/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/facade/opf-quick-buy.facade.ts
+++ b/integration-libs/opf/quick-buy/root/facade/opf-quick-buy.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/feature-name.ts
+++ b/integration-libs/opf/quick-buy/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/model/augmented-opf-quick-buy.model.ts
+++ b/integration-libs/opf/quick-buy/root/model/augmented-opf-quick-buy.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/model/constants.ts
+++ b/integration-libs/opf/quick-buy/root/model/constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/model/index.ts
+++ b/integration-libs/opf/quick-buy/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/model/opf-apple-pay.model.ts
+++ b/integration-libs/opf/quick-buy/root/model/opf-apple-pay.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/model/opf-quick-buy.model.ts
+++ b/integration-libs/opf/quick-buy/root/model/opf-quick-buy.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/opf-quick-buy-root.module.ts
+++ b/integration-libs/opf/quick-buy/root/opf-quick-buy-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/quick-buy/root/public_api.ts
+++ b/integration-libs/opf/quick-buy/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/schematics/add-opf/index.ts
+++ b/integration-libs/opf/schematics/add-opf/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/setup-jest.ts
+++ b/integration-libs/opf/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opf/test.ts
+++ b/integration-libs/opf/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/public_api.ts
+++ b/integration-libs/opps/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/config/default-opps-config.ts
+++ b/integration-libs/opps/root/config/default-opps-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/config/index.ts
+++ b/integration-libs/opps/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/config/opps-config.ts
+++ b/integration-libs/opps/root/config/opps-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/coupon-codes/http-interceptors/index.ts
+++ b/integration-libs/opps/root/coupon-codes/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/coupon-codes/http-interceptors/occ-opps-coupon-codes.interceptor.ts
+++ b/integration-libs/opps/root/coupon-codes/http-interceptors/occ-opps-coupon-codes.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/coupon-codes/index.ts
+++ b/integration-libs/opps/root/coupon-codes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/coupon-codes/opps-coupon-codes.module.ts
+++ b/integration-libs/opps/root/coupon-codes/opps-coupon-codes.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/coupon-codes/opps-coupon-codes.service.ts
+++ b/integration-libs/opps/root/coupon-codes/opps-coupon-codes.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/login-required/index.ts
+++ b/integration-libs/opps/root/login-required/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/login-required/opps-login-required.guard.ts
+++ b/integration-libs/opps/root/login-required/opps-login-required.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/login-required/opps-login-required.module.ts
+++ b/integration-libs/opps/root/login-required/opps-login-required.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/opps-root.module.ts
+++ b/integration-libs/opps/root/opps-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/root/public_api.ts
+++ b/integration-libs/opps/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/schematics/add-opps/index.ts
+++ b/integration-libs/opps/schematics/add-opps/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/setup-jest.ts
+++ b/integration-libs/opps/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/opps/test.ts
+++ b/integration-libs/opps/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/assets/public_api.ts
+++ b/integration-libs/s4-service/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/assets/translations/en/index.ts
+++ b/integration-libs/s4-service/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/assets/translations/translations.ts
+++ b/integration-libs/s4-service/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/checkout-delivery-mode/service-checkout-delivery-mode.component.ts
+++ b/integration-libs/s4-service/checkout/components/checkout-delivery-mode/service-checkout-delivery-mode.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/checkout-delivery-mode/service-checkout-delivery-mode.module.ts
+++ b/integration-libs/s4-service/checkout/components/checkout-delivery-mode/service-checkout-delivery-mode.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.component.ts
+++ b/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.module.ts
+++ b/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/checkout-service-details/checkout-service-details.component.ts
+++ b/integration-libs/s4-service/checkout/components/checkout-service-details/checkout-service-details.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/checkout-service-details/checkout-service-details.module.ts
+++ b/integration-libs/s4-service/checkout/components/checkout-service-details/checkout-service-details.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/guards/checkout-service-order-steps-set.guard.ts
+++ b/integration-libs/s4-service/checkout/components/guards/checkout-service-order-steps-set.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/guards/index.ts
+++ b/integration-libs/s4-service/checkout/components/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/index.ts
+++ b/integration-libs/s4-service/checkout/components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/components/s4-service-checkout-component.module.ts
+++ b/integration-libs/s4-service/checkout/components/s4-service-checkout-component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/core/connector/checkout-service-details.adapter.ts
+++ b/integration-libs/s4-service/checkout/core/connector/checkout-service-details.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/core/connector/checkout-service-details.connector.ts
+++ b/integration-libs/s4-service/checkout/core/connector/checkout-service-details.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/core/connector/index.ts
+++ b/integration-libs/s4-service/checkout/core/connector/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/core/facade/checkout-service-details.service.ts
+++ b/integration-libs/s4-service/checkout/core/facade/checkout-service-details.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/core/facade/index.ts
+++ b/integration-libs/s4-service/checkout/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/core/index.ts
+++ b/integration-libs/s4-service/checkout/core/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/core/s4-service-checkout-core.module.ts
+++ b/integration-libs/s4-service/checkout/core/s4-service-checkout-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/occ/adapter/index.ts
+++ b/integration-libs/s4-service/checkout/occ/adapter/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/occ/adapter/occ-checkout-service-details.adapter.ts
+++ b/integration-libs/s4-service/checkout/occ/adapter/occ-checkout-service-details.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/occ/config/default-occ-checkout-s4-service-config.ts
+++ b/integration-libs/s4-service/checkout/occ/config/default-occ-checkout-s4-service-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/occ/index.ts
+++ b/integration-libs/s4-service/checkout/occ/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/occ/s4-service-checkout-occ.module.ts
+++ b/integration-libs/s4-service/checkout/occ/s4-service-checkout-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/public_api.ts
+++ b/integration-libs/s4-service/checkout/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/checkout/s4-service-checkout.module.ts
+++ b/integration-libs/s4-service/checkout/s4-service-checkout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/cancel-service-order-headline/cancel-service-order-headline.component.ts
+++ b/integration-libs/s4-service/order/components/cancel-service-order-headline/cancel-service-order-headline.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/cancel-service-order-headline/cancel-service-order-headline.module.ts
+++ b/integration-libs/s4-service/order/components/cancel-service-order-headline/cancel-service-order-headline.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/cancel-service-order/cancel-service-order.component.ts
+++ b/integration-libs/s4-service/order/components/cancel-service-order/cancel-service-order.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/cancel-service-order/cancel-service-order.module.ts
+++ b/integration-libs/s4-service/order/components/cancel-service-order/cancel-service-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/guards/cancel-service-order.guard.ts
+++ b/integration-libs/s4-service/order/components/guards/cancel-service-order.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/guards/index.ts
+++ b/integration-libs/s4-service/order/components/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/guards/service-order.guard.ts
+++ b/integration-libs/s4-service/order/components/guards/service-order.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/index.ts
+++ b/integration-libs/s4-service/order/components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/order-summary/service-details-card.component.ts
+++ b/integration-libs/s4-service/order/components/order-summary/service-details-card.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/order-summary/service-details-card.module.ts
+++ b/integration-libs/s4-service/order/components/order-summary/service-details-card.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/order-summary/service-order-overview-component.service.ts
+++ b/integration-libs/s4-service/order/components/order-summary/service-order-overview-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/reschedule-service-order/reschedule-service-order.component.ts
+++ b/integration-libs/s4-service/order/components/reschedule-service-order/reschedule-service-order.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/reschedule-service-order/reschedule-service-order.module.ts
+++ b/integration-libs/s4-service/order/components/reschedule-service-order/reschedule-service-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/s4-service-components.module.ts
+++ b/integration-libs/s4-service/order/components/s4-service-components.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.ts
+++ b/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.module.ts
+++ b/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/connector/cancel-service-order.adapter.ts
+++ b/integration-libs/s4-service/order/core/connector/cancel-service-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/connector/cancel-service-order.connector.ts
+++ b/integration-libs/s4-service/order/core/connector/cancel-service-order.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/connector/index.ts
+++ b/integration-libs/s4-service/order/core/connector/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/connector/reschedule-service-order.adapter.ts
+++ b/integration-libs/s4-service/order/core/connector/reschedule-service-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/connector/reschedule-service-order.connector.ts
+++ b/integration-libs/s4-service/order/core/connector/reschedule-service-order.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/facade/cancel-service-order.service.ts
+++ b/integration-libs/s4-service/order/core/facade/cancel-service-order.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/facade/index.ts
+++ b/integration-libs/s4-service/order/core/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/facade/reschedule-service-order.service.ts
+++ b/integration-libs/s4-service/order/core/facade/reschedule-service-order.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/index.ts
+++ b/integration-libs/s4-service/order/core/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/core/s4-service-order-core.module.ts
+++ b/integration-libs/s4-service/order/core/s4-service-order-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/occ/adapters/index.ts
+++ b/integration-libs/s4-service/order/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/occ/adapters/occ-cancel-service-order.adapter.ts
+++ b/integration-libs/s4-service/order/occ/adapters/occ-cancel-service-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/occ/adapters/occ-reschedule-service-order.adapter.ts
+++ b/integration-libs/s4-service/order/occ/adapters/occ-reschedule-service-order.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/occ/config/default-occ-s4-service-config.ts
+++ b/integration-libs/s4-service/order/occ/config/default-occ-s4-service-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/occ/index.ts
+++ b/integration-libs/s4-service/order/occ/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/occ/model/index.ts
+++ b/integration-libs/s4-service/order/occ/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/occ/model/occ-s4-service-endpoints.model.ts
+++ b/integration-libs/s4-service/order/occ/model/occ-s4-service-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/occ/s4-service-order-occ.module.ts
+++ b/integration-libs/s4-service/order/occ/s4-service-order-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/public_api.ts
+++ b/integration-libs/s4-service/order/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/order/s4-service-order.module.ts
+++ b/integration-libs/s4-service/order/s4-service-order.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/public_api.ts
+++ b/integration-libs/s4-service/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/config/default-service-delivery-mode-config.ts
+++ b/integration-libs/s4-service/root/config/default-service-delivery-mode-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/config/default-service-details-checkout-config.ts
+++ b/integration-libs/s4-service/root/config/default-service-details-checkout-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/config/default-service-orders-routing-config.ts
+++ b/integration-libs/s4-service/root/config/default-service-orders-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/config/index.ts
+++ b/integration-libs/s4-service/root/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/events/checkout-service-details-event.listener.ts
+++ b/integration-libs/s4-service/root/events/checkout-service-details-event.listener.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/events/checkout-service-details-event.module.ts
+++ b/integration-libs/s4-service/root/events/checkout-service-details-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/events/checkout-service-details.events.ts
+++ b/integration-libs/s4-service/root/events/checkout-service-details.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/events/index.ts
+++ b/integration-libs/s4-service/root/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/facade/cancel-service-order.facade.ts
+++ b/integration-libs/s4-service/root/facade/cancel-service-order.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/facade/checkout-service-details.facade.ts
+++ b/integration-libs/s4-service/root/facade/checkout-service-details.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/facade/checkout-service-schedule-picker.service.ts
+++ b/integration-libs/s4-service/root/facade/checkout-service-schedule-picker.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/facade/index.ts
+++ b/integration-libs/s4-service/root/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/facade/reschedule-service-order.facade.ts
+++ b/integration-libs/s4-service/root/facade/reschedule-service-order.facade.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/feature-name.ts
+++ b/integration-libs/s4-service/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/model/augmented-types.model.ts
+++ b/integration-libs/s4-service/root/model/augmented-types.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/model/checkout-service-details.model.ts
+++ b/integration-libs/s4-service/root/model/checkout-service-details.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/model/index.ts
+++ b/integration-libs/s4-service/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/public_api.ts
+++ b/integration-libs/s4-service/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/root/s4-service-root.module.ts
+++ b/integration-libs/s4-service/root/s4-service-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/s4-service.module.ts
+++ b/integration-libs/s4-service/s4-service.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/schematics/add-s4-service/index.ts
+++ b/integration-libs/s4-service/schematics/add-s4-service/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/setup-jest.ts
+++ b/integration-libs/s4-service/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4-service/test.ts
+++ b/integration-libs/s4-service/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/assets/public_api.ts
+++ b/integration-libs/s4om/assets/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/assets/translations/en/index.ts
+++ b/integration-libs/s4om/assets/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/assets/translations/translations.ts
+++ b/integration-libs/s4om/assets/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/index.ts
+++ b/integration-libs/s4om/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/public_api.ts
+++ b/integration-libs/s4om/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/root/components/schedule-lines/schedule-lines.component.ts
+++ b/integration-libs/s4om/root/components/schedule-lines/schedule-lines.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/root/components/schedule-lines/schedule-lines.module.ts
+++ b/integration-libs/s4om/root/components/schedule-lines/schedule-lines.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/root/feature-name.ts
+++ b/integration-libs/s4om/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/root/model/augmented-core.model.ts
+++ b/integration-libs/s4om/root/model/augmented-core.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/root/model/index.ts
+++ b/integration-libs/s4om/root/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/root/model/schedule-line.model.ts
+++ b/integration-libs/s4om/root/model/schedule-line.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/root/public_api.ts
+++ b/integration-libs/s4om/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/root/s4om-root.module.ts
+++ b/integration-libs/s4om/root/s4om-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/s4om.module.ts
+++ b/integration-libs/s4om/s4om.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/schematics/add-s4om/index.ts
+++ b/integration-libs/s4om/schematics/add-s4om/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/schematics/constants.ts
+++ b/integration-libs/s4om/schematics/constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/setup-jest.ts
+++ b/integration-libs/s4om/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/s4om/test.ts
+++ b/integration-libs/s4om/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/public_api.ts
+++ b/integration-libs/segment-refs/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/root/config/default-segment-refs-config.ts
+++ b/integration-libs/segment-refs/root/config/default-segment-refs-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/root/config/segment-refs-config.ts
+++ b/integration-libs/segment-refs/root/config/segment-refs-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/root/feature-name.ts
+++ b/integration-libs/segment-refs/root/feature-name.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/root/http-interceptors/index.ts
+++ b/integration-libs/segment-refs/root/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/root/http-interceptors/occ-segment-refs.interceptor.ts
+++ b/integration-libs/segment-refs/root/http-interceptors/occ-segment-refs.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/root/public_api.ts
+++ b/integration-libs/segment-refs/root/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/root/segment-refs-root.module.ts
+++ b/integration-libs/segment-refs/root/segment-refs-root.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/schematics/add-segment-refs/index.ts
+++ b/integration-libs/segment-refs/schematics/add-segment-refs/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/setup-jest.ts
+++ b/integration-libs/segment-refs/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/integration-libs/segment-refs/test.ts
+++ b/integration-libs/segment-refs/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/assets/generate-translations-properties-2-ts.ts
+++ b/projects/assets/generate-translations-properties-2-ts.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/assets/generate-translations-ts-2-json.ts
+++ b/projects/assets/generate-translations-ts-2-json.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/assets/generate-translations-ts-2-properties.ts
+++ b/projects/assets/generate-translations-ts-2-properties.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/assets/src/public_api.ts
+++ b/projects/assets/src/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/assets/src/translations/en/index.ts
+++ b/projects/assets/src/translations/en/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/assets/src/translations/translation-chunks-config.ts
+++ b/projects/assets/src/translations/translation-chunks-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/assets/src/translations/translations.ts
+++ b/projects/assets/src/translations/translations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/public_api.ts
+++ b/projects/core/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/anonymous-consents.module.ts
+++ b/projects/core/src/anonymous-consents/anonymous-consents.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/config/anonymous-consents-config.ts
+++ b/projects/core/src/anonymous-consents/config/anonymous-consents-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/config/default-anonymous-consents-config.ts
+++ b/projects/core/src/anonymous-consents/config/default-anonymous-consents-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/connectors/anonymous-consent-templates.adapter.ts
+++ b/projects/core/src/anonymous-consents/connectors/anonymous-consent-templates.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/connectors/anonymous-consent-templates.connector.ts
+++ b/projects/core/src/anonymous-consents/connectors/anonymous-consent-templates.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/connectors/converters.ts
+++ b/projects/core/src/anonymous-consents/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/connectors/index.ts
+++ b/projects/core/src/anonymous-consents/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/facade/anonymous-consents.service.ts
+++ b/projects/core/src/anonymous-consents/facade/anonymous-consents.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/facade/index.ts
+++ b/projects/core/src/anonymous-consents/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/http-interceptors/anonymous-consents-interceptor.ts
+++ b/projects/core/src/anonymous-consents/http-interceptors/anonymous-consents-interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/http-interceptors/index.ts
+++ b/projects/core/src/anonymous-consents/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/index.ts
+++ b/projects/core/src/anonymous-consents/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/services/anonymous-consents-state-persistence.service.ts
+++ b/projects/core/src/anonymous-consents/services/anonymous-consents-state-persistence.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/services/index.ts
+++ b/projects/core/src/anonymous-consents/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/actions/anonymous-consents-group.ts
+++ b/projects/core/src/anonymous-consents/store/actions/anonymous-consents-group.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/actions/anonymous-consents.action.ts
+++ b/projects/core/src/anonymous-consents/store/actions/anonymous-consents.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/actions/index.ts
+++ b/projects/core/src/anonymous-consents/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/anonymous-consents-state.ts
+++ b/projects/core/src/anonymous-consents/store/anonymous-consents-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/anonymous-consents-store.module.ts
+++ b/projects/core/src/anonymous-consents/store/anonymous-consents-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/effects/anonymous-consents.effect.ts
+++ b/projects/core/src/anonymous-consents/store/effects/anonymous-consents.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/effects/index.ts
+++ b/projects/core/src/anonymous-consents/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/index.ts
+++ b/projects/core/src/anonymous-consents/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/reducers/anonymous-consents-banner.reducer.ts
+++ b/projects/core/src/anonymous-consents/store/reducers/anonymous-consents-banner.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/reducers/anonymous-consents-update.reducer.ts
+++ b/projects/core/src/anonymous-consents/store/reducers/anonymous-consents-update.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/reducers/anonymous-consents.reducer.ts
+++ b/projects/core/src/anonymous-consents/store/reducers/anonymous-consents.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/reducers/index.ts
+++ b/projects/core/src/anonymous-consents/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/selectors/anonymous-consent-templates.selectors.ts
+++ b/projects/core/src/anonymous-consents/store/selectors/anonymous-consent-templates.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/selectors/anonymous-consent-ui.selectors.ts
+++ b/projects/core/src/anonymous-consents/store/selectors/anonymous-consent-ui.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/selectors/anonymous-consents-group.selectors.ts
+++ b/projects/core/src/anonymous-consents/store/selectors/anonymous-consents-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/selectors/anonymous-consents.selectors.ts
+++ b/projects/core/src/anonymous-consents/store/selectors/anonymous-consents.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/selectors/feature.selector.ts
+++ b/projects/core/src/anonymous-consents/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/anonymous-consents/store/selectors/index.ts
+++ b/projects/core/src/anonymous-consents/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/auth.module.ts
+++ b/projects/core/src/auth/auth.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/client-auth.module.ts
+++ b/projects/core/src/auth/client-auth/client-auth.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/http-interceptors/client-token.interceptor.ts
+++ b/projects/core/src/auth/client-auth/http-interceptors/client-token.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/http-interceptors/index.ts
+++ b/projects/core/src/auth/client-auth/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/index.ts
+++ b/projects/core/src/auth/client-auth/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/models/client-token.model.ts
+++ b/projects/core/src/auth/client-auth/models/client-token.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/services/client-authentication-token.service.ts
+++ b/projects/core/src/auth/client-auth/services/client-authentication-token.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/services/client-error-handling.service.ts
+++ b/projects/core/src/auth/client-auth/services/client-error-handling.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/services/client-token.service.ts
+++ b/projects/core/src/auth/client-auth/services/client-token.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/services/index.ts
+++ b/projects/core/src/auth/client-auth/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/actions/client-token-group.actions.ts
+++ b/projects/core/src/auth/client-auth/store/actions/client-token-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/actions/client-token.action.ts
+++ b/projects/core/src/auth/client-auth/store/actions/client-token.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/actions/index.ts
+++ b/projects/core/src/auth/client-auth/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/client-auth-state.ts
+++ b/projects/core/src/auth/client-auth/store/client-auth-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/client-auth-store.module.ts
+++ b/projects/core/src/auth/client-auth/store/client-auth-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/effects/client-token.effect.ts
+++ b/projects/core/src/auth/client-auth/store/effects/client-token.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/effects/index.ts
+++ b/projects/core/src/auth/client-auth/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/index.ts
+++ b/projects/core/src/auth/client-auth/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/reducers/index.ts
+++ b/projects/core/src/auth/client-auth/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/selectors/client-token-group.selectors.ts
+++ b/projects/core/src/auth/client-auth/store/selectors/client-token-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/selectors/client-token.selectors.ts
+++ b/projects/core/src/auth/client-auth/store/selectors/client-token.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/selectors/feature.selector.ts
+++ b/projects/core/src/auth/client-auth/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/client-auth/store/selectors/index.ts
+++ b/projects/core/src/auth/client-auth/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/index.ts
+++ b/projects/core/src/auth/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/config/auth-config.ts
+++ b/projects/core/src/auth/user-auth/config/auth-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/config/base-url-config-validator.ts
+++ b/projects/core/src/auth/user-auth/config/base-url-config-validator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/config/default-auth-config.ts
+++ b/projects/core/src/auth/user-auth/config/default-auth-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/events/index.ts
+++ b/projects/core/src/auth/user-auth/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/events/user-auth-event.builder.ts
+++ b/projects/core/src/auth/user-auth/events/user-auth-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/events/user-auth-event.module.ts
+++ b/projects/core/src/auth/user-auth/events/user-auth-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/events/user-auth.events.ts
+++ b/projects/core/src/auth/user-auth/events/user-auth.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/facade/auth.service.ts
+++ b/projects/core/src/auth/user-auth/facade/auth.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/facade/index.ts
+++ b/projects/core/src/auth/user-auth/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/facade/user-id.service.ts
+++ b/projects/core/src/auth/user-auth/facade/user-id.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/guards/auth.guard.ts
+++ b/projects/core/src/auth/user-auth/guards/auth.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/guards/index.ts
+++ b/projects/core/src/auth/user-auth/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/guards/not-auth.guard.ts
+++ b/projects/core/src/auth/user-auth/guards/not-auth.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/http-interceptors/auth.interceptor.ts
+++ b/projects/core/src/auth/user-auth/http-interceptors/auth.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/http-interceptors/index.ts
+++ b/projects/core/src/auth/user-auth/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/http-interceptors/token-revocation.interceptor.ts
+++ b/projects/core/src/auth/user-auth/http-interceptors/token-revocation.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/index.ts
+++ b/projects/core/src/auth/user-auth/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/models/auth-token.model.ts
+++ b/projects/core/src/auth/user-auth/models/auth-token.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/models/oauth-flow.ts
+++ b/projects/core/src/auth/user-auth/models/oauth-flow.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/models/oauth-try-login-response.ts
+++ b/projects/core/src/auth/user-auth/models/oauth-try-login-response.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/auth-config.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-config.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/auth-flow-routes.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-flow-routes.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/auth-multisite-isolation.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-multisite-isolation.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/auth-redirect-storage.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-redirect-storage.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/auth-redirect.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-redirect.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/auth-state-persistence.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-state-persistence.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/auth-storage.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-storage.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/index.ts
+++ b/projects/core/src/auth/user-auth/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
+++ b/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/store/actions/auth-group.actions.ts
+++ b/projects/core/src/auth/user-auth/store/actions/auth-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/store/actions/index.ts
+++ b/projects/core/src/auth/user-auth/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/store/actions/login-logout.action.ts
+++ b/projects/core/src/auth/user-auth/store/actions/login-logout.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/user-auth.module.ts
+++ b/projects/core/src/auth/user-auth/user-auth.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/utils/index.ts
+++ b/projects/core/src/auth/user-auth/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/auth/user-auth/utils/oauth-constants.ts
+++ b/projects/core/src/auth/user-auth/utils/oauth-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/base-core.module.ts
+++ b/projects/core/src/base-core.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/checkout/connectors/checkout/converters.ts
+++ b/projects/core/src/checkout/connectors/checkout/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/checkout/connectors/checkout/index.ts
+++ b/projects/core/src/checkout/connectors/checkout/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/checkout/connectors/index.ts
+++ b/projects/core/src/checkout/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/checkout/connectors/payment/converters.ts
+++ b/projects/core/src/checkout/connectors/payment/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/checkout/connectors/payment/index.ts
+++ b/projects/core/src/checkout/connectors/payment/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/checkout/index.ts
+++ b/projects/core/src/checkout/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/cms.module.ts
+++ b/projects/core/src/cms/cms.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/config/cms-config.ts
+++ b/projects/core/src/cms/config/cms-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/config/cms-structure.config.ts
+++ b/projects/core/src/cms/config/cms-structure.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/config/default-cms-config.ts
+++ b/projects/core/src/cms/config/default-cms-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/config/index.ts
+++ b/projects/core/src/cms/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/connectors/component/cms-component.adapter.ts
+++ b/projects/core/src/cms/connectors/component/cms-component.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/connectors/component/cms-component.connector.ts
+++ b/projects/core/src/cms/connectors/component/cms-component.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/connectors/component/converters.ts
+++ b/projects/core/src/cms/connectors/component/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/connectors/component/index.ts
+++ b/projects/core/src/cms/connectors/component/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/connectors/index.ts
+++ b/projects/core/src/cms/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/connectors/page/cms-page.adapter.ts
+++ b/projects/core/src/cms/connectors/page/cms-page.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/connectors/page/cms-page.connector.ts
+++ b/projects/core/src/cms/connectors/page/cms-page.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/connectors/page/converters.ts
+++ b/projects/core/src/cms/connectors/page/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/connectors/page/index.ts
+++ b/projects/core/src/cms/connectors/page/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/decorators/component-decorator.ts
+++ b/projects/core/src/cms/decorators/component-decorator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/decorators/index.ts
+++ b/projects/core/src/cms/decorators/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/decorators/slot-decorator.ts
+++ b/projects/core/src/cms/decorators/slot-decorator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/facade/cms.service.ts
+++ b/projects/core/src/cms/facade/cms.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/facade/index.ts
+++ b/projects/core/src/cms/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/facade/page-meta.service.ts
+++ b/projects/core/src/cms/facade/page-meta.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/index.ts
+++ b/projects/core/src/cms/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/model/content-slot-component-data.model.ts
+++ b/projects/core/src/cms/model/content-slot-component-data.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/model/content-slot-data.model.ts
+++ b/projects/core/src/cms/model/content-slot-data.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/model/node-item.model.ts
+++ b/projects/core/src/cms/model/node-item.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/model/page.model.ts
+++ b/projects/core/src/cms/model/page.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/base-page-meta.resolver.ts
+++ b/projects/core/src/cms/page/base-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/config/default-page-meta.config.ts
+++ b/projects/core/src/cms/page/config/default-page-meta.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/config/index.ts
+++ b/projects/core/src/cms/page/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/config/page-meta.config.ts
+++ b/projects/core/src/cms/page/config/page-meta.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/content-page-meta.resolver.ts
+++ b/projects/core/src/cms/page/content-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/index.ts
+++ b/projects/core/src/cms/page/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/page-meta.module.ts
+++ b/projects/core/src/cms/page/page-meta.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/page-meta.resolver.ts
+++ b/projects/core/src/cms/page/page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/page.resolvers.ts
+++ b/projects/core/src/cms/page/page.resolvers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/routing/default-route-page-meta.resolver.ts
+++ b/projects/core/src/cms/page/routing/default-route-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/routing/index.ts
+++ b/projects/core/src/cms/page/routing/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/routing/page-link.service.ts
+++ b/projects/core/src/cms/page/routing/page-link.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/routing/route-page-meta.model.ts
+++ b/projects/core/src/cms/page/routing/route-page-meta.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/page/routing/routing-page-meta.resolver.ts
+++ b/projects/core/src/cms/page/routing/routing-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/services/cms-structure-config.service.ts
+++ b/projects/core/src/cms/services/cms-structure-config.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/services/dynamic-attribute.service.ts
+++ b/projects/core/src/cms/services/dynamic-attribute.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/services/index.ts
+++ b/projects/core/src/cms/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/actions/cms-group.actions.ts
+++ b/projects/core/src/cms/store/actions/cms-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/actions/components.action.ts
+++ b/projects/core/src/cms/store/actions/components.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/actions/index.ts
+++ b/projects/core/src/cms/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/actions/navigation-entry-item.action.ts
+++ b/projects/core/src/cms/store/actions/navigation-entry-item.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/actions/page.action.ts
+++ b/projects/core/src/cms/store/actions/page.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/cms-state.ts
+++ b/projects/core/src/cms/store/cms-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/cms-store.module.ts
+++ b/projects/core/src/cms/store/cms-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/effects/components.effect.ts
+++ b/projects/core/src/cms/store/effects/components.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/effects/index.ts
+++ b/projects/core/src/cms/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/effects/navigation-entry-item.effect.ts
+++ b/projects/core/src/cms/store/effects/navigation-entry-item.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/effects/page.effect.ts
+++ b/projects/core/src/cms/store/effects/page.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/index.ts
+++ b/projects/core/src/cms/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/reducers/components.reducer.ts
+++ b/projects/core/src/cms/store/reducers/components.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/reducers/index.ts
+++ b/projects/core/src/cms/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/reducers/navigation-entry-item.reducer.ts
+++ b/projects/core/src/cms/store/reducers/navigation-entry-item.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/reducers/page-data.reducer.ts
+++ b/projects/core/src/cms/store/reducers/page-data.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/reducers/page-index.reducer.ts
+++ b/projects/core/src/cms/store/reducers/page-index.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/selectors/cms-group.selectors.ts
+++ b/projects/core/src/cms/store/selectors/cms-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/selectors/components.selectors.ts
+++ b/projects/core/src/cms/store/selectors/components.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/selectors/feature.selectors.ts
+++ b/projects/core/src/cms/store/selectors/feature.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/selectors/index.ts
+++ b/projects/core/src/cms/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/selectors/navigation-entry-item.selectors.ts
+++ b/projects/core/src/cms/store/selectors/navigation-entry-item.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/store/selectors/page.selectors.ts
+++ b/projects/core/src/cms/store/selectors/page.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cms/utils/cms-utils.ts
+++ b/projects/core/src/cms/utils/cms-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-factory.ts
+++ b/projects/core/src/config/config-factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-initializer/config-initializer.module.ts
+++ b/projects/core/src/config/config-initializer/config-initializer.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-initializer/config-initializer.service.ts
+++ b/projects/core/src/config/config-initializer/config-initializer.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-initializer/config-initializer.ts
+++ b/projects/core/src/config/config-initializer/config-initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-initializer/index.ts
+++ b/projects/core/src/config/config-initializer/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-providers.ts
+++ b/projects/core/src/config/config-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-tokens.ts
+++ b/projects/core/src/config/config-tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-validator/config-validator.module.ts
+++ b/projects/core/src/config/config-validator/config-validator.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-validator/config-validator.ts
+++ b/projects/core/src/config/config-validator/config-validator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config-validator/index.ts
+++ b/projects/core/src/config/config-validator/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/config.module.ts
+++ b/projects/core/src/config/config.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/index.ts
+++ b/projects/core/src/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/services/configuration.service.ts
+++ b/projects/core/src/config/services/configuration.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/test-config.module.ts
+++ b/projects/core/src/config/test-config.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/utils/deep-merge.ts
+++ b/projects/core/src/config/utils/deep-merge.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/utils/get-cookie.ts
+++ b/projects/core/src/config/utils/get-cookie.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/config/utils/string-template.ts
+++ b/projects/core/src/config/utils/string-template.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cost-center/connectors/cost-center/converters.ts
+++ b/projects/core/src/cost-center/connectors/cost-center/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cost-center/connectors/cost-center/index.ts
+++ b/projects/core/src/cost-center/connectors/cost-center/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cost-center/connectors/index.ts
+++ b/projects/core/src/cost-center/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cost-center/cost-center.module.ts
+++ b/projects/core/src/cost-center/cost-center.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/cost-center/index.ts
+++ b/projects/core/src/cost-center/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/cx-error-handler.ts
+++ b/projects/core/src/error-handling/cx-error-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/effects-error-handler/cx-error-handler.effect.ts
+++ b/projects/core/src/error-handling/effects-error-handler/cx-error-handler.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/effects-error-handler/effects-error-handler.module.ts
+++ b/projects/core/src/error-handling/effects-error-handler/effects-error-handler.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/effects-error-handler/error-action.service.ts
+++ b/projects/core/src/error-handling/effects-error-handler/error-action.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/effects-error-handler/error-action.ts
+++ b/projects/core/src/error-handling/effects-error-handler/error-action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/effects-error-handler/index.ts
+++ b/projects/core/src/error-handling/effects-error-handler/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/error-handling.module.ts
+++ b/projects/core/src/error-handling/error-handling.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.ts
+++ b/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/http-error-handler/http-error-handler.module.ts
+++ b/projects/core/src/error-handling/http-error-handler/http-error-handler.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/http-error-handler/index.ts
+++ b/projects/core/src/error-handling/http-error-handler/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/http-error-handler/outbound-http-error.ts
+++ b/projects/core/src/error-handling/http-error-handler/outbound-http-error.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/index.ts
+++ b/projects/core/src/error-handling/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/multi-error-handler/index.ts
+++ b/projects/core/src/error-handling/multi-error-handler/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/multi-error-handler/logging-error-handler.ts
+++ b/projects/core/src/error-handling/multi-error-handler/logging-error-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/multi-error-handler/multi-error-handler.ts
+++ b/projects/core/src/error-handling/multi-error-handler/multi-error-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/error-handling/multi-error-handler/provide-multi-error-handler.ts
+++ b/projects/core/src/error-handling/multi-error-handler/provide-multi-error-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/event/cx-event.ts
+++ b/projects/core/src/event/cx-event.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/event/event.service.ts
+++ b/projects/core/src/event/event.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/event/index.ts
+++ b/projects/core/src/event/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/event/utils/merging-subject.ts
+++ b/projects/core/src/event/utils/merging-subject.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/config/features-config.ts
+++ b/projects/core/src/features-config/config/features-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/directives/feature-level.directive.ts
+++ b/projects/core/src/features-config/directives/feature-level.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/directives/feature.directive.ts
+++ b/projects/core/src/features-config/directives/feature.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/feature-toggles/feature-toggles-providers.ts
+++ b/projects/core/src/features-config/feature-toggles/feature-toggles-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/feature-toggles/feature-toggles-tokens.ts
+++ b/projects/core/src/features-config/feature-toggles/feature-toggles-tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/feature-toggles/index.ts
+++ b/projects/core/src/features-config/feature-toggles/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/feature-toggles/populate-feature-toggles-to-features-config.ts
+++ b/projects/core/src/features-config/feature-toggles/populate-feature-toggles-to-features-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/features-config.module.ts
+++ b/projects/core/src/features-config/features-config.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/index.ts
+++ b/projects/core/src/features-config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/services/feature-config.service.ts
+++ b/projects/core/src/features-config/services/feature-config.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/services/feature-styles.service.ts
+++ b/projects/core/src/features-config/services/feature-styles.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/utils/feature-config-utils.ts
+++ b/projects/core/src/features-config/utils/feature-config-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/features-config/utils/use-feature-styles.ts
+++ b/projects/core/src/features-config/utils/use-feature-styles.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/config/default-global-message-config.ts
+++ b/projects/core/src/global-message/config/default-global-message-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/config/global-message-config.ts
+++ b/projects/core/src/global-message/config/global-message-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/facade/global-message.service.ts
+++ b/projects/core/src/global-message/facade/global-message.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/facade/index.ts
+++ b/projects/core/src/global-message/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/global-message.module.ts
+++ b/projects/core/src/global-message/global-message.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/bad-gateway/bad-gateway.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/bad-gateway/bad-gateway.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/bad-request/bad-request.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/bad-request/bad-request.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/conflict/conflict.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/conflict/conflict.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/forbidden/forbidden.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/forbidden/forbidden.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/gateway/gateway-timeout.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/gateway/gateway-timeout.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/http-error.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/http-error.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/index.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/internal-server/internal-server.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/internal-server/internal-server.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/not-found/not-found.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/not-found/not-found.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/handlers/unknown-error/unknown-error.handler.ts
+++ b/projects/core/src/global-message/http-interceptors/handlers/unknown-error/unknown-error.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/http-error.interceptor.ts
+++ b/projects/core/src/global-message/http-interceptors/http-error.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/http-interceptors/index.ts
+++ b/projects/core/src/global-message/http-interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/index.ts
+++ b/projects/core/src/global-message/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/models/global-message.model.ts
+++ b/projects/core/src/global-message/models/global-message.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/models/response-status.model.ts
+++ b/projects/core/src/global-message/models/response-status.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/actions/global-message-group.actions.ts
+++ b/projects/core/src/global-message/store/actions/global-message-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/actions/global-message.actions.ts
+++ b/projects/core/src/global-message/store/actions/global-message.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/actions/index.ts
+++ b/projects/core/src/global-message/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/effects/global-message.effect.ts
+++ b/projects/core/src/global-message/store/effects/global-message.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/effects/index.ts
+++ b/projects/core/src/global-message/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/global-message-state.ts
+++ b/projects/core/src/global-message/store/global-message-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/global-message-store.module.ts
+++ b/projects/core/src/global-message/store/global-message-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/index.ts
+++ b/projects/core/src/global-message/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/reducers/global-message.reducer.ts
+++ b/projects/core/src/global-message/store/reducers/global-message.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/reducers/index.ts
+++ b/projects/core/src/global-message/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/selectors/feature.selector.ts
+++ b/projects/core/src/global-message/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/selectors/global-message-group.selectors.ts
+++ b/projects/core/src/global-message/store/selectors/global-message-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/selectors/global-message.selectors.ts
+++ b/projects/core/src/global-message/store/selectors/global-message.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/global-message/store/selectors/index.ts
+++ b/projects/core/src/global-message/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/http/http-timeout/default-http-timeout.config.ts
+++ b/projects/core/src/http/http-timeout/default-http-timeout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/http/http-timeout/http-timeout.config.ts
+++ b/projects/core/src/http/http-timeout/http-timeout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/http/http-timeout/http-timeout.interceptor.ts
+++ b/projects/core/src/http/http-timeout/http-timeout.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/http/http-timeout/http-timeout.module.ts
+++ b/projects/core/src/http/http-timeout/http-timeout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/http/http-timeout/index.ts
+++ b/projects/core/src/http/http-timeout/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/http/http.module.ts
+++ b/projects/core/src/http/http.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/http/index.ts
+++ b/projects/core/src/http/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/config/default-i18n-config.ts
+++ b/projects/core/src/i18n/config/default-i18n-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/config/i18n-config-initializer.ts
+++ b/projects/core/src/i18n/config/i18n-config-initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/config/i18n-config.ts
+++ b/projects/core/src/i18n/config/i18n-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/date.pipe.ts
+++ b/projects/core/src/i18n/date.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18n.module.ts
+++ b/projects/core/src/i18n/i18n.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-backend/i18next-backend.initializer.ts
+++ b/projects/core/src/i18n/i18next/i18next-backend/i18next-backend.initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-backend/i18next-backend.providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-backend/i18next-backend.providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-backend/i18next-backend.service.ts
+++ b/projects/core/src/i18n/i18next/i18next-backend/i18next-backend.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-backend/i18next-http-backend-client.ts
+++ b/projects/core/src/i18n/i18next/i18next-backend/i18next-http-backend-client.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-backend/i18next-http-backend.initializer.ts
+++ b/projects/core/src/i18n/i18next/i18next-backend/i18next-http-backend.initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-backend/i18next-resources-to-backend.initializer.ts
+++ b/projects/core/src/i18n/i18next/i18next-backend/i18next-resources-to-backend.initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-backend/index.ts
+++ b/projects/core/src/i18n/i18next/i18next-backend/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-initializer.ts
+++ b/projects/core/src/i18n/i18next/i18next-initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-instance.ts
+++ b/projects/core/src/i18n/i18next/i18next-instance.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-plugins/i18next-logger-plugin.ts
+++ b/projects/core/src/i18n/i18next/i18next-plugins/i18next-logger-plugin.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-providers.ts
+++ b/projects/core/src/i18n/i18next/i18next-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/i18next-translation.service.ts
+++ b/projects/core/src/i18n/i18next/i18next-translation.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/i18next/index.ts
+++ b/projects/core/src/i18n/i18next/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/index.ts
+++ b/projects/core/src/i18n/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/numeric.pipe.ts
+++ b/projects/core/src/i18n/numeric.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/testing/i18n-testing.module.ts
+++ b/projects/core/src/i18n/testing/i18n-testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/testing/index.ts
+++ b/projects/core/src/i18n/testing/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/testing/mock-date.pipe.ts
+++ b/projects/core/src/i18n/testing/mock-date.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/testing/mock-translate.pipe.ts
+++ b/projects/core/src/i18n/testing/mock-translate.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/testing/mock-translate.ts
+++ b/projects/core/src/i18n/testing/mock-translate.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/testing/mock-translation.service.ts
+++ b/projects/core/src/i18n/testing/mock-translation.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/translatable.ts
+++ b/projects/core/src/i18n/translatable.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/translate.pipe.ts
+++ b/projects/core/src/i18n/translate.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/translation-chunk.service.ts
+++ b/projects/core/src/i18n/translation-chunk.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/translation-resources.ts
+++ b/projects/core/src/i18n/translation-resources.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/i18n/translation.service.ts
+++ b/projects/core/src/i18n/translation.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/events/index.ts
+++ b/projects/core/src/lazy-loading/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/events/module-initialized-event.ts
+++ b/projects/core/src/lazy-loading/events/module-initialized-event.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/facade-factory/facade-descriptor.ts
+++ b/projects/core/src/lazy-loading/facade-factory/facade-descriptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/facade-factory/facade-factory.service.ts
+++ b/projects/core/src/lazy-loading/facade-factory/facade-factory.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/facade-factory/facade-factory.ts
+++ b/projects/core/src/lazy-loading/facade-factory/facade-factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/facade-factory/index.ts
+++ b/projects/core/src/lazy-loading/facade-factory/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/feature-modules.service.ts
+++ b/projects/core/src/lazy-loading/feature-modules.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/index.ts
+++ b/projects/core/src/lazy-loading/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/lazy-loading.module.ts
+++ b/projects/core/src/lazy-loading/lazy-loading.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/lazy-modules.service.ts
+++ b/projects/core/src/lazy-loading/lazy-modules.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/tokens.ts
+++ b/projects/core/src/lazy-loading/tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/lazy-loading/unified-injector.ts
+++ b/projects/core/src/lazy-loading/unified-injector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/logger/index.ts
+++ b/projects/core/src/logger/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/logger/logger.service.ts
+++ b/projects/core/src/logger/logger.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/address.model.ts
+++ b/projects/core/src/model/address.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/cms.model.ts
+++ b/projects/core/src/model/cms.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/consent.model.ts
+++ b/projects/core/src/model/consent.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/customer-coupon.model.ts
+++ b/projects/core/src/model/customer-coupon.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/image.model.ts
+++ b/projects/core/src/model/image.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/index.ts
+++ b/projects/core/src/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/misc.model.ts
+++ b/projects/core/src/model/misc.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/notification-preference.model.ts
+++ b/projects/core/src/model/notification-preference.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/org-unit.model.ts
+++ b/projects/core/src/model/org-unit.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/payment.model.ts
+++ b/projects/core/src/model/payment.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/point-of-service.model.ts
+++ b/projects/core/src/model/point-of-service.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/product-interest.model.ts
+++ b/projects/core/src/model/product-interest.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/product-search.model.ts
+++ b/projects/core/src/model/product-search.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/product.model.ts
+++ b/projects/core/src/model/product.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/scoped-data.ts
+++ b/projects/core/src/model/scoped-data.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/model/unused.model.ts
+++ b/projects/core/src/model/unused.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cms/cms-occ.module.ts
+++ b/projects/core/src/occ/adapters/cms/cms-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cms/converters/index.ts
+++ b/projects/core/src/occ/adapters/cms/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cms/converters/occ-cms-page-normalizer.ts
+++ b/projects/core/src/occ/adapters/cms/converters/occ-cms-page-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cms/index.ts
+++ b/projects/core/src/occ/adapters/cms/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cms/legacy-occ-cms-component.adapter.ts
+++ b/projects/core/src/occ/adapters/cms/legacy-occ-cms-component.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cms/occ-cms-component.adapter.ts
+++ b/projects/core/src/occ/adapters/cms/occ-cms-component.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cms/occ-cms-page.adapter.ts
+++ b/projects/core/src/occ/adapters/cms/occ-cms-page.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cost-center/converters/index.ts
+++ b/projects/core/src/occ/adapters/cost-center/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cost-center/converters/occ-cost-center-list-normalizer.ts
+++ b/projects/core/src/occ/adapters/cost-center/converters/occ-cost-center-list-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cost-center/converters/occ-cost-center-normalizer.ts
+++ b/projects/core/src/occ/adapters/cost-center/converters/occ-cost-center-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cost-center/converters/occ-cost-center-serializer.ts
+++ b/projects/core/src/occ/adapters/cost-center/converters/occ-cost-center-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cost-center/cost-center-occ.module.ts
+++ b/projects/core/src/occ/adapters/cost-center/cost-center-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cost-center/default-occ-cost-centers-config.ts
+++ b/projects/core/src/occ/adapters/cost-center/default-occ-cost-centers-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/cost-center/index.ts
+++ b/projects/core/src/occ/adapters/cost-center/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/index.ts
+++ b/projects/core/src/occ/adapters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/converters/index.ts
+++ b/projects/core/src/occ/adapters/product/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/converters/occ-product-references-list-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-references-list-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/occ-product-search-page-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/converters/product-image-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/product-image-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/converters/product-name-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/product-name-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/converters/product-reference-normalizer.ts
+++ b/projects/core/src/occ/adapters/product/converters/product-reference-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/default-occ-product-config.ts
+++ b/projects/core/src/occ/adapters/product/default-occ-product-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/index.ts
+++ b/projects/core/src/occ/adapters/product/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/occ-product-availability-adapter.ts
+++ b/projects/core/src/occ/adapters/product/occ-product-availability-adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/occ-product-references.adapter.ts
+++ b/projects/core/src/occ/adapters/product/occ-product-references.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/occ-product-reviews.adapter.ts
+++ b/projects/core/src/occ/adapters/product/occ-product-reviews.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/occ-product-search.adapter.ts
+++ b/projects/core/src/occ/adapters/product/occ-product-search.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/occ-product.adapter.ts
+++ b/projects/core/src/occ/adapters/product/occ-product.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/product-occ-config.ts
+++ b/projects/core/src/occ/adapters/product/product-occ-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/product/product-occ.module.ts
+++ b/projects/core/src/occ/adapters/product/product-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/site-context/converters/base-site-normalizer.ts
+++ b/projects/core/src/occ/adapters/site-context/converters/base-site-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/site-context/converters/index.ts
+++ b/projects/core/src/occ/adapters/site-context/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/site-context/default-occ-site-context-config.ts
+++ b/projects/core/src/occ/adapters/site-context/default-occ-site-context-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/site-context/index.ts
+++ b/projects/core/src/occ/adapters/site-context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/site-context/occ-site.adapter.ts
+++ b/projects/core/src/occ/adapters/site-context/occ-site.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/site-context/site-context-occ.module.ts
+++ b/projects/core/src/occ/adapters/site-context/site-context-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/site-context/site-context.interceptor.ts
+++ b/projects/core/src/occ/adapters/site-context/site-context.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/converters/anonymous-consents-normalizer.ts
+++ b/projects/core/src/occ/adapters/user/converters/anonymous-consents-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/converters/index.ts
+++ b/projects/core/src/occ/adapters/user/converters/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/converters/occ-address-list-normalizer.ts
+++ b/projects/core/src/occ/adapters/user/converters/occ-address-list-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/converters/occ-user-interests-normalizer.ts
+++ b/projects/core/src/occ/adapters/user/converters/occ-user-interests-normalizer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/default-occ-user-config.ts
+++ b/projects/core/src/occ/adapters/user/default-occ-user-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/index.ts
+++ b/projects/core/src/occ/adapters/user/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/occ-anonymous-consent-templates.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-anonymous-consent-templates.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/occ-customer-coupon.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-customer-coupon.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/occ-user-address.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-address.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/occ-user-consent.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-consent.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/occ-user-cost-centers.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-cost-centers.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/occ-user-interests.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-interests.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/occ-user-notification-preference.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-notification-preference.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/occ-user-payment.adapter.ts
+++ b/projects/core/src/occ/adapters/user/occ-user-payment.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/unit-test.helper.ts
+++ b/projects/core/src/occ/adapters/user/unit-test.helper.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/adapters/user/user-occ.module.ts
+++ b/projects/core/src/occ/adapters/user/user-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/base-occ.module.ts
+++ b/projects/core/src/occ/base-occ.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/config/config-from-meta-tag-factory.ts
+++ b/projects/core/src/occ/config/config-from-meta-tag-factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/config/default-occ-config.ts
+++ b/projects/core/src/occ/config/default-occ-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/config/loading-scopes-config.ts
+++ b/projects/core/src/occ/config/loading-scopes-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/config/meta-tag-config.module.ts
+++ b/projects/core/src/occ/config/meta-tag-config.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/config/occ-config-validator.ts
+++ b/projects/core/src/occ/config/occ-config-validator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/config/occ-config.ts
+++ b/projects/core/src/occ/config/occ-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/index.ts
+++ b/projects/core/src/occ/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/interceptors/index.ts
+++ b/projects/core/src/occ/interceptors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/interceptors/with-credentials.interceptor.ts
+++ b/projects/core/src/occ/interceptors/with-credentials.interceptor.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/occ-models/index.ts
+++ b/projects/core/src/occ/occ-models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/occ-models/occ-endpoints.model.ts
+++ b/projects/core/src/occ/occ-models/occ-endpoints.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/occ-models/occ.models.ts
+++ b/projects/core/src/occ/occ-models/occ.models.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/services/index.ts
+++ b/projects/core/src/occ/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/services/loading-scopes.service.ts
+++ b/projects/core/src/occ/services/loading-scopes.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/services/occ-endpoints.service.ts
+++ b/projects/core/src/occ/services/occ-endpoints.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/services/occ-fields.service.ts
+++ b/projects/core/src/occ/services/occ-fields.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/services/occ-requests-optimizer.service.ts
+++ b/projects/core/src/occ/services/occ-requests-optimizer.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/utils/index.ts
+++ b/projects/core/src/occ/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/utils/interceptor-util.ts
+++ b/projects/core/src/occ/utils/interceptor-util.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/utils/occ-constants.ts
+++ b/projects/core/src/occ/utils/occ-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/utils/occ-fields.ts
+++ b/projects/core/src/occ/utils/occ-fields.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/utils/occ-http-token.ts
+++ b/projects/core/src/occ/utils/occ-http-token.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/utils/occ-url-util.ts
+++ b/projects/core/src/occ/utils/occ-url-util.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/occ/utils/occ-user-ids.ts
+++ b/projects/core/src/occ/utils/occ-user-ids.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/index.ts
+++ b/projects/core/src/process/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/process.module.ts
+++ b/projects/core/src/process/process.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/store/index.ts
+++ b/projects/core/src/process/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/store/process-state.ts
+++ b/projects/core/src/process/store/process-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/store/process-store.module.ts
+++ b/projects/core/src/process/store/process-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/store/reducers/index.ts
+++ b/projects/core/src/process/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/store/selectors/feature.selector.ts
+++ b/projects/core/src/process/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/store/selectors/index.ts
+++ b/projects/core/src/process/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/store/selectors/process-group.selectors.ts
+++ b/projects/core/src/process/store/selectors/process-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/process/store/selectors/process.selectors.ts
+++ b/projects/core/src/process/store/selectors/process.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/index.ts
+++ b/projects/core/src/product/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/product/converters.ts
+++ b/projects/core/src/product/connectors/product/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/product/index.ts
+++ b/projects/core/src/product/connectors/product/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/product/prduct-availability.adapter.ts
+++ b/projects/core/src/product/connectors/product/prduct-availability.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/product/product-availability.connector.ts
+++ b/projects/core/src/product/connectors/product/product-availability.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/product/product.adapter.ts
+++ b/projects/core/src/product/connectors/product/product.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/product/product.connector.ts
+++ b/projects/core/src/product/connectors/product/product.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/product/scoped-product-data.ts
+++ b/projects/core/src/product/connectors/product/scoped-product-data.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/references/converters.ts
+++ b/projects/core/src/product/connectors/references/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/references/index.ts
+++ b/projects/core/src/product/connectors/references/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/references/product-references.adapter.ts
+++ b/projects/core/src/product/connectors/references/product-references.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/references/product-references.connector.ts
+++ b/projects/core/src/product/connectors/references/product-references.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/reviews/converters.ts
+++ b/projects/core/src/product/connectors/reviews/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/reviews/index.ts
+++ b/projects/core/src/product/connectors/reviews/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/reviews/product-reviews.adapter.ts
+++ b/projects/core/src/product/connectors/reviews/product-reviews.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/reviews/product-reviews.connector.ts
+++ b/projects/core/src/product/connectors/reviews/product-reviews.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/search/converters.ts
+++ b/projects/core/src/product/connectors/search/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/search/index.ts
+++ b/projects/core/src/product/connectors/search/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/search/product-search.adapter.ts
+++ b/projects/core/src/product/connectors/search/product-search.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/connectors/search/product-search.connector.ts
+++ b/projects/core/src/product/connectors/search/product-search.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/event/index.ts
+++ b/projects/core/src/product/event/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/event/product-event.builder.ts
+++ b/projects/core/src/product/event/product-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/event/product-event.module.ts
+++ b/projects/core/src/product/event/product-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/event/product.events.ts
+++ b/projects/core/src/product/event/product.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/facade/index.ts
+++ b/projects/core/src/product/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/facade/product-availability.service.ts
+++ b/projects/core/src/product/facade/product-availability.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/facade/product-reference.service.ts
+++ b/projects/core/src/product/facade/product-reference.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/facade/product-review.service.ts
+++ b/projects/core/src/product/facade/product-review.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/facade/product-search-by-category.service.ts
+++ b/projects/core/src/product/facade/product-search-by-category.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/facade/product-search-by-code.service.ts
+++ b/projects/core/src/product/facade/product-search-by-code.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/facade/product-search.service.ts
+++ b/projects/core/src/product/facade/product-search.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/facade/product.service.ts
+++ b/projects/core/src/product/facade/product.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/facade/searchbox.service.ts
+++ b/projects/core/src/product/facade/searchbox.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/index.ts
+++ b/projects/core/src/product/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/model/index.ts
+++ b/projects/core/src/product/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/model/product-scope.ts
+++ b/projects/core/src/product/model/product-scope.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/model/search-config.ts
+++ b/projects/core/src/product/model/search-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/product.module.ts
+++ b/projects/core/src/product/product.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/services/category-page-meta.resolver.ts
+++ b/projects/core/src/product/services/category-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/services/coupon-search-page-meta.resolver.ts
+++ b/projects/core/src/product/services/coupon-search-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/services/index.ts
+++ b/projects/core/src/product/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/services/product-loading.service.ts
+++ b/projects/core/src/product/services/product-loading.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/services/product-page-meta.resolver.ts
+++ b/projects/core/src/product/services/product-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/services/search-page-meta.resolver.ts
+++ b/projects/core/src/product/services/search-page-meta.resolver.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/actions/index.ts
+++ b/projects/core/src/product/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/actions/product-group.actions.ts
+++ b/projects/core/src/product/store/actions/product-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/actions/product-references.action.ts
+++ b/projects/core/src/product/store/actions/product-references.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/actions/product-reviews.action.ts
+++ b/projects/core/src/product/store/actions/product-reviews.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/actions/product-search-by-category.action.ts
+++ b/projects/core/src/product/store/actions/product-search-by-category.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/actions/product-search-by-code.action.ts
+++ b/projects/core/src/product/store/actions/product-search-by-code.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/actions/product-search.action.ts
+++ b/projects/core/src/product/store/actions/product-search.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/actions/product.action.ts
+++ b/projects/core/src/product/store/actions/product.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/effects/index.ts
+++ b/projects/core/src/product/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/effects/product-references.effect.ts
+++ b/projects/core/src/product/store/effects/product-references.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/effects/product-reviews.effect.ts
+++ b/projects/core/src/product/store/effects/product-reviews.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/effects/product-search-by-category.effect.ts
+++ b/projects/core/src/product/store/effects/product-search-by-category.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/effects/product-search-by-code.effect.ts
+++ b/projects/core/src/product/store/effects/product-search-by-code.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/effects/product-search.effect.ts
+++ b/projects/core/src/product/store/effects/product-search.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/effects/product.effect.ts
+++ b/projects/core/src/product/store/effects/product.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/index.ts
+++ b/projects/core/src/product/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/product-state.ts
+++ b/projects/core/src/product/store/product-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/product-store.module.ts
+++ b/projects/core/src/product/store/product-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/reducers/index.ts
+++ b/projects/core/src/product/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/reducers/product-references.reducer.ts
+++ b/projects/core/src/product/store/reducers/product-references.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/reducers/product-reviews.reducer.ts
+++ b/projects/core/src/product/store/reducers/product-reviews.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/reducers/product-search.reducer.ts
+++ b/projects/core/src/product/store/reducers/product-search.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/selectors/feature.selector.ts
+++ b/projects/core/src/product/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/selectors/index.ts
+++ b/projects/core/src/product/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/selectors/product-group.selectors.ts
+++ b/projects/core/src/product/store/selectors/product-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/selectors/product-references.selectors.ts
+++ b/projects/core/src/product/store/selectors/product-references.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/selectors/product-reviews.selectors.ts
+++ b/projects/core/src/product/store/selectors/product-reviews.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/selectors/product-search-by-category.selectors.ts
+++ b/projects/core/src/product/store/selectors/product-search-by-category.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/selectors/product-search-by-code.selectors.ts
+++ b/projects/core/src/product/store/selectors/product-search-by-code.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/selectors/product-search.selectors.ts
+++ b/projects/core/src/product/store/selectors/product-search.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/product/store/selectors/product.selectors.ts
+++ b/projects/core/src/product/store/selectors/product.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/config/routing-config.ts
+++ b/projects/core/src/routing/configurable-routes/config/routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/configurable-routes.service.ts
+++ b/projects/core/src/routing/configurable-routes/configurable-routes.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/index.ts
+++ b/projects/core/src/routing/configurable-routes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/routes-config.ts
+++ b/projects/core/src/routing/configurable-routes/routes-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/routing-config.service.ts
+++ b/projects/core/src/routing/configurable-routes/routing-config.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/secure-portal-config/secure-portal-config-initializer.ts
+++ b/projects/core/src/routing/configurable-routes/secure-portal-config/secure-portal-config-initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/index.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/path-utils.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/path-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/product-url.pipe.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/product-url.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/semantic-path.service.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/semantic-path.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/testing/mock-url.pipe.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/testing/mock-url.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/testing/url-testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/url-command.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/url-command.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/url-parsing.service.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/url-parsing.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/url.module.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/url.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/configurable-routes/url-translation/url.pipe.ts
+++ b/projects/core/src/routing/configurable-routes/url-translation/url.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/external-routes/external-routes-config.ts
+++ b/projects/core/src/routing/external-routes/external-routes-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/external-routes/external-routes.guard.ts
+++ b/projects/core/src/routing/external-routes/external-routes.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/external-routes/external-routes.module.ts
+++ b/projects/core/src/routing/external-routes/external-routes.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/external-routes/external-routes.providers.ts
+++ b/projects/core/src/routing/external-routes/external-routes.providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/external-routes/external-routes.service.ts
+++ b/projects/core/src/routing/external-routes/external-routes.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/external-routes/index.ts
+++ b/projects/core/src/routing/external-routes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/facade/routing-params.service.ts
+++ b/projects/core/src/routing/facade/routing-params.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/facade/routing.service.ts
+++ b/projects/core/src/routing/facade/routing.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/index.ts
+++ b/projects/core/src/routing/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/location-initialized-multi/location-initialized-multi.ts
+++ b/projects/core/src/routing/location-initialized-multi/location-initialized-multi.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/models/cms-route.ts
+++ b/projects/core/src/routing/models/cms-route.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/models/page-context.model.ts
+++ b/projects/core/src/routing/models/page-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/protected-routes/index.ts
+++ b/projects/core/src/routing/protected-routes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/protected-routes/protected-routes.guard.ts
+++ b/projects/core/src/routing/protected-routes/protected-routes.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/protected-routes/protected-routes.service.ts
+++ b/projects/core/src/routing/protected-routes/protected-routes.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/routing.module.ts
+++ b/projects/core/src/routing/routing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/services/activated-routes.service.ts
+++ b/projects/core/src/routing/services/activated-routes.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/services/index.ts
+++ b/projects/core/src/routing/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/services/url-matcher.service.ts
+++ b/projects/core/src/routing/services/url-matcher.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/actions/index.ts
+++ b/projects/core/src/routing/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/actions/router.action.ts
+++ b/projects/core/src/routing/store/actions/router.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/actions/routing-group.actions.ts
+++ b/projects/core/src/routing/store/actions/routing-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/effects/index.ts
+++ b/projects/core/src/routing/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/effects/router.effect.ts
+++ b/projects/core/src/routing/store/effects/router.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/index.ts
+++ b/projects/core/src/routing/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/reducers/index.ts
+++ b/projects/core/src/routing/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/reducers/router.reducer.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/routing-state.ts
+++ b/projects/core/src/routing/store/routing-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/selectors/index.ts
+++ b/projects/core/src/routing/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/selectors/routing-group.selectors.ts
+++ b/projects/core/src/routing/store/selectors/routing-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/store/selectors/routing.selector.ts
+++ b/projects/core/src/routing/store/selectors/routing.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/url-matcher/default-url-matcher.ts
+++ b/projects/core/src/routing/url-matcher/default-url-matcher.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/url-matcher/index.ts
+++ b/projects/core/src/routing/url-matcher/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/routing/url-matcher/url-matcher-factory.ts
+++ b/projects/core/src/routing/url-matcher/url-matcher-factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/config/base-site-config-validator.ts
+++ b/projects/core/src/site-context/config/base-site-config-validator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/config/config-loader/site-context-config-initializer.ts
+++ b/projects/core/src/site-context/config/config-loader/site-context-config-initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/config/context-config-utils.ts
+++ b/projects/core/src/site-context/config/context-config-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/config/default-site-context-config.ts
+++ b/projects/core/src/site-context/config/default-site-context-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/config/index.ts
+++ b/projects/core/src/site-context/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/config/site-context-config.ts
+++ b/projects/core/src/site-context/config/site-context-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/connectors/converters.ts
+++ b/projects/core/src/site-context/connectors/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/connectors/index.ts
+++ b/projects/core/src/site-context/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/connectors/site.adapter.ts
+++ b/projects/core/src/site-context/connectors/site.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/connectors/site.connector.ts
+++ b/projects/core/src/site-context/connectors/site.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/events/index.ts
+++ b/projects/core/src/site-context/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/events/site-context-event.builder.ts
+++ b/projects/core/src/site-context/events/site-context-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/events/site-context-event.module.ts
+++ b/projects/core/src/site-context/events/site-context-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/events/site-context.events.ts
+++ b/projects/core/src/site-context/events/site-context.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/facade/base-site.service.ts
+++ b/projects/core/src/site-context/facade/base-site.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/facade/currency.service.ts
+++ b/projects/core/src/site-context/facade/currency.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/facade/index.ts
+++ b/projects/core/src/site-context/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/facade/language.service.ts
+++ b/projects/core/src/site-context/facade/language.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/facade/site-context.interface.ts
+++ b/projects/core/src/site-context/facade/site-context.interface.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/index.ts
+++ b/projects/core/src/site-context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/providers/context-ids.ts
+++ b/projects/core/src/site-context/providers/context-ids.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/providers/context-initializer-providers.ts
+++ b/projects/core/src/site-context/providers/context-initializer-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/providers/context-service-map.ts
+++ b/projects/core/src/site-context/providers/context-service-map.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/providers/context-service-providers.ts
+++ b/projects/core/src/site-context/providers/context-service-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/providers/index.ts
+++ b/projects/core/src/site-context/providers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/providers/site-context-params-providers.ts
+++ b/projects/core/src/site-context/providers/site-context-params-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/services/base-site-initializer.ts
+++ b/projects/core/src/site-context/services/base-site-initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/services/currency-initializer.ts
+++ b/projects/core/src/site-context/services/currency-initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/services/currency-state-persistence.service.ts
+++ b/projects/core/src/site-context/services/currency-state-persistence.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/services/index.ts
+++ b/projects/core/src/site-context/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/services/language-initializer.ts
+++ b/projects/core/src/site-context/services/language-initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/services/language-state-persistence.service.ts
+++ b/projects/core/src/site-context/services/language-state-persistence.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/services/site-context-params.service.ts
+++ b/projects/core/src/site-context/services/site-context-params.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/services/site-context-routes-handler.ts
+++ b/projects/core/src/site-context/services/site-context-routes-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/services/site-context-url-serializer.ts
+++ b/projects/core/src/site-context/services/site-context-url-serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/site-context.module.ts
+++ b/projects/core/src/site-context/site-context.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/actions/base-site.action.ts
+++ b/projects/core/src/site-context/store/actions/base-site.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/actions/currencies.action.ts
+++ b/projects/core/src/site-context/store/actions/currencies.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/actions/index.ts
+++ b/projects/core/src/site-context/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/actions/languages.action.ts
+++ b/projects/core/src/site-context/store/actions/languages.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/actions/site-context-group.actions.ts
+++ b/projects/core/src/site-context/store/actions/site-context-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/effects/base-site.effect.ts
+++ b/projects/core/src/site-context/store/effects/base-site.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/effects/currencies.effect.ts
+++ b/projects/core/src/site-context/store/effects/currencies.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/effects/index.ts
+++ b/projects/core/src/site-context/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/effects/languages.effect.ts
+++ b/projects/core/src/site-context/store/effects/languages.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/index.ts
+++ b/projects/core/src/site-context/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/reducers/base-site.reducer.ts
+++ b/projects/core/src/site-context/store/reducers/base-site.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/reducers/currencies.reducer.ts
+++ b/projects/core/src/site-context/store/reducers/currencies.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/reducers/index.ts
+++ b/projects/core/src/site-context/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/reducers/languages.reducer.ts
+++ b/projects/core/src/site-context/store/reducers/languages.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/selectors/base-site.selectors.ts
+++ b/projects/core/src/site-context/store/selectors/base-site.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/selectors/currencies.selectors.ts
+++ b/projects/core/src/site-context/store/selectors/currencies.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/selectors/index.ts
+++ b/projects/core/src/site-context/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/selectors/languages.selectors.ts
+++ b/projects/core/src/site-context/store/selectors/languages.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/selectors/site-context-group.selectors.ts
+++ b/projects/core/src/site-context/store/selectors/site-context-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/selectors/site-context.selector.ts
+++ b/projects/core/src/site-context/store/selectors/site-context.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/site-context-store.module.ts
+++ b/projects/core/src/site-context/store/site-context-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-context/store/state.ts
+++ b/projects/core/src/site-context/store/state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/config/default-site-theme-config.ts
+++ b/projects/core/src/site-theme/config/default-site-theme-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/config/index.ts
+++ b/projects/core/src/site-theme/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/config/site-theme-config.ts
+++ b/projects/core/src/site-theme/config/site-theme-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/facade/index.ts
+++ b/projects/core/src/site-theme/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/facade/site-theme.service.ts
+++ b/projects/core/src/site-theme/facade/site-theme.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/index.ts
+++ b/projects/core/src/site-theme/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/providers/index.ts
+++ b/projects/core/src/site-theme/providers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/providers/site-theme-id.ts
+++ b/projects/core/src/site-theme/providers/site-theme-id.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/providers/site-theme-initializer-providers.ts
+++ b/projects/core/src/site-theme/providers/site-theme-initializer-providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/services/site-theme-initializer.ts
+++ b/projects/core/src/site-theme/services/site-theme-initializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/services/site-theme-persistence.service.ts
+++ b/projects/core/src/site-theme/services/site-theme-persistence.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/site-theme.module.ts
+++ b/projects/core/src/site-theme/site-theme.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/actions/index.ts
+++ b/projects/core/src/site-theme/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/actions/site-theme-group.actions.ts
+++ b/projects/core/src/site-theme/store/actions/site-theme-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/actions/site-themes.action.ts
+++ b/projects/core/src/site-theme/store/actions/site-themes.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/effects/index.ts
+++ b/projects/core/src/site-theme/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/effects/site-themes.effect.ts
+++ b/projects/core/src/site-theme/store/effects/site-themes.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/index.ts
+++ b/projects/core/src/site-theme/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/reducers/index.ts
+++ b/projects/core/src/site-theme/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/reducers/site-themes.reducer.ts
+++ b/projects/core/src/site-theme/store/reducers/site-themes.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/selectors/feature.selector.ts
+++ b/projects/core/src/site-theme/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/selectors/index.ts
+++ b/projects/core/src/site-theme/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/selectors/site-theme-group.selectors.ts
+++ b/projects/core/src/site-theme/store/selectors/site-theme-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/selectors/site-themes.selectors.ts
+++ b/projects/core/src/site-theme/store/selectors/site-themes.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/site-theme-store.module.ts
+++ b/projects/core/src/site-theme/store/site-theme-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/site-theme/store/state.ts
+++ b/projects/core/src/site-theme/store/state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/config/state-config.ts
+++ b/projects/core/src/state/config/state-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/event/action-to-event-mapping.ts
+++ b/projects/core/src/state/event/action-to-event-mapping.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/event/index.ts
+++ b/projects/core/src/state/event/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/event/state-event.service.ts
+++ b/projects/core/src/state/event/state-event.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/event/testing-utils/test-action-to-event-mapping.ts
+++ b/projects/core/src/state/event/testing-utils/test-action-to-event-mapping.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/index.ts
+++ b/projects/core/src/state/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/reducers/index.ts
+++ b/projects/core/src/state/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/reducers/transfer-state.reducer.ts
+++ b/projects/core/src/state/reducers/transfer-state.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/services/state-persistence.service.ts
+++ b/projects/core/src/state/services/state-persistence.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/state.module.ts
+++ b/projects/core/src/state/state.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/browser-storage.ts
+++ b/projects/core/src/state/utils/browser-storage.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-list-state.ts
+++ b/projects/core/src/state/utils/entity-list-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-loader/entity-loader-state.ts
+++ b/projects/core/src/state/utils/entity-loader/entity-loader-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-loader/entity-loader.action.ts
+++ b/projects/core/src/state/utils/entity-loader/entity-loader.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-loader/entity-loader.reducer.ts
+++ b/projects/core/src/state/utils/entity-loader/entity-loader.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-loader/entity-loader.selectors.ts
+++ b/projects/core/src/state/utils/entity-loader/entity-loader.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-loader/index.ts
+++ b/projects/core/src/state/utils/entity-loader/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader-state.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/entity-processes-loader.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity-processes-loader/index.ts
+++ b/projects/core/src/state/utils/entity-processes-loader/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity/entity-state.ts
+++ b/projects/core/src/state/utils/entity/entity-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity/entity.action.ts
+++ b/projects/core/src/state/utils/entity/entity.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity/entity.reducer.ts
+++ b/projects/core/src/state/utils/entity/entity.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity/entity.selectors.ts
+++ b/projects/core/src/state/utils/entity/entity.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/entity/index.ts
+++ b/projects/core/src/state/utils/entity/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/get-state-slice.ts
+++ b/projects/core/src/state/utils/get-state-slice.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/index.ts
+++ b/projects/core/src/state/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/loader/index.ts
+++ b/projects/core/src/state/utils/loader/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/loader/loader-state.ts
+++ b/projects/core/src/state/utils/loader/loader-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/loader/loader.action.ts
+++ b/projects/core/src/state/utils/loader/loader.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/loader/loader.reducer.ts
+++ b/projects/core/src/state/utils/loader/loader.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/loader/loader.selectors.ts
+++ b/projects/core/src/state/utils/loader/loader.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/processes-loader/index.ts
+++ b/projects/core/src/state/utils/processes-loader/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/processes-loader/processes-loader-state.ts
+++ b/projects/core/src/state/utils/processes-loader/processes-loader-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/processes-loader/processes-loader.action.ts
+++ b/projects/core/src/state/utils/processes-loader/processes-loader.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/processes-loader/processes-loader.reducer.ts
+++ b/projects/core/src/state/utils/processes-loader/processes-loader.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/processes-loader/processes-loader.selectors.ts
+++ b/projects/core/src/state/utils/processes-loader/processes-loader.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.actions.ts
+++ b/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.ts
+++ b/projects/core/src/state/utils/scoped-loader/entity-scoped-loader.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/scoped-loader/scoped-loader.reducer.ts
+++ b/projects/core/src/state/utils/scoped-loader/scoped-loader.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/scoped-loader/scoped-loader.state.ts
+++ b/projects/core/src/state/utils/scoped-loader/scoped-loader.state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/serializer.ts
+++ b/projects/core/src/state/utils/serializer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/state/utils/utils-group.ts
+++ b/projects/core/src/state/utils/utils-group.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/test.ts
+++ b/projects/core/src/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/address/converters.ts
+++ b/projects/core/src/user/connectors/address/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/address/index.ts
+++ b/projects/core/src/user/connectors/address/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/address/user-address.adapter.ts
+++ b/projects/core/src/user/connectors/address/user-address.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/address/user-address.connector.ts
+++ b/projects/core/src/user/connectors/address/user-address.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/consent/converters.ts
+++ b/projects/core/src/user/connectors/consent/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/consent/index.ts
+++ b/projects/core/src/user/connectors/consent/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/consent/user-consent.adapter.ts
+++ b/projects/core/src/user/connectors/consent/user-consent.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/consent/user-consent.connector.ts
+++ b/projects/core/src/user/connectors/consent/user-consent.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/cost-center/index.ts
+++ b/projects/core/src/user/connectors/cost-center/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/cost-center/user-cost-center.adapter.ts
+++ b/projects/core/src/user/connectors/cost-center/user-cost-center.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/cost-center/user-cost-center.connector.ts
+++ b/projects/core/src/user/connectors/cost-center/user-cost-center.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/customer-coupon/converters.ts
+++ b/projects/core/src/user/connectors/customer-coupon/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/customer-coupon/customer-coupon.adapter.ts
+++ b/projects/core/src/user/connectors/customer-coupon/customer-coupon.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/customer-coupon/customer-coupon.connector.ts
+++ b/projects/core/src/user/connectors/customer-coupon/customer-coupon.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/customer-coupon/index.ts
+++ b/projects/core/src/user/connectors/customer-coupon/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/index.ts
+++ b/projects/core/src/user/connectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/interests/converters.ts
+++ b/projects/core/src/user/connectors/interests/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/interests/index.ts
+++ b/projects/core/src/user/connectors/interests/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/interests/user-interests.adapter.ts
+++ b/projects/core/src/user/connectors/interests/user-interests.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/interests/user-interests.connector.ts
+++ b/projects/core/src/user/connectors/interests/user-interests.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/notification-preference/converters.ts
+++ b/projects/core/src/user/connectors/notification-preference/converters.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/notification-preference/index.ts
+++ b/projects/core/src/user/connectors/notification-preference/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/notification-preference/user-notification-preference.adapter.ts
+++ b/projects/core/src/user/connectors/notification-preference/user-notification-preference.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/notification-preference/user-notification-preference.connector.ts
+++ b/projects/core/src/user/connectors/notification-preference/user-notification-preference.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/payment/index.ts
+++ b/projects/core/src/user/connectors/payment/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/payment/user-payment.adapter.ts
+++ b/projects/core/src/user/connectors/payment/user-payment.adapter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/connectors/payment/user-payment.connector.ts
+++ b/projects/core/src/user/connectors/payment/user-payment.connector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/events/index.ts
+++ b/projects/core/src/user/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/events/user-event.builder.ts
+++ b/projects/core/src/user/events/user-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/events/user-event.module.ts
+++ b/projects/core/src/user/events/user-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/events/user.events.ts
+++ b/projects/core/src/user/events/user.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/facade/consent.service.ts
+++ b/projects/core/src/user/facade/consent.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/facade/customer-coupon.service.ts
+++ b/projects/core/src/user/facade/customer-coupon.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/facade/index.ts
+++ b/projects/core/src/user/facade/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/facade/user-address.service.ts
+++ b/projects/core/src/user/facade/user-address.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/facade/user-consent.service.ts
+++ b/projects/core/src/user/facade/user-consent.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/facade/user-cost-center.service.ts
+++ b/projects/core/src/user/facade/user-cost-center.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/facade/user-interests.service.ts
+++ b/projects/core/src/user/facade/user-interests.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/facade/user-notification-preference.service.ts
+++ b/projects/core/src/user/facade/user-notification-preference.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/facade/user-payment.service.ts
+++ b/projects/core/src/user/facade/user-payment.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/index.ts
+++ b/projects/core/src/user/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/billing-countries.action.ts
+++ b/projects/core/src/user/store/actions/billing-countries.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/customer-coupon.action.ts
+++ b/projects/core/src/user/store/actions/customer-coupon.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/delivery-countries.action.ts
+++ b/projects/core/src/user/store/actions/delivery-countries.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/index.ts
+++ b/projects/core/src/user/store/actions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/notification-preference.action.ts
+++ b/projects/core/src/user/store/actions/notification-preference.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/payment-methods.action.ts
+++ b/projects/core/src/user/store/actions/payment-methods.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/product-interests.actions.ts
+++ b/projects/core/src/user/store/actions/product-interests.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/regions.action.ts
+++ b/projects/core/src/user/store/actions/regions.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/user-addresses.action.ts
+++ b/projects/core/src/user/store/actions/user-addresses.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/user-consents.action.ts
+++ b/projects/core/src/user/store/actions/user-consents.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/user-cost-center.action.ts
+++ b/projects/core/src/user/store/actions/user-cost-center.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/user-group.actions.ts
+++ b/projects/core/src/user/store/actions/user-group.actions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/user-misc.action.ts
+++ b/projects/core/src/user/store/actions/user-misc.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/actions/user-register.action.ts
+++ b/projects/core/src/user/store/actions/user-register.action.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/billing-countries.effect.ts
+++ b/projects/core/src/user/store/effects/billing-countries.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/clear-miscs-data.effect.ts
+++ b/projects/core/src/user/store/effects/clear-miscs-data.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/customer-coupon.effect.ts
+++ b/projects/core/src/user/store/effects/customer-coupon.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/delivery-countries.effect.ts
+++ b/projects/core/src/user/store/effects/delivery-countries.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/index.ts
+++ b/projects/core/src/user/store/effects/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/notification-preference.effect.ts
+++ b/projects/core/src/user/store/effects/notification-preference.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/payment-methods.effect.ts
+++ b/projects/core/src/user/store/effects/payment-methods.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/product-interests.effect.ts
+++ b/projects/core/src/user/store/effects/product-interests.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/regions.effect.ts
+++ b/projects/core/src/user/store/effects/regions.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/user-addresses.effect.ts
+++ b/projects/core/src/user/store/effects/user-addresses.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/user-consents.effect.ts
+++ b/projects/core/src/user/store/effects/user-consents.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/effects/user-cost-center.effect.ts
+++ b/projects/core/src/user/store/effects/user-cost-center.effect.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/index.ts
+++ b/projects/core/src/user/store/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/billing-countries.reducer.ts
+++ b/projects/core/src/user/store/reducers/billing-countries.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/customer-coupon.reducer.ts
+++ b/projects/core/src/user/store/reducers/customer-coupon.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/delivery-countries.reducer.ts
+++ b/projects/core/src/user/store/reducers/delivery-countries.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/index.ts
+++ b/projects/core/src/user/store/reducers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/notification-preference.reducer.ts
+++ b/projects/core/src/user/store/reducers/notification-preference.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/payment-methods.reducer.ts
+++ b/projects/core/src/user/store/reducers/payment-methods.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/product-interests.reducer.ts
+++ b/projects/core/src/user/store/reducers/product-interests.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/regions.reducer.ts
+++ b/projects/core/src/user/store/reducers/regions.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/user-addresses.reducer.ts
+++ b/projects/core/src/user/store/reducers/user-addresses.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/user-consents.reducer.ts
+++ b/projects/core/src/user/store/reducers/user-consents.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/reducers/user-cost-center.reducer.ts
+++ b/projects/core/src/user/store/reducers/user-cost-center.reducer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/billing-countries.selectors.ts
+++ b/projects/core/src/user/store/selectors/billing-countries.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/customer-coupons.selectors.ts
+++ b/projects/core/src/user/store/selectors/customer-coupons.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/delivery-countries.selectors.ts
+++ b/projects/core/src/user/store/selectors/delivery-countries.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/feature.selector.ts
+++ b/projects/core/src/user/store/selectors/feature.selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/index.ts
+++ b/projects/core/src/user/store/selectors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/notification-preference.selectors.ts
+++ b/projects/core/src/user/store/selectors/notification-preference.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/payment-methods.selectors.ts
+++ b/projects/core/src/user/store/selectors/payment-methods.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/product-interests.selectors.ts
+++ b/projects/core/src/user/store/selectors/product-interests.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/regions.selectors.ts
+++ b/projects/core/src/user/store/selectors/regions.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/user-addresses.selectors.ts
+++ b/projects/core/src/user/store/selectors/user-addresses.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/user-consents.selectors.ts
+++ b/projects/core/src/user/store/selectors/user-consents.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/user-cost-center.selectors.ts
+++ b/projects/core/src/user/store/selectors/user-cost-center.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/selectors/users-group.selectors.ts
+++ b/projects/core/src/user/store/selectors/users-group.selectors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/user-state.ts
+++ b/projects/core/src/user/store/user-state.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/store/user-store.module.ts
+++ b/projects/core/src/user/store/user-store.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/user-transitional-tokens.ts
+++ b/projects/core/src/user/user-transitional-tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/user/user.module.ts
+++ b/projects/core/src/user/user.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/applicable.ts
+++ b/projects/core/src/util/applicable.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/combined-injector.ts
+++ b/projects/core/src/util/combined-injector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/command-query/command.service.ts
+++ b/projects/core/src/util/command-query/command.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/command-query/index.ts
+++ b/projects/core/src/util/command-query/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/command-query/query.service.ts
+++ b/projects/core/src/util/command-query/query.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/converter.service.ts
+++ b/projects/core/src/util/converter.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/create-from.ts
+++ b/projects/core/src/util/create-from.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/glob-utils.ts
+++ b/projects/core/src/util/glob-utils.ts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2010-2019 Google LLC. http://angular.io/license
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/glob.service.ts
+++ b/projects/core/src/util/glob.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/http-params-uri.encoder.ts
+++ b/projects/core/src/util/http-params-uri.encoder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/index.ts
+++ b/projects/core/src/util/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/is-key-invalid.ts
+++ b/projects/core/src/util/is-key-invalid.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/java-reg-exp-converter/index.ts
+++ b/projects/core/src/util/java-reg-exp-converter/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/java-reg-exp-converter/java-reg-exp-converter.ts
+++ b/projects/core/src/util/java-reg-exp-converter/java-reg-exp-converter.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/normalize-http-error.ts
+++ b/projects/core/src/util/normalize-http-error.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/object-comparison-utils.ts
+++ b/projects/core/src/util/object-comparison-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/occ-http-error-constants.ts
+++ b/projects/core/src/util/occ-http-error-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/occ-http-error-handlers.ts
+++ b/projects/core/src/util/occ-http-error-handlers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/regex-pattern.ts
+++ b/projects/core/src/util/regex-pattern.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/rxjs/back-off.ts
+++ b/projects/core/src/util/rxjs/back-off.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/rxjs/buffer-debounce-time.ts
+++ b/projects/core/src/util/rxjs/buffer-debounce-time.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/rxjs/get-last-value-sync.ts
+++ b/projects/core/src/util/rxjs/get-last-value-sync.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/rxjs/index.ts
+++ b/projects/core/src/util/rxjs/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/rxjs/unite-latest.ts
+++ b/projects/core/src/util/rxjs/unite-latest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/rxjs/withdraw-on.ts
+++ b/projects/core/src/util/rxjs/withdraw-on.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/rxjs/wrap-into-observable.ts
+++ b/projects/core/src/util/rxjs/wrap-into-observable.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/script-loader.service.ts
+++ b/projects/core/src/util/script-loader.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/ssr.tokens.ts
+++ b/projects/core/src/util/ssr.tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/testing-time-utils.ts
+++ b/projects/core/src/util/testing-time-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/time-utils.ts
+++ b/projects/core/src/util/time-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/try-normalize-http-error.ts
+++ b/projects/core/src/util/try-normalize-http-error.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/type-guards.ts
+++ b/projects/core/src/util/type-guards.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/util/type-utils.ts
+++ b/projects/core/src/util/type-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/window/index.ts
+++ b/projects/core/src/window/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/core/src/window/window-ref.ts
+++ b/projects/core/src/window/window-ref.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/index.ts
+++ b/projects/schematics/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/setup-jest.ts
+++ b/projects/schematics/setup-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-cms-component/index.ts
+++ b/projects/schematics/src/add-cms-component/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-cms-component/schema.ts
+++ b/projects/schematics/src/add-cms-component/schema.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-spartacus/configuration.ts
+++ b/projects/schematics/src/add-spartacus/configuration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-spartacus/schema.ts
+++ b/projects/schematics/src/add-spartacus/schema.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-spartacus/spartacus-feature-toggles.ts
+++ b/projects/schematics/src/add-spartacus/spartacus-feature-toggles.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-spartacus/spartacus-features.ts
+++ b/projects/schematics/src/add-spartacus/spartacus-features.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-spartacus/spartacus.ts
+++ b/projects/schematics/src/add-spartacus/spartacus.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-spartacus/store.ts
+++ b/projects/schematics/src/add-spartacus/store.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/add-ssr/index.ts
+++ b/projects/schematics/src/add-ssr/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/angular-json-styles/angular-json-styles.ts
+++ b/projects/schematics/src/migrations/2211_19/angular-json-styles/angular-json-styles.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/config-deprecations/config-deprecations.ts
+++ b/projects/schematics/src/migrations/2211_19/config-deprecations/config-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/constructor-deprecations/constructor-deprecations.ts
+++ b/projects/schematics/src/migrations/2211_19/constructor-deprecations/constructor-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/constructor-deprecations/data/generated-constructor.migration.ts
+++ b/projects/schematics/src/migrations/2211_19/constructor-deprecations/data/generated-constructor.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/css/css.ts
+++ b/projects/schematics/src/migrations/2211_19/css/css.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/dependency-management/dependency-management.ts
+++ b/projects/schematics/src/migrations/2211_19/dependency-management/dependency-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/methods-and-properties-deprecations/data/generated-methods-and-properties.migration.ts
+++ b/projects/schematics/src/migrations/2211_19/methods-and-properties-deprecations/data/generated-methods-and-properties.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
+++ b/projects/schematics/src/migrations/2211_19/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/missing-packages/missing-packages.ts
+++ b/projects/schematics/src/migrations/2211_19/missing-packages/missing-packages.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/removed-public-api-deprecations/data/generated-removed-public-api.migration.ts
+++ b/projects/schematics/src/migrations/2211_19/removed-public-api-deprecations/data/generated-removed-public-api.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/removed-public-api-deprecations/removed-public-api-deprecations.ts
+++ b/projects/schematics/src/migrations/2211_19/removed-public-api-deprecations/removed-public-api-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/rename-symbol/data/generated-rename-symbols.migration.ts
+++ b/projects/schematics/src/migrations/2211_19/rename-symbol/data/generated-rename-symbols.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/rename-symbol/rename-symbol.ts
+++ b/projects/schematics/src/migrations/2211_19/rename-symbol/rename-symbol.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/ssr/ssr.ts
+++ b/projects/schematics/src/migrations/2211_19/ssr/ssr.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/2211_19/update-ssr/update-ssr-files.ts
+++ b/projects/schematics/src/migrations/2211_19/update-ssr/update-ssr-files.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/add-dependencies/add-dependencies.ts
+++ b/projects/schematics/src/migrations/3_0/add-dependencies/add-dependencies.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/component-deprecations.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/component-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/added-to-cart-dialog.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/added-to-cart-dialog.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/cart-item.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/cart-item.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/checkout-progress-mobile-bottom.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/checkout-progress-mobile-bottom.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/checkout-progress-mobile-top.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/checkout-progress-mobile-top.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/checkout-progress.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/checkout-progress.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/close-account-modal.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/close-account-modal.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/delivery-mode.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/delivery-mode.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/order-detail-shipping.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/order-detail-shipping.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/payment-method.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/payment-method.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/place-order.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/place-order.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/shipping-address.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/shipping-address.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/component-deprecations/data/star-rating.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/component-deprecations/data/star-rating.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/config-deprecations/config-deprecation.ts
+++ b/projects/schematics/src/migrations/3_0/config-deprecations/config-deprecation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/config-deprecations/data/legacy-flag.migration.ts
+++ b/projects/schematics/src/migrations/3_0/config-deprecations/data/legacy-flag.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/constructor-deprecations.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/constructor-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/active-cart.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/active-cart.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/auth-redirect.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/auth-redirect.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/auth.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/auth.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/auth.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/auth.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/breakpoint.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/breakpoint.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/cart-not-empty.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/cart-not-empty.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/cart-voucher.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/cart-voucher.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/cdc-auth.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/cdc-auth.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-auth.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-auth.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-config.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-config.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-delivery.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-delivery.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-payment.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-payment.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-progress-mobile-bottom.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-progress-mobile-bottom.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-progress-mobile-top.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-progress-mobile-top.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-progress.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout-progress.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/checkout.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/content-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/content-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/customer-coupon.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/customer-coupon.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/delivery-mode-set.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/delivery-mode-set.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/delivery-mode.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/delivery-mode.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/feature-modules.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/feature-modules.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/forbidden.handler.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/forbidden.handler.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/forgot-password.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/forgot-password.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/json-ld.script.factory.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/json-ld.script.factory.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/jsonld-product-review.builder.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/jsonld-product-review.builder.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/login-form.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/login-form.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/logout-guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/logout-guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/multi-cart.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/multi-cart.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/not-auth.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/not-auth.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/not-checkout-auth.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/not-checkout-auth.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-cancellation.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-cancellation.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-confirmation-overview.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-confirmation-overview.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-detail-shipping.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-detail-shipping.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-history-component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-history-component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-return-request.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-return-request.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-return.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/order-return.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/outlet-ref.directive.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/outlet-ref.directive.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/outlet.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/outlet.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/page-slot.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/page-slot.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/payment-details-set.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/payment-details-set.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/payment-method.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/payment-method.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/place-order.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/place-order.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/product-carousel.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/product-carousel.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/product-variant.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/product-variant.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/register.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/register.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/review-submit.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/review-submit.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/routing.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/routing.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/selective-cart.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/selective-cart.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/shipping-address-set.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/shipping-address-set.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/shipping-address.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/shipping-address.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/split-view.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/split-view.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/star-rating.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/star-rating.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/stock-notification.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/stock-notification.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-address.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-address.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-consent.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-consent.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-interests.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-interests.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-notification-preference.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-notification-preference.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-order.effect.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-order.effect.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-order.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-order.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-payment.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-payment.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-register.effect.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user-register.effect.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/user.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/view.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/view.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/constructor-deprecations/data/wish-list.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/constructor-deprecations/data/wish-list.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/css/css.ts
+++ b/projects/schematics/src/migrations/3_0/css/css.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/anonymous-consent-templates.adapter.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/anonymous-consent-templates.adapter.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/anonymous-consent-templates.connector.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/anonymous-consent-templates.connector.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/asm-auth.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/asm-auth.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/asm-group.actions.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/asm-group.actions.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/asm-group.selectors.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/asm-group.selectors.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/auth-group.actions.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/auth-group.actions.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/auth.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/auth.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/auth.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/auth.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/base-site.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/base-site.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/breakpoint.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/breakpoint.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/cart-not-empty.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/cart-not-empty.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/cdc-auth.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/cdc-auth.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout-auth.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout-auth.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout-config.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout-config.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout-group.actions.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout-group.actions.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout.adapter.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout.adapter.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout.connector.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout.connector.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/checkout.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/cms-components.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/cms-components.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/currency.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/currency.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/feature-modules.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/feature-modules.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/item-counter.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/item-counter.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/language.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/language.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/login-form.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/login-form.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/logout.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/logout.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/multi-cart-state-persistence.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/multi-cart-state-persistence.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/not-auth.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/not-auth.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/not-checkout-auth.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/not-checkout-auth.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/occ-checkout.adapter.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/occ-checkout.adapter.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/occ-cms-component.adapter.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/occ-cms-component.adapter.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/order-confirmation-overview.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/order-confirmation-overview.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/order-detail-shipping.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/order-detail-shipping.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/page-meta.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/page-meta.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/product-carousel.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/product-carousel.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/product-list-component.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/product-list-component.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/product-reference.service.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/product-reference.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/protected-routes.guard.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/protected-routes.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/star-rating-component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/star-rating-component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/store-finder-group.actions.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/store-finder-group.actions.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/storefront-component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/storefront-component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/update-email.component.migration.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/data/update-email.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
+++ b/projects/schematics/src/migrations/3_0/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/removed-public-api-deprecations/removed-public-api-deprecation.ts
+++ b/projects/schematics/src/migrations/3_0/removed-public-api-deprecations/removed-public-api-deprecation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/ssr/ssr.ts
+++ b/projects/schematics/src/migrations/3_0/ssr/ssr.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/3_0/storefinder/storefinder.ts
+++ b/projects/schematics/src/migrations/3_0/storefinder/storefinder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/config-deprecations/config-deprecation.ts
+++ b/projects/schematics/src/migrations/4_0/config-deprecations/config-deprecation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/config-deprecations/data/product-configurator-rulebased-feature.migration.ts
+++ b/projects/schematics/src/migrations/4_0/config-deprecations/data/product-configurator-rulebased-feature.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/config-deprecations/data/product-configurator-textfield-feature.migration.ts
+++ b/projects/schematics/src/migrations/4_0/config-deprecations/data/product-configurator-textfield-feature.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/constructor-deprecations.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/constructor-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/abstract-store-item.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/abstract-store-item.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/add-to-saved-cart.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/add-to-saved-cart.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/added-to-cart-dialog.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/added-to-cart-dialog.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/address-book.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/address-book.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/address-book.component.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/address-book.component.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/address-form.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/address-form.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/anonymous-consent-management-banner.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/anonymous-consent-management-banner.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/anonymous-consent-open-dialog.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/anonymous-consent-open-dialog.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/asm-auth-http-header.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/asm-auth-http-header.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/auth-http-header.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/auth-http-header.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/auth-redirect.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/auth-redirect.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/base-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/base-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-details.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-details.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-item-list.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-item-list.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-item.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-item.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-list-item.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-list-item.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-page-event.builder.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cart-page-event.builder.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/category-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/category-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cdc-logout.guard.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cdc-logout.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/checkout-auth.guard.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/checkout-auth.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/checkout-event.module.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/checkout-event.module.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/checkout-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/checkout-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cms-components.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/cms-components.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/component-wrapper.directive.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/component-wrapper.directive.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configuration.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configuration.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-checkbox-list.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-checkbox-list.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-drop-down.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-drop-down.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-input-field.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-input-field.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-numeric-input-field.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-numeric-input-field.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-radio-button.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-attribute-radio-button.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-cart-entry-info.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-cart-entry-info.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-cart.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-cart.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-form.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-form.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-group-menu.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-group-menu.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-issues-notification.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-issues-notification.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-overview-attribute.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-overview-attribute.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-storefront-utils.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-storefront-utils.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-update-message.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/configurator-update-message.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/content-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/content-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/currency.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/currency.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/delete-item.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/delete-item.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/dynamic-attribute.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/dynamic-attribute.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/event.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/event.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/express-checkout.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/express-checkout.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/google-map-renderer.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/google-map-renderer.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/guest-register-form.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/guest-register-form.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/home-page-event.builder.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/home-page-event.builder.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/language.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/language.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/login-register.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/login-register.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/logout.guard.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/logout.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/media.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/media.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/modal.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/modal.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/navigation-ui.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/navigation-ui.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/on-navigate-focus.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/on-navigate-focus.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/order-detail-items.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/order-detail-items.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/organization-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/organization-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/page-meta.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/page-meta.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/popover.directive.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/popover.directive.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-grid-item.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-grid-item.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-list-component.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-list-component.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-list-item.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-list-item.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-loading.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-loading.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-page-event.builder.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-page-event.builder.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/product-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/protected-routes.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/protected-routes.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/qualtrics-loader.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/qualtrics-loader.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/replenishment-order-cancellation.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/replenishment-order-cancellation.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/replenishment-order-history.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/replenishment-order-history.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/routing.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/routing.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/saved-cart-details-action.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/saved-cart-details-action.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/saved-cart-details-overview.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/saved-cart-details-overview.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/saved-cart-form-dialog.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/saved-cart-form-dialog.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/saved-cart-list.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/saved-cart-list.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/schedule.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/schedule.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/search-box-component.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/search-box-component.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/search-box.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/search-box.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/search-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/search-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/store-finder-list-item.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/store-finder-list-item.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/store-finder-list.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/store-finder-list.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/store-finder-store-description.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/store-finder-store-description.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/store-finder.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/store-finder.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/tab-paragraph-container.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/tab-paragraph-container.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/toggle-status.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/toggle-status.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/unit-address-form.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/unit-address-form.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/unit-children.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/unit-children.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/unit-cost-centers.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/unit-cost-centers.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/unit-user-list.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/unit-user-list.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/update-email-component.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/update-email-component.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/user-address-service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/user-address-service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/user-group-user-list.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/user-group-user-list.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/constructor-deprecations/data/window-ref.migration.ts
+++ b/projects/schematics/src/migrations/4_0/constructor-deprecations/data/window-ref.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/css/css.ts
+++ b/projects/schematics/src/migrations/4_0/css/css.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/dependency-management/dependency-management.ts
+++ b/projects/schematics/src/migrations/4_0/dependency-management/dependency-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/added-to-cart-dialog-component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/added-to-cart-dialog-component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/base-site.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/base-site.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/cart-details-component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/cart-details-component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/cart-item-component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/cart-item-component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/cart-item-context-source.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/cart-item-context-source.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/cart-item-context.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/cart-item-context.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/config-initializer.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/config-initializer.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-attribute-drop-down.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-attribute-drop-down.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-attribute-numeric-input-field.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-attribute-numeric-input-field.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-attribute-radio-button.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-attribute-radio-button.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-group-menu.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-group-menu.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-product-title.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/configurator-product-title.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/content-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/content-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/currency.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/currency.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/dynamic-attribute.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/dynamic-attribute.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/express-checkout.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/express-checkout.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/language.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/language.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/occ-endpoint.model.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/occ-endpoint.model.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/occ-endpoints.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/occ-endpoints.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/order-detail-items.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/order-detail-items.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/order-overview.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/order-overview.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/page-event.builder.ts.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/page-event.builder.ts.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/popover-component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/popover-component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/popover-directive.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/popover-directive.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/product-list-component.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/product-list-component.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/product.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/product.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/routing.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/routing.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/saved-cart-details-action.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/saved-cart-details-action.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/saved-cart-list.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/saved-cart-list.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/selective-cart.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/selective-cart.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/unit-form.component.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/unit-form.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/user-id.service.migration.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/data/user-id.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
+++ b/projects/schematics/src/migrations/4_0/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/missing-packages/missing-packages.ts
+++ b/projects/schematics/src/migrations/4_0/missing-packages/missing-packages.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/removed-public-api-deprecations/removed-public-api-deprecation.ts
+++ b/projects/schematics/src/migrations/4_0/removed-public-api-deprecations/removed-public-api-deprecation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/4_0/rename-symbol/rename-symbol.ts
+++ b/projects/schematics/src/migrations/4_0/rename-symbol/rename-symbol.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/angular-json-styles/angular-json-styles.ts
+++ b/projects/schematics/src/migrations/5_0/angular-json-styles/angular-json-styles.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/config-deprecations/config-deprecations.ts
+++ b/projects/schematics/src/migrations/5_0/config-deprecations/config-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/constructor-deprecations.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/constructor-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/added-to-cart-dialog-event.listener.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/added-to-cart-dialog-event.listener.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/added-to-cart-dialog.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/added-to-cart-dialog.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/address-book.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/address-book.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/address-form.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/address-form.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/banner.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/banner.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cart-totals.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cart-totals.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cdc-js-service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cdc-js-service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cdc-logout.guard.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cdc-logout.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cds-merchandising-product.service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cds-merchandising-product.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cds-merchandising-user-context.service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/cds-merchandising-user-context.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/close-account-modal.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/close-account-modal.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/close-account.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/close-account.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/component-wrapper.directive.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/component-wrapper.directive.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-add-to-cart-button.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-add-to-cart-button.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-drop-down.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-drop-down.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-header.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-header.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-numeric-input-field.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-numeric-input-field.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-product-card.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-product-card.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-radio-button.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-radio-button.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-single-selection-base.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-attribute-single-selection-base.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-cart-entry-bundle-info.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-cart-entry-bundle-info.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-group-menu.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-group-menu.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-overview-bundle-attribute.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-overview-bundle-attribute.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-tab-bar.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/configurator-tab-bar.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/consignment-tracking.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/consignment-tracking.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/coupon-card.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/coupon-card.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/coupon-dialog.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/coupon-dialog.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/form-errors.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/form-errors.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/generic-link.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/generic-link.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/inner-components-host.directive.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/inner-components-host.directive.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/json-ld.directive.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/json-ld.directive.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/json-ld.script.factory.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/json-ld.script.factory.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/login.guard.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/login.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/logout.guard.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/logout.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/navigation-ui.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/navigation-ui.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/not-auth.guard.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/not-auth.guard.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/page-layout.service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/page-layout.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/paragraph.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/paragraph.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/product-intro.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/product-intro.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/quick-order-form.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/quick-order-form.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/quick-order.service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/quick-order.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/register.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/register.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/shipping-address.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/shipping-address.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/stock-notification-dialog.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/stock-notification-dialog.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/stock-notification.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/stock-notification.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/suggested-addresses-dialog.component-migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/suggested-addresses-dialog.component-migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/tab-paragraph-container.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/tab-paragraph-container.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/constructor-deprecations/data/tracking-events.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/constructor-deprecations/data/tracking-events.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/css/css.ts
+++ b/projects/schematics/src/migrations/5_0/css/css.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/dependency-management/dependency-management.ts
+++ b/projects/schematics/src/migrations/5_0/dependency-management/dependency-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/auth-http-header.service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/auth-http-header.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/auth-redirect.service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/auth-redirect.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/cds-merchandising-product.service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/cds-merchandising-product.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-attribute-header.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-attribute-header.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-attribute-multi-selection-bundle.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-attribute-multi-selection-bundle.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-attribute-single-selection-bundle.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-attribute-single-selection-bundle.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-commons-service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-commons-service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-group-title-component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-group-title-component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-storefront-utils.service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/configurator-storefront-utils.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/json-ld.script.factory.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/json-ld.script.factory.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/navigation-ui.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/navigation-ui.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/occ-configurator-variant-normalizer.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/occ-configurator-variant-normalizer.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/progress-button.component.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/progress-button.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/quick-order.service.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/quick-order.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/saved-cart-event.builder.migration.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/data/saved-cart-event.builder.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
+++ b/projects/schematics/src/migrations/5_0/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/missing-packages/missing-packages.ts
+++ b/projects/schematics/src/migrations/5_0/missing-packages/missing-packages.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/removed-public-api-deprecations/removed-public-api-deprecations.ts
+++ b/projects/schematics/src/migrations/5_0/removed-public-api-deprecations/removed-public-api-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/rename-symbol/checkout-rename-symbol.ts
+++ b/projects/schematics/src/migrations/5_0/rename-symbol/checkout-rename-symbol.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/5_0/rename-symbol/rename-symbol.ts
+++ b/projects/schematics/src/migrations/5_0/rename-symbol/rename-symbol.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/angular-json-styles/angular-json-styles.ts
+++ b/projects/schematics/src/migrations/6_0/angular-json-styles/angular-json-styles.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/config-deprecations/config-deprecations.ts
+++ b/projects/schematics/src/migrations/6_0/config-deprecations/config-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/constructor-deprecations/constructor-deprecations.ts
+++ b/projects/schematics/src/migrations/6_0/constructor-deprecations/constructor-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/constructor-deprecations/data/generated-constructor.migration.ts
+++ b/projects/schematics/src/migrations/6_0/constructor-deprecations/data/generated-constructor.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/css/css.ts
+++ b/projects/schematics/src/migrations/6_0/css/css.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/dependency-management/dependency-management.ts
+++ b/projects/schematics/src/migrations/6_0/dependency-management/dependency-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/methods-and-properties-deprecations/data/generated-methods-and-properties.migration.ts
+++ b/projects/schematics/src/migrations/6_0/methods-and-properties-deprecations/data/generated-methods-and-properties.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
+++ b/projects/schematics/src/migrations/6_0/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/missing-packages/missing-packages.ts
+++ b/projects/schematics/src/migrations/6_0/missing-packages/missing-packages.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/removed-public-api-deprecations/data/generated-removed-public-api.migration.ts
+++ b/projects/schematics/src/migrations/6_0/removed-public-api-deprecations/data/generated-removed-public-api.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/removed-public-api-deprecations/removed-public-api-deprecations.ts
+++ b/projects/schematics/src/migrations/6_0/removed-public-api-deprecations/removed-public-api-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/rename-symbol/data/generated-rename-symbol.migration.ts
+++ b/projects/schematics/src/migrations/6_0/rename-symbol/data/generated-rename-symbol.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/rename-symbol/rename-symbol.ts
+++ b/projects/schematics/src/migrations/6_0/rename-symbol/rename-symbol.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/6_0/ssr/ssr.ts
+++ b/projects/schematics/src/migrations/6_0/ssr/ssr.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/mechanism/component-deprecations/component-deprecations.ts
+++ b/projects/schematics/src/migrations/mechanism/component-deprecations/component-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/mechanism/config-deprecations/config-deprecation.ts
+++ b/projects/schematics/src/migrations/mechanism/config-deprecations/config-deprecation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/mechanism/constructor-deprecations/constructor-deprecations.ts
+++ b/projects/schematics/src/migrations/mechanism/constructor-deprecations/constructor-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/mechanism/dependency-management/dependency-management.ts
+++ b/projects/schematics/src/migrations/mechanism/dependency-management/dependency-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/mechanism/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
+++ b/projects/schematics/src/migrations/mechanism/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/mechanism/missing-packages/missing-packages.ts
+++ b/projects/schematics/src/migrations/mechanism/missing-packages/missing-packages.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/mechanism/removed-public-api-deprecations/removed-public-api-deprecation.ts
+++ b/projects/schematics/src/migrations/mechanism/removed-public-api-deprecations/removed-public-api-deprecation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/mechanism/rename-symbol/rename-symbol.ts
+++ b/projects/schematics/src/migrations/mechanism/rename-symbol/rename-symbol.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/mechanism/scaffold-app-structure/scaffold-app-structure.ts
+++ b/projects/schematics/src/migrations/mechanism/scaffold-app-structure/scaffold-app-structure.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/component-deprecations/component-deprecations.ts
+++ b/projects/schematics/src/migrations/test/component-deprecations/component-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/component-deprecations/data/anonymous-consent-dialog.component.migration.ts
+++ b/projects/schematics/src/migrations/test/component-deprecations/data/anonymous-consent-dialog.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/component-deprecations/data/consent-management-form.component.migration.ts
+++ b/projects/schematics/src/migrations/test/component-deprecations/data/consent-management-form.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/component-deprecations/data/consent-management.component.migration.ts
+++ b/projects/schematics/src/migrations/test/component-deprecations/data/consent-management.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/component-deprecations/data/navigation-ui.component.migration.ts
+++ b/projects/schematics/src/migrations/test/component-deprecations/data/navigation-ui.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/component-deprecations/data/product-facet-navigation-component.migration.ts
+++ b/projects/schematics/src/migrations/test/component-deprecations/data/product-facet-navigation-component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/component-deprecations/data/product-images.component.migration.ts
+++ b/projects/schematics/src/migrations/test/component-deprecations/data/product-images.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/config-deprecations/config-deprecation.ts
+++ b/projects/schematics/src/migrations/test/config-deprecations/config-deprecation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/config-deprecations/data/anonymous-consents-flag.migration.ts
+++ b/projects/schematics/src/migrations/test/config-deprecations/data/anonymous-consents-flag.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/constructor-deprecations.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/constructor-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/add-to-cart.component.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/add-to-cart.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/asm-auth-http-header.service.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/asm-auth-http-header.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/cart-page-layout-handler.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/cart-page-layout-handler.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/checkout.service.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/checkout.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/current-product-service.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/current-product-service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/dynamic-attribute.service.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/dynamic-attribute.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/page-resolvers/category-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/page-resolvers/category-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/page-resolvers/checkout-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/page-resolvers/checkout-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/page-resolvers/page-meta.service.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/page-resolvers/page-meta.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/page-resolvers/product-page-meta.resolver.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/page-resolvers/product-page-meta.resolver.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/page-slot.component.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/page-slot.component.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/selective-cart.service.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/selective-cart.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/constructor-deprecations/data/user-address.service.migration.ts
+++ b/projects/schematics/src/migrations/test/constructor-deprecations/data/user-address.service.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/dependency-management/dependency-management.ts
+++ b/projects/schematics/src/migrations/test/dependency-management/dependency-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/methods-and-properties-deprecations/data/cms-group.actions.migration.ts
+++ b/projects/schematics/src/migrations/test/methods-and-properties-deprecations/data/cms-group.actions.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/methods-and-properties-deprecations/data/cms-group.selectors.migration.ts
+++ b/projects/schematics/src/migrations/test/methods-and-properties-deprecations/data/cms-group.selectors.migration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
+++ b/projects/schematics/src/migrations/test/methods-and-properties-deprecations/methods-and-properties-deprecations.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/missing-packages/missing-packages.ts
+++ b/projects/schematics/src/migrations/test/missing-packages/missing-packages.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/removed-public-api-deprecations/removed-public-api-deprecation.ts
+++ b/projects/schematics/src/migrations/test/removed-public-api-deprecations/removed-public-api-deprecation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/migrations/test/rename-symbol/rename-symbol.ts
+++ b/projects/schematics/src/migrations/test/rename-symbol/rename-symbol.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/ng-add/index.ts
+++ b/projects/schematics/src/ng-add/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/constants.ts
+++ b/projects/schematics/src/shared/constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/index.ts
+++ b/projects/schematics/src/shared/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/asm-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/asm-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/cart-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/cart-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/checkout-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/checkout-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/customer-ticketing-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/customer-ticketing-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/estimated-delivery-date-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/estimated-delivery-date-schematics-config.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/index.ts
+++ b/projects/schematics/src/shared/lib-configs/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/cdc-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/cdc-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/cdp-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/cdp-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/cds-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/cds-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/cpq-quote-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/cpq-quote-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/digital-payments-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/digital-payments-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/epd-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/index.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/omf-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/omf-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/opf-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/opf-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/opps-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/opps-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/s4-service-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/s4-service-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/s4om-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/s4om-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/integration-libs/segment-refs-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/integration-libs/segment-refs-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/order-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/order-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/organization-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/organization-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/pdf-invoices-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/pdf-invoices-schematics-config.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/pickup-in-store-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/pickup-in-store-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/product-configurator-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/product-configurator-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/product-multi-dimensional-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/product-multi-dimensional-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/product-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/product-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/qualtrics-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/qualtrics-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/quote-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/quote-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/requested-delivery-date-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/requested-delivery-date-schematics-config.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/smartedit-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/smartedit-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/storefinder-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/storefinder-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/tracking-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/tracking-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/lib-configs/user-schematics-config.ts
+++ b/projects/schematics/src/shared/lib-configs/user-schematics-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/libs-constants.ts
+++ b/projects/schematics/src/shared/libs-constants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/schematics-config-mappings.ts
+++ b/projects/schematics/src/shared/schematics-config-mappings.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/config-utils.ts
+++ b/projects/schematics/src/shared/utils/config-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/dependency-utils.ts
+++ b/projects/schematics/src/shared/utils/dependency-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/feature-utils.ts
+++ b/projects/schematics/src/shared/utils/feature-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/file-utils.ts
+++ b/projects/schematics/src/shared/utils/file-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/generate-default-workspace.ts
+++ b/projects/schematics/src/shared/utils/generate-default-workspace.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/graph-utils.ts
+++ b/projects/schematics/src/shared/utils/graph-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/html-utils.ts
+++ b/projects/schematics/src/shared/utils/html-utils.ts
@@ -4,6 +4,7 @@ import { DefaultTreeAdapterMap, parse as parseHtml } from 'parse5';
 /*
  * Copyright Google LLC All Rights Reserved.
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/import-utils.ts
+++ b/projects/schematics/src/shared/utils/import-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/index.ts
+++ b/projects/schematics/src/shared/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/lib-utils.ts
+++ b/projects/schematics/src/shared/utils/lib-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/load-esm-module.ts
+++ b/projects/schematics/src/shared/utils/load-esm-module.ts
@@ -8,6 +8,7 @@
 /*
  * Copyright Google LLC All Rights Reserved.
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/logger-utils.ts
+++ b/projects/schematics/src/shared/utils/logger-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/module-file-utils.ts
+++ b/projects/schematics/src/shared/utils/module-file-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/new-module-utils.ts
+++ b/projects/schematics/src/shared/utils/new-module-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/package-utils.ts
+++ b/projects/schematics/src/shared/utils/package-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/program.ts
+++ b/projects/schematics/src/shared/utils/program.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/project-tsconfig-paths.ts
+++ b/projects/schematics/src/shared/utils/project-tsconfig-paths.ts
@@ -1,6 +1,7 @@
 /*
  * Copyright Google LLC All Rights Reserved.
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/schematics-config-utils.ts
+++ b/projects/schematics/src/shared/utils/schematics-config-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/styling-utils.ts
+++ b/projects/schematics/src/shared/utils/styling-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/test-utils.ts
+++ b/projects/schematics/src/shared/utils/test-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/transform-utils.ts
+++ b/projects/schematics/src/shared/utils/transform-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/tree-file-system.ts
+++ b/projects/schematics/src/shared/utils/tree-file-system.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/shared/utils/workspace-utils.ts
+++ b/projects/schematics/src/shared/utils/workspace-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/wrapper-module/index.ts
+++ b/projects/schematics/src/wrapper-module/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/schematics/src/wrapper-module/schema.ts
+++ b/projects/schematics/src/wrapper-module/schema.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/ssr-tests/src/environments/custom-test-environment.ts
+++ b/projects/ssr-tests/src/environments/custom-test-environment.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/ssr-tests/src/utils/http.utils.ts
+++ b/projects/ssr-tests/src/utils/http.utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/ssr-tests/src/utils/log.utils.ts
+++ b/projects/ssr-tests/src/utils/log.utils.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/ssr-tests/src/utils/proxy.utils.ts
+++ b/projects/ssr-tests/src/utils/proxy.utils.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/ssr-tests/src/utils/ssr.utils.ts
+++ b/projects/ssr-tests/src/utils/ssr.utils.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/ssr-tests/validate-ssr-build.ts
+++ b/projects/ssr-tests/validate-ssr-build.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress.config.ci.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress.config.ci.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/continuum.conf.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/continuum.conf.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/continuum.example-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/continuum.example-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/focus-management.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/focus-management.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/keyboard-navigation.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/keyboard-navigation.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/product-configurator-tabbing.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/product-configurator-tabbing.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/quote-tabbing.e2e-2211.FP4.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/quote-tabbing.e2e-2211.FP4.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/scroll-to-top-button.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/scroll-to-top-button.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/skip-focus-header-items-mobile.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/accessibility/skip-focus-header-items-mobile.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/accessibility/asm-b2b-customer-list-tabbling-order.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/accessibility/asm-b2b-customer-list-tabbling-order.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/asm-cost-center.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/asm-cost-center.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/asm.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/asm.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/customer-list.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/customer-list.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/customer360-promotion.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/asm/customer360-promotion.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/bulk-pricing/bulk-pricing.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/bulk-pricing/bulk-pricing.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/checkout/b2b-account-checkout-flow.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/checkout/b2b-account-checkout-flow.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/checkout/b2b-credit-card-checkout-flow.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/checkout/b2b-credit-card-checkout-flow.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/future-stock/future-stock.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/future-stock/future-stock.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/inventory-display/inventory-display.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/inventory-display/inventory-display.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/a11y.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/a11y.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/budgets.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/budgets.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/cost-centers.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/cost-centers.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/purchase-limits.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/purchase-limits.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/units.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/units.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/user-groups.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/my-company/user-groups.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/order-approval/b2b-order-approval.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/order-approval/b2b-order-approval.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/order-history/b2b-order-history-orders-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/order-history/b2b-order-history-orders-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quick-order/b2b-quick-order.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quick-order/b2b-quick-order.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-cart-flow.e2e-2211.FP4.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-cart-flow.e2e-2211.FP4.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-configurator.e2e-2211.FP4.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-configurator.e2e-2211.FP4.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-edit-flow.e2e-2211.FP4.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-edit-flow.e2e-2211.FP4.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-request-flow.e2e-2211.FP4.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-request-flow.e2e-2211.FP4.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-save-active-cart-flow.e2e-2211.FP4.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/quote/b2b-quote-save-active-cart-flow.e2e-2211.FP4.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-daily-replenishment-checkout-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-daily-replenishment-checkout-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-monthly-replenishment-checkout-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-monthly-replenishment-checkout-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-replenishment-order-details-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-replenishment-order-details-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-replenishment-order-history-no-orders-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-replenishment-order-history-no-orders-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-replenishment-order-history-orders-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-replenishment-order-history-orders-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-weekly-replenishment-checkout-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/replenishment/b2b-weekly-replenishment-checkout-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/saved-cart/b2b-saved-cart.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/saved-cart/b2b-saved-cart.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/secure-portal/b2b-secure-portal.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/secure-portal/b2b-secure-portal.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/unit-level-order/b2b-unit-level-order-history.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/unit-level-order/b2b-unit-level-order-history.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/unit-level-order/b2b-unit-level-order.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/unit-level-order/b2b-unit-level-order.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/user-registration/b2b-user-registration-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/user-registration/b2b-user-registration-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/user-registration/b2b-user-registration.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/b2b/regression/user-registration/b2b-user-registration.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/cx_mcs/regression/b2c/checkout-flow.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/cx_mcs/regression/b2c/checkout-flow.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/cx_mcs/regression/b2c/homepage.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/cx_mcs/regression/b2c/homepage.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/anonymous-consents/anonymous-consents-config-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/anonymous-consents/anonymous-consents-config-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/anonymous-consents/anonymous-consents-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/anonymous-consents/anonymous-consents-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/accessibility/customer360-promotion-tabbing-order.asm.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/accessibility/customer360-promotion-tabbing-order.asm.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/accessibility/tabbing-order.e2e.asm.e2e..cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/accessibility/tabbing-order.e2e.asm.e2e..cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/asm.deeplink.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/asm.deeplink.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/asm.emulation.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/asm.emulation.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/bind-cart.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/bind-cart.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/create-customer.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/create-customer.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/customer-list.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/customer-list.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/customer360.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/asm/customer360.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/auth-flow/auth-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/auth-flow/auth-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/added-to-cart-modal.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/added-to-cart-modal.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/added-to-cart-modal.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/added-to-cart-modal.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart-import-export.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart-import-export.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart-validation.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart-validation.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart-validation.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart-validation.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/cart.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/clear-cart.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/clear-cart.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/saved-cart.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/saved-cart.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/saved-cart.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cart/saved-cart.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-as-guest.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-as-guest.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-backoff.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-backoff.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-flow.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-flow.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-payment-billing-address.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-payment-billing-address.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/express-checkout.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/express-checkout.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cms/cms-navigation.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/cms/cms-navigation.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/consignment-tracking/consignment-tracking.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/consignment-tracking/consignment-tracking.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/customer-ticketing/create-ticket.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/customer-ticketing/create-ticket.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/customer-ticketing/ticket-listing.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/customer-ticketing/ticket-listing.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/customer-ticketing/view-ticket-details.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/customer-ticketing/view-ticket-details.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/homepage/homepage.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/homepage/homepage.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/image-zoom/image-zoom.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/image-zoom/image-zoom.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/inventory-display/inventory-display.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/inventory-display/inventory-display.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/miscellaneous/outlets.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/miscellaneous/outlets.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/miscellaneous/routing.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/miscellaneous/routing.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/multi-dimensional/multi-dimensional-checkout-as-guest.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/multi-dimensional/multi-dimensional-checkout-as-guest.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/multi-dimensional/multi-dimensional-checkout-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/multi-dimensional/multi-dimensional-checkout-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/multisite-isolation/multisite-isolation.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/multisite-isolation/multisite-isolation.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/accessibility/my-account-v2-email-management.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/accessibility/my-account-v2-email-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/accessibility/my-account-v2-profile-management.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/accessibility/my-account-v2-profile-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/accessibility/tabbing-order.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/accessibility/tabbing-order.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/accessibility/tabbing-order.e2e-my-account-v2.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/accessibility/tabbing-order.e2e-my-account-v2.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/address-book.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/address-book.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/close-account.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/close-account.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/consent-management.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/consent-management.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-consent-management.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-consent-management.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-email.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-email.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-landing-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-landing-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-notification-preference.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-notification-preference.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-orders.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-orders.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-password.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-password.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-profile.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/my-account-v2-profile.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/order-history-no-orders-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/order-history-no-orders-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/order-history-orders-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/order-history-orders-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/payment-methods.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/payment-methods.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-email.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-email.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-password.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-password.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-password.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-password.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-profile.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-profile.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/notification/my-interests.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/notification/my-interests.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/notification/notification-preference.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/notification/notification-preference.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/notification/stock-notification.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/notification/stock-notification.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/orders/order-cancellations-returns.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/orders/order-cancellations-returns.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/password-visibility/password-visibility.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/password-visibility/password-visibility.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-carousel/product-carousel.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-carousel/product-carousel.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-search/product-search-pricing-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-search/product-search-pricing-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-search/product-search-product-type-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-search/product-search-product-type-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-search/product-search-store-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-search/product-search-store-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-search/product-search.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product-search/product-search.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-mobile.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-mobile.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-textfield-order.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-textfield-order.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-textfield.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-textfield.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-cart.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-cart.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-interactive.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-interactive.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_details/product-details.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_details/product-details.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_details/show-promotions-in-PDP.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_details/show-promotions-in-PDP.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_details/show-real-time-stock-in-PDP.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_details/show-real-time-stock-in-PDP.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/promotions/applied-promotions.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/promotions/applied-promotions.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/qualtrics/qualtrics.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/qualtrics/qualtrics.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/redirects/auth-redirects.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/redirects/auth-redirects.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/reset-password/forgot-password.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/reset-password/forgot-password.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/reset-password/reset-password.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/reset-password/reset-password.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/save-for-later/save-for-later.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/save-for-later/save-for-later.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/scrolling/infinite-scroll.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/scrolling/infinite-scroll.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/scrolling/scroll-position-restoration.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/scrolling/scroll-position-restoration.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency-cart-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency-cart-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency-checkout-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency-checkout-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency-product-details-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency-product-details-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-cart-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-cart-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-checkout-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-checkout-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-my-account-pages.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-my-account-pages.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-product-details-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-product-details-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-product-search-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-product-search-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-registration-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language-registration-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/language/language.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-theme/site-theme.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-theme/site-theme.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/storefinder/store-finder.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/storefinder/store-finder.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/terms-and-conditions/terms-and-conditions-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/terms-and-conditions/terms-and-conditions-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/accessibility/captcha-tabbing-order.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/accessibility/captcha-tabbing-order.cy.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/early-login.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/early-login.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/login.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/login.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/mock-captcha.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/mock-captcha.core-e2e.cy.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/otp-login.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/otp-login.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/register.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/register.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-cart-import-export.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-cart-import-export.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-checkout-as-guest.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-checkout-as-guest.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-checkout-as-guest.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-checkout-as-guest.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-checkout-flow.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-checkout-flow.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-checkout-flow.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/variants/apparel-checkout-flow.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/wishlist/wish-list.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/wishlist/wish-list.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/ssr/pages.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/ssr/pages.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/ssr/product-listing-page.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/ssr/product-listing-page.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2b/b2b-register-org.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2b/b2b-register-org.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2b/b2b-scenarios.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2b/b2b-scenarios.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2c/b2c-scenarios.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2c/b2c-scenarios.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdp/cdp-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdp/cdp-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-brandpage.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-brandpage.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-categorypage.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-categorypage.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-events.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-events.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-homepage.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-homepage.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-productpage.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/merchandising-carousel/merchandising-carousel-productpage.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/profile-tag/custom-headers.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/profile-tag/custom-headers.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/profile-tag/default-events.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/profile-tag/default-events.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/profile-tag/login-notification.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cds/profile-tag/login-notification.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.ccv2-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.ccv2-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/quote/cpq-quote-discount.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/quote/cpq-quote-discount.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/quote/cpq-quote-download-proposal-document.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/quote/cpq-quote-download-proposal-document.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/digital-payments/digital-payments-with-billing-address.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/digital-payments/digital-payments-with-billing-address.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/digital-payments/digital-payments.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/digital-payments/digital-payments.core-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/epd-visualization/accessibility/visual-picking-tab-tabbing-order.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/epd-visualization/accessibility/visual-picking-tab-tabbing-order.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/epd-visualization/visualization-lookup/visualization-lookup.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/epd-visualization/visualization-lookup/visualization-lookup.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/estimated-delivery-date/estimated-delivery-date.e2e-flaky.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/estimated-delivery-date/estimated-delivery-date.e2e-flaky.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/omf/omf-order-v1-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/omf/omf-order-v1-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/omf/omf-order-v2-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/omf/omf-order-v2-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/opf/opf-billing-address.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/opf/opf-billing-address.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/opf/opf-payment-options.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/opf/opf-payment-options.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/opps/opps-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/opps/opps-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pdf-invoices/pdf-invoices.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pdf-invoices/pdf-invoices.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/cart-multiple-entries-checkout.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/cart-multiple-entries-checkout.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/cart-pickup-delivery-options.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/cart-pickup-delivery-options.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pdp-and-cart-logged-in-user-pickup-display.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pdp-and-cart-logged-in-user-pickup-display.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pdp-pickup-delivery-options.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pdp-pickup-delivery-options.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pdp-pickup-delivery-pickup.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pdp-pickup-delivery-pickup.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pickup-checkout-journey-guest-user.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pickup-checkout-journey-guest-user.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pickup-checkout-journey-logged-in-user.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pickup-checkout-journey-logged-in-user.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pickup-checkout-journey.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pickup-checkout-journey.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pickup-in-store-address-book.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/pickup-in-store-address-book.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/set-preferred-store.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/pickup-in-store/set-preferred-store.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/requested-delivery-date/requested-delivery-date.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/requested-delivery-date/requested-delivery-date.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/s4-service/service-order-cancel-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/s4-service/service-order-cancel-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/s4-service/service-order-checkout-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/s4-service/service-order-checkout-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/s4-service/service-order-reschedule-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/s4-service/service-order-reschedule-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/s4om/s4om-schedule-lines.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/s4om/s4om-schedule-lines.e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/segment-refs/segment-refs-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/segment-refs/segment-refs-e2e.cy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/b2b/tabbing-order.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/b2b/tabbing-order.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/group-skipping/group-skipping.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/group-skipping/group-skipping.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/group-skipping/group-skipping.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/group-skipping/group-skipping.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order.model.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/add-to-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/add-to-cart.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/asm.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/asm.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/cart.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/coupons.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/coupons.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/delivery-address.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/delivery-address.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/delivery-mode.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/delivery-mode.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/payment-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/payment-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/review-order.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/checkout/review-order.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/consignment-tracking.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/consignment-tracking.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/footer.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/footer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/header.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/header.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/home.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/home.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/login.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/login.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/address-book.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/address-book.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/change-password.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/change-password.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/close-account.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/close-account.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/consent-management.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/consent-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-account-v2-consent-management.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-account-v2-consent-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-account-v2-notification-preference.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-account-v2-notification-preference.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-account-v2-password.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-account-v2-password.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-coupons.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-coupons.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-interests.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/my-interests.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/notification-preference.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/notification-preference.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/order-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/order-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/order-history.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/order-history.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/payment-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/payment-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/personal-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/personal-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/reset-password.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/reset-password.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/update-email.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/update-email.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/wishlist.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/my-account/wishlist.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/product-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/product-list.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/product-page-pickup-modal.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/product-page-pickup-modal.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/product-page-tabs.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/product-page-tabs.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/product-page.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/product-page.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/register.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/register.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/save-for-later.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/save-for-later.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/stock-notification.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/stock-notification.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/countries-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/countries-list.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/default-view.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/default-view.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/search-results.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/search-results.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/store-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/store-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/stores-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/accessibility/tabbing-order/store-finder/stores-list.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/address-book.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/address-book.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/anonymous-consents.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/anonymous-consents.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/applied-promotions.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/applied-promotions.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/asm.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/asm.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/auth-forms.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/auth-forms.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/auth-redirects.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/auth-redirects.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/auth.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/auth.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-account-summary.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-account-summary.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-bulk-pricing.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-bulk-pricing.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-order-approval.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-order-approval.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-order-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-order-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-order-history.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-order-history.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-quick-order.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-quick-order.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-quote.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-quote.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-replenishment-order-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-replenishment-order-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-replenishment-order-history.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-replenishment-order-history.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-saved-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-saved-cart.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-secure-portal.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-secure-portal.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-user-registration.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-user-registration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/budget.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/budget.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/cost-center.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/cost-center.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/purchase-limit.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/purchase-limit.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/unit.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/unit.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/user-group.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/user-group.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/config/user.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/assignments.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/assignments.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/create.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/create.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/disable.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/disable.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/list.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/nested-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/nested-list.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/update.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/update.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/user-password.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/user-password.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/utils/form.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/utils/form.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/utils/list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/features/utils/list.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/models/index.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/models/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/models/my-company-row.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/models/my-company-row.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/models/my-company.config.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/models/my-company.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/models/my-company.model.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/models/my-company.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/my-company-features.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/my-company-features.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/my-company.utils.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/my-company/my-company.utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/benchmark.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/benchmark.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/cart-import-export.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/cart-import-export.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/cart-validation.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/cart-validation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/cart.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-guest.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-guest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-as-persistent-user.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-backoff.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-backoff.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-forms.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-forms.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-multi-dimensional.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-multi-dimensional.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-variants.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-variants.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/common.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/common.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/consent-management.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/consent-management.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/consignment-tracking.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/consignment-tracking.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/coupons/cart-coupon.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/coupons/cart-coupon.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/coupons/my-coupons.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/coupons/my-coupons.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing-helpers/create-tickets.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing-helpers/create-tickets.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing-helpers/customer-ticketing-commons.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing-helpers/customer-ticketing-commons.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing-helpers/ticket-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing-helpers/ticket-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing-helpers/ticket-listing.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing-helpers/ticket-listing.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/customer-ticketing/customer-ticketing.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/customer360.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/customer360.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/data-configuration.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/data-configuration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/estimated-delivery-date.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/estimated-delivery-date.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/express-checkout.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/express-checkout.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/form.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/form.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/global-message.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/global-message.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/homepage.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/homepage.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/infinite-scroll.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/infinite-scroll.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/inventory-display.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/inventory-display.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/language.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/language.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/login.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/login.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/navigation.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/navigation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/notification.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/notification.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/opf.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/opf.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/order-cancellations-returns.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/order-cancellations-returns.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/order-history.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/order-history.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/payment-methods.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/payment-methods.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/pickup-in-store-utils.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/pickup-in-store-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart-cpq.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart-cpq.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart-vc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart-vc.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-conflict-dialog.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-conflict-dialog.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cpq.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cpq.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview-cpq.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview-cpq.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview-vc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview-vc.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-overview.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-restart-dialog.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-restart-dialog.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-search.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-search.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/register.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/register.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/save-for-later.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/save-for-later.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/saved-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/saved-cart.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/site-context-selector.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/site-context-selector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/site-theme.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/site-theme.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/ssr/product-listing-page.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/ssr/product-listing-page.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/store-finder.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/store-finder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/textfield-configuration.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/textfield-configuration.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/update-email.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/update-email.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/update-password.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/update-password.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/update-profile.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/update-profile.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/user.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/variants/apparel-checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/variants/apparel-checkout-flow.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cdc/cdc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cdc/cdc.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cds/cds.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cds/cds.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cds/merchandising-carousel.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cds/merchandising-carousel.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cds/profile-tag.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cds/profile-tag.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cpq/cpq-quote-discount.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cpq/cpq-quote-discount.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cpq/cpq-quote-download.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cpq/cpq-quote-download.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/digital-payments/user.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/digital-payments/user.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/epd-visualization/visual-picking-tab.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/epd-visualization/visual-picking-tab.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/pdf-invoices/pdf-invoices.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/pdf-invoices/pdf-invoices.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/requested-delivery-date/requested-delivery-date.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/requested-delivery-date/requested-delivery-date.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/s4-service/s4-service-cancel.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/s4-service/s4-service-cancel.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/s4-service/s4-service.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/s4-service/s4-service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/s4om/s4om.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/s4om/s4om.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/viewport-context.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/viewport-context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/wish-list.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/apparel-checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/apparel-checkout-flow.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-account-summary.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-account-summary.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-bulk-pricing.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-bulk-pricing.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-checkout.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-checkout.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-order-approval.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-order-approval.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-order-details.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-order-details.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-order-history.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-order-history.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-saved-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/b2b-saved-cart.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/cart-validation.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/cart-validation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/checkout-flow.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/inventory-display.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/inventory-display.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/multi-dimensional-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/multi-dimensional-flow.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/order-cancellations-returns.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/order-cancellations-returns.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/saved-cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/saved-cart.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/service-order.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/service-order.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/shared-users.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/shared-users.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/sample-data/viewports.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/sample-data/viewports.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/a11y-tab.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/a11y-tab.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/cart.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/cart.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/continuum.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/continuum.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/cx-config.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/cx-config.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/login.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/login.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/ng-select.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/ng-select.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/order-placed.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/order-placed.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-costcenter-selected.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-costcenter-selected.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-customer-tickets-list.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-customer-tickets-list.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-delivery-address-added.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-delivery-address-added.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-delivery-method-selected.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-delivery-method-selected.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-logged-in.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-logged-in.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-payment-done.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-payment-done.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-payment-method-added.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-payment-method-added.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-payment-type-selected.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-payment-type-selected.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-placed-order.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-placed-order.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-product-added-to-cart.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-product-added-to-cart.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/require-saved-carts.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/require-saved-carts.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/select-user-menu-option.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/select-user-menu-option.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/storage.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/storage.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/utils/a11y-tab.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/utils/a11y-tab.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/utils/cart.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/utils/cart.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/utils/clear-all-storage.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/utils/clear-all-storage.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/utils/delivery-modes.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/utils/delivery-modes.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/utils/intercept.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/utils/intercept.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/utils/login.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/utils/login.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/utils/order-placed.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/utils/order-placed.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/utils/switch-site-context.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/utils/switch-site-context.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/utils/test-isolation.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/utils/test-isolation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/vendor/cds/merchandising-carousel.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/vendor/cds/merchandising-carousel.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp-e2e-cypress/cypress/support/viewport.commands.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/support/viewport.commands.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/server.ts
+++ b/projects/storefrontapp/server.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/app.server.module.ts
+++ b/projects/storefrontapp/src/app/app.server.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/asm/asm-customer-360-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/asm/asm-customer-360-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/asm/asm-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/asm/asm-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/cart/cart-base-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cart/cart-base-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/cart/cart-base-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cart/cart-base-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/cart/cart-import-export-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cart/cart-import-export-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/cart/cart-quick-order-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cart/cart-quick-order-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/cart/cart-saved-cart-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cart/cart-saved-cart-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/cart/wish-list-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cart/wish-list-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/cdc/cdc-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cdc/cdc-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/cds/cds-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cds/cds-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/checkout/checkout-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/checkout/checkout-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/checkout/checkout-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/checkout/checkout-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/cpq-quote/cpq-quote-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/cpq-quote/cpq-quote-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/customer-ticketing/customer-ticketing-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/customer-ticketing/customer-ticketing-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/customer-ticketing/customer-ticketing-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/customer-ticketing/customer-ticketing-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/digital-payments/digital-payments-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/digital-payments/digital-payments-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/epd-visualization/epd-visualization-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/estimated-delivery-date/estimated-delivery-date-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/estimated-delivery-date/estimated-delivery-date-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/omf/omf-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/omf/omf-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/opps/opps-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/opps/opps-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/order/order-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/order/order-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/order/order-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/order/order-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/organization/administration-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/organization/administration-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/organization/organization-account-summary-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/organization/organization-account-summary-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/organization/organization-administration-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/organization/organization-administration-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/organization/organization-order-approval-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/organization/organization-order-approval-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/organization/organization-unit-order-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/organization/organization-unit-order-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/organization/organization-user-registration-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/organization/organization-user-registration-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/pdf-invoices/pdf-invoices-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/pdf-invoices/pdf-invoices-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/pickup-in-store/pickup-in-store-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/pickup-in-store/pickup-in-store-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/product-configurator/product-configurator-rulebased-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/product-configurator/product-configurator-rulebased-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/product-configurator/product-configurator-textfield-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/product-configurator/product-configurator-textfield-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/product-configurator/rulebased-configurator-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/product-configurator/rulebased-configurator-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/product-multi-dimensional/product-multi-dimensional-list-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/product-multi-dimensional/product-multi-dimensional-list-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/product-multi-dimensional/product-multi-dimensional-selector-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/product-multi-dimensional/product-multi-dimensional-selector-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/product/product-bulk-pricing-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/product/product-bulk-pricing-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/product/product-future-stock-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/product/product-future-stock-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/product/product-image-zoom-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/product/product-image-zoom-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/product/product-variants-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/product/product-variants-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/qualtrics/qualtrics-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/qualtrics/qualtrics-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/quote-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/quote-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/registration-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/registration-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/requested-delivery-date/requested-delivery-date-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/requested-delivery-date/requested-delivery-date-feature.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/s4-service/s4-service-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/s4-service/s4-service-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/s4om/s4om-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/s4om/s4om-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/segment-refs/segment-refs-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/segment-refs/segment-refs-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/smartedit/smartedit-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/smartedit/smartedit-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/storefinder/storefinder-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/storefinder/storefinder-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/tracking/tracking-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/tracking/tracking-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/user/user-account-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/user/user-account-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/user/user-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/user/user-feature.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/features/user/user-profile-wrapper.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/user/user-profile-wrapper.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/spartacus-b2b-configuration.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-b2b-configuration.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/spartacus-b2c-configuration.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-b2c-configuration.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/app/spartacus/spartacus.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/environments/environment.prod.ts
+++ b/projects/storefrontapp/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/environments/models/build.process.env.d.ts
+++ b/projects/storefrontapp/src/environments/models/build.process.env.d.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/environments/models/environment.model.ts
+++ b/projects/storefrontapp/src/environments/models/environment.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/environments/models/feature.model.ts
+++ b/projects/storefrontapp/src/environments/models/feature.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/main.server.ts
+++ b/projects/storefrontapp/src/main.server.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/main.ts
+++ b/projects/storefrontapp/src/main.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/test-outlets/test-outlet-cms-page.config.ts
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-cms-page.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/test-outlets/test-outlet-component/test-outlet-component.component.ts
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-component/test-outlet-component.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/test-outlets/test-outlet-component/test-outlet-component.module.ts
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-component/test-outlet-component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/test-outlets/test-outlet-slot/test-outlet-slot.component.ts
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-slot/test-outlet-slot.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/test-outlets/test-outlet-slot/test-outlet-slot.module.ts
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-slot/test-outlet-slot.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/test-outlets/test-outlet-template/test-outlet-template.component.ts
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-template/test-outlet-template.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/test-outlets/test-outlet-template/test-outlet-template.module.ts
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-template/test-outlet-template.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/test-outlets/test-outlet.module.ts
+++ b/projects/storefrontapp/src/test-outlets/test-outlet.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontapp/src/test.ts
+++ b/projects/storefrontapp/src/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/base-storefront.module.ts
+++ b/projects/storefrontlib/base-storefront.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/anonymous-consent-management.module.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/anonymous-consent-management.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/default-anonymous-consent-layout.config.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/default-anonymous-consent-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/index.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/banner-carousel/banner-carousel.component.ts
+++ b/projects/storefrontlib/cms-components/content/banner-carousel/banner-carousel.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/banner-carousel/banner-carousel.module.ts
+++ b/projects/storefrontlib/cms-components/content/banner-carousel/banner-carousel.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/banner/banner.component.ts
+++ b/projects/storefrontlib/cms-components/content/banner/banner.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/banner/banner.module.ts
+++ b/projects/storefrontlib/cms-components/content/banner/banner.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/index.ts
+++ b/projects/storefrontlib/cms-components/content/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/link/link.component.ts
+++ b/projects/storefrontlib/cms-components/content/link/link.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/link/link.module.ts
+++ b/projects/storefrontlib/cms-components/content/link/link.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.ts
+++ b/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/paragraph/paragraph.module.ts
+++ b/projects/storefrontlib/cms-components/content/paragraph/paragraph.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/pdf/pdf.component.ts
+++ b/projects/storefrontlib/cms-components/content/pdf/pdf.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/pdf/pdf.module.ts
+++ b/projects/storefrontlib/cms-components/content/pdf/pdf.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.ts
+++ b/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.module.ts
+++ b/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/tab/panel/tab-panel.component.ts
+++ b/projects/storefrontlib/cms-components/content/tab/panel/tab-panel.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/tab/panel/tab-panel.module.ts
+++ b/projects/storefrontlib/cms-components/content/tab/panel/tab-panel.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/tab/tab.component.ts
+++ b/projects/storefrontlib/cms-components/content/tab/tab.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/tab/tab.model.ts
+++ b/projects/storefrontlib/cms-components/content/tab/tab.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/tab/tab.module.ts
+++ b/projects/storefrontlib/cms-components/content/tab/tab.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/tab/tab.utils.ts
+++ b/projects/storefrontlib/cms-components/content/tab/tab.utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/video/video.component.ts
+++ b/projects/storefrontlib/cms-components/content/video/video.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/content/video/video.module.ts
+++ b/projects/storefrontlib/cms-components/content/video/video.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/index.ts
+++ b/projects/storefrontlib/cms-components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/global-message/global-message.component.ts
+++ b/projects/storefrontlib/cms-components/misc/global-message/global-message.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/global-message/global-message.module.ts
+++ b/projects/storefrontlib/cms-components/misc/global-message/global-message.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/global-message/index.ts
+++ b/projects/storefrontlib/cms-components/misc/global-message/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/icon/default-icon.config.ts
+++ b/projects/storefrontlib/cms-components/misc/icon/default-icon.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/icon/fontawesome-icon.config.ts
+++ b/projects/storefrontlib/cms-components/misc/icon/fontawesome-icon.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/icon/icon-loader.service.ts
+++ b/projects/storefrontlib/cms-components/misc/icon/icon-loader.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/icon/icon.component.ts
+++ b/projects/storefrontlib/cms-components/misc/icon/icon.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/icon/icon.model.ts
+++ b/projects/storefrontlib/cms-components/misc/icon/icon.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/icon/icon.module.ts
+++ b/projects/storefrontlib/cms-components/misc/icon/icon.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/icon/index.ts
+++ b/projects/storefrontlib/cms-components/misc/icon/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/icon/testing/icon-testing.module.ts
+++ b/projects/storefrontlib/cms-components/misc/icon/testing/icon-testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/index.ts
+++ b/projects/storefrontlib/cms-components/misc/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/message/index.ts
+++ b/projects/storefrontlib/cms-components/misc/message/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/message/message.component.ts
+++ b/projects/storefrontlib/cms-components/misc/message/message.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/message/message.module.ts
+++ b/projects/storefrontlib/cms-components/misc/message/message.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/promotions/index.ts
+++ b/projects/storefrontlib/cms-components/misc/promotions/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/promotions/promotions.component.ts
+++ b/projects/storefrontlib/cms-components/misc/promotions/promotions.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/promotions/promotions.module.ts
+++ b/projects/storefrontlib/cms-components/misc/promotions/promotions.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/index.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/language-currency.component.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/language-currency.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-component.service.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.component.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.module.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/site-context.model.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/site-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-theme-switcher/index.ts
+++ b/projects/storefrontlib/cms-components/misc/site-theme-switcher/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-theme-switcher/site-theme-switcher.component.service.ts
+++ b/projects/storefrontlib/cms-components/misc/site-theme-switcher/site-theme-switcher.component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-theme-switcher/site-theme-switcher.component.ts
+++ b/projects/storefrontlib/cms-components/misc/site-theme-switcher/site-theme-switcher.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/misc/site-theme-switcher/site-theme-switcher.module.ts
+++ b/projects/storefrontlib/cms-components/misc/site-theme-switcher/site-theme-switcher.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/consent-management/components/consent-form/consent-management-form.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/consent-management/components/consent-form/consent-management-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/consent-management/components/consent-management.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/consent-management/components/consent-management.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/consent-management/consent-management-component.service.ts
+++ b/projects/storefrontlib/cms-components/myaccount/consent-management/consent-management-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/consent-management/consent-management.module.ts
+++ b/projects/storefrontlib/cms-components/myaccount/consent-management/consent-management.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/consent-management/index.ts
+++ b/projects/storefrontlib/cms-components/myaccount/consent-management/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/index.ts
+++ b/projects/storefrontlib/cms-components/myaccount/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/index.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/consent-form/my-account-v2-consent-management-form.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/consent-form/my-account-v2-consent-management-form.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/my-account-v2-consent-management.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/my-account-v2-consent-management.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/index.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/my-account-v2-consent-management.module.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/my-account-v2-consent-management.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-navigation/index.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-navigation/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-navigation/my-account-v2-navigation.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-navigation/my-account-v2-navigation.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-navigation/my-account-v2-navigation.module.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-navigation/my-account-v2-navigation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/index.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/my-account-v2-notification-preference.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/my-account-v2-notification-preference.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/my-account-v2-notification-preference.module.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/my-account-v2-notification-preference.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2.module.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/my-account-v2.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-account-v2/use-my-account-v2-consent-notification-perference.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-account-v2/use-my-account-v2-consent-notification-perference.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/claim-dialog/claim-dialog.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/claim-dialog/claim-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-card.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-card.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-dialog/coupon-dialog.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-card/coupon-dialog/coupon-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-claim/coupon-claim.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/coupon-claim/coupon-claim.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/default-coupon-card-layout.config.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/default-coupon-card-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/index.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.service.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.module.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-coupons/my-coupons.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.module.ts
+++ b/projects/storefrontlib/cms-components/myaccount/my-interests/my-interests.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/notification-preference/index.ts
+++ b/projects/storefrontlib/cms-components/myaccount/notification-preference/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/notification-preference/notification-preference.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/notification-preference/notification-preference.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/notification-preference/notification-preference.module.ts
+++ b/projects/storefrontlib/cms-components/myaccount/notification-preference/notification-preference.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/payment-methods/payment-methods.component.ts
+++ b/projects/storefrontlib/cms-components/myaccount/payment-methods/payment-methods.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/myaccount/payment-methods/payment-methods.module.ts
+++ b/projects/storefrontlib/cms-components/myaccount/payment-methods/payment-methods.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/breadcrumb/breadcrumb.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/breadcrumb/breadcrumb.module.ts
+++ b/projects/storefrontlib/cms-components/navigation/breadcrumb/breadcrumb.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/category-navigation/category-navigation.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/category-navigation/category-navigation.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/category-navigation/category-navigation.module.ts
+++ b/projects/storefrontlib/cms-components/navigation/category-navigation/category-navigation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/footer-navigation/footer-navigation.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/footer-navigation/footer-navigation.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/footer-navigation/footer-navigation.module.ts
+++ b/projects/storefrontlib/cms-components/navigation/footer-navigation/footer-navigation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/index.ts
+++ b/projects/storefrontlib/cms-components/navigation/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/navigation/navigation-node.model.ts
+++ b/projects/storefrontlib/cms-components/navigation/navigation/navigation-node.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/navigation/navigation-ui.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/navigation/navigation-ui.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/navigation/navigation.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/navigation/navigation.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/navigation/navigation.module.ts
+++ b/projects/storefrontlib/cms-components/navigation/navigation/navigation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/navigation/navigation.service.ts
+++ b/projects/storefrontlib/cms-components/navigation/navigation/navigation.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/page-header/page-title.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/page-header/page-title.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/page-header/page-title.module.ts
+++ b/projects/storefrontlib/cms-components/navigation/page-header/page-title.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/scroll-to-top/scroll-to-top.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/scroll-to-top/scroll-to-top.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/scroll-to-top/scroll-to-top.module.ts
+++ b/projects/storefrontlib/cms-components/navigation/scroll-to-top/scroll-to-top.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/search-box/highlight.pipe.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/highlight.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/search-box/index.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box-component.service.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box-features.model.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box-features.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box-outlets.model.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box-outlets.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.events.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.model.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.module.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/carousel/index.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel-item/product-carousel-item.component.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel-item/product-carousel-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel.model.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel.service.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.module.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/carousel/product-references/product-references.component.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-references/product-references.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/carousel/product-references/product-references.module.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-references/product-references.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/config/default-view-config.ts
+++ b/projects/storefrontlib/cms-components/product/config/default-view-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/current-product.service.ts
+++ b/projects/storefrontlib/cms-components/product/current-product.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/index.ts
+++ b/projects/storefrontlib/cms-components/product/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-images/product-images.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-images/product-images.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-images/product-images.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-images/product-images.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-intro/product-intro.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-intro/product-intro.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-intro/product-intro.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-intro/product-intro.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/container/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-list-component.service.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-list-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-list.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-list.model.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-list.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/container/product-scroll/product-scroll.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/container/product-scroll/product-scroll.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/model/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/model/product-list-item-context-source.model.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/model/product-list-item-context-source.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/model/product-list-item-context.model.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/model/product-list-item-context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/active-facets/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet.model.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/services/facet.service.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/services/facet.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/services/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/services/product-facet.service.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/services/product-facet.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-grid-item/product-grid-item.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-grid-item/product-grid-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-list-item/product-list-item.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-list-item/product-list-item.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-list.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-list.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-list.service.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-list.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-list/product-view/product-view.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-view/product-view.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-outlets.model.ts
+++ b/projects/storefrontlib/cms-components/product/product-outlets.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-summary/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-summary/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-summary/product-summary.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-summary/product-summary.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-summary/product-summary.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-summary/product-summary.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-tabs/index.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-attributes/product-attributes.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-attributes/product-attributes.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-attributes/product-attributes.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-attributes/product-attributes.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-details-tab/product-details-tab.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-tabs.module.ts
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-tabs.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/default-stock-notification-layout.config.ts
+++ b/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/default-stock-notification-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.ts
+++ b/projects/storefrontlib/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/stock-notification/stock-notification.component.ts
+++ b/projects/storefrontlib/cms-components/product/stock-notification/stock-notification.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/product/stock-notification/stock-notification.module.ts
+++ b/projects/storefrontlib/cms-components/product/stock-notification/stock-notification.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/user/index.ts
+++ b/projects/storefrontlib/cms-components/user/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/user/login-route/login-route.module.ts
+++ b/projects/storefrontlib/cms-components/user/login-route/login-route.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/user/login-route/login.guard.ts
+++ b/projects/storefrontlib/cms-components/user/login-route/login.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/user/logout/logout.guard.ts
+++ b/projects/storefrontlib/cms-components/user/logout/logout.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/user/logout/logout.module.ts
+++ b/projects/storefrontlib/cms-components/user/logout/logout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-components/user/user.module.ts
+++ b/projects/storefrontlib/cms-components/user/user.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-pages/index.ts
+++ b/projects/storefrontlib/cms-pages/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-pages/product-details-page/index.ts
+++ b/projects/storefrontlib/cms-pages/product-details-page/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-pages/product-details-page/product-details-page.module.ts
+++ b/projects/storefrontlib/cms-pages/product-details-page/product-details-page.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-pages/product-details-page/product-details-url-matcher.ts
+++ b/projects/storefrontlib/cms-pages/product-details-page/product-details-url-matcher.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-pages/product-listing-page/index.ts
+++ b/projects/storefrontlib/cms-pages/product-listing-page/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-pages/product-listing-page/product-listing-page.module.ts
+++ b/projects/storefrontlib/cms-pages/product-listing-page/product-listing-page.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-pages/product-listing-page/product-listing-url-matcher.ts
+++ b/projects/storefrontlib/cms-pages/product-listing-page/product-listing-url-matcher.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/guards/before-cms-page-guard.service.ts
+++ b/projects/storefrontlib/cms-structure/guards/before-cms-page-guard.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/guards/before-cms-page-guard.token.ts
+++ b/projects/storefrontlib/cms-structure/guards/before-cms-page-guard.token.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/guards/cms-page-guard.service.ts
+++ b/projects/storefrontlib/cms-structure/guards/cms-page-guard.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/guards/cms-page.guard.ts
+++ b/projects/storefrontlib/cms-structure/guards/cms-page.guard.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/guards/index.ts
+++ b/projects/storefrontlib/cms-structure/guards/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/index.ts
+++ b/projects/storefrontlib/cms-structure/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/outlet/index.ts
+++ b/projects/storefrontlib/cms-structure/outlet/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/outlet/outlet-ref/outlet-ref.directive.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet-ref/outlet-ref.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/outlet/outlet-ref/outlet-ref.module.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet-ref/outlet-ref.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/outlet/outlet-renderer.service.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet-renderer.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/outlet/outlet.directive.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/outlet/outlet.model.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/outlet/outlet.module.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/outlet/outlet.providers.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet.providers.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/outlet/outlet.service.ts
+++ b/projects/storefrontlib/cms-structure/outlet/outlet.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/component-wrapper.directive.ts
+++ b/projects/storefrontlib/cms-structure/page/component/component-wrapper.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/events/component.event.ts
+++ b/projects/storefrontlib/cms-structure/page/component/events/component.event.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/events/index.ts
+++ b/projects/storefrontlib/cms-structure/page/component/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/handlers/component-handler.ts
+++ b/projects/storefrontlib/cms-structure/page/component/handlers/component-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/handlers/default-component.handler.ts
+++ b/projects/storefrontlib/cms-structure/page/component/handlers/default-component.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/handlers/index.ts
+++ b/projects/storefrontlib/cms-structure/page/component/handlers/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/handlers/lazy-component.handler.ts
+++ b/projects/storefrontlib/cms-structure/page/component/handlers/lazy-component.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/handlers/web-component.handler.ts
+++ b/projects/storefrontlib/cms-structure/page/component/handlers/web-component.handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/index.ts
+++ b/projects/storefrontlib/cms-structure/page/component/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/inner-components-host.directive.ts
+++ b/projects/storefrontlib/cms-structure/page/component/inner-components-host.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/page-component.module.ts
+++ b/projects/storefrontlib/cms-structure/page/component/page-component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/services/cms-injector.service.ts
+++ b/projects/storefrontlib/cms-structure/page/component/services/cms-injector.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/services/component-data.provider.ts
+++ b/projects/storefrontlib/cms-structure/page/component/services/component-data.provider.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/services/component-handler.service.ts
+++ b/projects/storefrontlib/cms-structure/page/component/services/component-handler.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/services/cx-api.service.ts
+++ b/projects/storefrontlib/cms-structure/page/component/services/cx-api.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/component/services/index.ts
+++ b/projects/storefrontlib/cms-structure/page/component/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/index.ts
+++ b/projects/storefrontlib/cms-structure/page/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/model/cms-component-data.ts
+++ b/projects/storefrontlib/cms-structure/page/model/cms-component-data.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/model/index.ts
+++ b/projects/storefrontlib/cms-structure/page/model/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/page-layout/index.ts
+++ b/projects/storefrontlib/cms-structure/page/page-layout/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/page-layout/page-layout-handler.ts
+++ b/projects/storefrontlib/cms-structure/page/page-layout/page-layout-handler.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/page-layout/page-layout.component.ts
+++ b/projects/storefrontlib/cms-structure/page/page-layout/page-layout.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/page-layout/page-layout.module.ts
+++ b/projects/storefrontlib/cms-structure/page/page-layout/page-layout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/page-layout/page-layout.service.ts
+++ b/projects/storefrontlib/cms-structure/page/page-layout/page-layout.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/page-layout/page-template.directive.ts
+++ b/projects/storefrontlib/cms-structure/page/page-layout/page-template.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/slot/index.ts
+++ b/projects/storefrontlib/cms-structure/page/slot/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/slot/page-slot.component.ts
+++ b/projects/storefrontlib/cms-structure/page/slot/page-slot.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/slot/page-slot.module.ts
+++ b/projects/storefrontlib/cms-structure/page/slot/page-slot.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/page/slot/page-slot.service.ts
+++ b/projects/storefrontlib/cms-structure/page/slot/page-slot.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/pwa/components/add-to-home-screen-banner/add-to-home-screen-banner.component.ts
+++ b/projects/storefrontlib/cms-structure/pwa/components/add-to-home-screen-banner/add-to-home-screen-banner.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/pwa/components/add-to-home-screen-btn/add-to-home-screen-btn.component.ts
+++ b/projects/storefrontlib/cms-structure/pwa/components/add-to-home-screen-btn/add-to-home-screen-btn.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/pwa/components/add-to-home-screen.component.ts
+++ b/projects/storefrontlib/cms-structure/pwa/components/add-to-home-screen.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/pwa/index.ts
+++ b/projects/storefrontlib/cms-structure/pwa/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/pwa/pwa.module-config.ts
+++ b/projects/storefrontlib/cms-structure/pwa/pwa.module-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/pwa/pwa.module.ts
+++ b/projects/storefrontlib/cms-structure/pwa/pwa.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/pwa/services/add-to-home-screen.service.ts
+++ b/projects/storefrontlib/cms-structure/pwa/services/add-to-home-screen.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/routing/cms-route/add-cms-route.ts
+++ b/projects/storefrontlib/cms-structure/routing/cms-route/add-cms-route.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/routing/cms-route/cms-route.module.ts
+++ b/projects/storefrontlib/cms-structure/routing/cms-route/cms-route.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/routing/cms-route/index.ts
+++ b/projects/storefrontlib/cms-structure/routing/cms-route/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/routing/default-routing-config.ts
+++ b/projects/storefrontlib/cms-structure/routing/default-routing-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/routing/index.ts
+++ b/projects/storefrontlib/cms-structure/routing/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/routing/routing.module.ts
+++ b/projects/storefrontlib/cms-structure/routing/routing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/routing/suffix-routes/index.ts
+++ b/projects/storefrontlib/cms-structure/routing/suffix-routes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/routing/suffix-routes/suffix-url-matcher.ts
+++ b/projects/storefrontlib/cms-structure/routing/suffix-routes/suffix-url-matcher.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/config/default-seo.config.ts
+++ b/projects/storefrontlib/cms-structure/seo/config/default-seo.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/config/index.ts
+++ b/projects/storefrontlib/cms-structure/seo/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/config/seo.config.ts
+++ b/projects/storefrontlib/cms-structure/seo/config/seo.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/html-lang-provider.ts
+++ b/projects/storefrontlib/cms-structure/seo/html-lang-provider.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/index.ts
+++ b/projects/storefrontlib/cms-structure/seo/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/seo-meta.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/seo-meta.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/seo.module.ts
+++ b/projects/storefrontlib/cms-structure/seo/seo.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/breadcrumb/breadcrumb-schema.builder.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/breadcrumb/breadcrumb-schema.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/breadcrumb/index.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/breadcrumb/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/index.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/json-ld-builder.module.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/json-ld-builder.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/index.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/jsonld-base-product.builder.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/jsonld-base-product.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/jsonld-product-offer.builder.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/jsonld-product-offer.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/jsonld-product-review.builder.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/jsonld-product-review.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/product-schema.builder.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/product/product-schema.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/schema.interface.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/schema.interface.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/builders/tokens.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/builders/tokens.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/index.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/json-ld-script.factory.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/json-ld-script.factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/json-ld.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/structured-data.factory.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/structured-data.factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/seo/structured-data/structured-data.module.ts
+++ b/projects/storefrontlib/cms-structure/seo/structured-data/structured-data.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/services/cms-components.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-components.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/services/cms-features.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-features.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/services/cms-guards.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-guards.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/services/cms-i18n.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-i18n.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/services/cms-routes-impl.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-routes-impl.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/services/cms-routes.service.ts
+++ b/projects/storefrontlib/cms-structure/services/cms-routes.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/services/guards-composer.ts
+++ b/projects/storefrontlib/cms-structure/services/guards-composer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/services/index.ts
+++ b/projects/storefrontlib/cms-structure/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/utils/cms-structure.model.ts
+++ b/projects/storefrontlib/cms-structure/utils/cms-structure.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/utils/cms-structure.util.ts
+++ b/projects/storefrontlib/cms-structure/utils/cms-structure.util.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/cms-structure/utils/index.ts
+++ b/projects/storefrontlib/cms-structure/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/context/context.model.ts
+++ b/projects/storefrontlib/context/context.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/context/context.service.ts
+++ b/projects/storefrontlib/context/context.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/context/index.ts
+++ b/projects/storefrontlib/context/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/context/routing-context.service.ts
+++ b/projects/storefrontlib/context/routing-context.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/home/home-page-event.builder.ts
+++ b/projects/storefrontlib/events/home/home-page-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/home/home-page-event.module.ts
+++ b/projects/storefrontlib/events/home/home-page-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/home/home-page.events.ts
+++ b/projects/storefrontlib/events/home/home-page.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/home/index.ts
+++ b/projects/storefrontlib/events/home/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/index.ts
+++ b/projects/storefrontlib/events/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/navigation/index.ts
+++ b/projects/storefrontlib/events/navigation/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/navigation/navigation-event.builder.ts
+++ b/projects/storefrontlib/events/navigation/navigation-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/navigation/navigation-event.module.ts
+++ b/projects/storefrontlib/events/navigation/navigation-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/navigation/navigation.event.ts
+++ b/projects/storefrontlib/events/navigation/navigation.event.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/page/index.ts
+++ b/projects/storefrontlib/events/page/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/page/page.events.ts
+++ b/projects/storefrontlib/events/page/page.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/product/index.ts
+++ b/projects/storefrontlib/events/product/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/product/product-page-event.builder.ts
+++ b/projects/storefrontlib/events/product/product-page-event.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/product/product-page-event.module.ts
+++ b/projects/storefrontlib/events/product/product-page-event.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/events/product/product-page.events.ts
+++ b/projects/storefrontlib/events/product/product-page.events.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/btn-like-link/btn-like-link.directive.ts
+++ b/projects/storefrontlib/layout/a11y/btn-like-link/btn-like-link.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/btn-like-link/btn-like-link.module.ts
+++ b/projects/storefrontlib/layout/a11y/btn-like-link/btn-like-link.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/btn-like-link/index.ts
+++ b/projects/storefrontlib/layout/a11y/btn-like-link/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/index.ts
+++ b/projects/storefrontlib/layout/a11y/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.service.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/auto-focus.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/autofocus/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/base/base-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/base/base-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/base/base-focus.service.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/base/base-focus.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/base/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/base/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/block/block-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/block/block-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/block/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/block/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/escape/escape-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/escape/escape-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/escape/escape-focus.service.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/escape/escape-focus.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/escape/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/escape/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/focus-testing.module.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/focus-testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/keyboard-focus.model.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/keyboard-focus.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/keyboard-focus.module.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/keyboard-focus.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/keyboard-focus.utils.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/keyboard-focus.utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/lock/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/lock/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/lock/lock-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/lock/lock-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/lock/lock-focus.service.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/lock/lock-focus.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/persist/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/persist/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/persist/persist-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/persist/persist-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/persist/persist-focus.service.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/persist/persist-focus.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/services/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/services/keyboard-focus.service.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/services/keyboard-focus.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/services/select-focus.util.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/services/select-focus.util.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/skip-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/skip-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/tab/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/tab/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/tab/tab-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/tab/tab-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/tab/tab-focus.service.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/tab/tab-focus.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/trap/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/trap/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/trap/trap-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/trap/trap-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/trap/trap-focus.service.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/trap/trap-focus.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/visible/index.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/visible/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/keyboard-focus/visible/visible-focus.directive.ts
+++ b/projects/storefrontlib/layout/a11y/keyboard-focus/visible/visible-focus.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/skip-link/component/skip-link.component.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/component/skip-link.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/skip-link/config/default-skip-link.config.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/config/default-skip-link.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/skip-link/config/index.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/skip-link/config/skip-link.config.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/config/skip-link.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/skip-link/directive/skip-link.directive.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/directive/skip-link.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/skip-link/index.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/skip-link/service/skip-link.service.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/service/skip-link.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/a11y/skip-link/skip-link.module.ts
+++ b/projects/storefrontlib/layout/a11y/skip-link/skip-link.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/breakpoint/breakpoint.service.ts
+++ b/projects/storefrontlib/layout/breakpoint/breakpoint.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/breakpoint/index.ts
+++ b/projects/storefrontlib/layout/breakpoint/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/config/default-layout.config.ts
+++ b/projects/storefrontlib/layout/config/default-layout.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/config/index.ts
+++ b/projects/storefrontlib/layout/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/config/layout-config.ts
+++ b/projects/storefrontlib/layout/config/layout-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/direction/config/default-direction.config.ts
+++ b/projects/storefrontlib/layout/direction/config/default-direction.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/direction/config/direction.config.ts
+++ b/projects/storefrontlib/layout/direction/config/direction.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/direction/config/direction.model.ts
+++ b/projects/storefrontlib/layout/direction/config/direction.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/direction/direction.module.ts
+++ b/projects/storefrontlib/layout/direction/direction.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/direction/direction.service.ts
+++ b/projects/storefrontlib/layout/direction/direction.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/direction/index.ts
+++ b/projects/storefrontlib/layout/direction/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/header/hamburger-menu/hamburger-menu.component.ts
+++ b/projects/storefrontlib/layout/header/hamburger-menu/hamburger-menu.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/header/hamburger-menu/hamburger-menu.module.ts
+++ b/projects/storefrontlib/layout/header/hamburger-menu/hamburger-menu.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/header/hamburger-menu/hamburger-menu.service.ts
+++ b/projects/storefrontlib/layout/header/hamburger-menu/hamburger-menu.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/header/index.ts
+++ b/projects/storefrontlib/layout/header/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/index.ts
+++ b/projects/storefrontlib/layout/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/config/index.ts
+++ b/projects/storefrontlib/layout/launch-dialog/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/config/launch-config.ts
+++ b/projects/storefrontlib/layout/launch-dialog/config/launch-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/index.ts
+++ b/projects/storefrontlib/layout/launch-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/launch-dialog.module.ts
+++ b/projects/storefrontlib/layout/launch-dialog/launch-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/services/index.ts
+++ b/projects/storefrontlib/layout/launch-dialog/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/services/inline-render.strategy.ts
+++ b/projects/storefrontlib/layout/launch-dialog/services/inline-render.strategy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/services/inline-root-render.strategy.ts
+++ b/projects/storefrontlib/layout/launch-dialog/services/inline-root-render.strategy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/services/launch-dialog.service.ts
+++ b/projects/storefrontlib/layout/launch-dialog/services/launch-dialog.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/services/launch-render.strategy.ts
+++ b/projects/storefrontlib/layout/launch-dialog/services/launch-render.strategy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/services/outlet-render.strategy.ts
+++ b/projects/storefrontlib/layout/launch-dialog/services/outlet-render.strategy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/launch-dialog/services/routing-render.strategy.ts
+++ b/projects/storefrontlib/layout/launch-dialog/services/routing-render.strategy.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/layout.module.ts
+++ b/projects/storefrontlib/layout/layout.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/loading/defer-loader.service.ts
+++ b/projects/storefrontlib/layout/loading/defer-loader.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/loading/index.ts
+++ b/projects/storefrontlib/layout/loading/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/loading/intersection.model.ts
+++ b/projects/storefrontlib/layout/loading/intersection.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/loading/intersection.service.ts
+++ b/projects/storefrontlib/layout/loading/intersection.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/main/index.ts
+++ b/projects/storefrontlib/layout/main/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/main/storefront-component.module.ts
+++ b/projects/storefrontlib/layout/main/storefront-component.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/main/storefront-outlets.model.ts
+++ b/projects/storefrontlib/layout/main/storefront-outlets.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/main/storefront.component.ts
+++ b/projects/storefrontlib/layout/main/storefront.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/theme/index.ts
+++ b/projects/storefrontlib/layout/theme/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/theme/theme.module.ts
+++ b/projects/storefrontlib/layout/theme/theme.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/layout/theme/theme.service.ts
+++ b/projects/storefrontlib/layout/theme/theme.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/public_api.ts
+++ b/projects/storefrontlib/public_api.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/recipes/config/default-media.config.ts
+++ b/projects/storefrontlib/recipes/config/default-media.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/recipes/config/index.ts
+++ b/projects/storefrontlib/recipes/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/recipes/config/layout-config.ts
+++ b/projects/storefrontlib/recipes/config/layout-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/recipes/config/static-cms-structure.ts
+++ b/projects/storefrontlib/recipes/config/static-cms-structure.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/recipes/index.ts
+++ b/projects/storefrontlib/recipes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/router/app-routing.module.ts
+++ b/projects/storefrontlib/router/app-routing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/router/config/default-on-navigate-config.ts
+++ b/projects/storefrontlib/router/config/default-on-navigate-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/router/config/index.ts
+++ b/projects/storefrontlib/router/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/router/config/on-navigate-config.ts
+++ b/projects/storefrontlib/router/config/on-navigate-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/router/index.ts
+++ b/projects/storefrontlib/router/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/router/on-navigate.service.ts
+++ b/projects/storefrontlib/router/on-navigate.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.ts
+++ b/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consents-dialog.module.ts
+++ b/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consents-dialog.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/anonymous-consents-dialog/index.ts
+++ b/projects/storefrontlib/shared/components/anonymous-consents-dialog/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/assistive-technology-message/assistive-technology-message.directive.ts
+++ b/projects/storefrontlib/shared/components/assistive-technology-message/assistive-technology-message.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/assistive-technology-message/assistive-technology-message.module.ts
+++ b/projects/storefrontlib/shared/components/assistive-technology-message/assistive-technology-message.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/assistive-technology-message/index.ts
+++ b/projects/storefrontlib/shared/components/assistive-technology-message/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/captcha/captcha-api-config.ts
+++ b/projects/storefrontlib/shared/components/captcha/captcha-api-config.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/captcha/captcha.component.ts
+++ b/projects/storefrontlib/shared/components/captcha/captcha.component.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/captcha/captcha.model.ts
+++ b/projects/storefrontlib/shared/components/captcha/captcha.model.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/captcha/captcha.module.ts
+++ b/projects/storefrontlib/shared/components/captcha/captcha.module.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/captcha/captcha.renderer.ts
+++ b/projects/storefrontlib/shared/components/captcha/captcha.renderer.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/captcha/captcha.service.ts
+++ b/projects/storefrontlib/shared/components/captcha/captcha.service.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/captcha/index.ts
+++ b/projects/storefrontlib/shared/components/captcha/index.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/captcha/mock-captcha/config/mock-captcha-api-config.ts
+++ b/projects/storefrontlib/shared/components/captcha/mock-captcha/config/mock-captcha-api-config.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/captcha/mock-captcha/mock-captcha.service.ts
+++ b/projects/storefrontlib/shared/components/captcha/mock-captcha/mock-captcha.service.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2023 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/card/card.component.ts
+++ b/projects/storefrontlib/shared/components/card/card.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/card/card.module.ts
+++ b/projects/storefrontlib/shared/components/card/card.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/card/index.ts
+++ b/projects/storefrontlib/shared/components/card/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/carousel/carousel.module.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/carousel/carousel.service.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/carousel/focusable-carousel-item/focusable-carousel-item.directive.ts
+++ b/projects/storefrontlib/shared/components/carousel/focusable-carousel-item/focusable-carousel-item.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/carousel/index.ts
+++ b/projects/storefrontlib/shared/components/carousel/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/chat-messaging/avatar/avatar.component.ts
+++ b/projects/storefrontlib/shared/components/chat-messaging/avatar/avatar.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/chat-messaging/avatar/index.ts
+++ b/projects/storefrontlib/shared/components/chat-messaging/avatar/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/chat-messaging/chat-messaging.module.ts
+++ b/projects/storefrontlib/shared/components/chat-messaging/chat-messaging.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/chat-messaging/index.ts
+++ b/projects/storefrontlib/shared/components/chat-messaging/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/chat-messaging/messaging/index.ts
+++ b/projects/storefrontlib/shared/components/chat-messaging/messaging/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/chat-messaging/messaging/messaging.component.ts
+++ b/projects/storefrontlib/shared/components/chat-messaging/messaging/messaging.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/chat-messaging/messaging/messaging.model.ts
+++ b/projects/storefrontlib/shared/components/chat-messaging/messaging/messaging.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/date-picker/date-picker.component.ts
+++ b/projects/storefrontlib/shared/components/form/date-picker/date-picker.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/date-picker/date-picker.module.ts
+++ b/projects/storefrontlib/shared/components/form/date-picker/date-picker.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/date-picker/date-picker.service.ts
+++ b/projects/storefrontlib/shared/components/form/date-picker/date-picker.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/date-picker/index.ts
+++ b/projects/storefrontlib/shared/components/form/date-picker/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/file-upload/file-upload.component.ts
+++ b/projects/storefrontlib/shared/components/form/file-upload/file-upload.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/file-upload/file-upload.module.ts
+++ b/projects/storefrontlib/shared/components/form/file-upload/file-upload.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/file-upload/index.ts
+++ b/projects/storefrontlib/shared/components/form/file-upload/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/form-errors/form-errors.component.ts
+++ b/projects/storefrontlib/shared/components/form/form-errors/form-errors.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/form-errors/form-errors.module.ts
+++ b/projects/storefrontlib/shared/components/form/form-errors/form-errors.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/form-errors/index.ts
+++ b/projects/storefrontlib/shared/components/form/form-errors/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/index.ts
+++ b/projects/storefrontlib/shared/components/form/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/password-visibility-toggle/index.ts
+++ b/projects/storefrontlib/shared/components/form/password-visibility-toggle/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-input-visibility.model.ts
+++ b/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-input-visibility.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.component.ts
+++ b/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.directive.ts
+++ b/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.module.ts
+++ b/projects/storefrontlib/shared/components/form/password-visibility-toggle/password-visibility-toggle.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/generic-link/generic-link-component.service.ts
+++ b/projects/storefrontlib/shared/components/generic-link/generic-link-component.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/generic-link/generic-link.component.ts
+++ b/projects/storefrontlib/shared/components/generic-link/generic-link.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/generic-link/generic-link.module.ts
+++ b/projects/storefrontlib/shared/components/generic-link/generic-link.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/generic-link/index.ts
+++ b/projects/storefrontlib/shared/components/generic-link/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/index.ts
+++ b/projects/storefrontlib/shared/components/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/item-counter/index.ts
+++ b/projects/storefrontlib/shared/components/item-counter/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/item-counter/item-counter.component.ts
+++ b/projects/storefrontlib/shared/components/item-counter/item-counter.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/item-counter/item-counter.module.ts
+++ b/projects/storefrontlib/shared/components/item-counter/item-counter.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/index.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/list-navigation.module.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/list-navigation.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/config/default-pagination.config.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/config/default-pagination.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/config/index.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/config/pagination.config.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/config/pagination.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/index.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.builder.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.builder.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.component.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.model.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.module.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/pagination.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/pagination/testing/pagination-testing.module.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/pagination/testing/pagination-testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/sorting/index.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/sorting/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/sorting/sorting.component.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/sorting/sorting.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/sorting/sorting.module.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/sorting/sorting.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/total/index.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/total/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/total/total.component.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/total/total.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/list-navigation/total/total.module.ts
+++ b/projects/storefrontlib/shared/components/list-navigation/total/total.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/media/index.ts
+++ b/projects/storefrontlib/shared/components/media/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/media/media-sources.pipe.ts
+++ b/projects/storefrontlib/shared/components/media/media-sources.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/media/media.component.ts
+++ b/projects/storefrontlib/shared/components/media/media.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/media/media.config.ts
+++ b/projects/storefrontlib/shared/components/media/media.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/media/media.model.ts
+++ b/projects/storefrontlib/shared/components/media/media.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/media/media.module.ts
+++ b/projects/storefrontlib/shared/components/media/media.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/media/media.service.ts
+++ b/projects/storefrontlib/shared/components/media/media.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/media/media.token.ts
+++ b/projects/storefrontlib/shared/components/media/media.token.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/ng-select-a11y/index.ts
+++ b/projects/storefrontlib/shared/components/ng-select-a11y/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
+++ b/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.module.ts
+++ b/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/popover/index.ts
+++ b/projects/storefrontlib/shared/components/popover/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/popover/popover.component.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/popover/popover.directive.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/popover/popover.model.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/popover/popover.module.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/popover/popover.service.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/progress-button/index.ts
+++ b/projects/storefrontlib/shared/components/progress-button/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/progress-button/progress-button.component.ts
+++ b/projects/storefrontlib/shared/components/progress-button/progress-button.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/progress-button/progress-button.module.ts
+++ b/projects/storefrontlib/shared/components/progress-button/progress-button.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/spinner/index.ts
+++ b/projects/storefrontlib/shared/components/spinner/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/spinner/spinner.component.ts
+++ b/projects/storefrontlib/shared/components/spinner/spinner.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/spinner/spinner.module.ts
+++ b/projects/storefrontlib/shared/components/spinner/spinner.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/split-view/index.ts
+++ b/projects/storefrontlib/shared/components/split-view/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/split-view/split-view.module.ts
+++ b/projects/storefrontlib/shared/components/split-view/split-view.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/split-view/split-view.service.ts
+++ b/projects/storefrontlib/shared/components/split-view/split-view.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/split-view/split/index.ts
+++ b/projects/storefrontlib/shared/components/split-view/split/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/split-view/split/split-view.component.ts
+++ b/projects/storefrontlib/shared/components/split-view/split/split-view.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/split-view/split/split-view.model.ts
+++ b/projects/storefrontlib/shared/components/split-view/split/split-view.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/split-view/testing/spit-view-testing.module.ts
+++ b/projects/storefrontlib/shared/components/split-view/testing/spit-view-testing.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/split-view/view/index.ts
+++ b/projects/storefrontlib/shared/components/split-view/view/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/split-view/view/view.component.ts
+++ b/projects/storefrontlib/shared/components/split-view/view/view.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/star-rating/index.ts
+++ b/projects/storefrontlib/shared/components/star-rating/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/star-rating/star-rating.component.ts
+++ b/projects/storefrontlib/shared/components/star-rating/star-rating.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/star-rating/star-rating.module.ts
+++ b/projects/storefrontlib/shared/components/star-rating/star-rating.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/config/default-table.config.ts
+++ b/projects/storefrontlib/shared/components/table/config/default-table.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/config/table.config.ts
+++ b/projects/storefrontlib/shared/components/table/config/table.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/index.ts
+++ b/projects/storefrontlib/shared/components/table/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/table-data-cell/table-data-cell.component.ts
+++ b/projects/storefrontlib/shared/components/table/table-data-cell/table-data-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/table-data-cell/table-data-cell.module.ts
+++ b/projects/storefrontlib/shared/components/table/table-data-cell/table-data-cell.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/table-header-cell/table-header-cell.component.ts
+++ b/projects/storefrontlib/shared/components/table/table-header-cell/table-header-cell.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/table-header-cell/table-header-cell.module.ts
+++ b/projects/storefrontlib/shared/components/table/table-header-cell/table-header-cell.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/table-renderer.service.ts
+++ b/projects/storefrontlib/shared/components/table/table-renderer.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/table.component.ts
+++ b/projects/storefrontlib/shared/components/table/table.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/table.model.ts
+++ b/projects/storefrontlib/shared/components/table/table.model.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/table.module.ts
+++ b/projects/storefrontlib/shared/components/table/table.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/table/table.service.ts
+++ b/projects/storefrontlib/shared/components/table/table.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/truncate-text-popover/index.ts
+++ b/projects/storefrontlib/shared/components/truncate-text-popover/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/truncate-text-popover/truncate-text-popover.component.ts
+++ b/projects/storefrontlib/shared/components/truncate-text-popover/truncate-text-popover.component.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/truncate-text-popover/truncate-text-popover.module.ts
+++ b/projects/storefrontlib/shared/components/truncate-text-popover/truncate-text-popover.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/components/truncate-text-popover/truncate.pipe.ts
+++ b/projects/storefrontlib/shared/components/truncate-text-popover/truncate.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/config/default-form-config.ts
+++ b/projects/storefrontlib/shared/config/default-form-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/config/form-config.ts
+++ b/projects/storefrontlib/shared/config/form-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/config/index.ts
+++ b/projects/storefrontlib/shared/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/config/view-config.ts
+++ b/projects/storefrontlib/shared/config/view-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/index.ts
+++ b/projects/storefrontlib/shared/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/pipes/index.ts
+++ b/projects/storefrontlib/shared/pipes/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.module.ts
+++ b/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.pipe.ts
+++ b/projects/storefrontlib/shared/pipes/suplement-hash-anchors/supplement-hash-anchors.pipe.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/file/csv/csv-file-validation-errors.ts
+++ b/projects/storefrontlib/shared/services/file/csv/csv-file-validation-errors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/file/csv/export-csv-file.service.ts
+++ b/projects/storefrontlib/shared/services/file/csv/export-csv-file.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/file/csv/import-csv-file.service.ts
+++ b/projects/storefrontlib/shared/services/file/csv/import-csv-file.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/file/csv/index.ts
+++ b/projects/storefrontlib/shared/services/file/csv/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/file/export-file-options.ts
+++ b/projects/storefrontlib/shared/services/file/export-file-options.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/file/file-download.service.ts
+++ b/projects/storefrontlib/shared/services/file/file-download.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/file/file-reader.service.ts
+++ b/projects/storefrontlib/shared/services/file/file-reader.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/file/files-form-validators.ts
+++ b/projects/storefrontlib/shared/services/file/files-form-validators.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/file/index.ts
+++ b/projects/storefrontlib/shared/services/file/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/index.ts
+++ b/projects/storefrontlib/shared/services/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/services/positioning/positioning.service.ts
+++ b/projects/storefrontlib/shared/services/positioning/positioning.service.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/test/mock-feature-directive.ts
+++ b/projects/storefrontlib/shared/test/mock-feature-directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/test/mock-feature-directives.module.ts
+++ b/projects/storefrontlib/shared/test/mock-feature-directives.module.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/test/mock-feature-level-directive.ts
+++ b/projects/storefrontlib/shared/test/mock-feature-level-directive.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/utils/forms/form-test-utils.ts
+++ b/projects/storefrontlib/shared/utils/forms/form-test-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/utils/forms/title-utils.ts
+++ b/projects/storefrontlib/shared/utils/forms/title-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/utils/index.ts
+++ b/projects/storefrontlib/shared/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/shared/utils/validators/custom-form-validators.ts
+++ b/projects/storefrontlib/shared/utils/validators/custom-form-validators.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/test.ts
+++ b/projects/storefrontlib/test.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/utils/address-number-utils.ts
+++ b/projects/storefrontlib/utils/address-number-utils.ts
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/utils/form-utils.ts
+++ b/projects/storefrontlib/utils/form-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontlib/utils/index.ts
+++ b/projects/storefrontlib/utils/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/storefrontstyles/test-jest.ts
+++ b/projects/storefrontstyles/test-jest.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/scripts/i18n/convert-translations-json-2-ts.ts
+++ b/scripts/i18n/convert-translations-json-2-ts.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/scripts/i18n/convert-translations-ts-2-json.ts
+++ b/scripts/i18n/convert-translations-ts-2-json.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/testing/patch-object-define-property.ts
+++ b/testing/patch-object-define-property.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/common.ts
+++ b/tools/breaking-changes/common.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/compare.ts
+++ b/tools/breaking-changes/compare.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/extract.ts
+++ b/tools/breaking-changes/extract.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/generate-constructors.ts
+++ b/tools/breaking-changes/generate-constructors.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/generate-deleted.ts
+++ b/tools/breaking-changes/generate-deleted.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/generate-doc.ts
+++ b/tools/breaking-changes/generate-doc.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/generate-methods-props.ts
+++ b/tools/breaking-changes/generate-methods-props.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/generate-moved.ts
+++ b/tools/breaking-changes/generate-moved.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/generate-stats.ts
+++ b/tools/breaking-changes/generate-stats.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/breaking-changes/parse.ts
+++ b/tools/breaking-changes/parse.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/build-lib/augmented-types/index.ts
+++ b/tools/build-lib/augmented-types/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/chalk/index.ts
+++ b/tools/chalk/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/config/const.ts
+++ b/tools/config/const.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/config/index.ts
+++ b/tools/config/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/config/manage-dependencies.ts
+++ b/tools/config/manage-dependencies.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/config/tsconfig-paths.ts
+++ b/tools/config/tsconfig-paths.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/eslint-rules/index.ts
+++ b/tools/eslint-rules/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/eslint-rules/jest.config.ts
+++ b/tools/eslint-rules/jest.config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/eslint-rules/rules/no-ngrx-fail-action-without-error-action-implementation.ts
+++ b/tools/eslint-rules/rules/no-ngrx-fail-action-without-error-action-implementation.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/eslint-rules/rules/use-provide-default-config-factory.ts
+++ b/tools/eslint-rules/rules/use-provide-default-config-factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/eslint-rules/rules/use-provide-default-config.ts
+++ b/tools/eslint-rules/rules/use-provide-default-config.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/eslint-rules/rules/use-provide-default-feature-toggles-factory.ts
+++ b/tools/eslint-rules/rules/use-provide-default-feature-toggles-factory.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/eslint-rules/rules/use-provide-default-feature-toggles.ts
+++ b/tools/eslint-rules/rules/use-provide-default-feature-toggles.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/eslint-rules/rules/utils/implements-interface-utils.ts
+++ b/tools/eslint-rules/rules/utils/implements-interface-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/eslint-rules/rules/utils/import-utils.ts
+++ b/tools/eslint-rules/rules/utils/import-utils.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/schematics/dependency-collector.ts
+++ b/tools/schematics/dependency-collector.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/schematics/testing.ts
+++ b/tools/schematics/testing.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Fixes [https://github.com/SAP/spartacus/security/code-scanning/50](https://github.com/SAP/spartacus/security/code-scanning/50)

To fix the problem, we need to ensure that the function `convertToCdcPreference` does not allow the creation of properties that could lead to prototype pollution. This can be achieved by blocking the `__proto__` and `constructor` properties from being used as keys in the nested object creation process.

- Modify the `convertToCdcPreference` function to check for and block the `__proto__` and `constructor` properties.
- Specifically, add a check within the loop that processes each key in the path. If the key is `__proto__` or `constructor`, skip the assignment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
