### PR TITLE
fix: (CXSPA-9016) - Fix screen reader not reading 'Auto Replenish order' label for radio buttons

### DIFF
--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.html
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.html
@@ -1,8 +1,13 @@
-<div class="cx-order-type-card">
+<div
+  class="cx-order-type-card"
+  role="region"
+  [attr.aria-labelledby]="'checkout-schedule-replenishment-order-title'"
+>
   <div class="cx-label-container">
     <!-- TODO: (CXSPA-6306) - Remove feature flag next major release -->
     <h3
       *cxFeature="'a11yScheduleReplenishment'"
+      id="checkout-schedule-replenishment-order-title"
       class="cx-order-replenishment-header"
     >
       {{ 'checkoutScheduledReplenishment.autoReplenishOrder' | cxTranslate }}


### PR DESCRIPTION
Closes: [CXSPA-9016](https://jira.tools.sap/browse/CXSPA-9016)

Fix 'Auto Replenish order' label is read for radio buttons