### PR TITLE
bugfix-CXSPA-9247: CDC-B2C E2E Failing due to functionality

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2b/b2b-scenarios.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2b/b2b-scenarios.core-e2e.cy.ts
@@ -289,9 +289,9 @@ describe('CDC B2B scenarios', () => {
       cy.window().then((win) => win.sessionStorage.clear());
     });
 
-    it('should NOT send email to invalid email address in CDC screenset (CXINT-23)', () => {
+    it('should send email to invalid email address in CDC screenset (CXINT-23)', () => {
       cdc.forgotPassword('invalid_email@sapcx.com');
-      cdc.verifyForgotPasswordError();
+      cdc.verifyForgotPasswordSuccess();
     });
 
     it('should send email to invalid email address in CDC screenset (CXINT-23)', () => {
@@ -305,9 +305,9 @@ describe('CDC B2B scenarios', () => {
       cy.window().then((win) => win.sessionStorage.clear());
     });
 
-    it('should NOT send email to invalid email address in CDC (CXINT-23)', () => {
+    it('should send email to invalid email address in CDC (CXINT-23)', () => {
       cdc.forgotPasswordWithoutScreenset('invalid_email@sapcx.com');
-      cdc.verifyForgotPasswordWithoutScreensetError();
+      cdc.verifyForgotPasswordWithoutScreensetSuccess();
     });
 
     it('should send email to valid email address in CDC (CXINT-23)', () => {

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2c/b2c-scenarios.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cdc/b2c/b2c-scenarios.core-e2e.cy.ts
@@ -6,7 +6,7 @@
 
 import * as alerts from '../../../../helpers/global-message';
 import * as cdc from '../../../../helpers/vendor/cdc/cdc';
-const requiredFieldMessage = 'This field is required';
+const requiredFieldMessage = 'Field is required';
 const message = 'New address was added successfully!';
 
 describe('CDC', () => {
@@ -245,9 +245,9 @@ describe('CDC', () => {
       cy.window().then((win) => win.sessionStorage.clear());
     });
 
-    it('should NOT send email to invalid email address in CDC screenset (CXINT-23)', () => {
+    it('should send email to invalid email address in CDC screenset (CXINT-23)', () => {
       cdc.forgotPassword('invalid_email@sapcx.com');
-      cdc.verifyForgotPasswordError();
+      cdc.verifyForgotPasswordSuccess();
     });
 
     it('should send email to invalid email address in CDC screenset (CXINT-23)', () => {
@@ -261,9 +261,9 @@ describe('CDC', () => {
       cy.window().then((win) => win.sessionStorage.clear());
     });
 
-    it('should NOT send email to invalid email address in CDC (CXINT-23)', () => {
+    it('should send email to invalid email address in CDC (CXINT-23)', () => {
       cdc.forgotPasswordWithoutScreenset('invalid_email@sapcx.com');
-      cdc.verifyForgotPasswordWithoutScreensetError();
+      cdc.verifyForgotPasswordWithoutScreensetSuccess();
     });
 
     it('should send email to valid email address in CDC (CXINT-23)', () => {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cdc/cdc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/vendor/cdc/cdc.ts
@@ -20,7 +20,7 @@ import { listenForTokenRevocationRequest } from '../../login';
 export const updatedName = ' updated';
 export const updatedEmail = 'cypress_user_updated@sapcx.com';
 export const updatedB2BEmail = 'spartacusb2bupdated@sapcx.com';
-export const updatedPassword = 'NewPassword123.';
+export const updatedPassword = 'NewPas!sword123.';
 
 export function registerUser(cdcUser) {
   cy.findByText("Don't have an account yet?").click();


### PR DESCRIPTION
https://jira.tools.sap/browse/CXSPA-9247 

CDC - E2E Tests:
1. The mandatory field message is changed. Updated the E2E accordingly.
2. The Password cannot have same letter consecutively as per latest SPA. Updated test case accordingly.
3. The CDC policy for sending email for reset password is updated. It will send password reset message without validating the user email (https://help.sap.com/whats-new/c9917beea34b4628adfa2b3a3a915379?locale=en-US ). Updated E2E test case accordingly