### PR TITLE
fix: (CXSPA-8994) - Prevent forced colors from interfering with contrast themes

### DIFF
--- a/feature-libs/cart/base/styles/components/_mini-cart.scss
+++ b/feature-libs/cart/base/styles/components/_mini-cart.scss
@@ -63,27 +63,9 @@
     }
   }
 
-  @mixin native-high-contrast-fix {
-    @media (forced-colors: active) {
-      a {
-        forced-color-adjust: none;
-        background: LinkText;
-        color: Canvas;
-
-        &:hover {
-          background: LinkText;
-          color: Canvas;
-        }
-      }
-    }
-  }
-
-  @include native-high-contrast-fix;
-
   @include cx-highContrastTheme {
     a {
       color: var(--cx-color-medium);
     }
-    @include native-high-contrast-fix;
   }
 }

--- a/feature-libs/pickup-in-store/styles/_pickup-options.scss
+++ b/feature-libs/pickup-in-store/styles/_pickup-options.scss
@@ -107,15 +107,6 @@
           color: var(--cx-color-text);
         }
       }
-
-      // native high contrast themes fix
-      @media (forced-colors: active) {
-        button.tab-btn.active {
-          &:after {
-            background-color: LinkText;
-          }
-        }
-      }
     }
   }
 }

--- a/projects/storefrontstyles/scss/components/layout/_storefront.scss
+++ b/projects/storefrontstyles/scss/components/layout/_storefront.scss
@@ -48,4 +48,13 @@
       background-color: var(--cx-color-background);
     }
   }
+
+  &.cx-theme-high-contrast-dark,
+  &.cx-theme-high-contrast-light {
+    @media (forced-colors: active) {
+      // Prevents forced colors from being applied while Spartacus contrast themes are active.
+      // This prevents interference with the contrast themes yet still allows the default one to be modified.
+      forced-color-adjust: none !important;
+    }
+  }
 }

--- a/projects/storefrontstyles/scss/components/product/carousel/_carousel.scss
+++ b/projects/storefrontstyles/scss/components/product/carousel/_carousel.scss
@@ -206,33 +206,6 @@
     }
   }
 
-  @mixin carousel-native-high-contrast {
-    @media (forced-colors: active) {
-      .indicators button .cx-icon {
-        forced-color-adjust: none;
-        background-color: Canvas;
-        border-color: CanvasText;
-        color: Canvas;
-      }
-
-      .indicators button[disabled] {
-        .cx-icon {
-          color: CanvasText;
-          background-color: Canvas;
-          padding: 2px;
-        }
-      }
-
-      .indicators button[aria-disabled='true'] {
-        .cx-icon {
-          color: CanvasText;
-          background-color: Canvas;
-          padding: 4px;
-        }
-      }
-    }
-  }
-
   @include cx-highContrastTheme {
     .indicators {
       button {
@@ -259,7 +232,5 @@
       background-color: var(--cx-color-dark);
       border: 3px solid var(--cx-color-dark);
     }
-
-    @include carousel-native-high-contrast;
   }
 }

--- a/projects/storefrontstyles/scss/components/product/list/_facet.scss
+++ b/projects/storefrontstyles/scss/components/product/list/_facet.scss
@@ -188,39 +188,4 @@ $intialExpandedFacetsLarge: 3 !default;
       }
     }
   }
-
-  @mixin native-high-contrast-fix {
-    @media (forced-colors: active) {
-      a,
-      button {
-        color: CanvasText;
-        &.value:hover {
-          color: LinkText;
-        }
-      }
-
-      &.multi-select a.value {
-        forced-color-adjust: none;
-        &:hover {
-          &:not(.selected)::before {
-            border-color: LinkText;
-          }
-        }
-        &::before {
-          border: solid 2px CanvasText;
-        }
-        &.selected::before {
-          background-color: Canvas;
-          border-color: CanvasText;
-          color: CanvasText;
-        }
-      }
-    }
-  }
-
-  @include native-high-contrast-fix;
-
-  @include cx-highContrastTheme {
-    @include native-high-contrast-fix;
-  }
 }

--- a/projects/storefrontstyles/scss/components/product/search/_searchbox.scss
+++ b/projects/storefrontstyles/scss/components/product/search/_searchbox.scss
@@ -939,10 +939,5 @@
         border: 1px solid var(--cx-color-text);
       }
     }
-
-    // native high contrast themes fix
-    @media (forced-colors: active) {
-      border-color: Canvas;
-    }
   }
 }


### PR DESCRIPTION
Closes: [CXSPA-8994](https://jira.tools.sap/browse/CXSPA-8994)

The Spartacus custom high contrast themes should not be affected by external solutions. These contrast themes are tailored to provide good accessibility without sacrificing readability and usability of the app. The same cannot be guaranteed with one-size-fits-all solutions like the Windows/MacOS contrast themes.

Therefore, we should not make changes to accommodate external stylings that users might apply. These can vary greatly and it would be impossible to satisfy all. However, we allow the default theme to be modified so users can still use other solutions if preferred.