### PR TITLE
bugfix/CXSPA-9251: DI of CDC-B2B services are not effective

### DIFF
--- a/integration-libs/cdc/organization/administration/cdc-administration.module.ts
+++ b/integration-libs/cdc/organization/administration/cdc-administration.module.ts
@@ -31,7 +31,6 @@ import { CdcUserListService } from './cdc-user-list.service';
               provide: UserListService,
               useExisting: CdcUserListService,
             },
-            //to override B2BUserService in UserDetailsComponent, UnitUserListComponent
             { provide: B2BUserService, useClass: CdcB2BUserService },
             userCmsConfig.cmsComponents?.ManageUsersListComponent?.providers ||
               [],
@@ -39,6 +38,8 @@ import { CdcUserListService } from './cdc-user-list.service';
         },
       },
     }),
+    //to override B2BUserService in UserDetailsComponent, UnitUserListComponent
+    { provide: B2BUserService, useClass: CdcB2BUserService },
     //to override B2BUserService in UnitUserRolesCellComponent
     provideDefaultConfig(<CmsConfig>{
       cmsComponents: {
@@ -55,6 +56,7 @@ import { CdcUserListService } from './cdc-user-list.service';
         },
       },
     }),
+    { provide: OrgUnitService, useClass: CdcOrgUnitService },
   ],
 })
 export class CdcAdministrationModule {}

--- a/integration-libs/cdc/organization/administration/cdc-administration.module.ts
+++ b/integration-libs/cdc/organization/administration/cdc-administration.module.ts
@@ -31,14 +31,14 @@ import { CdcUserListService } from './cdc-user-list.service';
               provide: UserListService,
               useExisting: CdcUserListService,
             },
+            //to override B2BUserService in UserDetailsComponent, UnitUserListComponent
+            { provide: B2BUserService, useClass: CdcB2BUserService },
             userCmsConfig.cmsComponents?.ManageUsersListComponent?.providers ||
               [],
           ],
         },
       },
     }),
-    //to override B2BUserService in UserDetailsComponent, UnitUserListComponent
-    { provide: B2BUserService, useClass: CdcB2BUserService },
     //to override B2BUserService in UnitUserRolesCellComponent
     provideDefaultConfig(<CmsConfig>{
       cmsComponents: {
@@ -48,13 +48,13 @@ import { CdcUserListService } from './cdc-user-list.service';
               provide: B2BUserService,
               useExisting: CdcB2BUserService,
             },
+            { provide: OrgUnitService, useClass: CdcOrgUnitService },
             unitsCmsConfig.cmsComponents?.ManageUnitsListComponent?.providers ||
               [],
           ],
         },
       },
     }),
-    { provide: OrgUnitService, useClass: CdcOrgUnitService },
   ],
 })
 export class CdcAdministrationModule {}


### PR DESCRIPTION
The logic of CDC services are not taken into effect.
Test scenario:
1. `https://b2bspastore.cg79x9wuu9-eccommerc1-s1-public.model-t.myhybris.cloud/powertools-spa/en/USD/organization/users/898352f8-571f-4d6c-9a4c-35d2117f0302` with anjana.b.l+kristester@sap.com / Pasword123.
2. You wont see `Edit` button
3. When you try out the same with `develop-next-major`, you will see `Edit` button
