### PR TITLE
feat: silence the deprecation warnings about Sass `@import`usage in new apps via our installation schematics

### DIFF
--- a/feature-libs/asm/schematics/add-asm/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/asm/schematics/add-asm/__snapshots__/index_spec.ts.snap
@@ -110,7 +110,12 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -175,7 +180,12 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/cart/schematics/add-cart/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/cart/schematics/add-cart/__snapshots__/index_spec.ts.snap
@@ -130,7 +130,12 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -195,7 +200,12 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -315,7 +325,12 @@ exports[`Spartacus Cart schematics: ng-add Cart Import Export feature general se
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -380,7 +395,12 @@ exports[`Spartacus Cart schematics: ng-add Cart Import Export feature general se
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -500,7 +520,12 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -565,7 +590,12 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -685,7 +715,12 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -750,7 +785,12 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -880,7 +920,12 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -945,7 +990,12 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/checkout/schematics/add-checkout/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/checkout/schematics/add-checkout/__snapshots__/index_spec.ts.snap
@@ -182,7 +182,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -247,7 +252,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -367,7 +377,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -432,7 +447,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -646,7 +666,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -711,7 +736,12 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/customer-ticketing/schematics/add-customer-ticketing/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/customer-ticketing/schematics/add-customer-ticketing/__snapshots__/index_spec.ts.snap
@@ -110,7 +110,12 @@ exports[`Spartacus Customer Ticketing schematics: ng-add Customer Ticketing feat
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -175,7 +180,12 @@ exports[`Spartacus Customer Ticketing schematics: ng-add Customer Ticketing feat
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/__snapshots__/index_spec.ts.snap
@@ -95,7 +95,12 @@ exports[`Spartacus Estimated-Delivery-Date schematics: ng-add Estimated-Delivery
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -161,7 +166,12 @@ exports[`Spartacus Estimated-Delivery-Date schematics: ng-add Estimated-Delivery
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/order/schematics/add-order/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/order/schematics/add-order/__snapshots__/index_spec.ts.snap
@@ -110,7 +110,12 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -175,7 +180,12 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/organization/schematics/add-organization/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/organization/schematics/add-organization/__snapshots__/index_spec.ts.snap
@@ -145,7 +145,12 @@ exports[`Spartacus Organization schematics: ng-add Account summary feature gener
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -210,7 +215,12 @@ exports[`Spartacus Organization schematics: ng-add Account summary feature gener
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -365,7 +375,12 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -430,7 +445,12 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -585,7 +605,12 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -650,7 +675,12 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -805,7 +835,12 @@ exports[`Spartacus Organization schematics: ng-add Unit order feature general se
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -870,7 +905,12 @@ exports[`Spartacus Organization schematics: ng-add Unit order feature general se
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -1025,7 +1065,12 @@ exports[`Spartacus Organization schematics: ng-add User registration feature gen
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -1090,7 +1135,12 @@ exports[`Spartacus Organization schematics: ng-add User registration feature gen
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/pdf-invoices/schematics/add-pdf-invoices/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/pdf-invoices/schematics/add-pdf-invoices/__snapshots__/index_spec.ts.snap
@@ -59,7 +59,12 @@ exports[`Spartacus PDF Invoices schematics: ng-add PDF Invoices feature general 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -124,7 +129,12 @@ exports[`Spartacus PDF Invoices schematics: ng-add PDF Invoices feature general 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/pickup-in-store/schematics/add-pickup-in-store/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/pickup-in-store/schematics/add-pickup-in-store/__snapshots__/index_spec.ts.snap
@@ -110,7 +110,12 @@ exports[`Spartacus Pickup in Store schematics: ng-add Pick Up In Store feature g
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -175,7 +180,12 @@ exports[`Spartacus Pickup in Store schematics: ng-add Pick Up In Store feature g
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/product-configurator/schematics/add-product-configurator/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product-configurator/schematics/add-product-configurator/__snapshots__/index_spec.ts.snap
@@ -179,7 +179,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -244,7 +249,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -419,7 +429,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -484,7 +499,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -638,7 +658,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -703,7 +728,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -823,7 +853,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -888,7 +923,12 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/__snapshots__/index_spec.ts.snap
@@ -62,7 +62,12 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add list feature gen
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -126,7 +131,12 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add list feature gen
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -246,7 +256,12 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add selector feature
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -311,7 +326,12 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add selector feature
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/product/schematics/add-product/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product/schematics/add-product/__snapshots__/index_spec.ts.snap
@@ -145,7 +145,12 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -210,7 +215,12 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -365,7 +375,12 @@ exports[`Spartacus Product schematics: ng-add FutureStock feature general setup 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -430,7 +445,12 @@ exports[`Spartacus Product schematics: ng-add FutureStock feature general setup 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -550,7 +570,12 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -615,7 +640,12 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -735,7 +765,12 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -800,7 +835,12 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/qualtrics/schematics/add-qualtrics/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/qualtrics/schematics/add-qualtrics/__snapshots__/index_spec.ts.snap
@@ -94,7 +94,12 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -159,7 +164,12 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/quote/schematics/add-quote/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/quote/schematics/add-quote/__snapshots__/index_spec.ts.snap
@@ -165,7 +165,12 @@ exports[`Spartacus Quote schematics: ng-add Quote feature general setup styling 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -230,7 +235,12 @@ exports[`Spartacus Quote schematics: ng-add Quote feature general setup styling 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/__snapshots__/index_spec.ts.snap
@@ -59,7 +59,12 @@ exports[`Spartacus Requested Delivery Date schematics: ng-add Requested Delivery
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -124,7 +129,12 @@ exports[`Spartacus Requested Delivery Date schematics: ng-add Requested Delivery
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/smartedit/schematics/add-smartedit/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/smartedit/schematics/add-smartedit/__snapshots__/index_spec.ts.snap
@@ -76,7 +76,12 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -145,7 +150,12 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/storefinder/schematics/add-storefinder/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/storefinder/schematics/add-storefinder/__snapshots__/index_spec.ts.snap
@@ -110,7 +110,12 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -175,7 +180,12 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/feature-libs/user/schematics/add-user/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/user/schematics/add-user/__snapshots__/index_spec.ts.snap
@@ -141,7 +141,12 @@ exports[`Spartacus User schematics: ng-add User Profile feature general setup st
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -206,7 +211,12 @@ exports[`Spartacus User schematics: ng-add User Profile feature general setup st
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -326,7 +336,12 @@ exports[`Spartacus User schematics: ng-add User-Account feature general setup st
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -391,7 +406,12 @@ exports[`Spartacus User schematics: ng-add User-Account feature general setup st
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
@@ -169,7 +169,12 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -234,7 +239,12 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/integration-libs/opf/schematics/add-opf/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/opf/schematics/add-opf/__snapshots__/index_spec.ts.snap
@@ -121,7 +121,12 @@ exports[`Spartacus SAP OPF integration schematics: ng-add SAP OPF feature genera
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -186,7 +191,12 @@ exports[`Spartacus SAP OPF integration schematics: ng-add SAP OPF feature genera
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -373,6 +373,10 @@ export function createStylePreprocessorOptions(
       stylePreprocessorOptions: testStylePreprocessorOptions,
     };
 
+    context.logger.warn(
+      `⚠️ Warnings about the Sass '@import' usage were silenced, because Sass '@import' is used in Spartacus and Bootstrap 4 styles. To enable warnings back, in your angular.json remove the "import" value from the array at section 'architect.build.options.stylePreprocessorOptions.sass.silenceDeprecations'. For more, see: https://sass-lang.com/blog/import-is-deprecated and https://angular.dev/reference/configs/workspace-config#style-preprocessor-options`
+    );
+
     const updatedAngularJson = {
       ...angularJson,
       projects: {
@@ -425,7 +429,17 @@ function createStylePreprocessorOptionsArray(angularJsonStylePreprocessorOptions
     ])
   );
 
-  const DEFAULT_SILENCE_DEPRECATIONS = ['import'];
+  const DEFAULT_SILENCE_DEPRECATIONS = [
+    // We need to silence the deprecation warning for the `@import` directive
+    // because `@import` is used in the Spartacus styles and in the Bootstrap 4 styles
+    // (which are imported by the Spartacus styles).
+    // Otherwise, since Angular v19, all apps would have a wall of deprecation warnings
+    // in the console when running `ng serve`.
+    //
+    // CXSPA-447: Eventually we should remove all the `@import` directives from the Spartacus styles
+    // and drop the usage of Bootstrap 4, and then we can remove the `silenceDeprecations` option.
+    'import',
+  ];
   const silenceDeprecations = Array.from(
     new Set([
       ...(angularJsonStylePreprocessorOptions.sass?.silenceDeprecations || []),

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -403,30 +403,44 @@ export function createStylePreprocessorOptions(
 }
 
 function createStylePreprocessorOptionsArray(angularJsonStylePreprocessorOptions: {
+  includePaths?: string[];
+  sass?: {
+    silenceDeprecations?: string[];
+  };
+  [key: string]: any;
+}): {
   includePaths: string[];
-}): { includePaths: string[] } {
-  const NODE_MODULES_PATH = 'node_modules/';
+  sass: { silenceDeprecations: string[] };
+  [key: string]: any;
+} {
   if (!angularJsonStylePreprocessorOptions) {
-    angularJsonStylePreprocessorOptions = {
-      includePaths: [NODE_MODULES_PATH],
-    };
-  } else {
-    if (!angularJsonStylePreprocessorOptions.includePaths) {
-      angularJsonStylePreprocessorOptions.includePaths = [NODE_MODULES_PATH];
-    } else {
-      if (
-        !angularJsonStylePreprocessorOptions.includePaths.includes(
-          NODE_MODULES_PATH
-        )
-      ) {
-        angularJsonStylePreprocessorOptions.includePaths.push(
-          NODE_MODULES_PATH
-        );
-      }
-    }
+    angularJsonStylePreprocessorOptions = {};
   }
 
-  return angularJsonStylePreprocessorOptions;
+  const NODE_MODULES_PATH = 'node_modules/';
+  const includePaths = Array.from(
+    new Set([
+      ...(angularJsonStylePreprocessorOptions.includePaths || []),
+      NODE_MODULES_PATH,
+    ])
+  );
+
+  const DEFAULT_SILENCE_DEPRECATIONS = ['import'];
+  const silenceDeprecations = Array.from(
+    new Set([
+      ...(angularJsonStylePreprocessorOptions.sass?.silenceDeprecations || []),
+      ...DEFAULT_SILENCE_DEPRECATIONS,
+    ])
+  );
+
+  return {
+    ...angularJsonStylePreprocessorOptions,
+    includePaths,
+    sass: {
+      ...angularJsonStylePreprocessorOptions.sass,
+      silenceDeprecations,
+    },
+  };
 }
 
 function prepareDependencies(features: string[]): NodeDependency[] {

--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -60,6 +60,11 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
               "includePaths": [
                 "node_modules/",
               ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import",
+                ],
+              },
             },
             "styles": [
               "src/styles.scss",
@@ -101,6 +106,11 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
               "includePaths": [
                 "node_modules/",
               ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import",
+                ],
+              },
             },
             "styles": [
               "src/styles.scss",

--- a/projects/schematics/src/shared/utils/__snapshots__/lib-utils_spec.ts.snap
+++ b/projects/schematics/src/shared/utils/__snapshots__/lib-utils_spec.ts.snap
@@ -176,7 +176,12 @@ exports[`Lib utils assets options should update angular.json file with assets 1`
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -240,7 +245,12 @@ exports[`Lib utils assets options should update angular.json file with assets 1`
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }
@@ -304,7 +314,12 @@ exports[`Lib utils assets options should update angular.json file with assets 2`
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           },
           "configurations": {
@@ -374,7 +389,12 @@ exports[`Lib utils assets options should update angular.json file with assets 2`
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
-              ]
+              ],
+              "sass": {
+                "silenceDeprecations": [
+                  "import"
+                ]
+              }
             }
           }
         }

--- a/projects/schematics/src/shared/utils/__snapshots__/workspace-utils_spec.ts.snap
+++ b/projects/schematics/src/shared/utils/__snapshots__/workspace-utils_spec.ts.snap
@@ -47,6 +47,11 @@ exports[`Workspace utils getProject should return project 1`] = `
           "includePaths": [
             "node_modules/",
           ],
+          "sass": {
+            "silenceDeprecations": [
+              "import",
+            ],
+          },
         },
         "styles": [
           "src/styles.scss",
@@ -88,6 +93,11 @@ exports[`Workspace utils getProject should return project 1`] = `
           "includePaths": [
             "node_modules/",
           ],
+          "sass": {
+            "silenceDeprecations": [
+              "import",
+            ],
+          },
         },
         "styles": [
           "src/styles.scss",
@@ -161,6 +171,11 @@ exports[`Workspace utils getProjectTargets should return project targets 1`] = `
         "includePaths": [
           "node_modules/",
         ],
+        "sass": {
+          "silenceDeprecations": [
+            "import",
+          ],
+        },
       },
       "styles": [
         "src/styles.scss",
@@ -202,6 +217,11 @@ exports[`Workspace utils getProjectTargets should return project targets 1`] = `
         "includePaths": [
           "node_modules/",
         ],
+        "sass": {
+          "silenceDeprecations": [
+            "import",
+          ],
+        },
       },
       "styles": [
         "src/styles.scss",


### PR DESCRIPTION
fixes https://jira.tools.sap/browse/CXSPA-9272

**QA steps:**
1. on this branch `npm run build:libs`
2. on this branch publish the built libs to verdaccio (e.g. via `npx ts-node schematics/testing.ts`)
4. in a separate folder create a fresh ng19 app `npx @angular/cli@19 new test-app --standalone=false`
5. enter the subfolder of the test-app and there install spartacus (with libs from verdaccio) `ng add @spartacus/schematics@2211.31.0-1`
6. run the app `npm run start` and wait for the successful build
7. verify that the build output in the terminald doensn't contain warnings about Sass `@import` usage

BEFORE:
![image](https://github.com/user-attachments/assets/e456ce4e-05c8-404e-9670-c4178c09ef2f)

AFTER:
![image](https://github.com/user-attachments/assets/abd6fd77-2c35-4c8a-940a-39aafb54fc14)

