### PR TITLE
chore: remove redundant 2024 year from the license headers in TS files

### DIFF
--- a/feature-libs/asm/assets/translations/cs/index.ts
+++ b/feature-libs/asm/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/es/index.ts
+++ b/feature-libs/asm/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/es_CO/index.ts
+++ b/feature-libs/asm/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/fr/index.ts
+++ b/feature-libs/asm/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/hi/index.ts
+++ b/feature-libs/asm/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/hu/index.ts
+++ b/feature-libs/asm/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/id/index.ts
+++ b/feature-libs/asm/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/it/index.ts
+++ b/feature-libs/asm/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/ko/index.ts
+++ b/feature-libs/asm/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/pl/index.ts
+++ b/feature-libs/asm/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/pt/index.ts
+++ b/feature-libs/asm/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/ru/index.ts
+++ b/feature-libs/asm/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/assets/translations/zh_TW/index.ts
+++ b/feature-libs/asm/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/cs/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/es/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/es_CO/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/fr/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/hi/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/hu/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/id/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/it/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/ko/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/pl/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/pt/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/ru/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/asm/customer-360/assets/translations/zh_TW/index.ts
+++ b/feature-libs/asm/customer-360/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/cs/index.ts
+++ b/feature-libs/cart/base/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/es/index.ts
+++ b/feature-libs/cart/base/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/es_CO/index.ts
+++ b/feature-libs/cart/base/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/fr/index.ts
+++ b/feature-libs/cart/base/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/hi/index.ts
+++ b/feature-libs/cart/base/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/hu/index.ts
+++ b/feature-libs/cart/base/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/id/index.ts
+++ b/feature-libs/cart/base/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/it/index.ts
+++ b/feature-libs/cart/base/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/ko/index.ts
+++ b/feature-libs/cart/base/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/pl/index.ts
+++ b/feature-libs/cart/base/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/pt/index.ts
+++ b/feature-libs/cart/base/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/ru/index.ts
+++ b/feature-libs/cart/base/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/base/assets/translations/zh_TW/index.ts
+++ b/feature-libs/cart/base/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/cs/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/es/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/es_CO/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/fr/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/hi/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/hu/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/id/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/it/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/ko/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/pl/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/pt/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/ru/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/import-export/assets/translations/zh_TW/index.ts
+++ b/feature-libs/cart/import-export/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/cs/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/es/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/es_CO/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/fr/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/hi/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/hu/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/id/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/it/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/ko/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/pl/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/pt/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/ru/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/quick-order/assets/translations/zh_TW/index.ts
+++ b/feature-libs/cart/quick-order/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/cs/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/es/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/es_CO/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/fr/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/hi/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/hu/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/id/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/it/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/ko/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/pl/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/pt/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/ru/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/saved-cart/assets/translations/zh_TW/index.ts
+++ b/feature-libs/cart/saved-cart/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/cs/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/es/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/es_CO/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/fr/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/hi/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/hu/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/id/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/it/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/ko/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/pl/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/pt/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/ru/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/cart/wish-list/assets/translations/zh_TW/index.ts
+++ b/feature-libs/cart/wish-list/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/cs/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/es/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/es_CO/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/fr/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/hi/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/hu/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/id/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/it/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/ko/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/pl/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/pt/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/ru/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/b2b/assets/translations/zh_TW/index.ts
+++ b/feature-libs/checkout/b2b/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/cs/index.ts
+++ b/feature-libs/checkout/base/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/es/index.ts
+++ b/feature-libs/checkout/base/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/es_CO/index.ts
+++ b/feature-libs/checkout/base/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/fr/index.ts
+++ b/feature-libs/checkout/base/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/hi/index.ts
+++ b/feature-libs/checkout/base/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/hu/index.ts
+++ b/feature-libs/checkout/base/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/id/index.ts
+++ b/feature-libs/checkout/base/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/it/index.ts
+++ b/feature-libs/checkout/base/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/ko/index.ts
+++ b/feature-libs/checkout/base/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/pl/index.ts
+++ b/feature-libs/checkout/base/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/pt/index.ts
+++ b/feature-libs/checkout/base/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/ru/index.ts
+++ b/feature-libs/checkout/base/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/base/assets/translations/zh_TW/index.ts
+++ b/feature-libs/checkout/base/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/cs/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/es/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/es_CO/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/fr/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/hi/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/hu/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/id/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/it/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/ko/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/pl/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/pt/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/ru/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/checkout/scheduled-replenishment/assets/translations/zh_TW/index.ts
+++ b/feature-libs/checkout/scheduled-replenishment/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/cs/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/es/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/es_CO/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/fr/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/hi/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/hu/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/id/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/it/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/ko/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/pl/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/pt/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/ru/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/customer-ticketing/assets/translations/zh_TW/index.ts
+++ b/feature-libs/customer-ticketing/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/cs/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/es/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/es_CO/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/fr/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/hi/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/hu/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/id/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/it/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/ko/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/pl/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/pt/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/ru/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/estimated-delivery-date/assets/translations/zh_TW/index.ts
+++ b/feature-libs/estimated-delivery-date/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/cs/index.ts
+++ b/feature-libs/order/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/es/index.ts
+++ b/feature-libs/order/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/es_CO/index.ts
+++ b/feature-libs/order/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/fr/index.ts
+++ b/feature-libs/order/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/hi/index.ts
+++ b/feature-libs/order/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/hu/index.ts
+++ b/feature-libs/order/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/id/index.ts
+++ b/feature-libs/order/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/it/index.ts
+++ b/feature-libs/order/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/ko/index.ts
+++ b/feature-libs/order/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/pl/index.ts
+++ b/feature-libs/order/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/pt/index.ts
+++ b/feature-libs/order/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/ru/index.ts
+++ b/feature-libs/order/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/order/assets/translations/zh_TW/index.ts
+++ b/feature-libs/order/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/cs/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/es/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/es_CO/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/fr/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/hi/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/hu/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/id/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/it/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/ko/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/pl/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/pt/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/ru/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/account-summary/assets/translations/zh_TW/index.ts
+++ b/feature-libs/organization/account-summary/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/cs/index.ts
+++ b/feature-libs/organization/administration/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/es/index.ts
+++ b/feature-libs/organization/administration/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/es_CO/index.ts
+++ b/feature-libs/organization/administration/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/fr/index.ts
+++ b/feature-libs/organization/administration/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/hi/index.ts
+++ b/feature-libs/organization/administration/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/hu/index.ts
+++ b/feature-libs/organization/administration/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/id/index.ts
+++ b/feature-libs/organization/administration/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/it/index.ts
+++ b/feature-libs/organization/administration/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/ko/index.ts
+++ b/feature-libs/organization/administration/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/pl/index.ts
+++ b/feature-libs/organization/administration/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/pt/index.ts
+++ b/feature-libs/organization/administration/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/ru/index.ts
+++ b/feature-libs/organization/administration/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/administration/assets/translations/zh_TW/index.ts
+++ b/feature-libs/organization/administration/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/cs/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/es/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/es_CO/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/fr/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/hi/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/hu/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/id/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/it/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/ko/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/pl/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/pt/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/ru/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/order-approval/assets/translations/zh_TW/index.ts
+++ b/feature-libs/organization/order-approval/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/cs/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/es/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/es_CO/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/fr/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/hi/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/hu/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/id/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/it/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/ko/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/pl/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/pt/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/ru/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/unit-order/assets/translations/zh_TW/index.ts
+++ b/feature-libs/organization/unit-order/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/cs/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/es/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/es_CO/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/fr/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/hi/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/hu/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/id/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/it/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/ko/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/pl/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/pt/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/ru/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/organization/user-registration/assets/translations/zh_TW/index.ts
+++ b/feature-libs/organization/user-registration/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/cs/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/es/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/es_CO/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/fr/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/hi/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/hu/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/id/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/it/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/ko/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/pl/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/pt/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/ru/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pdf-invoices/assets/translations/zh_TW/index.ts
+++ b/feature-libs/pdf-invoices/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/cs/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/es/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/es_CO/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/fr/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/hi/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/hu/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/id/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/it/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/ko/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/pl/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/pt/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/ru/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/pickup-in-store/assets/translations/zh_TW/index.ts
+++ b/feature-libs/pickup-in-store/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/cs/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/es/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/es_CO/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/fr/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/hi/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/hu/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/id/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/it/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/ko/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/pl/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/pt/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/ru/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-configurator/common/assets/translations/zh_TW/index.ts
+++ b/feature-libs/product-configurator/common/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/cs/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/es/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/es_CO/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/fr/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/hi/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/hu/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/id/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/it/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/ko/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/pl/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/pt/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/ru/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product-multi-dimensional/selector/assets/translations/zh_TW/index.ts
+++ b/feature-libs/product-multi-dimensional/selector/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/cs/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/es/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/es_CO/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/fr/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/hi/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/hu/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/id/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/it/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/ko/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/pl/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/pt/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/ru/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/bulk-pricing/assets/translations/zh_TW/index.ts
+++ b/feature-libs/product/bulk-pricing/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/cs/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/es/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/es_CO/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/fr/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/hi/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/hu/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/id/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/it/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/ko/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/pl/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/pt/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/ru/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/future-stock/assets/translations/zh_TW/index.ts
+++ b/feature-libs/product/future-stock/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/cs/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/es/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/es_CO/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/fr/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/hi/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/hu/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/id/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/it/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/ko/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/pl/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/pt/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/ru/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/image-zoom/assets/translations/zh_TW/index.ts
+++ b/feature-libs/product/image-zoom/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/cs/index.ts
+++ b/feature-libs/product/variants/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/es/index.ts
+++ b/feature-libs/product/variants/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/es_CO/index.ts
+++ b/feature-libs/product/variants/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/fr/index.ts
+++ b/feature-libs/product/variants/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/hi/index.ts
+++ b/feature-libs/product/variants/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/hu/index.ts
+++ b/feature-libs/product/variants/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/id/index.ts
+++ b/feature-libs/product/variants/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/it/index.ts
+++ b/feature-libs/product/variants/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/ko/index.ts
+++ b/feature-libs/product/variants/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/pl/index.ts
+++ b/feature-libs/product/variants/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/pt/index.ts
+++ b/feature-libs/product/variants/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/ru/index.ts
+++ b/feature-libs/product/variants/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/product/variants/assets/translations/zh_TW/index.ts
+++ b/feature-libs/product/variants/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/cs/index.ts
+++ b/feature-libs/quote/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/es/index.ts
+++ b/feature-libs/quote/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/es_CO/index.ts
+++ b/feature-libs/quote/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/fr/index.ts
+++ b/feature-libs/quote/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/hi/index.ts
+++ b/feature-libs/quote/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/hu/index.ts
+++ b/feature-libs/quote/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/id/index.ts
+++ b/feature-libs/quote/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/it/index.ts
+++ b/feature-libs/quote/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/ko/index.ts
+++ b/feature-libs/quote/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/pl/index.ts
+++ b/feature-libs/quote/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/pt/index.ts
+++ b/feature-libs/quote/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/ru/index.ts
+++ b/feature-libs/quote/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/quote/assets/translations/zh_TW/index.ts
+++ b/feature-libs/quote/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/cs/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/es/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/es_CO/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/fr/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/hi/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/hu/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/id/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/it/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/ko/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/pl/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/pt/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/ru/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/requested-delivery-date/assets/translations/zh_TW/index.ts
+++ b/feature-libs/requested-delivery-date/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/cs/index.ts
+++ b/feature-libs/storefinder/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/es/index.ts
+++ b/feature-libs/storefinder/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/es_CO/index.ts
+++ b/feature-libs/storefinder/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/fr/index.ts
+++ b/feature-libs/storefinder/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/hi/index.ts
+++ b/feature-libs/storefinder/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/hu/index.ts
+++ b/feature-libs/storefinder/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/id/index.ts
+++ b/feature-libs/storefinder/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/it/index.ts
+++ b/feature-libs/storefinder/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/ko/index.ts
+++ b/feature-libs/storefinder/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/pl/index.ts
+++ b/feature-libs/storefinder/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/pt/index.ts
+++ b/feature-libs/storefinder/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/ru/index.ts
+++ b/feature-libs/storefinder/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/storefinder/assets/translations/zh_TW/index.ts
+++ b/feature-libs/storefinder/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/cs/index.ts
+++ b/feature-libs/user/account/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/es/index.ts
+++ b/feature-libs/user/account/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/es_CO/index.ts
+++ b/feature-libs/user/account/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/fr/index.ts
+++ b/feature-libs/user/account/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/hi/index.ts
+++ b/feature-libs/user/account/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/hu/index.ts
+++ b/feature-libs/user/account/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/id/index.ts
+++ b/feature-libs/user/account/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/it/index.ts
+++ b/feature-libs/user/account/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/ko/index.ts
+++ b/feature-libs/user/account/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/pl/index.ts
+++ b/feature-libs/user/account/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/pt/index.ts
+++ b/feature-libs/user/account/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/ru/index.ts
+++ b/feature-libs/user/account/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/account/assets/translations/zh_TW/index.ts
+++ b/feature-libs/user/account/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/cs/index.ts
+++ b/feature-libs/user/profile/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/es/index.ts
+++ b/feature-libs/user/profile/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/es_CO/index.ts
+++ b/feature-libs/user/profile/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/fr/index.ts
+++ b/feature-libs/user/profile/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/hi/index.ts
+++ b/feature-libs/user/profile/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/hu/index.ts
+++ b/feature-libs/user/profile/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/id/index.ts
+++ b/feature-libs/user/profile/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/it/index.ts
+++ b/feature-libs/user/profile/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/ko/index.ts
+++ b/feature-libs/user/profile/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/pl/index.ts
+++ b/feature-libs/user/profile/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/pt/index.ts
+++ b/feature-libs/user/profile/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/ru/index.ts
+++ b/feature-libs/user/profile/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/feature-libs/user/profile/assets/translations/zh_TW/index.ts
+++ b/feature-libs/user/profile/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/cs/index.ts
+++ b/integration-libs/cdc/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/es/index.ts
+++ b/integration-libs/cdc/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/es_CO/index.ts
+++ b/integration-libs/cdc/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/fr/index.ts
+++ b/integration-libs/cdc/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/hi/index.ts
+++ b/integration-libs/cdc/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/hu/index.ts
+++ b/integration-libs/cdc/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/id/index.ts
+++ b/integration-libs/cdc/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/it/index.ts
+++ b/integration-libs/cdc/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/ko/index.ts
+++ b/integration-libs/cdc/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/pl/index.ts
+++ b/integration-libs/cdc/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/pt/index.ts
+++ b/integration-libs/cdc/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/ru/index.ts
+++ b/integration-libs/cdc/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cdc/assets/translations/zh_TW/index.ts
+++ b/integration-libs/cdc/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/cs/index.ts
+++ b/integration-libs/cds/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/es/index.ts
+++ b/integration-libs/cds/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/es_CO/index.ts
+++ b/integration-libs/cds/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/fr/index.ts
+++ b/integration-libs/cds/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/hi/index.ts
+++ b/integration-libs/cds/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/hu/index.ts
+++ b/integration-libs/cds/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/id/index.ts
+++ b/integration-libs/cds/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/it/index.ts
+++ b/integration-libs/cds/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/ko/index.ts
+++ b/integration-libs/cds/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/pl/index.ts
+++ b/integration-libs/cds/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/pt/index.ts
+++ b/integration-libs/cds/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/ru/index.ts
+++ b/integration-libs/cds/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cds/assets/translations/zh_TW/index.ts
+++ b/integration-libs/cds/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/cs/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/es/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/es_CO/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/fr/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/hi/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/hu/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/id/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/it/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/ko/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/pl/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/pt/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/ru/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/cpq-quote/assets/translations/zh_TW/index.ts
+++ b/integration-libs/cpq-quote/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/cs/index.ts
+++ b/integration-libs/digital-payments/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/es/index.ts
+++ b/integration-libs/digital-payments/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/es_CO/index.ts
+++ b/integration-libs/digital-payments/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/fr/index.ts
+++ b/integration-libs/digital-payments/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/hi/index.ts
+++ b/integration-libs/digital-payments/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/hu/index.ts
+++ b/integration-libs/digital-payments/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/id/index.ts
+++ b/integration-libs/digital-payments/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/it/index.ts
+++ b/integration-libs/digital-payments/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/ko/index.ts
+++ b/integration-libs/digital-payments/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/pl/index.ts
+++ b/integration-libs/digital-payments/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/pt/index.ts
+++ b/integration-libs/digital-payments/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/ru/index.ts
+++ b/integration-libs/digital-payments/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/digital-payments/assets/translations/zh_TW/index.ts
+++ b/integration-libs/digital-payments/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/cs/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/es/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/es_CO/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/fr/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/hi/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/hu/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/id/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/it/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/ko/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/pl/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/pt/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/ru/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/epd-visualization/assets/translations/zh_TW/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/cs/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/de/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/de/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/es/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/es_CO/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/fr/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/hi/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/hu/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/id/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/it/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/ja/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/ja/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/ko/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/pl/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/pt/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/ru/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/zh/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/zh/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/checkout/assets/translations/zh_TW/index.ts
+++ b/integration-libs/opf/checkout/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/cs/index.ts
+++ b/integration-libs/opf/payment/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/de/index.ts
+++ b/integration-libs/opf/payment/assets/translations/de/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/es/index.ts
+++ b/integration-libs/opf/payment/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/es_CO/index.ts
+++ b/integration-libs/opf/payment/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/fr/index.ts
+++ b/integration-libs/opf/payment/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/hi/index.ts
+++ b/integration-libs/opf/payment/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/hu/index.ts
+++ b/integration-libs/opf/payment/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/id/index.ts
+++ b/integration-libs/opf/payment/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/it/index.ts
+++ b/integration-libs/opf/payment/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/ja/index.ts
+++ b/integration-libs/opf/payment/assets/translations/ja/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/ko/index.ts
+++ b/integration-libs/opf/payment/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/pl/index.ts
+++ b/integration-libs/opf/payment/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/pt/index.ts
+++ b/integration-libs/opf/payment/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/ru/index.ts
+++ b/integration-libs/opf/payment/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/zh/index.ts
+++ b/integration-libs/opf/payment/assets/translations/zh/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/opf/payment/assets/translations/zh_TW/index.ts
+++ b/integration-libs/opf/payment/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/cs/index.ts
+++ b/integration-libs/s4-service/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/es/index.ts
+++ b/integration-libs/s4-service/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/es_CO/index.ts
+++ b/integration-libs/s4-service/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/fr/index.ts
+++ b/integration-libs/s4-service/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/hi/index.ts
+++ b/integration-libs/s4-service/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/hu/index.ts
+++ b/integration-libs/s4-service/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/id/index.ts
+++ b/integration-libs/s4-service/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/it/index.ts
+++ b/integration-libs/s4-service/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/ko/index.ts
+++ b/integration-libs/s4-service/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/pl/index.ts
+++ b/integration-libs/s4-service/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/pt/index.ts
+++ b/integration-libs/s4-service/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/ru/index.ts
+++ b/integration-libs/s4-service/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4-service/assets/translations/zh_TW/index.ts
+++ b/integration-libs/s4-service/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/cs/index.ts
+++ b/integration-libs/s4om/assets/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/es/index.ts
+++ b/integration-libs/s4om/assets/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/es_CO/index.ts
+++ b/integration-libs/s4om/assets/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/fr/index.ts
+++ b/integration-libs/s4om/assets/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/hi/index.ts
+++ b/integration-libs/s4om/assets/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/hu/index.ts
+++ b/integration-libs/s4om/assets/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/id/index.ts
+++ b/integration-libs/s4om/assets/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/it/index.ts
+++ b/integration-libs/s4om/assets/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/ko/index.ts
+++ b/integration-libs/s4om/assets/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/pl/index.ts
+++ b/integration-libs/s4om/assets/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/pt/index.ts
+++ b/integration-libs/s4om/assets/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/ru/index.ts
+++ b/integration-libs/s4om/assets/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/integration-libs/s4om/assets/translations/zh_TW/index.ts
+++ b/integration-libs/s4om/assets/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/cs/index.ts
+++ b/projects/assets/src/translations/cs/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/es/index.ts
+++ b/projects/assets/src/translations/es/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/es_CO/index.ts
+++ b/projects/assets/src/translations/es_CO/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/fr/index.ts
+++ b/projects/assets/src/translations/fr/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/hi/index.ts
+++ b/projects/assets/src/translations/hi/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/hu/index.ts
+++ b/projects/assets/src/translations/hu/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/id/index.ts
+++ b/projects/assets/src/translations/id/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/it/index.ts
+++ b/projects/assets/src/translations/it/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/ko/index.ts
+++ b/projects/assets/src/translations/ko/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/pl/index.ts
+++ b/projects/assets/src/translations/pl/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/pt/index.ts
+++ b/projects/assets/src/translations/pt/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/ru/index.ts
+++ b/projects/assets/src/translations/ru/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/assets/src/translations/zh_TW/index.ts
+++ b/projects/assets/src/translations/zh_TW/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/core/src/i18n/extract-translation-chunks-config.ts
+++ b/projects/core/src/i18n/extract-translation-chunks-config.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/navigation-login-a11y.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/user_access/navigation-login-a11y.e2e.cy.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/storefrontlib/layout/a11y/on-dom-change/dom-change.directive.ts
+++ b/projects/storefrontlib/layout/a11y/on-dom-change/dom-change.directive.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/storefrontlib/layout/a11y/on-dom-change/dom-change.module.ts
+++ b/projects/storefrontlib/layout/a11y/on-dom-change/dom-change.module.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0

--- a/projects/storefrontlib/layout/a11y/on-dom-change/index.ts
+++ b/projects/storefrontlib/layout/a11y/on-dom-change/index.ts
@@ -1,5 +1,4 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP Spartacus team <spartacus-team@sap.com>
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Although we've already replaced the year 2024 with 2025 in all license headers in January, the recent PRs merged to develop brought redundant 2024+2025 headers.
This PR removes the unnecessary 2024