### PR TITLE
fix: prevent removing new-lines from original server.ts file

### DIFF
--- a/projects/schematics/src/migrations/2211_35/ssr/update-ssr/update-server-files.ts
+++ b/projects/schematics/src/migrations/2211_35/ssr/update-ssr/update-server-files.ts
@@ -24,40 +24,6 @@ function findServerFile(tree: Tree): string | null {
 }
 
 /**
- * Creates a new AST node for the indexHtml assignment.
- * The new assignment will use serverDistFolder and index.server.html.
- * @param originalQuoteStyle - Whether to use single (true) or double (false) quotes
- */
-function createNewIndexHtmlAssignment(
-  originalQuoteStyle: boolean = true
-): ts.Statement {
-  return ts.factory.createVariableStatement(
-    undefined,
-    ts.factory.createVariableDeclarationList(
-      [
-        ts.factory.createVariableDeclaration(
-          ts.factory.createIdentifier('indexHtml'),
-          undefined,
-          undefined,
-          ts.factory.createCallExpression(
-            ts.factory.createIdentifier('join'),
-            undefined,
-            [
-              ts.factory.createIdentifier('serverDistFolder'),
-              ts.factory.createStringLiteral(
-                'index.server.html',
-                originalQuoteStyle
-              ),
-            ]
-          )
-        ),
-      ],
-      ts.NodeFlags.Const
-    )
-  );
-}
-
-/**
  * Determines if a string literal uses single or double quotes.
  * @param node - The string literal node to check
  * @returns true for single quotes, false for double quotes
@@ -100,62 +66,43 @@ function isJoinCallWithIndexHtml(node: ts.Node): JoinCallResult {
 }
 
 /**
- * Updates the server.ts file content by replacing the indexHtml assignment
- * that uses browserDistFolder/index.html with serverDistFolder/index.server.html.
- * Preserves the original quote style and all other content.
+ * Visits the node and tries to find recursively the indexHtml const.
+ * When found, it updates the indexHtml const to use serverDistFolder and index.server.html.
  */
-function updateServerContent(content: string): string {
-  const sourceFile = ts.createSourceFile(
-    'server.ts',
-    content,
-    ts.ScriptTarget.Latest,
-    true
-  );
+function visitNodeToUpdateIndexHtmlConst(
+  node: ts.Node,
+  content: string
+): string {
+  let updatedContent = content;
 
-  const printer = ts.createPrinter({
-    newLine: ts.NewLineKind.LineFeed,
-    removeComments: false,
-  });
-
-  // Create a transformer to handle nested replacements
-  const transformer = (context: ts.TransformationContext) => {
-    const visit = (node: ts.Node): ts.Node => {
-      // Recursively visit and transform nodes
-      node = ts.visitEachChild(node, visit, context);
-
-      // Check if this node is a variable statement containing indexHtml assignment
-      if (ts.isVariableStatement(node)) {
-        const declarations = node.declarationList.declarations;
-        if (declarations.length === 1) {
-          const declaration = declarations[0];
-          if (
-            ts.isIdentifier(declaration.name) &&
-            declaration.name.text === 'indexHtml' &&
-            declaration.initializer
-          ) {
-            const { isMatch, quotePreference } = isJoinCallWithIndexHtml(
-              declaration.initializer
-            );
-            if (isMatch) {
-              return createNewIndexHtmlAssignment(quotePreference);
-            }
-          }
+  if (ts.isVariableStatement(node)) {
+    const declarations = node.declarationList.declarations;
+    if (declarations.length === 1) {
+      const declaration = declarations[0];
+      if (
+        ts.isIdentifier(declaration.name) &&
+        declaration.name.text === 'indexHtml' &&
+        declaration.initializer
+      ) {
+        const { isMatch, quotePreference } = isJoinCallWithIndexHtml(
+          declaration.initializer
+        );
+        if (isMatch) {
+          const originalText = node.getText();
+          const quote = quotePreference ? "'" : '"';
+          const newText = `const indexHtml = join(serverDistFolder, ${quote}index.server.html${quote});`;
+          updatedContent = updatedContent.replace(originalText, newText);
         }
       }
+    }
+  }
 
-      return node;
-    };
+  // Recursively visit all children
+  ts.forEachChild(node, (childNode) => {
+    updatedContent = visitNodeToUpdateIndexHtmlConst(childNode, updatedContent);
+  });
 
-    return (node: ts.Node) => ts.visitNode(node, visit);
-  };
-
-  // Apply the transformer
-  const result = ts.transform(sourceFile, [transformer]);
-  const transformedSourceFile = result.transformed[0];
-
-  const output = printer.printFile(transformedSourceFile as ts.SourceFile);
-  result.dispose(); // Clean up
-  return output;
+  return updatedContent;
 }
 
 /**
@@ -163,7 +110,7 @@ function updateServerContent(content: string): string {
  * instead of index.html when using the application builder.
  */
 export function updateServerFile(): Rule {
-  return async (tree: Tree, context: SchematicContext) => {
+  return (tree: Tree, context: SchematicContext) => {
     context.logger.info('🔍 Checking if server.ts needs to be updated...');
     const serverFilePath = findServerFile(tree);
     if (!serverFilePath) {
@@ -175,17 +122,28 @@ export function updateServerFile(): Rule {
       `🔄 Updating ${serverFilePath} to use index.server.html`
     );
 
-    const buffer = tree.read(serverFilePath);
-    if (!buffer) {
+    const fileContentBuffer = tree.read(serverFilePath);
+    if (!fileContentBuffer) {
       context.logger.warn(
         `⚠️ Could not read ${serverFilePath} - skipping update`
       );
       return;
     }
 
-    const content = buffer.toString();
-    const updatedContent = updateServerContent(content);
-    tree.overwrite(serverFilePath, updatedContent);
-    context.logger.info(`✅ Successfully updated ${serverFilePath}`);
+    const content = fileContentBuffer.toString('utf-8');
+    const sourceFile = ts.createSourceFile(
+      'server.ts',
+      content,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const updatedContent = visitNodeToUpdateIndexHtmlConst(sourceFile, content);
+
+    if (updatedContent !== content) {
+      tree.overwrite(serverFilePath, updatedContent);
+      context.logger.info(`✅ Successfully updated ${serverFilePath}`);
+    }
+    return tree;
   };
 }


### PR DESCRIPTION
New-lines are preserved now in `server.ts` after running the schematics:
See the related comment https://github.com/SAP/spartacus/pull/19848#discussion_r1930153004

By the way, removed the usage of `printer` in favor of a more common approach in our schematics - returning the modified `Tree`.

Result:
![image](https://github.com/user-attachments/assets/f66eb1f7-0b18-4658-90e0-3982a9939a6e)
