### PR TITLE
chore(schematics/testing): add voice notification when finished a task (under optional flag `--voice-notify`)

### DIFF
--- a/tools/schematics/testing.ts
+++ b/tools/schematics/testing.ts
@@ -84,6 +84,20 @@ const commands = [
 ] as const;
 type Command = (typeof commands)[number];
 
+const isVoiceNotifyEnabled = process.argv.includes('--voice-notify');
+if (isVoiceNotifyEnabled) {
+  console.log('Voice notifications enabled');
+}
+function voiceAlert(message: string): void {
+  if (isVoiceNotifyEnabled) {
+    try {
+      execSync(`say "${message}"`);
+    } catch (error) {
+      console.warn('Voice notification failed:', error);
+    }
+  }
+}
+
 const buildLibRegEx = new RegExp('build (.*?)/schematics');
 const verdaccioRegistryUrl = 'http://localhost:4873/';
 const originalRegistryUrl = execSync('npm config get @spartacus:registry')
@@ -204,9 +218,11 @@ async function executeCommand(command: Command): Promise<void> {
   switch (command) {
     case 'publish':
       publishLibs();
+      voiceAlert('Publishing completed');
       break;
     case 'build projects/schematics':
       buildSchematics({ publish: true });
+      voiceAlert('Schematics build completed');
       break;
     case 'build asm/schematics':
     case 'build cart/schematics':
@@ -240,12 +256,15 @@ async function executeCommand(command: Command): Promise<void> {
       const lib =
         buildLibRegEx.exec(command)?.pop() ?? 'LIB-REGEX-DOES-NOT-MATCH';
       buildSchematicsAndPublish(`npm run build:${lib}`);
+      voiceAlert(`Schematics build of lib ${lib} completed`);
       break;
     case 'build all libs':
       buildLibs();
+      voiceAlert('All libraries build completed');
       break;
     case 'test all schematics':
       testAllSchematics();
+      voiceAlert('All schematics tests completed');
       break;
     case 'exit':
       beforeExit();


### PR DESCRIPTION
Note: The util is enabled only after running the `schmatics/testing.ts` script with an optional flag `--voice-notify` 

QA steps:
1. enable sound in your speakers
2. build libs
3. run `npx ts-node ./tools/schematics/testing.ts --voice-notify` and then select `publish`
4. Wait for the publish and then verify you heard a voice notification in the end
5. Kill the script
6. Run `npx ts-node ./tools/schematics/testing.ts` (without any flags) and then select `publish`. Publish and verify there was no voice notification