### PR TITLE
feat: update jest setup files to remove warning (CXSPA-9288)

### DIFF
--- a/feature-libs/asm/setup-jest.ts
+++ b/feature-libs/asm/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/cart/setup-jest.ts
+++ b/feature-libs/cart/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/checkout/setup-jest.ts
+++ b/feature-libs/checkout/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/customer-ticketing/setup-jest.ts
+++ b/feature-libs/customer-ticketing/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/estimated-delivery-date/setup-jest.ts
+++ b/feature-libs/estimated-delivery-date/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/order/setup-jest.ts
+++ b/feature-libs/order/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/organization/setup-jest.ts
+++ b/feature-libs/organization/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/pdf-invoices/setup-jest.ts
+++ b/feature-libs/pdf-invoices/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/pickup-in-store/setup-jest.ts
+++ b/feature-libs/pickup-in-store/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/product-configurator/setup-jest.ts
+++ b/feature-libs/product-configurator/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/product-multi-dimensional/setup-jest.ts
+++ b/feature-libs/product-multi-dimensional/setup-jest.ts
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 
 setupZoneTestEnv();

--- a/feature-libs/product-multi-dimensional/setup-jest.ts
+++ b/feature-libs/product-multi-dimensional/setup-jest.ts
@@ -3,6 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+setupZoneTestEnv();

--- a/feature-libs/product/setup-jest.ts
+++ b/feature-libs/product/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/qualtrics/setup-jest.ts
+++ b/feature-libs/qualtrics/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/quote/setup-jest.ts
+++ b/feature-libs/quote/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/requested-delivery-date/setup-jest.ts
+++ b/feature-libs/requested-delivery-date/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/smartedit/setup-jest.ts
+++ b/feature-libs/smartedit/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/storefinder/setup-jest.ts
+++ b/feature-libs/storefinder/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/tracking/setup-jest.ts
+++ b/feature-libs/tracking/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/feature-libs/user/setup-jest.ts
+++ b/feature-libs/user/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/cdc/setup-jest.ts
+++ b/integration-libs/cdc/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/cdp/setup-jest.ts
+++ b/integration-libs/cdp/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/cds/setup-jest.ts
+++ b/integration-libs/cds/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/cpq-quote/setup-jest.ts
+++ b/integration-libs/cpq-quote/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/digital-payments/setup-jest.ts
+++ b/integration-libs/digital-payments/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/epd-visualization/setup-jest.ts
+++ b/integration-libs/epd-visualization/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/omf/setup-jest.ts
+++ b/integration-libs/omf/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/opf/setup-jest.ts
+++ b/integration-libs/opf/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/opps/setup-jest.ts
+++ b/integration-libs/opps/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/s4-service/setup-jest.ts
+++ b/integration-libs/s4-service/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/s4om/setup-jest.ts
+++ b/integration-libs/s4om/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/integration-libs/segment-refs/setup-jest.ts
+++ b/integration-libs/segment-refs/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/projects/schematics/setup-jest.ts
+++ b/projects/schematics/setup-jest.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'jest-preset-angular/setup-jest';
-import 'zone.js';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-9288

Notes:
```
import 'jest-preset-angular/setup-jest';
import 'zone.js';
```
The above two lines have been replaced in all instances of setup-jest.ts as below

```
import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
setupZoneTestEnv();
```
