### PR TITLE
Remove common part from add/remove imports list

### DIFF
--- a/projects/schematics/src/modernize-app-migrated-from-68-to-221119/ssr/update-server-ts/add-imports-to-server-ts.ts
+++ b/projects/schematics/src/modernize-app-migrated-from-68-to-221119/ssr/update-server-ts/add-imports-to-server-ts.ts
@@ -34,19 +34,6 @@ export function addImportsToServerTs(updatedContent: string): string {
     asName?: string;
   }[] = [
     {
-      importPath: '@angular/common',
-      symbolName: 'APP_BASE_HREF',
-    },
-    {
-      importPath: '@spartacus/setup/ssr',
-      symbolName: 'NgExpressEngineDecorator',
-    },
-    {
-      importPath: '@spartacus/setup/ssr',
-      symbolName: 'ngExpressEngine',
-      asName: 'engine',
-    },
-    {
       importPath: 'express',
       symbolName: 'express',
       isDefault: true,

--- a/projects/schematics/src/modernize-app-migrated-from-68-to-221119/ssr/update-server-ts/remove-imports-from-server-ts.ts
+++ b/projects/schematics/src/modernize-app-migrated-from-68-to-221119/ssr/update-server-ts/remove-imports-from-server-ts.ts
@@ -25,15 +25,9 @@ import { removeImportFromContent } from '../../../shared/utils/file-utils';
 export function removeImportsFromServerTs(updatedContent: string): string {
   const importsToRemove: { symbolName?: string; importPath: string }[] = [
     { importPath: 'zone.js/node' },
-    { symbolName: 'ngExpressEngine', importPath: '@spartacus/setup/ssr' },
-    {
-      symbolName: 'NgExpressEngineDecorator',
-      importPath: '@spartacus/setup/ssr',
-    },
     { symbolName: 'express', importPath: 'express' },
     { symbolName: 'join', importPath: 'path' },
     { symbolName: 'AppServerModule', importPath: './src/main.server' },
-    { symbolName: 'APP_BASE_HREF', importPath: '@angular/common' },
     { symbolName: 'existsSync', importPath: 'fs' },
   ];
 


### PR DESCRIPTION
This PR contain adjustment in add/remove imports for the `servet.ts` file. Migration unnecessarily removed and the re-imported common imports for the old and the new shape of the server file.

In addition, the adjustment helps to avoid the following issue:
https://github.com/SAP/spartacus/pull/19957#issuecomment-2630616020

closes [CXSPA-9371](https://jira.tools.sap/browse/CXSPA-9371)