### PR TITLE
fix: (CXSPA-9265) reduced width of spare part tab content

### DIFF
--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.html
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.html
@@ -1,6 +1,5 @@
 <div
-  [class.container-fluid]="!hideViewport"
-  [class.container]="hideViewport"
+  class="container"
   [hidden]="!hideNoProductReferencesIndicator"
 >
   <cx-epd-visualization-viewer

--- a/integration-libs/epd-visualization/styles/components/visual-picking/visual-picking-tab.component.scss
+++ b/integration-libs/epd-visualization/styles/components/visual-picking/visual-picking-tab.component.scss
@@ -1,9 +1,8 @@
 %cx-epd-visualization-visual-picking-tab {
   .container-fluid:not(.no-product-references),
   .container:not(.no-product-references) {
-    padding: 1em 0;
+    padding: 1em;
     background-color: $body-bg;
-
     display: flex;
     justify-content: space-between;
     flex-direction: column;


### PR DESCRIPTION
In previous Spartacus version, the spare parts tab looked like this:
<img width="1590" alt="image" src="https://github.com/user-attachments/assets/6a91d1d5-c85c-4764-b26d-3d091f109a77" />

With the current Spartacus code it looks like this:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/30929915-654d-4ded-8a9c-6aac53e06dc7" />

With the changes in this PR, it looks like this:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/80143d80-645a-4151-95f3-6ab868b86d4e" />

JIRA: https://jira.tools.sap/browse/CXSPA-9265