### PR TITLE
Revert: "chore: set feature toggle productConfiguratorDeltaRendering to true (CXSPA-9412) (#19987)"

### DIFF
--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -1007,7 +1007,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   productConfiguratorAttributeTypesV2: true,
   propagateErrorsToServer: false,
   ssrStrictErrorHandlingForHttpAndNgrx: false,
-  productConfiguratorDeltaRendering: true,
+  productConfiguratorDeltaRendering: false,
   a11yRequiredAsterisks: true,
   a11yQuantityOrderTabbing: true,
   a11yNavigationUiKeyboardControls: true,


### PR DESCRIPTION
The original PR was meant for the March release, so temporarily reverting it, until we cut off the Feb release branch. Later we'll add it back.

Original PR: https://github.com/SAP/spartacus/pull/19987