### PR TITLE
fix: Enable a11yScrollToTopPositioning feature flag

### DIFF
--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -439,7 +439,7 @@ if (environment.cpq) {
         a11yHamburgerMenuTrapFocus: true,
         useExtendedMediaComponentConfiguration: true,
         showRealTimeStockInPDP: false,
-        a11yScrollToTopPositioning: false,
+        a11yScrollToTopPositioning: true,
         a11yWrapReviewOrderInSection: true,
         enableCarouselCategoryProducts: true,
         enableSecurePasswordValidation: true,


### PR DESCRIPTION
Ideally our example storefrontapp should have all toggles enabled if possible (to be able to test the example app with all toggles enabled), as noted in our [Coding Guidelines](https://wiki.one.int.sap/wiki/display/spar/Coding+Guidelines#CodingGuidelines-AddaFeatureToggleinthecodesourcecode).