### PR TITLE
Login when initial token is invalid

### DIFF
--- a/integration-libs/punchout/root/model/punchout.model.ts
+++ b/integration-libs/punchout/root/model/punchout.model.ts
@@ -6,6 +6,7 @@
 
 export const PUNCHOUT_SESSION_KEY = 'sid';
 export const PUNCHOUT_ERROR_PAGE_URL = '/punchout/cxml/error';
+export const PUNCHOUT_SESSION_PAGE_URL = '/punchout/cxml/session';
 export const PUNCHOUT_SESSION_ID = 'punchoutSessionId';
 
 export enum PunchOutLevel {

--- a/integration-libs/punchout/root/public_api.ts
+++ b/integration-libs/punchout/root/public_api.ts
@@ -8,3 +8,4 @@ export * from './facade/index';
 export * from './feature-name';
 export * from './model/index';
 export * from './punchout.root.module';
+export * from './services/index';

--- a/integration-libs/punchout/root/punchout.root.module.ts
+++ b/integration-libs/punchout/root/punchout.root.module.ts
@@ -5,8 +5,13 @@
  */
 
 import { NgModule } from '@angular/core';
-import { CmsConfig, provideDefaultConfigFactory } from '@spartacus/core';
+import {
+  AuthHttpHeaderService,
+  CmsConfig,
+  provideDefaultConfigFactory,
+} from '@spartacus/core';
 import { PUNCHOUT_FEATURE } from './feature-name';
+import { PunchoutAuthHttpHeaderService } from './services/punchout-auth-http-header.service';
 
 export function defaultPunchoutCmsComponentsConfig(): CmsConfig {
   const config: CmsConfig = {
@@ -20,6 +25,12 @@ export function defaultPunchoutCmsComponentsConfig(): CmsConfig {
 }
 
 @NgModule({
-  providers: [provideDefaultConfigFactory(defaultPunchoutCmsComponentsConfig)],
+  providers: [
+    provideDefaultConfigFactory(defaultPunchoutCmsComponentsConfig),
+    {
+      provide: AuthHttpHeaderService,
+      useExisting: PunchoutAuthHttpHeaderService,
+    },
+  ],
 })
 export class PunchoutRootModule {}

--- a/integration-libs/punchout/root/services/index.ts
+++ b/integration-libs/punchout/root/services/index.ts
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './punchout-auth-http-header.service';
 export * from './punchout-detection.service';

--- a/integration-libs/punchout/root/services/index.ts
+++ b/integration-libs/punchout/root/services/index.ts
@@ -1,0 +1,2 @@
+export * from './punchout-auth-http-header.service';
+export * from './punchout-detection.service';

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
@@ -1,0 +1,122 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  AuthRedirectService,
+  AuthService,
+  AuthStorageService,
+  AuthToken,
+  GlobalMessageService,
+  OAuthLibWrapperService,
+  OccEndpointsService,
+  RoutingService,
+} from '@spartacus/core';
+import { of } from 'rxjs';
+import { PunchoutAuthHttpHeaderService } from './punchout-auth-http-header.service';
+import { PunchoutDetectionService } from './punchout-detection.service';
+
+class MockPunchoutDetectionService
+  implements Partial<PunchoutDetectionService>
+{
+  isPunchoutSessionPage(): boolean {
+    return true;
+  }
+}
+
+class MockAuthService implements Partial<AuthService> {
+  coreLogout(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MockAuthStorageService implements Partial<AuthStorageService> {
+  getToken() {
+    return of({ access_token: 'acc_token' } as AuthToken);
+  }
+}
+
+class MockOAuthLibWrapperService implements Partial<OAuthLibWrapperService> {}
+
+class MockRoutingService implements Partial<RoutingService> {
+  go = () => Promise.resolve(true);
+}
+
+class MockGlobalMessageService implements Partial<GlobalMessageService> {
+  add() {}
+  remove() {}
+}
+
+class MockOccEndpointsService implements Partial<OccEndpointsService> {
+  getBaseUrl() {
+    return 'some-server/occ';
+  }
+  getRawEndpointValue(): string {
+    return 'some-endpoint';
+  }
+}
+
+class MockAuthRedirectService implements Partial<AuthRedirectService> {
+  saveCurrentNavigationUrl = jasmine.createSpy('saveCurrentNavigationUrl');
+}
+
+describe('PunchoutAuthHttpHeaderService', () => {
+  let service: PunchoutAuthHttpHeaderService;
+  let authService: AuthService;
+  let punchoutDetectionService: PunchoutDetectionService;
+  let globalMessageService: GlobalMessageService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [
+        {
+          provide: PunchoutDetectionService,
+          useClass: MockPunchoutDetectionService,
+        },
+        { provide: AuthService, useClass: MockAuthService },
+        { provide: GlobalMessageService, useClass: MockGlobalMessageService },
+        { provide: OccEndpointsService, useClass: MockOccEndpointsService },
+        { provide: AuthStorageService, useClass: MockAuthStorageService },
+        { provide: AuthRedirectService, useClass: MockAuthRedirectService },
+        {
+          provide: OAuthLibWrapperService,
+          useClass: MockOAuthLibWrapperService,
+        },
+        { provide: RoutingService, useClass: MockRoutingService },
+      ],
+    });
+    service = TestBed.inject(PunchoutAuthHttpHeaderService);
+    authService = TestBed.inject(AuthService);
+    punchoutDetectionService = TestBed.inject(PunchoutDetectionService);
+    globalMessageService = TestBed.inject(GlobalMessageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should handleExpiredRefreshToken call super coreLogout when not Punchout Session page', async () => {
+    spyOn(authService, 'coreLogout').and.callThrough();
+    spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
+      false
+    );
+    spyOn(globalMessageService, 'remove').and.callThrough();
+
+    service.handleExpiredRefreshToken();
+    await Promise.resolve();
+
+    expect(authService.coreLogout).toHaveBeenCalled();
+    expect(globalMessageService.remove).not.toHaveBeenCalled();
+  });
+
+  it('should handleExpiredRefreshToken silently logout when Punchout Session page', async () => {
+    spyOn(authService, 'coreLogout').and.callThrough();
+    spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
+      true
+    );
+    spyOn(globalMessageService, 'remove').and.callThrough();
+
+    service.handleExpiredRefreshToken();
+    await Promise.resolve();
+
+    expect(authService.coreLogout).toHaveBeenCalled();
+    expect(globalMessageService.remove).toHaveBeenCalled();
+  });
+});

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -1,0 +1,57 @@
+import { inject, Injectable } from '@angular/core';
+import {
+  AuthHttpHeaderService,
+  AuthRedirectService,
+  AuthService,
+  AuthStorageService,
+  GlobalMessageService,
+  GlobalMessageType,
+  OAuthLibWrapperService,
+  OccEndpointsService,
+  RoutingService,
+} from '@spartacus/core';
+import { PunchoutDetectionService } from './punchout-detection.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
+  protected punchoutInitService = inject(PunchoutDetectionService);
+  constructor(
+    protected authService: AuthService,
+    protected authStorageService: AuthStorageService,
+    protected oAuthLibWrapperService: OAuthLibWrapperService,
+    protected routingService: RoutingService,
+    protected globalMessageService: GlobalMessageService,
+    protected occEndpointsService: OccEndpointsService,
+    protected authRedirectService: AuthRedirectService
+  ) {
+    super(
+      authService,
+      authStorageService,
+      oAuthLibWrapperService,
+      routingService,
+      occEndpointsService,
+      globalMessageService,
+      authRedirectService
+    );
+  }
+
+  /**
+   * @override
+   *
+   * On backend errors indicating expired `refresh_token` we need to logout
+   * silently revoke invalid/expired token
+   */
+  public handleExpiredRefreshToken(): void {
+    if (!this.punchoutInitService.isPunchoutSessionPage()) {
+      super.handleExpiredRefreshToken();
+    } else {
+      this.authService.coreLogout().finally(() => {
+        this.globalMessageService.remove(
+          GlobalMessageType.MSG_TYPE_CONFIRMATION
+        );
+      });
+    }
+  }
+}

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -46,9 +46,9 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
   /**
    * @override
    *
-   * On backend errors indicating expired `refresh_token` we need to logout
-   * silently by revoke invalid/expired token and prevent Login page redirection.
-   * Workaround to address CXSPA-9608 - Public pages not displayed when token is invalid
+   * On backend errors indicating expired `refresh_token`, we need to silently logout
+   * by revoking invalid token and preventing Login page redirection.
+   * It is a workaround to address CXSPA-9608 - Public pages not displayed when token is invalid.
    * To be removed once CXSPA-9608 is closed.
    */
   public handleExpiredRefreshToken(): void {

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -41,7 +41,9 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
    * @override
    *
    * On backend errors indicating expired `refresh_token` we need to logout
-   * silently revoke invalid/expired token
+   * silently by revoke invalid/expired token and prevent Login page redirection.
+   * Workaround to address CXSPA-9608 - Public pages not displayed when token is invalid
+   * To be removed once CXSPA-9608 is closed.
    */
   public handleExpiredRefreshToken(): void {
     if (!this.punchoutInitService.isPunchoutSessionPage()) {

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { inject, Injectable } from '@angular/core';
 import {
   AuthHttpHeaderService,

--- a/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
@@ -1,0 +1,48 @@
+import { Location } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { PUNCHOUT_SESSION_PAGE_URL } from '../model';
+import { PunchoutDetectionService } from './punchout-detection.service';
+
+const MOCK_URL = 'https://test';
+const MOCK_URL_WITH_PUNCHOUT = `https://spartacus/${PUNCHOUT_SESSION_PAGE_URL}?sid=abc123`;
+
+class MockLocation implements Partial<Location> {
+  path() {
+    return MOCK_URL;
+  }
+}
+
+describe('PunchoutDetectionService', () => {
+  let service: PunchoutDetectionService;
+  let location: Location;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [{ provide: Location, useClass: MockLocation }],
+    });
+
+    location = TestBed.inject(Location);
+    service = TestBed.inject(PunchoutDetectionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should isPunchoutSessionPage falsy when url is not punchout session', (done) => {
+    spyOn(location, 'path').and.returnValue(MOCK_URL);
+
+    const value = service.isPunchoutSessionPage();
+    expect(value).toEqual(false);
+    done();
+  });
+
+  it('should isPunchoutSessionPage truthy when url punchout session', (done) => {
+    spyOn(location, 'path').and.returnValue(MOCK_URL_WITH_PUNCHOUT);
+
+    const value = service.isPunchoutSessionPage();
+    expect(value).toEqual(true);
+    done();
+  });
+});

--- a/integration-libs/punchout/root/services/punchout-detection.service.ts
+++ b/integration-libs/punchout/root/services/punchout-detection.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Location } from '@angular/common';
 import { Injectable, inject } from '@angular/core';
 import { PUNCHOUT_SESSION_PAGE_URL } from '../model';

--- a/integration-libs/punchout/root/services/punchout-detection.service.ts
+++ b/integration-libs/punchout/root/services/punchout-detection.service.ts
@@ -1,0 +1,21 @@
+import { Location } from '@angular/common';
+import { Injectable, inject } from '@angular/core';
+import { PUNCHOUT_SESSION_PAGE_URL } from '../model';
+
+@Injectable({ providedIn: 'root' })
+export class PunchoutDetectionService {
+  protected location = inject(Location);
+
+  /**
+   * Check if browser url is the punchout initial session page.
+   * With default config, the expected url shape is '/punchout/cxml/session?abcd'.
+   * @returns boolean
+   */
+  isPunchoutSessionPage(): boolean {
+    const urlSections = this.location.path().split('?');
+    return (
+      urlSections.length > 1 &&
+      urlSections[0].includes(PUNCHOUT_SESSION_PAGE_URL)
+    );
+  }
+}


### PR DESCRIPTION
Workaround to address CXSPA-9608 - Public pages not displayed when token is invalid

Overriding AuthHttpHeaderService.handleExpiredRefreshToken method which was redirecting user to login page.
We want user to stay on Punchout Session page, so the Punchout Session CMS page can be fetched.