### PR TITLE
Add persistence

### DIFF
--- a/integration-libs/punchout/components/punchout-session/punchout-session.component.ts
+++ b/integration-libs/punchout/components/punchout-session/punchout-session.component.ts
@@ -27,7 +27,7 @@ export class PunchoutSessionComponent implements OnInit {
     this.activatedRoute.queryParams.pipe(take(1)).subscribe((param: Params) => {
       const punchoutSessionId = param?.[PUNCHOUT_SESSION_KEY];
       this.punchoutFacade
-        .getPunchoutSession(punchoutSessionId)
+        .getPunchoutSession({ punchoutSessionId })
         .pipe(take(1))
         .subscribe();
     });

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -6,14 +6,15 @@ import {
   PunchOutOperation,
   PunchoutRequisition,
   PunchoutSession,
+  PunchoutSessionInput,
 } from '@spartacus/punchout/root';
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 import { PunchoutConnector } from '../connectors';
 import { PunchoutAuthService } from '../services';
 import { PunchoutService } from './punchout.service';
 import createSpy = jasmine.createSpy;
 
-const mockSid = 'mockSid';
+const mockSessionInput: PunchoutSessionInput = { punchoutSessionId: 'mockSid' };
 
 const mockPunchoutSessionResponse: PunchoutSession = {
   customerId: 'test@test.com',
@@ -82,10 +83,12 @@ describe('Punchoutservice', () => {
     spyOn(connector, 'getPunchoutSession').and.returnValue(
       of(mockPunchoutSessionResponse)
     );
-    service.getPunchoutSession(mockSid).subscribe({
+    service.getPunchoutSession(mockSessionInput).subscribe({
       next: (result) => {
         expect(result).toEqual(mockPunchoutSessionResponse);
-        expect(connector.getPunchoutSession).toHaveBeenCalledWith(mockSid);
+        expect(connector.getPunchoutSession).toHaveBeenCalledWith(
+          mockSessionInput.punchoutSessionId
+        );
         done();
       },
     });
@@ -95,20 +98,22 @@ describe('Punchoutservice', () => {
     spyOn(connector, 'getPunchoutSessionRequisition').and.returnValue(
       of(mockPunchoutRequisitionResponse)
     );
-    service.getPunchoutSessionRequisition(mockSid).subscribe({
-      next: (result) => {
-        expect(result).toEqual(mockPunchoutRequisitionResponse);
-        expect(connector.getPunchoutSessionRequisition).toHaveBeenCalledWith(
-          mockSid
-        );
-        done();
-      },
-    });
+    service
+      .getPunchoutSessionRequisition(mockSessionInput.punchoutSessionId)
+      .subscribe({
+        next: (result) => {
+          expect(result).toEqual(mockPunchoutRequisitionResponse);
+          expect(connector.getPunchoutSessionRequisition).toHaveBeenCalledWith(
+            mockSessionInput.punchoutSessionId
+          );
+          done();
+        },
+      });
   });
 
   it('should getPunchoutSessionRequisition with empty param opens error page', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
-    service.getPunchoutSession('').subscribe({
+    service.getPunchoutSession({ punchoutSessionId: '' }).subscribe({
       error: () => {
         expect(routingService.go).toHaveBeenCalledWith(PUNCHOUT_ERROR_PAGE_URL);
         done();
@@ -116,12 +121,27 @@ describe('Punchoutservice', () => {
     });
   });
 
+  it('should getPunchoutSession stays on page when isPageRefresh is true', (done) => {
+    spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
+    spyOn(connector, 'getPunchoutSessionRequisition').and.returnValue(
+      of(mockPunchoutRequisitionResponse)
+    );
+    service
+      .getPunchoutSession({ ...mockSessionInput, isPageRefresh: true })
+      .subscribe({
+        next: () => {
+          expect(routingService.go).not.toHaveBeenCalled();
+          done();
+        },
+      });
+  });
+
   it('should getPunchoutSession opens error page when request failed', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
     spyOn(connector, 'getPunchoutSession').and.returnValue(
-      throwError(() => 'error')
+      of({ ...mockPunchoutSessionResponse, token: undefined })
     );
-    service.getPunchoutSession(mockSid).subscribe({
+    service.getPunchoutSession(mockSessionInput).subscribe({
       error: () => {
         expect(routingService.go).toHaveBeenCalledWith(PUNCHOUT_ERROR_PAGE_URL);
         done();
@@ -135,7 +155,7 @@ describe('Punchoutservice', () => {
       of({ ...mockPunchoutSessionResponse, token: undefined })
     );
 
-    service.getPunchoutSession(mockSid).subscribe({
+    service.getPunchoutSession(mockSessionInput).subscribe({
       error: () => {
         expect(routingService.go).toHaveBeenCalledWith(PUNCHOUT_ERROR_PAGE_URL);
         done();
@@ -149,7 +169,7 @@ describe('Punchoutservice', () => {
       of({ ...mockPunchoutSessionResponse, selectedItem: '' })
     );
 
-    service.getPunchoutSession(mockSid).subscribe({
+    service.getPunchoutSession(mockSessionInput).subscribe({
       next: () => {
         expect(routingService.go).toHaveBeenCalledWith('/');
         done();

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -12,6 +12,7 @@ import {
   PunchoutFacade,
   PunchoutRequisition,
   PunchoutSession,
+  PunchoutStoreService,
 } from '@spartacus/punchout/root';
 
 import {
@@ -32,6 +33,7 @@ export class PunchoutService implements PunchoutFacade {
   protected punchoutAuthService = inject(PunchoutAuthService);
   protected commandService = inject(CommandService);
   protected routingService = inject(RoutingService);
+  protected punchoutStoreService = inject(PunchoutStoreService);
 
   /**
    * getPunchoutSession workflow:
@@ -42,7 +44,7 @@ export class PunchoutService implements PunchoutFacade {
    * Redirect to Punchout Error page if error occurs
    */
   protected getPunchoutSessionCommand: Command<
-    { sessionId: string },
+    { sessionId: string; isPageRefresh: boolean },
     PunchoutSession
   > = this.commandService.create((payload) => {
     if (!payload?.sessionId) {
@@ -71,7 +73,14 @@ export class PunchoutService implements PunchoutFacade {
             punchoutSession.token.accessToken,
             punchoutSession.customerId
           );
-          this.routeToTargetPage(punchoutSession);
+
+          this.punchoutStoreService.setPunchoutState({
+            sessionId: payload.sessionId,
+            session: { ...punchoutSession },
+          });
+          if (!payload?.isPageRefresh) {
+            this.routeToTargetPage(punchoutSession);
+          }
         } else {
           throw new Error('Punchout Access Token missing');
         }
@@ -85,8 +94,11 @@ export class PunchoutService implements PunchoutFacade {
     );
   });
 
-  getPunchoutSession(sessionId: string): Observable<PunchoutSession> {
-    return this.getPunchoutSessionCommand.execute({ sessionId });
+  getPunchoutSession(
+    sessionId: string,
+    isPageRefresh = false
+  ): Observable<PunchoutSession> {
+    return this.getPunchoutSessionCommand.execute({ sessionId, isPageRefresh });
   }
 
   getPunchoutSessionRequisition(

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -12,6 +12,7 @@ import {
   PunchoutFacade,
   PunchoutRequisition,
   PunchoutSession,
+  PunchoutSessionInput,
   PunchoutStoreService,
 } from '@spartacus/punchout/root';
 
@@ -44,61 +45,62 @@ export class PunchoutService implements PunchoutFacade {
    * Redirect to Punchout Error page if error occurs
    */
   protected getPunchoutSessionCommand: Command<
-    { sessionId: string; isPageRefresh: boolean },
+    PunchoutSessionInput,
     PunchoutSession
   > = this.commandService.create((payload) => {
-    if (!payload?.sessionId) {
+    if (!payload?.punchoutSessionId) {
       this.displayErrorPage();
       return throwError(() => new Error('Punchout Session Id missing'));
     }
-    return this.punchoutConnector.getPunchoutSession(payload.sessionId).pipe(
-      map((punchoutSession) => {
-        if (
-          !punchoutSession?.token?.accessToken ||
-          !punchoutSession?.customerId
-        ) {
-          throw new Error('Punchout login info missing');
-        }
-        return punchoutSession;
-      }),
-      switchMap((punchoutSession) => {
-        return forkJoin({
-          punchoutSession: of(punchoutSession),
-          logout: this.punchoutAuthService.logout(),
-        });
-      }),
-      map(({ punchoutSession }) => {
-        if (punchoutSession?.token?.accessToken) {
-          this.punchoutAuthService.loginWithToken(
-            punchoutSession.token.accessToken,
-            punchoutSession.customerId
-          );
-
-          this.punchoutStoreService.setPunchoutState({
-            sessionId: payload.sessionId,
-            session: { ...punchoutSession },
-          });
-          if (!payload?.isPageRefresh) {
-            this.routeToTargetPage(punchoutSession);
+    return this.punchoutConnector
+      .getPunchoutSession(payload.punchoutSessionId)
+      .pipe(
+        map((punchoutSession) => {
+          if (
+            !punchoutSession?.token?.accessToken ||
+            !punchoutSession?.customerId
+          ) {
+            throw new Error('Punchout login info missing');
           }
-        } else {
-          throw new Error('Punchout Access Token missing');
-        }
+          return punchoutSession;
+        }),
+        switchMap((punchoutSession) => {
+          return forkJoin({
+            punchoutSession: of(punchoutSession),
+            logout: this.punchoutAuthService.logout(),
+          });
+        }),
+        map(({ punchoutSession }) => {
+          if (punchoutSession?.token?.accessToken) {
+            this.punchoutAuthService.loginWithToken(
+              punchoutSession.token.accessToken,
+              punchoutSession.customerId
+            );
 
-        return punchoutSession;
-      }),
-      catchError((error) => {
-        this.displayErrorPage();
-        return throwError(() => new Error(error));
-      })
-    );
+            this.punchoutStoreService.setPunchoutState({
+              sessionId: payload.punchoutSessionId,
+              session: { ...punchoutSession },
+            });
+            if (!payload?.isPageRefresh) {
+              this.routeToTargetPage(punchoutSession);
+            }
+          } else {
+            throw new Error('Punchout Access Token missing');
+          }
+
+          return punchoutSession;
+        }),
+        catchError((error) => {
+          this.displayErrorPage();
+          return throwError(() => new Error(error));
+        })
+      );
   });
 
   getPunchoutSession(
-    sessionId: string,
-    isPageRefresh = false
+    punchoutSessionInput: PunchoutSessionInput
   ): Observable<PunchoutSession> {
-    return this.getPunchoutSessionCommand.execute({ sessionId, isPageRefresh });
+    return this.getPunchoutSessionCommand.execute(punchoutSessionInput);
   }
 
   getPunchoutSessionRequisition(

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -78,8 +78,8 @@ export class PunchoutService implements PunchoutFacade {
             );
 
             this.punchoutStoreService.setPunchoutState({
-              sessionId: payload.punchoutSessionId,
-              session: { ...punchoutSession },
+              punchoutSessionId: payload.punchoutSessionId,
+              punchoutSession: { ...punchoutSession },
             });
             if (!payload?.isPageRefresh) {
               this.routeToTargetPage(punchoutSession);

--- a/integration-libs/punchout/core/services/punchout-auth.service.ts
+++ b/integration-libs/punchout/core/services/punchout-auth.service.ts
@@ -14,7 +14,8 @@ import {
   GlobalMessageType,
   UserIdService,
 } from '@spartacus/core';
-import { from, map, Observable, of, switchMap, take } from 'rxjs';
+import { PunchoutStoreService } from '@spartacus/punchout/root';
+import { from, map, Observable, of, switchMap, take, tap } from 'rxjs';
 
 const ACCESS_TOKEN = 'access_token';
 const ACCESS_TOKEN_STORED_AT = 'access_token_stored_at';
@@ -26,10 +27,12 @@ export class PunchoutAuthService {
   protected authStorageService = inject(AuthStorageService);
   protected userIdService = inject(UserIdService);
   protected store = inject(Store);
+  protected punchoutStoreService = inject(PunchoutStoreService);
 
   logout(): Observable<boolean> {
     return this.authService.isUserLoggedIn().pipe(
       take(1),
+      tap(() => this.punchoutStoreService.clearPunchoutState()),
       switchMap((isLoggedIn) => {
         return isLoggedIn
           ? from(this.authService.coreLogout()).pipe(

--- a/integration-libs/punchout/package.json
+++ b/integration-libs/punchout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spartacus/punchout",
-  "version": "2211.37.0-1",
+  "version": "2211.37.0",
   "description": "punchout library for Spartacus",
   "keywords": [
     "spartacus",
@@ -30,8 +30,8 @@
     "@angular/core": "^19.0.3",
     "@angular/router": "^19.0.3",
     "@ngrx/store": "^19.0.0",
-    "@spartacus/core": "2211.37.0-1",
-    "@spartacus/schematics": "2211.37.0-1",
+    "@spartacus/core": "2211.37.0",
+    "@spartacus/schematics": "2211.37.0",
     "rxjs": "^7.8.0"
   },
   "publishConfig": {

--- a/integration-libs/punchout/package.json
+++ b/integration-libs/punchout/package.json
@@ -25,11 +25,11 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "@angular-devkit/schematics": "^19.0.4",
-    "@angular/common": "^19.0.3",
-    "@angular/core": "^19.0.3",
-    "@angular/router": "^19.0.3",
-    "@ngrx/store": "^19.0.0",
+    "@angular-devkit/schematics": "^19.1.9",
+    "@angular/common": "^19.1.8",
+    "@angular/core": "^19.1.8",
+    "@angular/router": "^19.1.8",
+    "@ngrx/store": "^19.0.1",
     "@spartacus/core": "2211.37.0",
     "@spartacus/schematics": "2211.37.0",
     "rxjs": "^7.8.0"

--- a/integration-libs/punchout/root/facade/punchout.facade.ts
+++ b/integration-libs/punchout/root/facade/punchout.facade.ts
@@ -8,7 +8,11 @@ import { Injectable } from '@angular/core';
 import { facadeFactory } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { PUNCHOUT_FEATURE } from '../feature-name';
-import { PunchoutRequisition, PunchoutSession } from '../model/punchout.model';
+import {
+  PunchoutRequisition,
+  PunchoutSession,
+  PunchoutSessionInput,
+} from '../model/punchout.model';
 
 export function punchoutFacadeFactory() {
   return facadeFactory({
@@ -28,8 +32,7 @@ export abstract class PunchoutFacade {
    * @param sessionId is the sesssion Id given by ARIBA via url param
    */
   abstract getPunchoutSession(
-    sessionId: string,
-    isPageRefresh?: boolean
+    punchoutSessionInput: PunchoutSessionInput
   ): Observable<PunchoutSession>;
 
   /**

--- a/integration-libs/punchout/root/facade/punchout.facade.ts
+++ b/integration-libs/punchout/root/facade/punchout.facade.ts
@@ -27,7 +27,10 @@ export abstract class PunchoutFacade {
    * Abstract method used to get Punchout Session
    * @param sessionId is the sesssion Id given by ARIBA via url param
    */
-  abstract getPunchoutSession(sessionId: string): Observable<PunchoutSession>;
+  abstract getPunchoutSession(
+    sessionId: string,
+    isPageRefresh?: boolean
+  ): Observable<PunchoutSession>;
 
   /**
    * Abstract method used to get Punchout Session Requisition data

--- a/integration-libs/punchout/root/model/punchout.model.ts
+++ b/integration-libs/punchout/root/model/punchout.model.ts
@@ -23,6 +23,8 @@ export enum PunchOutOperation {
   SOURCE = 'source',
 }
 
+export const PUNCHOUT_STORAGE_KEY = 'punchout';
+
 export interface PunchoutSessionInput {
   punchoutSessionId: string;
   isPageRefresh?: boolean;
@@ -46,6 +48,6 @@ export interface PunchoutRequisition {
 }
 
 export interface PunchoutState {
-  session?: PunchoutSession;
-  sessionId?: string;
+  punchoutSession?: PunchoutSession;
+  punchoutSessionId?: string;
 }

--- a/integration-libs/punchout/root/model/punchout.model.ts
+++ b/integration-libs/punchout/root/model/punchout.model.ts
@@ -6,8 +6,8 @@
 
 export const PUNCHOUT_SESSION_KEY = 'sid';
 export const PUNCHOUT_ERROR_PAGE_URL = '/punchout/cxml/error';
-export const PUNCHOUT_SESSION_PAGE_URL = '/punchout/cxml/session';
 export const PUNCHOUT_SESSION_ID = 'punchoutSessionId';
+export const PUNCHOUT_SESSION_PAGE_URL = '/punchout/cxml/session';
 
 export enum PunchOutLevel {
   STORE = 'store',
@@ -38,4 +38,9 @@ export interface PunchoutSession {
 export interface PunchoutRequisition {
   browseFormPostUrl: string;
   orderAsCXML: string;
+}
+
+export interface PunchoutState {
+  session?: PunchoutSession;
+  sessionId?: string;
 }

--- a/integration-libs/punchout/root/model/punchout.model.ts
+++ b/integration-libs/punchout/root/model/punchout.model.ts
@@ -23,6 +23,11 @@ export enum PunchOutOperation {
   SOURCE = 'source',
 }
 
+export interface PunchoutSessionInput {
+  punchoutSessionId: string;
+  isPageRefresh?: boolean;
+}
+
 export interface PunchoutSession {
   customerId: string;
   cartId: string;

--- a/integration-libs/punchout/root/punchout.root.module.ts
+++ b/integration-libs/punchout/root/punchout.root.module.ts
@@ -27,7 +27,6 @@ export function defaultPunchoutCmsComponentsConfig(): CmsConfig {
 
 export function opfStatePersistenceFactory(): () => void {
   const punchoutPersistenceService = inject(PunchoutStatePersistanceService);
-  console.log('opfStatePersistenceFactory');
   return () => punchoutPersistenceService.initSync();
 }
 

--- a/integration-libs/punchout/root/punchout.root.module.ts
+++ b/integration-libs/punchout/root/punchout.root.module.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { NgModule } from '@angular/core';
+import { inject, NgModule, provideAppInitializer } from '@angular/core';
 import {
   AuthHttpHeaderService,
   CmsConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
 import { PUNCHOUT_FEATURE } from './feature-name';
+import { PunchoutStatePersistanceService } from './services';
 import { PunchoutAuthHttpHeaderService } from './services/punchout-auth-http-header.service';
 
 export function defaultPunchoutCmsComponentsConfig(): CmsConfig {
@@ -24,8 +25,20 @@ export function defaultPunchoutCmsComponentsConfig(): CmsConfig {
   return config;
 }
 
+export function opfStatePersistenceFactory(): () => void {
+  const punchoutPersistenceService = inject(PunchoutStatePersistanceService);
+  console.log('opfStatePersistenceFactory');
+  return () => punchoutPersistenceService.initSync();
+}
+
 @NgModule({
   providers: [
+    provideAppInitializer(() => {
+      const punchoutPersistenceService = inject(
+        PunchoutStatePersistanceService
+      );
+      punchoutPersistenceService.initSync();
+    }),
     provideDefaultConfigFactory(defaultPunchoutCmsComponentsConfig),
     {
       provide: AuthHttpHeaderService,

--- a/integration-libs/punchout/root/services/index.ts
+++ b/integration-libs/punchout/root/services/index.ts
@@ -6,3 +6,5 @@
 
 export * from './punchout-auth-http-header.service';
 export * from './punchout-detection.service';
+export * from './punchout-state-persistence.service';
+export * from './punchout-store.service';

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -22,7 +22,7 @@ import { PunchoutDetectionService } from './punchout-detection.service';
   providedIn: 'root',
 })
 export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
-  protected punchoutInitService = inject(PunchoutDetectionService);
+  protected punchoutDetectionService = inject(PunchoutDetectionService);
   constructor(
     protected authService: AuthService,
     protected authStorageService: AuthStorageService,
@@ -52,7 +52,7 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
    * To be removed once CXSPA-9608 is closed.
    */
   public handleExpiredRefreshToken(): void {
-    if (!this.punchoutInitService.isPunchoutSessionPage()) {
+    if (!this.punchoutDetectionService.isPunchoutSessionPage()) {
       super.handleExpiredRefreshToken();
     } else {
       this.authService.coreLogout().finally(() => {

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.spec.ts
@@ -1,0 +1,184 @@
+import { TestBed } from '@angular/core/testing';
+import { StatePersistenceService } from '@spartacus/core';
+import { of } from 'rxjs';
+import { PunchoutFacade } from '../facade';
+import {
+  PunchOutLevel,
+  PunchOutOperation,
+  PunchoutSession,
+  PunchoutState,
+} from '../model';
+import { PunchoutDetectionService } from './punchout-detection.service';
+import { PunchoutStatePersistanceService } from './punchout-state-persistence.service';
+import { PunchoutStoreService } from './punchout-store.service';
+
+const mockPunchoutSession: PunchoutSession = {
+  customerId: 'test@test.com',
+  cartId: 'mockCart',
+  punchOutLevel: PunchOutLevel.PRODUCT,
+  punchOutOperation: PunchOutOperation.EDIT,
+  selectedItem: 'mockItemId',
+  token: {
+    accessToken: 'mockToken',
+    tokenType: 'Bearer',
+  },
+};
+
+const mockSessionId = 'abc123';
+
+const mockPunchoutState: PunchoutState = {
+  punchoutSessionId: mockSessionId,
+  punchoutSession: mockPunchoutSession,
+};
+
+class MockPunchoutStoreService implements Partial<PunchoutStoreService> {
+  setPunchoutState = () => {};
+  getPunchoutState = () => of(mockPunchoutState);
+  clearState = () => {};
+}
+
+class MockPunchoutDetectionService
+  implements Partial<PunchoutDetectionService>
+{
+  isPunchoutSessionPage = () => false;
+}
+
+class MockPunchoutFacade implements Partial<PunchoutFacade> {
+  getPunchoutSession = () => of(mockPunchoutSession);
+}
+
+describe('PunchoutStatePersistenceService', () => {
+  let service: PunchoutStatePersistanceService;
+  let punchoutStoreService: PunchoutStoreService;
+  let punchoutDetectionService: PunchoutDetectionService;
+  let statePersistenceServiceMock: jasmine.SpyObj<StatePersistenceService>;
+  let punchoutFacade: PunchoutFacade;
+
+  beforeEach(() => {
+    statePersistenceServiceMock = jasmine.createSpyObj(
+      'StatePersistenceService',
+      ['syncWithStorage', 'readStateFromStorage']
+    );
+    // punchoutFacadeMock = jasmine.createSpyObj('PunchoutFacade', [
+    //   'getPunchoutSession',
+    // ]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: StatePersistenceService,
+          useValue: statePersistenceServiceMock,
+        },
+
+        { provide: PunchoutStoreService, useClass: MockPunchoutStoreService },
+        {
+          provide: PunchoutDetectionService,
+          useClass: MockPunchoutDetectionService,
+        },
+        {
+          provide: PunchoutFacade,
+          useClass: MockPunchoutFacade,
+        },
+      ],
+    });
+    service = TestBed.inject(PunchoutStatePersistanceService);
+    punchoutStoreService = TestBed.inject(PunchoutStoreService);
+    punchoutDetectionService = TestBed.inject(PunchoutDetectionService);
+    punchoutFacade = TestBed.inject(PunchoutFacade);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should initialize the synchronization with state and browser storage', () => {
+    spyOn(punchoutStoreService, 'getPunchoutState').and.returnValue(
+      of(mockPunchoutState)
+    );
+    spyOn(service['subscription'], 'add').and.returnValue();
+    service.initSync();
+
+    expect(service['subscription'].add).toHaveBeenCalled();
+    expect(statePersistenceServiceMock.syncWithStorage).toHaveBeenCalled();
+  });
+
+  it('should onRead call request PunchoutSession', () => {
+    spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
+      false
+    );
+    spyOn(punchoutFacade, 'getPunchoutSession').and.returnValue(
+      of(mockPunchoutSession)
+    );
+    service['onRead'](mockPunchoutState);
+
+    expect(punchoutFacade.getPunchoutSession).toHaveBeenCalled();
+  });
+
+  it('should onRead do nothing when user on punchout session page', () => {
+    spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
+      true
+    );
+    spyOn(punchoutFacade, 'getPunchoutSession').and.returnValue(
+      of(mockPunchoutSession)
+    );
+    service['onRead'](mockPunchoutState);
+    expect(punchoutFacade.getPunchoutSession).not.toHaveBeenCalled();
+  });
+
+  it('should onRead do nothing when no sessionId stored', () => {
+    spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
+      true
+    );
+    spyOn(punchoutFacade, 'getPunchoutSession').and.returnValue(
+      of(mockPunchoutSession)
+    );
+    service['onRead']({ ...mockPunchoutState, punchoutSessionId: undefined });
+    expect(punchoutFacade.getPunchoutSession).not.toHaveBeenCalled();
+  });
+
+  it('should ngOnDestroy removes subscription', () => {
+    spyOn(service['subscription'], 'unsubscribe').and.returnValue();
+    service.ngOnDestroy();
+    expect(service['subscription'].unsubscribe).toHaveBeenCalled();
+  });
+
+  it('should getPunchoutSessionId stores sessionId', (done) => {
+    spyOn(punchoutStoreService, 'getPunchoutState').and.returnValue(
+      of(mockPunchoutState)
+    );
+    service['getPunchoutSessionId']().subscribe({
+      next: (response) => {
+        expect(response).toEqual({
+          punchoutSessionId: mockPunchoutState.punchoutSessionId,
+        });
+        done();
+      },
+    });
+  });
+
+  it('should getPunchoutSessionId stores sessionId', (done) => {
+    spyOn(punchoutStoreService, 'getPunchoutState').and.returnValue(
+      of(mockPunchoutState)
+    );
+    service['getPunchoutSessionId']().subscribe({
+      next: (response) => {
+        expect(response).toEqual({
+          punchoutSessionId: mockPunchoutState.punchoutSessionId,
+        });
+        done();
+      },
+    });
+  });
+
+  it('should getPunchoutSessionId stores empty object', (done) => {
+    spyOn(punchoutStoreService, 'getPunchoutState').and.returnValue(
+      of({ ...mockPunchoutState, punchoutSessionId: undefined })
+    );
+    service['getPunchoutSessionId']().subscribe({
+      next: (response) => {
+        expect(response).toEqual({});
+        done();
+      },
+    });
+  });
+});

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
@@ -1,0 +1,71 @@
+import { inject, Injectable, OnDestroy } from '@angular/core';
+import { RoutingService, StatePersistenceService } from '@spartacus/core';
+import { map, Observable, Subscription, take } from 'rxjs';
+import { PunchoutFacade } from '../facade';
+import { PunchoutState } from '../model';
+import { PunchoutDetectionService } from './punchout-detection.service';
+import { PunchoutStoreService } from './punchout-store.service';
+
+@Injectable({ providedIn: 'root' })
+export class PunchoutStatePersistanceService implements OnDestroy {
+  protected punchoutStatePersistenceService = inject(StatePersistenceService);
+  protected punchoutStoreService = inject(PunchoutStoreService);
+  protected routingService = inject(RoutingService);
+  protected subscription = new Subscription();
+  protected punchoutFacade = inject(PunchoutFacade);
+  protected punchoutDetectionService = inject(PunchoutDetectionService);
+  /**
+   * Identifier used for storage key.
+   */
+  protected key = 'punchout';
+
+  /**
+   * Initializes the synchronization between state and browser storage.
+   */
+  public initSync() {
+    this.subscription.add(
+      this.punchoutStatePersistenceService.syncWithStorage({
+        key: this.key,
+        state$: this.getPunchoutSessionId(),
+        onRead: (state) => this.onRead(state),
+      })
+    );
+  }
+
+  /**
+   * Gets and transforms state from different sources into the form that should
+   * be saved in storage.
+   */
+  protected getPunchoutSessionId(): Observable<PunchoutState> {
+    return this.punchoutStoreService.getPunchoutState().pipe(
+      map((punchoutState) => {
+        //  const { token, ...stateSession } = punchoutSession?.session;
+        return { sessionId: punchoutState.sessionId };
+      })
+    );
+  }
+
+  /**
+   * Function called on each browser storage read.
+   * Used to update state from browser -> state.
+   */
+  protected onRead(state: PunchoutState | undefined) {
+    console.log('flo onRead0');
+    if (
+      state?.sessionId &&
+      !this.punchoutDetectionService.isPunchoutSessionPage()
+    ) {
+      console.log('flo onRead1');
+      this.punchoutFacade
+        .getPunchoutSession(state?.sessionId, true)
+        .pipe(take(1))
+        .subscribe(() => {
+          console.log('flo onRead2');
+        });
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+}

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
@@ -57,7 +57,10 @@ export class PunchoutStatePersistanceService implements OnDestroy {
     ) {
       console.log('flo onRead1');
       this.punchoutFacade
-        .getPunchoutSession(state?.sessionId, true)
+        .getPunchoutSession({
+          punchoutSessionId: state?.sessionId,
+          isPageRefresh: true,
+        })
         .pipe(take(1))
         .subscribe(() => {
           console.log('flo onRead2');

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { inject, Injectable, OnDestroy } from '@angular/core';
 import { StatePersistenceService } from '@spartacus/core';
 import { map, Observable, Subscription, take } from 'rxjs';

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
@@ -1,8 +1,8 @@
 import { inject, Injectable, OnDestroy } from '@angular/core';
-import { RoutingService, StatePersistenceService } from '@spartacus/core';
+import { StatePersistenceService } from '@spartacus/core';
 import { map, Observable, Subscription, take } from 'rxjs';
 import { PunchoutFacade } from '../facade';
-import { PunchoutState } from '../model';
+import { PUNCHOUT_STORAGE_KEY, PunchoutState } from '../model';
 import { PunchoutDetectionService } from './punchout-detection.service';
 import { PunchoutStoreService } from './punchout-store.service';
 
@@ -10,22 +10,18 @@ import { PunchoutStoreService } from './punchout-store.service';
 export class PunchoutStatePersistanceService implements OnDestroy {
   protected punchoutStatePersistenceService = inject(StatePersistenceService);
   protected punchoutStoreService = inject(PunchoutStoreService);
-  protected routingService = inject(RoutingService);
-  protected subscription = new Subscription();
   protected punchoutFacade = inject(PunchoutFacade);
   protected punchoutDetectionService = inject(PunchoutDetectionService);
-  /**
-   * Identifier used for storage key.
-   */
-  protected key = 'punchout';
+  protected subscription = new Subscription();
 
   /**
    * Initializes the synchronization between state and browser storage.
+   * Through getPunchoutSessionId(), storage is updated everytime PunchoutState is modified.
    */
   public initSync() {
     this.subscription.add(
       this.punchoutStatePersistenceService.syncWithStorage({
-        key: this.key,
+        key: PUNCHOUT_STORAGE_KEY,
         state$: this.getPunchoutSessionId(),
         onRead: (state) => this.onRead(state),
       })
@@ -33,14 +29,15 @@ export class PunchoutStatePersistanceService implements OnDestroy {
   }
 
   /**
-   * Gets and transforms state from different sources into the form that should
+   * Gets and transforms state into the form that should
    * be saved in storage.
    */
   protected getPunchoutSessionId(): Observable<PunchoutState> {
     return this.punchoutStoreService.getPunchoutState().pipe(
       map((punchoutState) => {
-        //  const { token, ...stateSession } = punchoutSession?.session;
-        return { sessionId: punchoutState.sessionId };
+        return punchoutState?.punchoutSessionId
+          ? { punchoutSessionId: punchoutState?.punchoutSessionId }
+          : {};
       })
     );
   }
@@ -48,17 +45,18 @@ export class PunchoutStatePersistanceService implements OnDestroy {
   /**
    * Function called on each browser storage read.
    * Used to update state from browser -> state.
+   * storage stores minimum data: only punchoutSessionId.
+   * Full PunchoutSession object is retrieved by calling punchoutFacade.getPunchoutSession
+   * Note that punchoutState is updated within punchoutFacade.getPunchoutSession, thus no need to do it here.
    */
   protected onRead(state: PunchoutState | undefined) {
-    console.log('flo onRead0');
     if (
-      state?.sessionId &&
+      state?.punchoutSessionId &&
       !this.punchoutDetectionService.isPunchoutSessionPage()
     ) {
-      console.log('flo onRead1');
       this.punchoutFacade
         .getPunchoutSession({
-          punchoutSessionId: state?.sessionId,
+          punchoutSessionId: state?.punchoutSessionId,
           isPageRefresh: true,
         })
         .pipe(take(1))

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
@@ -66,9 +66,7 @@ export class PunchoutStatePersistanceService implements OnDestroy {
           isPageRefresh: true,
         })
         .pipe(take(1))
-        .subscribe(() => {
-          console.log('flo onRead2');
-        });
+        .subscribe();
     }
   }
 

--- a/integration-libs/punchout/root/services/punchout-store.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-store.service.spec.ts
@@ -1,0 +1,80 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  PunchOutLevel,
+  PunchOutOperation,
+  PunchoutSession,
+  PunchoutState,
+} from '../model';
+import { PunchoutStoreService } from './punchout-store.service';
+
+const INITIAL_STATE: PunchoutState = {
+  punchoutSessionId: undefined,
+  punchoutSession: undefined,
+};
+
+const mockPunchoutSession: PunchoutSession = {
+  customerId: 'test@test.com',
+  cartId: 'mockCart',
+  punchOutLevel: PunchOutLevel.PRODUCT,
+  punchOutOperation: PunchOutOperation.EDIT,
+  selectedItem: 'mockItemId',
+  token: {
+    accessToken: 'mockToken',
+    tokenType: 'Bearer',
+  },
+};
+
+const mockSessionId = 'abc123';
+
+const mockPunchoutState: PunchoutState = {
+  punchoutSessionId: mockSessionId,
+  punchoutSession: mockPunchoutSession,
+};
+
+describe('PunchoutStoreService', () => {
+  let service: PunchoutStoreService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PunchoutStoreService],
+    });
+
+    service = TestBed.inject(PunchoutStoreService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should initialize with the initial state', () => {
+    expect(service['punchoutState'].value).toEqual(INITIAL_STATE);
+  });
+
+  it('should return the current PunchoutStoreService as an observable', (done) => {
+    service['punchoutState'].next(mockPunchoutState);
+
+    service.getPunchoutState().subscribe((state) => {
+      expect(state).toEqual(mockPunchoutState);
+      done();
+    });
+  });
+
+  it('should set PunchoutStoreService with the given payload', () => {
+    const newMockedState: PunchoutState = {
+      ...mockPunchoutState,
+      punchoutSessionId: 'newPunchoutSessionId',
+    };
+
+    service['punchoutState'].next(mockPunchoutState);
+    service.setPunchoutState(newMockedState);
+
+    expect(service['punchoutState'].value).toEqual(newMockedState);
+  });
+
+  it('should clearPunchoutState', () => {
+    service.setPunchoutState(mockPunchoutState);
+    service.clearPunchoutState();
+
+    expect(service['punchoutState'].value).toEqual(INITIAL_STATE);
+  });
+});

--- a/integration-libs/punchout/root/services/punchout-store.service.ts
+++ b/integration-libs/punchout/root/services/punchout-store.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { PunchoutState } from '../model';

--- a/integration-libs/punchout/root/services/punchout-store.service.ts
+++ b/integration-libs/punchout/root/services/punchout-store.service.ts
@@ -5,20 +5,20 @@ import { PunchoutState } from '../model';
 @Injectable({ providedIn: 'root' })
 export class PunchoutStoreService {
   protected readonly INITIAL_STATE: PunchoutState = Object.freeze({
-    sId: undefined,
-    session: undefined,
+    punchoutSessionId: undefined,
+    punchoutSession: undefined,
   });
 
-  punchoutState = new BehaviorSubject<PunchoutState>(this.INITIAL_STATE);
+  protected punchoutState = new BehaviorSubject<PunchoutState>(
+    this.INITIAL_STATE
+  );
 
   getPunchoutState(): Observable<PunchoutState> {
     return this.punchoutState.asObservable();
   }
 
   setPunchoutState(payload: Partial<PunchoutState>): void {
-    console.log('setPunchoutState', payload);
     this.punchoutState.next({
-      ...this.punchoutState.value,
       ...payload,
     });
   }

--- a/integration-libs/punchout/root/services/punchout-store.service.ts
+++ b/integration-libs/punchout/root/services/punchout-store.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { PunchoutState } from '../model';
+
+@Injectable({ providedIn: 'root' })
+export class PunchoutStoreService {
+  protected readonly INITIAL_STATE: PunchoutState = Object.freeze({
+    sId: undefined,
+    session: undefined,
+  });
+
+  punchoutState = new BehaviorSubject<PunchoutState>(this.INITIAL_STATE);
+
+  getPunchoutState(): Observable<PunchoutState> {
+    return this.punchoutState.asObservable();
+  }
+
+  setPunchoutState(payload: Partial<PunchoutState>): void {
+    console.log('setPunchoutState', payload);
+    this.punchoutState.next({
+      ...this.punchoutState.value,
+      ...payload,
+    });
+  }
+
+  clearPunchoutState(): void {
+    this.punchoutState.next(this.INITIAL_STATE);
+  }
+}

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -438,13 +438,13 @@
     "rxjs": "^7.8.0"
   },
   "@spartacus/punchout": {
-    "@angular-devkit/schematics": "^19.0.4",
-    "@angular/common": "^19.0.3",
-    "@angular/core": "^19.0.3",
-    "@angular/router": "^19.0.3",
-    "@ngrx/store": "^19.0.0",
-    "@spartacus/core": "2211.37.0-1",
-    "@spartacus/schematics": "2211.37.0-1",
+    "@angular-devkit/schematics": "^19.1.9",
+    "@angular/common": "^19.1.8",
+    "@angular/core": "^19.1.8",
+    "@angular/router": "^19.1.8",
+    "@ngrx/store": "^19.0.1",
+    "@spartacus/core": "2211.37.0",
+    "@spartacus/schematics": "2211.37.0",
     "rxjs": "^7.8.0"
   },
   "@spartacus/s4-service": {


### PR DESCRIPTION
2 new services, highlights:
- punchoutStoreService
----> handle Store ops: add, set, clear.
- punchoutStatePersistenceService
- --> save minimum value: punchoutSessionId in storage
----> at APP INIT time, fetch full punchoutSession  from server when punchoutSessionId exists in storage.

update state (setPunchoutState(val)) when we get new punchoutSession object from server.
clearStore() when punchout logout