### PR TITLE
Refresh punchout session when auth token is invalid

### DIFF
--- a/integration-libs/punchout/occ/config/default-occ-punchout-config.ts
+++ b/integration-libs/punchout/occ/config/default-occ-punchout-config.ts
@@ -5,11 +5,13 @@
  */
 
 import { OccConfig } from '@spartacus/core';
+import { PUNCHOUT_OCC_API_URL_SEGMENT } from '@spartacus/punchout/root';
 import { PunchoutOccEndpoints } from '../model/occ-punchout.model';
 
 const punchoutOccEndpoints: PunchoutOccEndpoints = {
-  punchoutSession: 'punchout/sessions/${sessionId}',
-  punchoutSessionRequisition: 'punchout/sessions/${sessionId}/requisition',
+  punchoutSession: PUNCHOUT_OCC_API_URL_SEGMENT + '/${sessionId}',
+  punchoutSessionRequisition:
+    PUNCHOUT_OCC_API_URL_SEGMENT + '/${sessionId}/requisition',
 };
 
 export const defaultOccPunchoutConfig: OccConfig = {

--- a/integration-libs/punchout/root/model/punchout.model.ts
+++ b/integration-libs/punchout/root/model/punchout.model.ts
@@ -8,6 +8,8 @@ export const PUNCHOUT_SESSION_KEY = 'sid';
 export const PUNCHOUT_ERROR_PAGE_URL = '/punchout/cxml/error';
 export const PUNCHOUT_SESSION_ID = 'punchoutSessionId';
 export const PUNCHOUT_SESSION_PAGE_URL = '/punchout/cxml/session';
+export const PUNCHOUT_STORAGE_KEY = 'punchout';
+export const PUNCHOUT_OCC_API_URL_SEGMENT = 'punchout/sessions';
 
 export enum PunchOutLevel {
   STORE = 'store',
@@ -22,8 +24,6 @@ export enum PunchOutOperation {
   INSPECT = 'inspect',
   SOURCE = 'source',
 }
-
-export const PUNCHOUT_STORAGE_KEY = 'punchout';
 
 export interface PunchoutSessionInput {
   punchoutSessionId: string;

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpHandler, HttpRequest } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import {
   AuthRedirectService,
@@ -10,14 +11,44 @@ import {
   RoutingService,
 } from '@spartacus/core';
 import { of } from 'rxjs';
+import {
+  PUNCHOUT_ERROR_PAGE_URL,
+  PUNCHOUT_OCC_API_URL_SEGMENT,
+  PUNCHOUT_SESSION_KEY,
+  PUNCHOUT_SESSION_PAGE_URL,
+  PunchOutLevel,
+  PunchOutOperation,
+  PunchoutSession,
+  PunchoutState,
+} from '../model';
 import { PunchoutAuthHttpHeaderService } from './punchout-auth-http-header.service';
 import { PunchoutDetectionService } from './punchout-detection.service';
+import { PunchoutStoreService } from './punchout-store.service';
 
+const mockSessionId = '123abc';
+const mockPunchoutSession: PunchoutSession = {
+  customerId: 'test@test.com',
+  cartId: 'mockCart',
+  punchOutLevel: PunchOutLevel.PRODUCT,
+  punchOutOperation: PunchOutOperation.EDIT,
+  selectedItem: 'mockItemId',
+  token: {
+    accessToken: 'mockToken',
+    tokenType: 'Bearer',
+  },
+};
+const mockPunchoutState: PunchoutState = {
+  punchoutSessionId: mockSessionId,
+  punchoutSession: mockPunchoutSession,
+};
 class MockPunchoutDetectionService
   implements Partial<PunchoutDetectionService>
 {
   isPunchoutSessionPage(): boolean {
     return true;
+  }
+  getPunchoutSessionId(): string | undefined {
+    return mockSessionId;
   }
 }
 
@@ -33,10 +64,12 @@ class MockAuthStorageService implements Partial<AuthStorageService> {
   }
 }
 
-class MockOAuthLibWrapperService implements Partial<OAuthLibWrapperService> {}
-
+class MockOAuthLibWrapperService implements Partial<OAuthLibWrapperService> {
+  refreshToken(): void {}
+}
 class MockRoutingService implements Partial<RoutingService> {
   go = () => Promise.resolve(true);
+  goByUrl = () => Promise.resolve(true);
 }
 
 class MockGlobalMessageService implements Partial<GlobalMessageService> {
@@ -57,15 +90,25 @@ class MockAuthRedirectService implements Partial<AuthRedirectService> {
   saveCurrentNavigationUrl = jasmine.createSpy('saveCurrentNavigationUrl');
 }
 
+class MockPunchoutStoreService implements Partial<PunchoutStoreService> {
+  setPunchoutState = () => {};
+  getPunchoutState = () => of(mockPunchoutState);
+  clearState = () => {};
+  getPunchoutSessionId = () => mockPunchoutState.punchoutSessionId;
+}
+
 describe('PunchoutAuthHttpHeaderService', () => {
   let service: PunchoutAuthHttpHeaderService;
   let authService: AuthService;
   let punchoutDetectionService: PunchoutDetectionService;
   let globalMessageService: GlobalMessageService;
+  let routingService: RoutingService;
+  let punchoutStoreService: PunchoutStoreService;
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
       providers: [
+        { provide: PunchoutStoreService, useClass: MockPunchoutStoreService },
         {
           provide: PunchoutDetectionService,
           useClass: MockPunchoutDetectionService,
@@ -86,6 +129,8 @@ describe('PunchoutAuthHttpHeaderService', () => {
     authService = TestBed.inject(AuthService);
     punchoutDetectionService = TestBed.inject(PunchoutDetectionService);
     globalMessageService = TestBed.inject(GlobalMessageService);
+    routingService = TestBed.inject(RoutingService);
+    punchoutStoreService = TestBed.inject(PunchoutStoreService);
   });
 
   it('should be created', () => {
@@ -97,6 +142,7 @@ describe('PunchoutAuthHttpHeaderService', () => {
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
       false
     );
+    spyOn(punchoutStoreService, 'getPunchoutSessionId').and.returnValue('');
     spyOn(globalMessageService, 'remove').and.callThrough();
 
     service.handleExpiredRefreshToken();
@@ -118,5 +164,74 @@ describe('PunchoutAuthHttpHeaderService', () => {
 
     expect(authService.coreLogout).toHaveBeenCalled();
     expect(globalMessageService.remove).toHaveBeenCalled();
+  });
+
+  it('should handleExpiredAccessToken redirect to punchout session page', async () => {
+    const initialToken: AuthToken = {
+      access_token: `old_token`,
+      access_token_stored_at: '123',
+      refresh_token: 'ref_token',
+    };
+    const handler = (a: any) => of(a);
+    spyOn(routingService, 'goByUrl').and.callThrough();
+
+    await service.handleExpiredAccessToken(
+      new HttpRequest(
+        'GET',
+        `some-server/${PUNCHOUT_OCC_API_URL_SEGMENT}/sessions?${PUNCHOUT_SESSION_KEY}${mockSessionId}`
+      ),
+      { handle: handler } as HttpHandler,
+      initialToken
+    );
+
+    expect(routingService.goByUrl).toHaveBeenCalledWith(
+      `${PUNCHOUT_SESSION_PAGE_URL}?${PUNCHOUT_SESSION_KEY}=${mockSessionId}`
+    );
+  });
+
+  it('should handleExpiredAccessToken without occ punchout request not redirect to any page', async () => {
+    const initialToken: AuthToken = {
+      access_token: `old_token`,
+      access_token_stored_at: '123',
+      refresh_token: 'ref_token',
+    };
+    const handler = (a: any) => of(a);
+    spyOn(routingService, 'goByUrl').and.callThrough();
+    spyOn(punchoutStoreService, 'getPunchoutSessionId').and.returnValue('');
+
+    await service.handleExpiredAccessToken(
+      new HttpRequest(
+        'GET',
+        `some-server/occ/test?${PUNCHOUT_SESSION_KEY}${mockSessionId}`
+      ),
+      { handle: handler } as HttpHandler,
+      initialToken
+    );
+
+    expect(routingService.goByUrl).not.toHaveBeenCalled();
+  });
+
+  it('should handleExpiredAccessToken without sessionId redirects to error page', async () => {
+    const initialToken: AuthToken = {
+      access_token: `old_token`,
+      access_token_stored_at: '123',
+      refresh_token: 'ref_token',
+    };
+    const handler = (a: any) => of(a);
+    spyOn(routingService, 'goByUrl').and.callThrough();
+    spyOn(punchoutStoreService, 'getPunchoutSessionId').and.returnValue('');
+
+    await service.handleExpiredAccessToken(
+      new HttpRequest(
+        'GET',
+        `some-server/${PUNCHOUT_OCC_API_URL_SEGMENT}/sessions?${PUNCHOUT_SESSION_KEY}${mockSessionId}`
+      ),
+      { handle: handler } as HttpHandler,
+      initialToken
+    );
+
+    expect(routingService.goByUrl).toHaveBeenCalledWith(
+      PUNCHOUT_ERROR_PAGE_URL
+    );
   });
 });

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -4,25 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import {
   AuthHttpHeaderService,
   AuthRedirectService,
   AuthService,
   AuthStorageService,
+  AuthToken,
   GlobalMessageService,
   GlobalMessageType,
   OAuthLibWrapperService,
   OccEndpointsService,
   RoutingService,
 } from '@spartacus/core';
+import { Observable } from 'rxjs';
+import {
+  PUNCHOUT_ERROR_PAGE_URL,
+  PUNCHOUT_OCC_API_URL_SEGMENT,
+  PUNCHOUT_SESSION_KEY,
+  PUNCHOUT_SESSION_PAGE_URL,
+} from '../model';
 import { PunchoutDetectionService } from './punchout-detection.service';
+import { PunchoutStoreService } from './punchout-store.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
   protected punchoutDetectionService = inject(PunchoutDetectionService);
+  protected punchoutStoreService = inject(PunchoutStoreService);
   constructor(
     protected authService: AuthService,
     protected authStorageService: AuthStorageService,
@@ -48,18 +59,57 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
    *
    * On backend errors indicating expired `refresh_token`, we need to silently logout
    * by revoking invalid token and preventing Login page redirection.
+   * This rule is applied on punchout instance: punchoutSessionId in storage or browser on PunchoutSession page
    * It is a workaround to address CXSPA-9608 - Public pages not displayed when token is invalid.
    * To be removed once CXSPA-9608 is closed.
    */
   public handleExpiredRefreshToken(): void {
-    if (!this.punchoutDetectionService.isPunchoutSessionPage()) {
-      super.handleExpiredRefreshToken();
+    if (
+      this.punchoutDetectionService.isPunchoutSessionPage() ||
+      !!this.punchoutStoreService.getPunchoutSessionId()
+    ) {
+      this.silentLogout();
     } else {
-      this.authService.coreLogout().finally(() => {
-        this.globalMessageService.remove(
-          GlobalMessageType.MSG_TYPE_CONFIRMATION
-        );
-      });
+      super.handleExpiredRefreshToken();
     }
+  }
+
+  /**
+   * @override
+   * Refreshes access_token and then retries the call with the new token.
+   * When url is a Punchout OCC call, redirect to PunchoutSession page to refresh the auth token.
+   */
+  public handleExpiredAccessToken(
+    request: HttpRequest<any>,
+    next: HttpHandler,
+    initialToken: AuthToken | undefined
+  ): Observable<HttpEvent<AuthToken>> {
+    if (this.isPunchoutOccApiRequest(request)) {
+      this.goToPunchoutPage();
+    }
+    return super.handleExpiredAccessToken(request, next, initialToken);
+  }
+
+  protected silentLogout(): void {
+    this.authService.coreLogout().finally(() => {
+      this.globalMessageService.remove(GlobalMessageType.MSG_TYPE_CONFIRMATION);
+    });
+  }
+
+  protected isPunchoutOccApiRequest(request: HttpRequest<any>): boolean {
+    return request.url.includes(PUNCHOUT_OCC_API_URL_SEGMENT);
+  }
+
+  protected buildPunchoutSessionUrl(punchoutSessionId: string): string {
+    return `${PUNCHOUT_SESSION_PAGE_URL}?${PUNCHOUT_SESSION_KEY}=${punchoutSessionId}`;
+  }
+
+  protected goToPunchoutPage(): void {
+    const punchoutSessionId = this.punchoutStoreService.getPunchoutSessionId();
+    this.routingService.goByUrl(
+      punchoutSessionId
+        ? this.buildPunchoutSessionUrl(punchoutSessionId)
+        : PUNCHOUT_ERROR_PAGE_URL
+    );
   }
 }

--- a/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
@@ -15,7 +15,6 @@ class MockLocation implements Partial<Location> {
 describe('PunchoutDetectionService', () => {
   let service: PunchoutDetectionService;
   let location: Location;
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],

--- a/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
@@ -15,6 +15,7 @@ class MockLocation implements Partial<Location> {
 describe('PunchoutDetectionService', () => {
   let service: PunchoutDetectionService;
   let location: Location;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
@@ -53,13 +53,13 @@ export class PunchoutStatePersistanceService implements OnDestroy {
    * Used to update state from browser -> state.
    * storage stores minimum data: only punchoutSessionId.
    * Full PunchoutSession object is retrieved by calling punchoutFacade.getPunchoutSession
-   * Note that punchoutState is updated within punchoutFacade.getPunchoutSession, thus no need to do it here.
    */
   protected onRead(state: PunchoutState | undefined) {
     if (
       state?.punchoutSessionId &&
       !this.punchoutDetectionService.isPunchoutSessionPage()
     ) {
+      this.punchoutStoreService.setPunchoutState(state);
       this.punchoutFacade
         .getPunchoutSession({
           punchoutSessionId: state?.punchoutSessionId,

--- a/integration-libs/punchout/root/services/punchout-store.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-store.service.spec.ts
@@ -77,4 +77,10 @@ describe('PunchoutStoreService', () => {
 
     expect(service['punchoutState'].value).toEqual(INITIAL_STATE);
   });
+
+  it('should getPunchoutSessionId', () => {
+    service.setPunchoutState(mockPunchoutState);
+    const response = service.getPunchoutSessionId();
+    expect(response).toEqual(mockPunchoutState.punchoutSessionId);
+  });
 });

--- a/integration-libs/punchout/root/services/punchout-store.service.ts
+++ b/integration-libs/punchout/root/services/punchout-store.service.ts
@@ -19,6 +19,10 @@ export class PunchoutStoreService {
     this.INITIAL_STATE
   );
 
+  getPunchoutSessionId(): string | undefined {
+    return this.punchoutState?.value?.punchoutSessionId;
+  }
+
   getPunchoutState(): Observable<PunchoutState> {
     return this.punchoutState.asObservable();
   }


### PR DESCRIPTION
overwrite 2 methods in auth-http-heder service

- handleExpiredRefreshToken: to avoid navigation to login page
- handleExpiredAccessToken: to trigger the refresh token logic, which consists to navigate to punchout session page (= punchout landing page)

Behavior before: on Punchout session, modify auth token in storage, reload page -> navigate to Login page

New behavior: on Punchout session, modify auth token in storage, reload page -> navigate to Punchout Session page which re-init the punchout session (includes: logout, call occ punchout api, get new auth token, update  store)