### PR TITLE
fix: fix description of the injection token `PROPAGATE_ERROR_TO_SERVER`

### DIFF
--- a/core-libs/setup/ssr/error-handling/error-response/propagate-error-to-server.ts
+++ b/core-libs/setup/ssr/error-handling/error-response/propagate-error-to-server.ts
@@ -19,4 +19,4 @@ import { InjectionToken } from '@angular/core';
  */
 export const PROPAGATE_ERROR_TO_SERVER = new InjectionToken<
   (error: unknown) => void
->('PROPAGATE_ERROR_RESPONSE');
+>('PROPAGATE_ERROR_TO_SERVER');


### PR DESCRIPTION
Aligned the injection token's description it with the real injection token name. 

The previous name-vs-description mismatch was misleading and caused harder troubleshooting when an error happened:
```
Internal server error: NullInjectorError: No provider for InjectionToken PROPAGATE_ERROR_RESPONSE!
```
It was hard to search/find it in the codebase, because there is no such injection token like `PROPAGATE_ERROR_RESPONSE`, but only `PROPAGATE_ERROR_TO_SERVER`.