### PR TITLE
fix: Prevent app from being stuck if oAuthService.tryLogin fail

### DIFF
--- a/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.spec.ts
@@ -293,5 +293,22 @@ describe('OAuthLibWrapperService', () => {
         tokenReceived: false,
       });
     });
+
+    it('should reject promise if oAuthService.tryLogin throws an error', async () => {
+      const error = new Error('Login failed');
+
+      spyOn(oAuthService, 'tryLogin').and.returnValue(Promise.reject(error));
+
+      try {
+        await service.tryLogin();
+        fail('Expected tryLogin() to throw');
+      } catch (err) {
+        expect(err).toEqual(error);
+      }
+
+      expect(oAuthService.tryLogin).toHaveBeenCalledWith({
+        disableOAuth2StateCheck: true,
+      });
+    });
   });
 });

--- a/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
+++ b/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
@@ -132,7 +132,7 @@ export class OAuthLibWrapperService {
    * In cases where we don't receive this event, the token has been obtained from storage.
    */
   tryLogin(): Promise<OAuthTryLoginResult> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       // We use the 'token_received' event to check if we have returned
       // from the auth server.
       let tokenReceivedEvent: OAuthEvent | undefined;
@@ -153,6 +153,9 @@ export class OAuthLibWrapperService {
             result: result,
             tokenReceived: !!tokenReceivedEvent,
           });
+        })
+        .catch((error) => {
+          reject(error);
         })
         .finally(() => {
           subscription.unsubscribe();


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-9790