### PR TITLE
fix: (CXSPA-9653) Product detail page - tabs don't follow page layout in browser

### DIFF
--- a/projects/storefrontstyles/scss/components/content/tab/_tab.scss
+++ b/projects/storefrontstyles/scss/components/content/tab/_tab.scss
@@ -2,7 +2,7 @@
   // Tabs
   --cx-tab-gap: 0;
   --cx-tab-btn-bg-color: var(--cx-color-background);
-  --cx-tab-btn-width: 20%;
+  --cx-tab-btn-width: 100%;
   --cx-tab-btn-border: none;
   --cx-tab-btn-border-radius: none;
   --cx-tab-btn-font-size: 1.2rem;

--- a/projects/storefrontstyles/scss/components/content/tab/_tab.scss
+++ b/projects/storefrontstyles/scss/components/content/tab/_tab.scss
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 %cx-tab {
   // Tabs
   --cx-tab-gap: 0;


### PR DESCRIPTION
* Increased a width of a tab button
* closes https://jira.tools.sap/browse/CXSPA-9653