### PR TITLE
Land on Login page when error

### DIFF
--- a/integration-libs/punchout/components/punchout-requisition/punchout-requisition.component.ts
+++ b/integration-libs/punchout/components/punchout-requisition/punchout-requisition.component.ts
@@ -45,7 +45,7 @@ export class PunchoutRequisitionComponent implements OnInit {
             this.punchoutFormElement.nativeElement.submit();
           },
           error: () => {
-            this.punchoutFacade.logoutPunchoutUser(true);
+            this.punchoutFacade.endPunchoutSession();
           },
         });
         this.punchoutFormGroup.setValue({

--- a/integration-libs/punchout/components/punchout-requisition/punchout-requisition.component.ts
+++ b/integration-libs/punchout/components/punchout-requisition/punchout-requisition.component.ts
@@ -14,11 +14,7 @@ import {
 } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { RoutingService } from '@spartacus/core';
-import {
-  PUNCHOUT_ERROR_PAGE_URL,
-  PunchoutFacade,
-  PunchoutRequisition,
-} from '@spartacus/punchout/root';
+import { PunchoutFacade, PunchoutRequisition } from '@spartacus/punchout/root';
 import { filter, map, Observable, switchMap, take, tap, timer } from 'rxjs';
 
 @Component({
@@ -49,7 +45,7 @@ export class PunchoutRequisitionComponent implements OnInit {
             this.punchoutFormElement.nativeElement.submit();
           },
           error: () => {
-            this.routingService.go(PUNCHOUT_ERROR_PAGE_URL);
+            this.punchoutFacade.logoutPunchoutUser(true);
           },
         });
         this.punchoutFormGroup.setValue({

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -172,7 +172,7 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSessionRequisition with empty param opens error page', (done) => {
+  it('should getPunchoutSessionRequisition with empty param ends punchout session', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
     service.getPunchoutSession({ punchoutSessionId: '' }).subscribe({
       error: () => {
@@ -182,7 +182,7 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSessionRequisition without logged-in user opens error page', (done) => {
+  it('should getPunchoutSessionRequisition without logged-in user ends punchout session', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
     spyOn(punchoutAuthService, 'isUserLoggedIn').and.returnValue(of(false));
     service.getPunchoutSessionRequisition().subscribe({
@@ -208,7 +208,7 @@ describe('Punchoutservice', () => {
       });
   });
 
-  it('should getPunchoutSession opens error page when request failed', (done) => {
+  it('should getPunchoutSession ends punchout session when request failed', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
     spyOn(connector, 'getPunchoutSession').and.returnValue(
       of({ ...mockPunchoutSessionResponse, token: undefined })
@@ -221,7 +221,7 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSession opens error page when no auth token', (done) => {
+  it('should getPunchoutSession ends punchout session when no auth token', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
     spyOn(connector, 'getPunchoutSession').and.returnValue(
       of({ ...mockPunchoutSessionResponse, token: undefined })
@@ -293,7 +293,7 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should logoutPunchoutUser calls punchoutAuthService logout method', (done) => {
+  it('should logoutPunchoutUser calls punchoutAuthService silentLogout method', (done) => {
     spyOn(connector, 'getPunchoutSessionRequisition').and.returnValue(
       of(mockPunchoutRequisitionResponse)
     );
@@ -305,6 +305,25 @@ describe('Punchoutservice', () => {
       next: (result) => {
         expect(result).toEqual(true);
         expect(punchoutAuthService.silentLogout).toHaveBeenCalled();
+        expect(punchoutAuthService.endPunchoutSession).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('should logoutPunchoutUser with endSession calls punchoutAuthService endPunchoutSession method', (done) => {
+    spyOn(connector, 'getPunchoutSessionRequisition').and.returnValue(
+      of(mockPunchoutRequisitionResponse)
+    );
+    spyOn(punchoutStoreService, 'getPunchoutState').and.returnValue(
+      of(mockPunchoutState)
+    );
+
+    service.logoutPunchoutUser(true).subscribe({
+      next: (result) => {
+        expect(result).toEqual(true);
+        expect(punchoutAuthService.silentLogout).not.toHaveBeenCalled();
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
         done();
       },
     });

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -75,7 +75,9 @@ class MockPunchoutConnector implements Partial<PunchoutConnector> {
 }
 
 class MockPunchoutAuthService implements Partial<PunchoutAuthService> {
-  logout = createSpy('PunchoutAuthService.logout').and.callFake(() => of(true));
+  silentLogout = createSpy('PunchoutAuthService.logout').and.callFake(() =>
+    of(true)
+  );
   loginWithToken = createSpy('PunchoutAuthService.loginWithToken').and.callFake(
     () => {}
   );
@@ -300,7 +302,7 @@ describe('Punchoutservice', () => {
     service.logoutPunchoutUser().subscribe({
       next: (result) => {
         expect(result).toEqual(true);
-        expect(punchoutAuthService.logout).toHaveBeenCalled();
+        expect(punchoutAuthService.silentLogout).toHaveBeenCalled();
         done();
       },
     });

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -187,7 +187,7 @@ describe('Punchoutservice', () => {
     spyOn(punchoutAuthService, 'isUserLoggedIn').and.returnValue(of(false));
     service.getPunchoutSessionRequisition().subscribe({
       error: () => {
-        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
       },
     });
@@ -215,7 +215,7 @@ describe('Punchoutservice', () => {
     );
     service.getPunchoutSession(mockSessionInput).subscribe({
       error: () => {
-        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
       },
     });
@@ -229,7 +229,7 @@ describe('Punchoutservice', () => {
 
     service.getPunchoutSession(mockSessionInput).subscribe({
       error: () => {
-        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
       },
     });

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -314,7 +314,7 @@ describe('Punchoutservice', () => {
   it('should endPunchoutSession calls punchoutAuthService endPunchoutSession method', (done) => {
     service.endPunchoutSession().subscribe({
       next: () => {
-        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
       },
     });

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing';
 import { MultiCartFacade } from '@spartacus/cart/base/root';
 import { CommandService, RoutingService, UserIdService } from '@spartacus/core';
 import {
-  PUNCHOUT_ERROR_PAGE_URL,
   PunchOutLevel,
   PunchOutOperation,
   PunchoutRequisition,
@@ -82,6 +81,9 @@ class MockPunchoutAuthService implements Partial<PunchoutAuthService> {
     () => {}
   );
   isUserLoggedIn = () => of(true);
+  endPunchoutSession = createSpy(
+    'PunchoutAuthService.loginWithToken'
+  ).and.callFake(() => {});
 }
 
 const commandServiceMock = {
@@ -174,7 +176,7 @@ describe('Punchoutservice', () => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
     service.getPunchoutSession({ punchoutSessionId: '' }).subscribe({
       error: () => {
-        expect(routingService.go).toHaveBeenCalledWith(PUNCHOUT_ERROR_PAGE_URL);
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
         done();
       },
     });
@@ -185,7 +187,7 @@ describe('Punchoutservice', () => {
     spyOn(punchoutAuthService, 'isUserLoggedIn').and.returnValue(of(false));
     service.getPunchoutSessionRequisition().subscribe({
       error: () => {
-        expect(routingService.go).toHaveBeenCalledWith(PUNCHOUT_ERROR_PAGE_URL);
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
         done();
       },
     });
@@ -213,7 +215,7 @@ describe('Punchoutservice', () => {
     );
     service.getPunchoutSession(mockSessionInput).subscribe({
       error: () => {
-        expect(routingService.go).toHaveBeenCalledWith(PUNCHOUT_ERROR_PAGE_URL);
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
         done();
       },
     });
@@ -227,7 +229,7 @@ describe('Punchoutservice', () => {
 
     service.getPunchoutSession(mockSessionInput).subscribe({
       error: () => {
-        expect(routingService.go).toHaveBeenCalledWith(PUNCHOUT_ERROR_PAGE_URL);
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
         done();
       },
     });

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -82,7 +82,7 @@ class MockPunchoutAuthService implements Partial<PunchoutAuthService> {
   );
   isUserLoggedIn = () => of(true);
   endPunchoutSession = createSpy(
-    'PunchoutAuthService.loginWithToken'
+    'PunchoutAuthService.endPunchoutSession'
   ).and.callFake(() => {});
 }
 
@@ -176,7 +176,7 @@ describe('Punchoutservice', () => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
     service.getPunchoutSession({ punchoutSessionId: '' }).subscribe({
       error: () => {
-        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
+        expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
       },
     });
@@ -311,18 +311,9 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should logoutPunchoutUser with endSession calls punchoutAuthService endPunchoutSession method', (done) => {
-    spyOn(connector, 'getPunchoutSessionRequisition').and.returnValue(
-      of(mockPunchoutRequisitionResponse)
-    );
-    spyOn(punchoutStoreService, 'getPunchoutState').and.returnValue(
-      of(mockPunchoutState)
-    );
-
-    service.logoutPunchoutUser(true).subscribe({
-      next: (result) => {
-        expect(result).toEqual(true);
-        expect(punchoutAuthService.silentLogout).not.toHaveBeenCalled();
+  it('should endPunchoutSession calls punchoutAuthService endPunchoutSession method', (done) => {
+    service.endPunchoutSession().subscribe({
+      next: () => {
         expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalled();
         done();
       },

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -10,7 +10,6 @@ import {
   Command,
   CommandService,
   GlobalMessageService,
-  GlobalMessageType,
   RoutingService,
   UserIdService,
 } from '@spartacus/core';
@@ -28,7 +27,6 @@ import {
 import { MultiCartFacade } from '@spartacus/cart/base/root';
 import {
   catchError,
-  forkJoin,
   map,
   Observable,
   of,
@@ -72,18 +70,13 @@ export class PunchoutService implements PunchoutFacade {
     PunchoutSession
   > = this.commandService.create((payload) => {
     if (!payload?.punchoutSessionId) {
-      this.displayErrorPage();
+      this.punchoutAuthService.endPunchoutSession();
       return throwError(() => new Error('Punchout Session Id missing'));
     }
 
-    return this.requestPunchoutSession(payload.punchoutSessionId).pipe(
-      switchMap((punchoutSession) => {
-        return forkJoin({
-          punchoutSession: of(punchoutSession),
-          logout: this.punchoutAuthService.logout(),
-        });
-      }),
-      map(({ punchoutSession }) => {
+    return this.punchoutAuthService.silentLogout().pipe(
+      switchMap(() => this.requestPunchoutSession(payload.punchoutSessionId)),
+      map((punchoutSession) => {
         if (punchoutSession?.token?.accessToken) {
           this.punchoutAuthService.loginWithToken(
             punchoutSession.token.accessToken,
@@ -109,7 +102,7 @@ export class PunchoutService implements PunchoutFacade {
         return punchoutSession;
       }),
       catchError((error) => {
-        this.displayErrorPage();
+        this.punchoutAuthService.endPunchoutSession();
         return throwError(() => new Error(error));
       })
     );
@@ -153,15 +146,19 @@ export class PunchoutService implements PunchoutFacade {
           : throwError(() => new Error('Punchout Session Id missing'));
       }),
       catchError((error) => {
-        this.displayErrorPage();
+        this.punchoutAuthService.endPunchoutSession();
         return throwError(() => new Error(error));
       })
     );
   });
 
-  protected logoutPunchoutUserCommand: Command<undefined, boolean> =
-    this.commandService.create(() => {
-      return this.punchoutAuthService.logout();
+  protected logoutPunchoutUserCommand: Command<boolean, boolean> =
+    this.commandService.create((endSession: boolean) => {
+      return endSession
+        ? of(true).pipe(
+            tap(() => this.punchoutAuthService.endPunchoutSession())
+          )
+        : this.punchoutAuthService.silentLogout();
     });
 
   /**
@@ -198,7 +195,7 @@ export class PunchoutService implements PunchoutFacade {
           return true;
         }),
         catchError((error) => {
-          this.displayErrorPage();
+          this.punchoutAuthService.endPunchoutSession();
           return throwError(() => new Error(error));
         })
       );
@@ -247,8 +244,8 @@ export class PunchoutService implements PunchoutFacade {
     return this.getPunchoutRequisitionCommand.execute(undefined);
   }
 
-  logoutPunchoutUser(): Observable<boolean> {
-    return this.logoutPunchoutUserCommand.execute(undefined);
+  logoutPunchoutUser(endSession = false): Observable<boolean> {
+    return this.logoutPunchoutUserCommand.execute(endSession);
   }
 
   requestPunchoutSession(
@@ -270,15 +267,6 @@ export class PunchoutService implements PunchoutFacade {
       return;
     }
     this.routingService.go('/');
-  }
-
-  protected displayErrorPage() {
-    this.punchoutStoreService.clearPunchoutState();
-    this.globalMessageService.add(
-      { key: 'punchout.backToRequisition' },
-      GlobalMessageType.MSG_TYPE_ERROR
-    );
-    this.punchoutAuthService.routeToLogout();
   }
 
   protected loadCart(cartId: string): Observable<string> {

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -161,7 +161,7 @@ export class PunchoutService implements PunchoutFacade {
    * endUserSession workflow:
    * clear punchout state,logout, redirect to login page, display message
    */
-  protected endUserSessionCommand: Command<void, unknown> =
+  protected endPunchoutSessionCommand: Command<void> =
     this.commandService.create<void>(() =>
       of(true).pipe(
         tap(() => {
@@ -258,7 +258,7 @@ export class PunchoutService implements PunchoutFacade {
   }
 
   endPunchoutSession(): Observable<unknown> {
-    return this.endUserSessionCommand.execute(undefined);
+    return this.endPunchoutSessionCommand.execute();
   }
 
   requestPunchoutSession(

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -154,7 +154,7 @@ export class PunchoutService implements PunchoutFacade {
    * clear punchout state
    * silent logout, meaning no notification displayed and redirection.
    */
-  protected logoutPunchoutUserCommand: Command<boolean, boolean> =
+  protected logoutPunchoutUserCommand: Command<void, boolean> =
     this.commandService.create(() => this.punchoutAuthService.silentLogout());
 
   /**
@@ -163,7 +163,11 @@ export class PunchoutService implements PunchoutFacade {
    */
   protected endUserSessionCommand: Command<void, unknown> =
     this.commandService.create<void>(() =>
-      of().pipe(tap(() => this.punchoutAuthService.endPunchoutSession()))
+      of(true).pipe(
+        tap(() => {
+          this.punchoutAuthService.endPunchoutSession();
+        })
+      )
     );
 
   /**
@@ -249,8 +253,8 @@ export class PunchoutService implements PunchoutFacade {
     return this.getPunchoutRequisitionCommand.execute(undefined);
   }
 
-  logoutPunchoutUser(endSession = false): Observable<boolean> {
-    return this.logoutPunchoutUserCommand.execute(endSession);
+  logoutPunchoutUser(): Observable<boolean> {
+    return this.logoutPunchoutUserCommand.execute();
   }
 
   endPunchoutSession(): Observable<unknown> {

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -149,14 +149,22 @@ export class PunchoutService implements PunchoutFacade {
     );
   });
 
+  /**
+   * logoutPunchoutUser workflow:
+   * clear punchout state
+   * silent logout, meaning no notification displayed and redirection.
+   */
   protected logoutPunchoutUserCommand: Command<boolean, boolean> =
-    this.commandService.create((endSession: boolean) => {
-      return endSession
-        ? of(true).pipe(
-            tap(() => this.punchoutAuthService.endPunchoutSession())
-          )
-        : this.punchoutAuthService.silentLogout();
-    });
+    this.commandService.create(() => this.punchoutAuthService.silentLogout());
+
+  /**
+   * endUserSession workflow:
+   * clear punchout state,logout, redirect to login page, display message
+   */
+  protected endUserSessionCommand: Command<void, unknown> =
+    this.commandService.create<void>(() =>
+      of().pipe(tap(() => this.punchoutAuthService.endPunchoutSession()))
+    );
 
   /**
    * closePunchoutSession workflow:
@@ -243,6 +251,10 @@ export class PunchoutService implements PunchoutFacade {
 
   logoutPunchoutUser(endSession = false): Observable<boolean> {
     return this.logoutPunchoutUserCommand.execute(endSession);
+  }
+
+  endPunchoutSession(): Observable<unknown> {
+    return this.endUserSessionCommand.execute(undefined);
   }
 
   requestPunchoutSession(

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -9,11 +9,12 @@ import { inject, Injectable } from '@angular/core';
 import {
   Command,
   CommandService,
+  GlobalMessageService,
+  GlobalMessageType,
   RoutingService,
   UserIdService,
 } from '@spartacus/core';
 import {
-  PUNCHOUT_ERROR_PAGE_URL,
   PUNCHOUT_REQUISITION_PAGE_URL,
   PunchoutFacade,
   PunchOutOperation,
@@ -48,6 +49,7 @@ export class PunchoutService implements PunchoutFacade {
   protected punchoutStoreService = inject(PunchoutStoreService);
   protected multiCartFacade = inject(MultiCartFacade);
   protected userIdService = inject(UserIdService);
+  protected globalMessageService = inject(GlobalMessageService);
 
   /**
    * getPunchoutSession workflow:
@@ -241,7 +243,12 @@ export class PunchoutService implements PunchoutFacade {
   }
 
   protected displayErrorPage() {
-    this.routingService.go(PUNCHOUT_ERROR_PAGE_URL);
+    this.punchoutStoreService.clearPunchoutState();
+    this.globalMessageService.add(
+      { key: 'punchout.backToRequisition' },
+      GlobalMessageType.MSG_TYPE_ERROR
+    );
+    this.punchoutAuthService.routeToLogout();
   }
 
   protected loadCart(cartId: string): Observable<string> {

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -9,7 +9,6 @@ import { inject, Injectable } from '@angular/core';
 import {
   Command,
   CommandService,
-  GlobalMessageService,
   RoutingService,
   UserIdService,
 } from '@spartacus/core';
@@ -47,7 +46,6 @@ export class PunchoutService implements PunchoutFacade {
   protected punchoutStoreService = inject(PunchoutStoreService);
   protected multiCartFacade = inject(MultiCartFacade);
   protected userIdService = inject(UserIdService);
-  protected globalMessageService = inject(GlobalMessageService);
 
   /**
    * punchoutSession ajax request will always return same response during a punchout session.
@@ -57,8 +55,8 @@ export class PunchoutService implements PunchoutFacade {
 
   /**
    * getPunchoutSession workflow:
-   * Get PunchoutSession from  occ api
    * Logout silently
+   * Get PunchoutSession from  occ api
    * Login silently
    * Load Cart
    * Only for EDIT mode: Fetch Requisition to store initial cart in CXML format.
@@ -79,8 +77,7 @@ export class PunchoutService implements PunchoutFacade {
       map((punchoutSession) => {
         if (punchoutSession?.token?.accessToken) {
           this.punchoutAuthService.loginWithToken(
-            punchoutSession.token.accessToken,
-            punchoutSession.customerId
+            punchoutSession.token.accessToken
           );
           this.loadCart(punchoutSession.cartId).subscribe();
           this.punchoutStoreService.setPunchoutState({

--- a/integration-libs/punchout/core/services/punchout-auth.service.spec.ts
+++ b/integration-libs/punchout/core/services/punchout-auth.service.spec.ts
@@ -93,7 +93,7 @@ describe('PunchoutAuthService', () => {
     spyOn(userIdService, 'setUserId');
     spyOn(globalMessageService, 'remove');
 
-    service.logout().subscribe({
+    service.silentLogout().subscribe({
       next: (value) => {
         expect(value).toEqual(true);
         expect(authService.coreLogout).toHaveBeenCalled();
@@ -108,7 +108,7 @@ describe('PunchoutAuthService', () => {
     spyOn(authService, 'isUserLoggedIn').and.returnValue(of(false));
     spyOn(userIdService, 'setUserId');
 
-    service.logout().subscribe({
+    service.silentLogout().subscribe({
       next: (value) => {
         expect(value).toEqual(false);
         expect(authService.coreLogout).not.toHaveBeenCalled();

--- a/integration-libs/punchout/core/services/punchout-auth.service.spec.ts
+++ b/integration-libs/punchout/core/services/punchout-auth.service.spec.ts
@@ -4,13 +4,13 @@ import {
   AuthService,
   AuthStorageService,
   GlobalMessageService,
+  OCC_USER_ID_CURRENT,
   UserIdService,
 } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
 import { PunchoutAuthService } from './punchout-auth.service';
 
 const MOCK_TOKEN = 'abc';
-const MOCK_USER_ID = 'testUser';
 
 class MockGlobalMessageService implements Partial<GlobalMessageService> {
   remove() {
@@ -76,12 +76,12 @@ describe('PunchoutAuthService', () => {
     spyOn(globalMessageService, 'remove');
     spyOn(store, 'dispatch');
 
-    service.loginWithToken(MOCK_TOKEN, MOCK_USER_ID);
+    service.loginWithToken(MOCK_TOKEN);
     expect(authStorageService.setItem).toHaveBeenCalledWith(
       'access_token',
       MOCK_TOKEN
     );
-    expect(userIdService.setUserId).toHaveBeenCalledWith(MOCK_USER_ID);
+    expect(userIdService.setUserId).toHaveBeenCalledWith(OCC_USER_ID_CURRENT);
     expect(globalMessageService.remove).toHaveBeenCalled();
     expect(store.dispatch).toHaveBeenCalled();
     done();

--- a/integration-libs/punchout/core/services/punchout-auth.service.ts
+++ b/integration-libs/punchout/core/services/punchout-auth.service.ts
@@ -8,45 +8,38 @@ import { inject, Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import {
   AuthActions,
+  AuthRedirectService,
   AuthService,
   AuthStorageService,
   GlobalMessageService,
   GlobalMessageType,
+  OCC_USER_ID_CURRENT,
   RoutingService,
   UserIdService,
 } from '@spartacus/core';
-import { PunchoutStoreService } from '@spartacus/punchout/root';
+import {
+  PunchoutDetectionService,
+  PunchoutStoreService,
+} from '@spartacus/punchout/root';
 import { from, map, Observable, of, switchMap, take, tap } from 'rxjs';
 
 const ACCESS_TOKEN = 'access_token';
 const ACCESS_TOKEN_STORED_AT = 'access_token_stored_at';
+const TOKEN_TYPE = 'token_type';
 
 @Injectable()
 export class PunchoutAuthService {
   protected authService = inject(AuthService);
   protected globalMessageService = inject(GlobalMessageService);
   protected authStorageService = inject(AuthStorageService);
+  protected authRedirectService = inject(AuthRedirectService);
   protected userIdService = inject(UserIdService);
   protected store = inject(Store);
   protected punchoutStoreService = inject(PunchoutStoreService);
+  protected punchoutDetectionService = inject(PunchoutDetectionService);
   protected routingService = inject(RoutingService);
 
-  isSameAccessToken(punchoutToken: string | undefined): Observable<boolean> {
-    if (!punchoutToken) {
-      return of(false);
-    }
-    return this.authStorageService.getToken().pipe(
-      take(1),
-      map((token) => {
-        console.log('storedAccessToken', token?.access_token);
-        console.log('punchoutToken', punchoutToken);
-        const storedAccessToken = token?.access_token;
-        return storedAccessToken === punchoutToken;
-      })
-    );
-  }
-
-  logout(): Observable<boolean> {
+  silentLogout(): Observable<boolean> {
     return this.isUserLoggedIn().pipe(
       tap(() => this.punchoutStoreService.clearPunchoutState()),
       switchMap((isLoggedIn) => {
@@ -71,7 +64,9 @@ export class PunchoutAuthService {
       ACCESS_TOKEN_STORED_AT,
       Date.now().toString()
     );
-    this.userIdService.setUserId(userId);
+    this.authStorageService.setItem(TOKEN_TYPE, 'Bearer');
+    console.log('userId', userId);
+    this.userIdService.setUserId(OCC_USER_ID_CURRENT);
     this.store.dispatch(new AuthActions.Login());
     this.globalMessageService.remove(GlobalMessageType.MSG_TYPE_CONFIRMATION);
   }
@@ -80,7 +75,17 @@ export class PunchoutAuthService {
     return this.authService.isUserLoggedIn().pipe(take(1));
   }
 
-  routeToLogout() {
+  endPunchoutSession() {
+    this.punchoutStoreService.clearPunchoutState();
+    this.globalMessageService.add(
+      { key: 'httpHandlers.unauthorized.common' },
+      GlobalMessageType.MSG_TYPE_ERROR
+    );
+
+    if (this.punchoutDetectionService.isPunchoutSessionPage()) {
+      this.authRedirectService.setRedirectUrl('/');
+    }
+
     this.authService.coreLogout().finally(() => {
       this.routingService.go({ cxRoute: 'login' });
     });

--- a/integration-libs/punchout/core/services/punchout-auth.service.ts
+++ b/integration-libs/punchout/core/services/punchout-auth.service.ts
@@ -12,6 +12,7 @@ import {
   AuthStorageService,
   GlobalMessageService,
   GlobalMessageType,
+  RoutingService,
   UserIdService,
 } from '@spartacus/core';
 import { PunchoutStoreService } from '@spartacus/punchout/root';
@@ -28,6 +29,22 @@ export class PunchoutAuthService {
   protected userIdService = inject(UserIdService);
   protected store = inject(Store);
   protected punchoutStoreService = inject(PunchoutStoreService);
+  protected routingService = inject(RoutingService);
+
+  isSameAccessToken(punchoutToken: string | undefined): Observable<boolean> {
+    if (!punchoutToken) {
+      return of(false);
+    }
+    return this.authStorageService.getToken().pipe(
+      take(1),
+      map((token) => {
+        console.log('storedAccessToken', token?.access_token);
+        console.log('punchoutToken', punchoutToken);
+        const storedAccessToken = token?.access_token;
+        return storedAccessToken === punchoutToken;
+      })
+    );
+  }
 
   logout(): Observable<boolean> {
     return this.isUserLoggedIn().pipe(
@@ -61,5 +78,11 @@ export class PunchoutAuthService {
 
   isUserLoggedIn(): Observable<boolean> {
     return this.authService.isUserLoggedIn().pipe(take(1));
+  }
+
+  routeToLogout() {
+    this.authService.coreLogout().finally(() => {
+      this.routingService.go({ cxRoute: 'login' });
+    });
   }
 }

--- a/integration-libs/punchout/core/services/punchout-auth.service.ts
+++ b/integration-libs/punchout/core/services/punchout-auth.service.ts
@@ -57,7 +57,7 @@ export class PunchoutAuthService {
     );
   }
 
-  loginWithToken(accessToken: string, userId: string): void {
+  loginWithToken(accessToken: string): void {
     // Code mostly based on auth lib we use and the way it handles token properties
     this.authStorageService.setItem(ACCESS_TOKEN, accessToken);
     this.authStorageService.setItem(
@@ -65,7 +65,6 @@ export class PunchoutAuthService {
       Date.now().toString()
     );
     this.authStorageService.setItem(TOKEN_TYPE, 'Bearer');
-    console.log('userId', userId);
     this.userIdService.setUserId(OCC_USER_ID_CURRENT);
     this.store.dispatch(new AuthActions.Login());
     this.globalMessageService.remove(GlobalMessageType.MSG_TYPE_CONFIRMATION);
@@ -75,7 +74,7 @@ export class PunchoutAuthService {
     return this.authService.isUserLoggedIn().pipe(take(1));
   }
 
-  endPunchoutSession() {
+  endPunchoutSession(): void {
     this.punchoutStoreService.clearPunchoutState();
     this.globalMessageService.add(
       { key: 'httpHandlers.unauthorized.common' },

--- a/integration-libs/punchout/root/facade/punchout.facade.ts
+++ b/integration-libs/punchout/root/facade/punchout.facade.ts
@@ -24,6 +24,7 @@ export function punchoutFacadeFactory() {
       'logoutPunchoutUser',
       'closePunchoutSession',
       'requestPunchoutSession',
+      'endPunchoutSession',
     ],
   });
 }
@@ -51,9 +52,14 @@ export abstract class PunchoutFacade {
 
   /**
    * Abstract method used to logout punchout user
-   * @param endSession set to true means punchout session is ended with flow: logout, clear punchout state and redirect to login page
    */
-  abstract logoutPunchoutUser(endSession?: boolean): Observable<boolean>;
+  abstract logoutPunchoutUser(): Observable<boolean>;
+
+  /**
+   *  Abstract method used to end punchout session
+   *  Flow: logout, clear punchout state and redirect to login page
+   */
+  abstract endPunchoutSession(): Observable<unknown>;
 
   /**
    * Abstract method used to close punchout session

--- a/integration-libs/punchout/root/facade/punchout.facade.ts
+++ b/integration-libs/punchout/root/facade/punchout.facade.ts
@@ -51,8 +51,9 @@ export abstract class PunchoutFacade {
 
   /**
    * Abstract method used to logout punchout user
+   * @param endSession set to true means punchout session is ended with flow: logout, clear punchout state and redirect to login page
    */
-  abstract logoutPunchoutUser(): Observable<boolean>;
+  abstract logoutPunchoutUser(endSession?: boolean): Observable<boolean>;
 
   /**
    * Abstract method used to close punchout session

--- a/integration-libs/punchout/root/guards/punchout-navigation.guard.ts
+++ b/integration-libs/punchout/root/guards/punchout-navigation.guard.ts
@@ -16,7 +16,6 @@ import {
 import { catchError, map, Observable, of, switchMap, take } from 'rxjs';
 import { PunchoutFacade } from '../facade';
 import {
-  PUNCHOUT_ERROR_PAGE_URL,
   PUNCHOUT_INSPECT_PAGE_URL,
   PUNCHOUT_REQUISITION_PAGE_URL,
   PUNCHOUT_SESSION_PAGE_URL,
@@ -48,7 +47,6 @@ export class PunchoutNavigationGuard {
   protected readonly allowedUrlsForAll: string[] = [
     PUNCHOUT_SESSION_PAGE_URL,
     PUNCHOUT_REQUISITION_PAGE_URL,
-    PUNCHOUT_ERROR_PAGE_URL,
   ];
   protected readonly allowedCxRoutesForEdit: string[] = [
     'category',

--- a/integration-libs/punchout/root/model/punchout.model.ts
+++ b/integration-libs/punchout/root/model/punchout.model.ts
@@ -5,7 +5,6 @@
  */
 
 export const PUNCHOUT_SESSION_KEY = 'sid';
-export const PUNCHOUT_ERROR_PAGE_URL = '/punchout/cxml/error';
 export const PUNCHOUT_SESSION_ID = 'punchoutSessionId';
 export const PUNCHOUT_SESSION_PAGE_URL = '/punchout/cxml/session';
 export const PUNCHOUT_REQUISITION_PAGE_URL = '/punchout/cxml/requisition';

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
@@ -11,15 +11,12 @@ import {
   RoutingService,
 } from '@spartacus/core';
 import { of } from 'rxjs';
+import { PunchoutFacade } from '../facade';
 import {
-  PUNCHOUT_ERROR_PAGE_URL,
-  PUNCHOUT_OCC_API_URL_SEGMENT,
   PUNCHOUT_SESSION_KEY,
-  PUNCHOUT_SESSION_PAGE_URL,
   PunchOutLevel,
   PunchOutOperation,
   PunchoutSession,
-  PunchoutState,
 } from '../model';
 import { PunchoutAuthHttpHeaderService } from './punchout-auth-http-header.service';
 import { PunchoutDetectionService } from './punchout-detection.service';
@@ -37,10 +34,7 @@ const mockPunchoutSession: PunchoutSession = {
     tokenType: 'Bearer',
   },
 };
-const mockPunchoutState: PunchoutState = {
-  punchoutSessionId: mockSessionId,
-  punchoutSession: mockPunchoutSession,
-};
+
 class MockPunchoutDetectionService
   implements Partial<PunchoutDetectionService>
 {
@@ -49,6 +43,9 @@ class MockPunchoutDetectionService
   }
   getPunchoutSessionId(): string | undefined {
     return mockSessionId;
+  }
+  isPunchoutSession(): boolean | undefined {
+    return false;
   }
 }
 
@@ -88,13 +85,12 @@ class MockOccEndpointsService implements Partial<OccEndpointsService> {
 
 class MockAuthRedirectService implements Partial<AuthRedirectService> {
   saveCurrentNavigationUrl = jasmine.createSpy('saveCurrentNavigationUrl');
+  setRedirectUrl = jasmine.createSpy('setRedirectUrl');
 }
 
-class MockPunchoutStoreService implements Partial<PunchoutStoreService> {
-  setPunchoutState = () => {};
-  getPunchoutState = () => of(mockPunchoutState);
-  clearState = () => {};
-  getPunchoutSessionId = () => mockPunchoutState.punchoutSessionId;
+class MockPunchoutFacade implements Partial<PunchoutFacade> {
+  getPunchoutSession = () => of(mockPunchoutSession);
+  logoutPunchoutUser = () => of(true);
 }
 
 describe('PunchoutAuthHttpHeaderService', () => {
@@ -104,11 +100,12 @@ describe('PunchoutAuthHttpHeaderService', () => {
   let globalMessageService: GlobalMessageService;
   let routingService: RoutingService;
   let punchoutStoreService: PunchoutStoreService;
+  let punchoutfacade: PunchoutFacade;
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
       providers: [
-        { provide: PunchoutStoreService, useClass: MockPunchoutStoreService },
+        { provide: PunchoutFacade, useClass: MockPunchoutFacade },
         {
           provide: PunchoutDetectionService,
           useClass: MockPunchoutDetectionService,
@@ -131,6 +128,7 @@ describe('PunchoutAuthHttpHeaderService', () => {
     globalMessageService = TestBed.inject(GlobalMessageService);
     routingService = TestBed.inject(RoutingService);
     punchoutStoreService = TestBed.inject(PunchoutStoreService);
+    punchoutfacade = TestBed.inject(PunchoutFacade);
   });
 
   it('should be created', () => {
@@ -157,36 +155,13 @@ describe('PunchoutAuthHttpHeaderService', () => {
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
       true
     );
-    spyOn(globalMessageService, 'remove').and.callThrough();
+    spyOn(punchoutDetectionService, 'isPunchoutSession').and.returnValue(true);
+    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
 
     service.handleExpiredRefreshToken();
     await Promise.resolve();
 
-    expect(authService.coreLogout).toHaveBeenCalled();
-    expect(globalMessageService.remove).toHaveBeenCalled();
-  });
-
-  it('should handleExpiredAccessToken redirect to punchout session page', async () => {
-    const initialToken: AuthToken = {
-      access_token: `old_token`,
-      access_token_stored_at: '123',
-      refresh_token: 'ref_token',
-    };
-    const handler = (a: any) => of(a);
-    spyOn(routingService, 'goByUrl').and.callThrough();
-
-    await service.handleExpiredAccessToken(
-      new HttpRequest(
-        'GET',
-        `some-server/${PUNCHOUT_OCC_API_URL_SEGMENT}/sessions?${PUNCHOUT_SESSION_KEY}${mockSessionId}`
-      ),
-      { handle: handler } as HttpHandler,
-      initialToken
-    );
-
-    expect(routingService.goByUrl).toHaveBeenCalledWith(
-      `${PUNCHOUT_SESSION_PAGE_URL}?${PUNCHOUT_SESSION_KEY}=${mockSessionId}`
-    );
+    expect(punchoutfacade.logoutPunchoutUser).toHaveBeenCalled();
   });
 
   it('should handleExpiredAccessToken without occ punchout request not redirect to any page', async () => {
@@ -211,27 +186,27 @@ describe('PunchoutAuthHttpHeaderService', () => {
     expect(routingService.goByUrl).not.toHaveBeenCalled();
   });
 
-  it('should handleExpiredAccessToken without sessionId redirects to error page', async () => {
+  it('should handleExpiredAccessToken in active punchout session to call logout', async () => {
     const initialToken: AuthToken = {
       access_token: `old_token`,
       access_token_stored_at: '123',
       refresh_token: 'ref_token',
     };
     const handler = (a: any) => of(a);
-    spyOn(routingService, 'goByUrl').and.callThrough();
-    spyOn(punchoutStoreService, 'getPunchoutSessionId').and.returnValue('');
+
+    spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
+      true
+    );
+    spyOn(punchoutDetectionService, 'isPunchoutSession').and.returnValue(true);
+    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
 
     await service.handleExpiredAccessToken(
-      new HttpRequest(
-        'GET',
-        `some-server/${PUNCHOUT_OCC_API_URL_SEGMENT}/sessions?${PUNCHOUT_SESSION_KEY}${mockSessionId}`
-      ),
+      new HttpRequest('GET', `some-server`),
       { handle: handler } as HttpHandler,
       initialToken
     );
 
-    expect(routingService.goByUrl).toHaveBeenCalledWith(
-      PUNCHOUT_ERROR_PAGE_URL
-    );
+    // navigate with empty sessionId then punchout facade will take care of error handling
+    expect(punchoutfacade.logoutPunchoutUser).toHaveBeenCalled();
   });
 });

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
@@ -91,6 +91,7 @@ class MockAuthRedirectService implements Partial<AuthRedirectService> {
 class MockPunchoutFacade implements Partial<PunchoutFacade> {
   getPunchoutSession = () => of(mockPunchoutSession);
   logoutPunchoutUser = () => of(true);
+  endPunchoutSession = () => of();
 }
 
 describe('PunchoutAuthHttpHeaderService', () => {
@@ -156,12 +157,12 @@ describe('PunchoutAuthHttpHeaderService', () => {
       true
     );
     spyOn(punchoutDetectionService, 'isPunchoutSession').and.returnValue(true);
-    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
+    spyOn(punchoutfacade, 'endPunchoutSession').and.callThrough();
 
     service.handleExpiredRefreshToken();
     await Promise.resolve();
 
-    expect(punchoutfacade.logoutPunchoutUser).toHaveBeenCalled();
+    expect(punchoutfacade.endPunchoutSession).toHaveBeenCalled();
   });
 
   it('should handleExpiredAccessToken without occ punchout request not redirect to any page', async () => {
@@ -198,7 +199,7 @@ describe('PunchoutAuthHttpHeaderService', () => {
       true
     );
     spyOn(punchoutDetectionService, 'isPunchoutSession').and.returnValue(true);
-    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
+    spyOn(punchoutfacade, 'endPunchoutSession').and.callThrough();
 
     await service.handleExpiredAccessToken(
       new HttpRequest('GET', `some-server`),
@@ -207,6 +208,6 @@ describe('PunchoutAuthHttpHeaderService', () => {
     );
 
     // navigate with empty sessionId then punchout facade will take care of error handling
-    expect(punchoutfacade.logoutPunchoutUser).toHaveBeenCalled();
+    expect(punchoutfacade.endPunchoutSession).toHaveBeenCalled();
   });
 });

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
@@ -162,7 +162,7 @@ describe('PunchoutAuthHttpHeaderService', () => {
     service.handleExpiredRefreshToken();
     await Promise.resolve();
 
-    expect(punchoutfacade.endPunchoutSession).toHaveBeenCalled();
+    expect(punchoutfacade.endPunchoutSession).toHaveBeenCalledWith();
   });
 
   it('should handleExpiredAccessToken without occ punchout request not redirect to any page', async () => {
@@ -208,6 +208,6 @@ describe('PunchoutAuthHttpHeaderService', () => {
     );
 
     // navigate with empty sessionId then punchout facade will take care of error handling
-    expect(punchoutfacade.endPunchoutSession).toHaveBeenCalled();
+    expect(punchoutfacade.endPunchoutSession).toHaveBeenCalledWith();
   });
 });

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -59,7 +59,7 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
       this.punchoutDetectionService.isPunchoutSession() ||
       this.punchoutDetectionService.isPunchoutSessionPage()
     ) {
-      this.punchoutFacade.logoutPunchoutUser(true).subscribe();
+      this.punchoutFacade.endPunchoutSession().subscribe();
     } else {
       super.handleExpiredRefreshToken();
     }
@@ -79,7 +79,7 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
       this.punchoutDetectionService.isPunchoutSession() ||
       this.punchoutDetectionService.isPunchoutSessionPage()
     ) {
-      this.punchoutFacade.logoutPunchoutUser(true).subscribe();
+      this.punchoutFacade.endPunchoutSession().subscribe();
     }
     return super.handleExpiredAccessToken(request, next, initialToken);
   }

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -13,26 +13,20 @@ import {
   AuthStorageService,
   AuthToken,
   GlobalMessageService,
-  GlobalMessageType,
   OAuthLibWrapperService,
   OccEndpointsService,
   RoutingService,
 } from '@spartacus/core';
 import { Observable } from 'rxjs';
-import {
-  PUNCHOUT_OCC_API_URL_SEGMENT,
-  PUNCHOUT_SESSION_KEY,
-  PUNCHOUT_SESSION_PAGE_URL,
-} from '../model';
+import { PunchoutFacade } from '../facade';
 import { PunchoutDetectionService } from './punchout-detection.service';
-import { PunchoutStoreService } from './punchout-store.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
   protected punchoutDetectionService = inject(PunchoutDetectionService);
-  protected punchoutStoreService = inject(PunchoutStoreService);
+  protected punchoutFacade = inject(PunchoutFacade);
   constructor(
     protected authService: AuthService,
     protected authStorageService: AuthStorageService,
@@ -56,25 +50,16 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
   /**
    * @override
    *
-   * On backend errors indicating expired `refresh_token`, we need to silently logout
-   * by revoking invalid token and preventing Login page redirection.
-   * This rule is applied on punchout instance: punchoutSessionId in storage or browser on PunchoutSession page
+   * On backend errors indicating expired `refresh_token`, punchout session gets ended, user is redirected to login page
    * It is a workaround to address CXSPA-9608 - Public pages not displayed when token is invalid.
    * To be removed once CXSPA-9608 is closed.
    */
   public handleExpiredRefreshToken(): void {
-    if (this.punchoutDetectionService.isPunchoutSessionPage()) {
-      this.authRedirectService.setRedirectUrl('/');
-      this.authService.coreLogout().finally(() => {
-        this.routingService.go({ cxRoute: 'login' });
-
-        this.globalMessageService.add(
-          {
-            key: 'httpHandlers.sessionExpired',
-          },
-          GlobalMessageType.MSG_TYPE_ERROR
-        );
-      });
+    if (
+      this.punchoutDetectionService.isPunchoutSession() ||
+      this.punchoutDetectionService.isPunchoutSessionPage()
+    ) {
+      this.punchoutFacade.logoutPunchoutUser(true).subscribe();
     } else {
       super.handleExpiredRefreshToken();
     }
@@ -83,38 +68,19 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
   /**
    * @override
    * Refreshes access_token and then retries the call with the new token.
-   * When url is a Punchout OCC call, redirect to PunchoutSession page to refresh the auth token.
+   * When punchout session exists,  punchout session gets ended, user is redirected to login page
    */
   public handleExpiredAccessToken(
     request: HttpRequest<any>,
     next: HttpHandler,
     initialToken: AuthToken | undefined
   ): Observable<HttpEvent<AuthToken>> {
-    if (this.isPunchoutOccApiRequest(request)) {
-      this.goToPunchoutPage();
+    if (
+      this.punchoutDetectionService.isPunchoutSession() ||
+      this.punchoutDetectionService.isPunchoutSessionPage()
+    ) {
+      this.punchoutFacade.logoutPunchoutUser(true).subscribe();
     }
     return super.handleExpiredAccessToken(request, next, initialToken);
-  }
-
-  protected silentLogout(): void {
-    this.authService.coreLogout().finally(() => {
-      this.globalMessageService.remove(GlobalMessageType.MSG_TYPE_CONFIRMATION);
-    });
-  }
-
-  protected isPunchoutOccApiRequest(request: HttpRequest<any>): boolean {
-    return request.url.includes(PUNCHOUT_OCC_API_URL_SEGMENT);
-  }
-
-  protected buildPunchoutSessionUrl(punchoutSessionId: string): string {
-    return `${PUNCHOUT_SESSION_PAGE_URL}?${PUNCHOUT_SESSION_KEY}=${punchoutSessionId}`;
-  }
-
-  protected goToPunchoutPage(): void {
-    this.routingService.goByUrl(
-      this.buildPunchoutSessionUrl(
-        this.punchoutStoreService.getPunchoutSessionId() ?? ''
-      )
-    );
   }
 }

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -20,7 +20,6 @@ import {
 } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import {
-  PUNCHOUT_ERROR_PAGE_URL,
   PUNCHOUT_OCC_API_URL_SEGMENT,
   PUNCHOUT_SESSION_KEY,
   PUNCHOUT_SESSION_PAGE_URL,
@@ -64,11 +63,18 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
    * To be removed once CXSPA-9608 is closed.
    */
   public handleExpiredRefreshToken(): void {
-    if (
-      this.punchoutDetectionService.isPunchoutSessionPage() ||
-      !!this.punchoutStoreService.getPunchoutSessionId()
-    ) {
-      this.silentLogout();
+    if (this.punchoutDetectionService.isPunchoutSessionPage()) {
+      this.authRedirectService.setRedirectUrl('/');
+      this.authService.coreLogout().finally(() => {
+        this.routingService.go({ cxRoute: 'login' });
+
+        this.globalMessageService.add(
+          {
+            key: 'httpHandlers.sessionExpired',
+          },
+          GlobalMessageType.MSG_TYPE_ERROR
+        );
+      });
     } else {
       super.handleExpiredRefreshToken();
     }
@@ -105,11 +111,10 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
   }
 
   protected goToPunchoutPage(): void {
-    const punchoutSessionId = this.punchoutStoreService.getPunchoutSessionId();
     this.routingService.goByUrl(
-      punchoutSessionId
-        ? this.buildPunchoutSessionUrl(punchoutSessionId)
-        : PUNCHOUT_ERROR_PAGE_URL
+      this.buildPunchoutSessionUrl(
+        this.punchoutStoreService.getPunchoutSessionId() ?? ''
+      )
     );
   }
 }

--- a/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
@@ -2,6 +2,7 @@ import { Location } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { PUNCHOUT_SESSION_PAGE_URL } from '../model';
 import { PunchoutDetectionService } from './punchout-detection.service';
+import { PunchoutStoreService } from './punchout-store.service';
 
 const MOCK_URL = 'https://test';
 const MOCK_URL_WITH_PUNCHOUT = `https://spartacus/${PUNCHOUT_SESSION_PAGE_URL}?sid=abc123`;
@@ -11,19 +12,28 @@ class MockLocation implements Partial<Location> {
     return MOCK_URL;
   }
 }
+const mockSessionId = '123abc';
+class MockPunchoutStoreService implements Partial<PunchoutStoreService> {
+  getPunchoutSessionId = () => mockSessionId;
+}
 
 describe('PunchoutDetectionService', () => {
   let service: PunchoutDetectionService;
   let location: Location;
+  let punchoutStoreService: PunchoutStoreService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
-      providers: [{ provide: Location, useClass: MockLocation }],
+      providers: [
+        { provide: Location, useClass: MockLocation },
+        { provide: PunchoutStoreService, useClass: MockPunchoutStoreService },
+      ],
     });
 
     location = TestBed.inject(Location);
     service = TestBed.inject(PunchoutDetectionService);
+    punchoutStoreService = TestBed.inject(PunchoutStoreService);
   });
 
   it('should be created', () => {
@@ -43,6 +53,26 @@ describe('PunchoutDetectionService', () => {
 
     const value = service.isPunchoutSessionPage();
     expect(value).toEqual(true);
+    done();
+  });
+
+  it('should isPunchoutSessionActive truthy when user punchoutSessionId exists', (done) => {
+    spyOn(punchoutStoreService, 'getPunchoutSessionId').and.returnValue(
+      mockSessionId
+    );
+
+    const value = service.isPunchoutSession();
+    expect(value).toEqual(true);
+    done();
+  });
+
+  it('should isPunchoutSessionActive falsy when punchoutSessionId undefined', (done) => {
+    spyOn(punchoutStoreService, 'getPunchoutSessionId').and.returnValue(
+      undefined
+    );
+
+    const value = service.isPunchoutSession();
+    expect(value).toEqual(false);
     done();
   });
 });

--- a/integration-libs/punchout/root/services/punchout-detection.service.ts
+++ b/integration-libs/punchout/root/services/punchout-detection.service.ts
@@ -5,12 +5,14 @@
  */
 
 import { Location } from '@angular/common';
-import { Injectable, inject } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { PUNCHOUT_SESSION_PAGE_URL } from '../model';
+import { PunchoutStoreService } from './punchout-store.service';
 
 @Injectable({ providedIn: 'root' })
 export class PunchoutDetectionService {
   protected location = inject(Location);
+  protected punchoutStoreService = inject(PunchoutStoreService);
 
   /**
    * Check if browser url is the punchout initial session page.
@@ -23,5 +25,8 @@ export class PunchoutDetectionService {
       urlSections.length > 1 &&
       urlSections[0].includes(PUNCHOUT_SESSION_PAGE_URL)
     );
+  }
+  isPunchoutSession(): boolean | undefined {
+    return !!this.punchoutStoreService.getPunchoutSessionId();
   }
 }


### PR DESCRIPTION
a- Removed punchout error page
b- Instead we now end punchout session by: logout, clear punchout storage, navigate to login page with authorization message.
c- added facade method 'endPunchoutSession()' to address 'b'.
d- fixed token revoking prob by setting login user with 'current' rather than the actual userId string.
e- better designed by silentLogout before calling punchout occ api (fixed probs that were triggered token expiration in specific use cases)
f- improve/simplified  accesstoken and refreshtoken expiration event by just ending punchout session.