### PR TITLE
fix: navigation guard when page refreshed

### DIFF
--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -72,7 +72,7 @@ export class PunchoutService implements PunchoutFacade {
       return throwError(() => new Error('Punchout Session Id missing'));
     }
 
-    return this.punchoutAuthService.silentLogout().pipe(
+    return this.punchoutAuthService.silentLogout(payload?.isPageRefresh).pipe(
       switchMap(() => this.requestPunchoutSession(payload.punchoutSessionId)),
       map((punchoutSession) => {
         if (punchoutSession?.token?.accessToken) {

--- a/integration-libs/punchout/core/services/punchout-auth.service.ts
+++ b/integration-libs/punchout/core/services/punchout-auth.service.ts
@@ -39,9 +39,13 @@ export class PunchoutAuthService {
   protected punchoutDetectionService = inject(PunchoutDetectionService);
   protected routingService = inject(RoutingService);
 
-  silentLogout(): Observable<boolean> {
+  silentLogout(isPageRefresh = false): Observable<boolean> {
     return this.isUserLoggedIn().pipe(
-      tap(() => this.punchoutStoreService.clearPunchoutState()),
+      tap(() => {
+        if (!isPageRefresh) {
+          this.punchoutStoreService.clearPunchoutState();
+        }
+      }),
       switchMap((isLoggedIn) => {
         return isLoggedIn
           ? from(this.authService.coreLogout()).pipe(


### PR DESCRIPTION
fix navigation guard
when page gets refresh:
no need to clear punchoutState when page get refreshed. 
navigation guard gets broken as no access to punchoutSessionId.

More context:
when page is refreshed,
punchoutState is already filled correctly with punchoutSessionId by 'punchout-state-persistence.service' in onRead method, no need to clear it, the rest of data (PunchoutLevel,PunchoutOperation..) can be then retrieve via api.