### PR TITLE
fix: invalid token throwing error

### DIFF
--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.spec.ts
@@ -1,4 +1,3 @@
-import { HttpHandler, HttpRequest } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import {
   AuthRedirectService,
@@ -12,12 +11,7 @@ import {
 } from '@spartacus/core';
 import { of } from 'rxjs';
 import { PunchoutFacade } from '../facade';
-import {
-  PUNCHOUT_SESSION_KEY,
-  PunchOutLevel,
-  PunchOutOperation,
-  PunchoutSession,
-} from '../model';
+import { PunchOutLevel, PunchOutOperation, PunchoutSession } from '../model';
 import { PunchoutAuthHttpHeaderService } from './punchout-auth-http-header.service';
 import { PunchoutDetectionService } from './punchout-detection.service';
 import { PunchoutStoreService } from './punchout-store.service';
@@ -98,8 +92,6 @@ describe('PunchoutAuthHttpHeaderService', () => {
   let service: PunchoutAuthHttpHeaderService;
   let authService: AuthService;
   let punchoutDetectionService: PunchoutDetectionService;
-  let globalMessageService: GlobalMessageService;
-  let routingService: RoutingService;
   let punchoutStoreService: PunchoutStoreService;
   let punchoutfacade: PunchoutFacade;
   beforeEach(() => {
@@ -126,8 +118,6 @@ describe('PunchoutAuthHttpHeaderService', () => {
     service = TestBed.inject(PunchoutAuthHttpHeaderService);
     authService = TestBed.inject(AuthService);
     punchoutDetectionService = TestBed.inject(PunchoutDetectionService);
-    globalMessageService = TestBed.inject(GlobalMessageService);
-    routingService = TestBed.inject(RoutingService);
     punchoutStoreService = TestBed.inject(PunchoutStoreService);
     punchoutfacade = TestBed.inject(PunchoutFacade);
   });
@@ -138,17 +128,18 @@ describe('PunchoutAuthHttpHeaderService', () => {
 
   it('should handleExpiredRefreshToken call super coreLogout when not Punchout Session page', async () => {
     spyOn(authService, 'coreLogout').and.callThrough();
+    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
       false
     );
     spyOn(punchoutStoreService, 'getPunchoutSessionId').and.returnValue('');
-    spyOn(globalMessageService, 'remove').and.callThrough();
+    spyOn(punchoutfacade, 'endPunchoutSession').and.callThrough();
 
     service.handleExpiredRefreshToken();
     await Promise.resolve();
-
     expect(authService.coreLogout).toHaveBeenCalled();
-    expect(globalMessageService.remove).not.toHaveBeenCalled();
+    expect(punchoutfacade.logoutPunchoutUser).not.toHaveBeenCalled();
+    expect(punchoutfacade.endPunchoutSession).not.toHaveBeenCalled();
   });
 
   it('should handleExpiredRefreshToken silently logout when Punchout Session page', async () => {
@@ -158,56 +149,30 @@ describe('PunchoutAuthHttpHeaderService', () => {
     );
     spyOn(punchoutDetectionService, 'isPunchoutSession').and.returnValue(true);
     spyOn(punchoutfacade, 'endPunchoutSession').and.callThrough();
+    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
 
     service.handleExpiredRefreshToken();
     await Promise.resolve();
 
-    expect(punchoutfacade.endPunchoutSession).toHaveBeenCalledWith();
+    expect(punchoutfacade.logoutPunchoutUser).toHaveBeenCalledWith();
+    expect(punchoutfacade.endPunchoutSession).not.toHaveBeenCalledWith();
+    expect(authService.coreLogout).not.toHaveBeenCalled();
   });
 
-  it('should handleExpiredAccessToken without occ punchout request not redirect to any page', async () => {
-    const initialToken: AuthToken = {
-      access_token: `old_token`,
-      access_token_stored_at: '123',
-      refresh_token: 'ref_token',
-    };
-    const handler = (a: any) => of(a);
-    spyOn(routingService, 'goByUrl').and.callThrough();
-    spyOn(punchoutStoreService, 'getPunchoutSessionId').and.returnValue('');
-
-    await service.handleExpiredAccessToken(
-      new HttpRequest(
-        'GET',
-        `some-server/occ/test?${PUNCHOUT_SESSION_KEY}${mockSessionId}`
-      ),
-      { handle: handler } as HttpHandler,
-      initialToken
-    );
-
-    expect(routingService.goByUrl).not.toHaveBeenCalled();
-  });
-
-  it('should handleExpiredAccessToken in active punchout session to call logout', async () => {
-    const initialToken: AuthToken = {
-      access_token: `old_token`,
-      access_token_stored_at: '123',
-      refresh_token: 'ref_token',
-    };
-    const handler = (a: any) => of(a);
-
+  it('should handleExpiredRefreshToken endPunchoutSession when Punchout Session already exists', async () => {
+    spyOn(authService, 'coreLogout').and.callThrough();
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
-      true
+      false
     );
     spyOn(punchoutDetectionService, 'isPunchoutSession').and.returnValue(true);
     spyOn(punchoutfacade, 'endPunchoutSession').and.callThrough();
+    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
 
-    await service.handleExpiredAccessToken(
-      new HttpRequest('GET', `some-server`),
-      { handle: handler } as HttpHandler,
-      initialToken
-    );
+    service.handleExpiredRefreshToken();
+    await Promise.resolve();
 
-    // navigate with empty sessionId then punchout facade will take care of error handling
+    expect(punchoutfacade.logoutPunchoutUser).not.toHaveBeenCalledWith();
     expect(punchoutfacade.endPunchoutSession).toHaveBeenCalledWith();
+    expect(authService.coreLogout).not.toHaveBeenCalled();
   });
 });

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -4,20 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import {
   AuthHttpHeaderService,
   AuthRedirectService,
   AuthService,
   AuthStorageService,
-  AuthToken,
   GlobalMessageService,
   OAuthLibWrapperService,
   OccEndpointsService,
   RoutingService,
 } from '@spartacus/core';
-import { Observable } from 'rxjs';
 import { PunchoutFacade } from '../facade';
 import { PunchoutDetectionService } from './punchout-detection.service';
 
@@ -50,37 +47,21 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
   /**
    * @override
    *
-   * On backend errors indicating expired `refresh_token`, punchout session gets ended, user is redirected to login page
+   * On backend errors indicating expired `refresh_token`, 2 punchout use cases:
+   * - When initializing punchout session, previous user gets silently logout, punchoutfacade can then create punchout session.
+   * - When punchout session is already running, punchout session gets ended.
    * It is a workaround to address CXSPA-9608 - Public pages not displayed when token is invalid.
    * To be removed once CXSPA-9608 is closed.
    */
   public handleExpiredRefreshToken(): void {
-    if (
-      this.punchoutDetectionService.isPunchoutSession() ||
-      this.punchoutDetectionService.isPunchoutSessionPage()
-    ) {
-      this.punchoutFacade.endPunchoutSession().subscribe();
-    } else {
-      super.handleExpiredRefreshToken();
+    if (this.punchoutDetectionService.isPunchoutSessionPage()) {
+      this.punchoutFacade.logoutPunchoutUser().subscribe();
+      return;
     }
-  }
-
-  /**
-   * @override
-   * Refreshes access_token and then retries the call with the new token.
-   * When punchout session exists,  punchout session gets ended, user is redirected to login page
-   */
-  public handleExpiredAccessToken(
-    request: HttpRequest<any>,
-    next: HttpHandler,
-    initialToken: AuthToken | undefined
-  ): Observable<HttpEvent<AuthToken>> {
-    if (
-      this.punchoutDetectionService.isPunchoutSession() ||
-      this.punchoutDetectionService.isPunchoutSessionPage()
-    ) {
+    if (this.punchoutDetectionService.isPunchoutSession()) {
       this.punchoutFacade.endPunchoutSession().subscribe();
+      return;
     }
-    return super.handleExpiredAccessToken(request, next, initialToken);
+    super.handleExpiredRefreshToken();
   }
 }

--- a/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
+++ b/integration-libs/punchout/root/services/punchout-auth-http-header.service.ts
@@ -48,8 +48,8 @@ export class PunchoutAuthHttpHeaderService extends AuthHttpHeaderService {
    * @override
    *
    * On backend errors indicating expired `refresh_token`, 2 punchout use cases:
-   * - When initializing punchout session, previous user gets silently logout, punchoutfacade can then create punchout session.
-   * - When punchout session is already running, punchout session gets ended.
+   * - When initializing punchout session, previous token gets silently revoked, punchoutFacade can then create punchout session.
+   * - When punchout session already exists, punchout session gets ended.
    * It is a workaround to address CXSPA-9608 - Public pages not displayed when token is invalid.
    * To be removed once CXSPA-9608 is closed.
    */


### PR DESCRIPTION
steps to replicate:
- set invalid token on previous instance, eg: login with standard user, modify access token in storage, close browser
- start punchout session
---> inside Punchout Session page, user gets redirected to Login page before even fetch punchout occ api.
technically: when authorisation error occurs, we always end punchout session (logout, redirect to login page)

expected:
Punchout session to be initialized.
technically expected: silently logout user (no redirection) when authorization error occurs on punchout session page. PunchoutSessionComponent will take care of initializing punchout session.