### PR TITLE
fix: Skip page redirection when initial requisition is fetched

### DIFF
--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -190,7 +190,7 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSessionRequisition with empty param ends punchout session', (done) => {
+  it('should getPunchoutSession with empty param ends punchout session', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
     service.getPunchoutSession({ punchoutSessionId: '' }).subscribe({
       error: () => {
@@ -305,7 +305,7 @@ describe('Punchoutservice', () => {
     );
     spyOn(punchoutStoreService, 'updatePunchoutState').and.callThrough();
     service.getPunchoutSession(mockSessionInput).subscribe({
-      next: () => {
+      complete: () => {
         expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'cart' });
         expect(punchoutStoreService.updatePunchoutState).toHaveBeenCalledWith({
           punchoutInitialRequisition: { ...mockPunchoutInitialRequisition },
@@ -315,25 +315,55 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should redirect to home page if requisition page was open manually', (done) => {
+  it('should getPunchoutSessionRequisition not redirect user when isInitialRequisition is true', (done) => {
+    spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
+    spyOn(connector, 'getPunchoutSessionRequisition').and.returnValue(
+      of(mockPunchoutRequisitionResponse)
+    );
     spyOn(punchoutStoreService, 'getPunchoutState').and.returnValue(
       of({
+        ...mockPunchoutState,
         cancelRequisition: undefined,
         closePunchoutSession: undefined,
       })
     );
-    spyOn(routingService, 'go').and.stub();
-    service.getPunchoutSession(mockSessionInput).subscribe({
-      next: () => {
+
+    service.getPunchoutSessionRequisition(true).subscribe({
+      complete: () => {
+        expect(globalMessageService.add).not.toHaveBeenCalledWith(
+          {
+            key: 'organization.notification.noSufficientPermissions',
+          },
+          GlobalMessageType.MSG_TYPE_WARNING
+        );
+        expect(routingService.go).not.toHaveBeenCalledWith({ cxRoute: 'home' });
+        done();
+      },
+    });
+  });
+
+  it('should getPunchoutSessionRequisition redirects to home page when isInitialRequisition is false', (done) => {
+    spyOn(connector, 'getPunchoutSessionRequisition').and.returnValue(
+      of(mockPunchoutRequisitionResponse)
+    );
+    spyOn(punchoutStoreService, 'getPunchoutState').and.returnValue(
+      of({
+        ...mockPunchoutState,
+        cancelRequisition: undefined,
+        closePunchoutSession: undefined,
+      })
+    );
+
+    spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
+    service.getPunchoutSessionRequisition(false).subscribe({
+      complete: () => {
         expect(globalMessageService.add).toHaveBeenCalledWith(
           {
             key: 'organization.notification.noSufficientPermissions',
           },
           GlobalMessageType.MSG_TYPE_WARNING
         );
-        expect(routingService.go).toHaveBeenCalledWith({
-          cxRoute: 'home',
-        });
+        expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'home' });
         done();
       },
     });

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -305,7 +305,7 @@ describe('Punchoutservice', () => {
     );
     spyOn(punchoutStoreService, 'updatePunchoutState').and.callThrough();
     service.getPunchoutSession(mockSessionInput).subscribe({
-      complete: () => {
+      next: () => {
         expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'cart' });
         expect(punchoutStoreService.updatePunchoutState).toHaveBeenCalledWith({
           punchoutInitialRequisition: { ...mockPunchoutInitialRequisition },

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -114,6 +114,7 @@ export class PunchoutService implements PunchoutFacade {
    * getPunchoutRequisition workflow:
    * Ensure user is logged-in
    * get punchoutSessionId from PunchoutState
+   * Redirect user to homePage if method is called from Requisition page manual navigation
    * Get PunchoutSessionRequisition from  occ api OR from PunchoutState
    * Redirect to Punchout Error page if error occurs
    */
@@ -131,6 +132,8 @@ export class PunchoutService implements PunchoutFacade {
       take(1),
       switchMap((punchoutState: PunchoutState) => {
         // prevent manual navigation to requisition page
+        // isInitialRequisition handles use case where this method is called out of Requisition page,
+        // when fetching the initial requisition object from setPunchoutInitialRequisition().
         console.log(isInitialRequisition);
         if (
           !isInitialRequisition &&

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -336,7 +336,16 @@ export class PunchoutService implements PunchoutFacade {
     );
   }
 
+  /**
+   * Take a snapshot of initial requisition and store it in the state.
+   * This is used to send the initial cart snapshot in CXML when the user
+   * closes the punchout session via 'Close Session' button.
+   *
+   * This method is called only in EDIT mode.
+   * @returns
+   */
   protected setPunchoutInitialRequisition(): void {
+    // isInitialRequisition is set to true as hitting initial Requisition use case.
     this.getPunchoutSessionRequisition(true)
       .pipe(take(1))
       .subscribe({

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -119,9 +119,9 @@ export class PunchoutService implements PunchoutFacade {
    */
 
   protected getPunchoutRequisitionCommand: Command<
-    undefined,
+    boolean,
     PunchoutRequisition
-  > = this.commandService.create(() => {
+  > = this.commandService.create((isInitialRequisition: boolean) => {
     return this.punchoutAuthService.isUserLoggedIn().pipe(
       switchMap((isLoggedIn) => {
         return isLoggedIn
@@ -131,7 +131,9 @@ export class PunchoutService implements PunchoutFacade {
       take(1),
       switchMap((punchoutState: PunchoutState) => {
         // prevent manual navigation to requisition page
+        console.log(isInitialRequisition);
         if (
+          !isInitialRequisition &&
           punchoutState?.closePunchoutSession === undefined &&
           punchoutState?.cancelRequisition === undefined
         ) {
@@ -268,8 +270,10 @@ export class PunchoutService implements PunchoutFacade {
     return this.getPunchoutSessionCommand.execute(punchoutSessionInput);
   }
 
-  getPunchoutSessionRequisition(): Observable<PunchoutRequisition | undefined> {
-    return this.getPunchoutRequisitionCommand.execute(undefined);
+  getPunchoutSessionRequisition(
+    isInitialRequisition = false
+  ): Observable<PunchoutRequisition | undefined> {
+    return this.getPunchoutRequisitionCommand.execute(isInitialRequisition);
   }
 
   logoutPunchoutUser(): Observable<boolean> {
@@ -331,7 +335,7 @@ export class PunchoutService implements PunchoutFacade {
   }
 
   protected setPunchoutInitialRequisition(): void {
-    this.getPunchoutSessionRequisition()
+    this.getPunchoutSessionRequisition(true)
       .pipe(take(1))
       .subscribe({
         next: (punchoutRequisition) => {

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -134,7 +134,6 @@ export class PunchoutService implements PunchoutFacade {
         // prevent manual navigation to requisition page
         // isInitialRequisition handles use case where this method is called out of Requisition page,
         // when fetching the initial requisition object from setPunchoutInitialRequisition().
-        console.log(isInitialRequisition);
         if (
           !isInitialRequisition &&
           punchoutState?.closePunchoutSession === undefined &&


### PR DESCRIPTION
handle use case where Requsition is not called from Requisition component.
In this scenario, it is called when punchout session starts to keep initial requisition in memory. see setPunchoutInitialRequisition() method.
we don't want to redirect user when requisition is called via setPunchoutInitialRequisition().
new flag 'isInitialRequisition' gets introduced to handle this use case.