### PR TITLE
fix: rename facade method getPunchoutSession

### DIFF
--- a/integration-libs/punchout/components/punchout-session/punchout-session.component.spec.ts
+++ b/integration-libs/punchout/components/punchout-session/punchout-session.component.spec.ts
@@ -35,7 +35,7 @@ describe('PunchoutSessionComponent', () => {
 
   beforeEach(() => {
     punchoutFacadeMock = jasmine.createSpyObj('PunchoutFacade', [
-      'getPunchoutSession',
+      'initPunchoutSession',
     ]);
     globalMessageServiceMock = jasmine.createSpyObj('GlobalMessageService', [
       'add',
@@ -51,7 +51,7 @@ describe('PunchoutSessionComponent', () => {
     });
     fixture = TestBed.createComponent(PunchoutSessionComponent);
     component = fixture.componentInstance;
-    punchoutFacadeMock.getPunchoutSession.and.returnValue(
+    punchoutFacadeMock.initPunchoutSession.and.returnValue(
       of(mockPunchoutSession)
     );
   });
@@ -60,9 +60,9 @@ describe('PunchoutSessionComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call getPunchoutSession on ngOnInit', () => {
+  it('should call initPunchoutSession on ngOnInit', () => {
     component.ngOnInit();
-    expect(punchoutFacadeMock.getPunchoutSession).toHaveBeenCalledWith({
+    expect(punchoutFacadeMock.initPunchoutSession).toHaveBeenCalledWith({
       punchoutSessionId: '123abc',
     });
     expect(globalMessageServiceMock.add).toHaveBeenCalledWith(

--- a/integration-libs/punchout/components/punchout-session/punchout-session.component.ts
+++ b/integration-libs/punchout/components/punchout-session/punchout-session.component.ts
@@ -36,7 +36,7 @@ export class PunchoutSessionComponent implements OnInit {
             },
             GlobalMessageType.MSG_TYPE_INFO
           );
-          return this.punchoutFacade.getPunchoutSession({
+          return this.punchoutFacade.initPunchoutSession({
             punchoutSessionId: param?.[PUNCHOUT_SESSION_KEY],
           });
         }),

--- a/integration-libs/punchout/core/connectors/punchout.adapter.ts
+++ b/integration-libs/punchout/core/connectors/punchout.adapter.ts
@@ -12,7 +12,7 @@ export abstract class PunchoutAdapter {
    * Abstract method used to get Punchout Session
    * @param sessionId is the sesssion Id given by ARIBA via url
    */
-  abstract getPunchoutSession(sessionId: string): Observable<PunchoutSession>;
+  abstract initPunchoutSession(sessionId: string): Observable<PunchoutSession>;
 
   /**
    * Abstract method used to get Punchout Session Requisition data

--- a/integration-libs/punchout/core/connectors/punchout.connector.spec.ts
+++ b/integration-libs/punchout/core/connectors/punchout.connector.spec.ts
@@ -29,7 +29,7 @@ const mockPunchoutRequisitionResponse: PunchoutRequisition = {
 };
 
 class MockPunchoutAdapter implements PunchoutAdapter {
-  getPunchoutSession = createSpy('getPunchoutSession').and.callFake(() =>
+  initPunchoutSession = createSpy('initPunchoutSession').and.callFake(() =>
     of(mockPunchoutSessionResponse)
   );
   getPunchoutSessionRequisition = createSpy(
@@ -56,11 +56,11 @@ describe('PunchoutConnector', () => {
     expect(service).toBeTruthy();
   });
 
-  it('getPunchoutSession should call adapter', (done) => {
-    service.getPunchoutSession(mockSid).subscribe({
+  it('initPunchoutSession should call adapter', (done) => {
+    service.initPunchoutSession(mockSid).subscribe({
       next: (result) => {
         expect(result).toEqual(mockPunchoutSessionResponse);
-        expect(adapter.getPunchoutSession).toHaveBeenCalledWith(mockSid);
+        expect(adapter.initPunchoutSession).toHaveBeenCalledWith(mockSid);
         done();
       },
     });

--- a/integration-libs/punchout/core/connectors/punchout.connector.ts
+++ b/integration-libs/punchout/core/connectors/punchout.connector.ts
@@ -13,8 +13,8 @@ import { PunchoutAdapter } from './punchout.adapter';
 export class PunchoutConnector {
   protected adapter = inject(PunchoutAdapter);
 
-  public getPunchoutSession(sessionId: string): Observable<PunchoutSession> {
-    return this.adapter.getPunchoutSession(sessionId);
+  public initPunchoutSession(sessionId: string): Observable<PunchoutSession> {
+    return this.adapter.initPunchoutSession(sessionId);
   }
 
   public getPunchoutSessionRequisition(

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -78,7 +78,7 @@ class MockPunchoutStoreService implements Partial<PunchoutStoreService> {
 }
 
 class MockPunchoutConnector implements Partial<PunchoutConnector> {
-  getPunchoutSession = () => of(mockPunchoutSessionResponse);
+  initPunchoutSession = () => of(mockPunchoutSessionResponse);
   getPunchoutSessionRequisition = () => of(mockPunchoutRequisitionResponse);
 }
 
@@ -155,14 +155,14 @@ describe('Punchoutservice', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should getPunchoutSession calls connector', (done) => {
-    spyOn(connector, 'getPunchoutSession').and.returnValue(
+  it('should initPunchoutSession calls connector', (done) => {
+    spyOn(connector, 'initPunchoutSession').and.returnValue(
       of(mockPunchoutSessionResponse)
     );
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: (result) => {
         expect(result).toEqual(mockPunchoutSessionResponse);
-        expect(connector.getPunchoutSession).toHaveBeenCalledWith(
+        expect(connector.initPunchoutSession).toHaveBeenCalledWith(
           mockSessionInput.punchoutSessionId
         );
         done();
@@ -190,9 +190,9 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSession with empty param ends punchout session', (done) => {
+  it('should initPunchoutSession with empty param ends punchout session', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
-    service.getPunchoutSession({ punchoutSessionId: '' }).subscribe({
+    service.initPunchoutSession({ punchoutSessionId: '' }).subscribe({
       error: () => {
         expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
@@ -217,7 +217,7 @@ describe('Punchoutservice', () => {
       of(mockPunchoutRequisitionResponse)
     );
     service
-      .getPunchoutSession({ ...mockSessionInput, isPageRefresh: true })
+      .initPunchoutSession({ ...mockSessionInput, isPageRefresh: true })
       .subscribe({
         next: () => {
           expect(routingService.go).not.toHaveBeenCalled();
@@ -226,12 +226,12 @@ describe('Punchoutservice', () => {
       });
   });
 
-  it('should getPunchoutSession ends punchout session when request failed', (done) => {
+  it('should initPunchoutSession ends punchout session when request failed', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
-    spyOn(connector, 'getPunchoutSession').and.returnValue(
+    spyOn(connector, 'initPunchoutSession').and.returnValue(
       of({ ...mockPunchoutSessionResponse, token: undefined })
     );
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       error: () => {
         expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
@@ -239,13 +239,13 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSession ends punchout session when no auth token', (done) => {
+  it('should initPunchoutSession ends punchout session when no auth token', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
-    spyOn(connector, 'getPunchoutSession').and.returnValue(
+    spyOn(connector, 'initPunchoutSession').and.returnValue(
       of({ ...mockPunchoutSessionResponse, token: undefined })
     );
 
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       error: () => {
         expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
@@ -253,9 +253,9 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSession opens home page when no product item and CREATE Level ', (done) => {
+  it('should initPunchoutSession opens home page when no product item and CREATE Level ', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
-    spyOn(connector, 'getPunchoutSession').and.returnValue(
+    spyOn(connector, 'initPunchoutSession').and.returnValue(
       of({
         ...mockPunchoutSessionResponse,
         punchOutOperation: PunchOutOperation.CREATE,
@@ -263,7 +263,7 @@ describe('Punchoutservice', () => {
       })
     );
 
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: () => {
         expect(routingService.go).toHaveBeenCalledWith('/');
         done();
@@ -271,9 +271,9 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSession opens PUNCHOUT_INSPECT_PAGE_URL page when no product item and INSPECT Level ', (done) => {
+  it('should initPunchoutSession opens PUNCHOUT_INSPECT_PAGE_URL page when no product item and INSPECT Level ', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
-    spyOn(connector, 'getPunchoutSession').and.returnValue(
+    spyOn(connector, 'initPunchoutSession').and.returnValue(
       of({
         ...mockPunchoutSessionResponse,
         punchOutOperation: PunchOutOperation.INSPECT,
@@ -281,7 +281,7 @@ describe('Punchoutservice', () => {
       })
     );
 
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: () => {
         expect(routingService.go).toHaveBeenCalledWith(
           PUNCHOUT_INSPECT_PAGE_URL
@@ -292,9 +292,9 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSession opens cart page when no product item and EDIT Level ', (done) => {
+  it('should initPunchoutSession opens cart page when no product item and EDIT Level ', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
-    spyOn(connector, 'getPunchoutSession').and.returnValue(
+    spyOn(connector, 'initPunchoutSession').and.returnValue(
       of({
         ...mockPunchoutSessionResponse,
         selectedItem: '',
@@ -304,7 +304,7 @@ describe('Punchoutservice', () => {
       of(mockPunchoutInitialRequisition)
     );
     spyOn(punchoutStoreService, 'updatePunchoutState').and.callThrough();
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: () => {
         expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'cart' });
         expect(punchoutStoreService.updatePunchoutState).toHaveBeenCalledWith({
@@ -369,13 +369,13 @@ describe('Punchoutservice', () => {
     });
   });
 
-  it('should getPunchoutSession opens pdp when selectedItem is present ', (done) => {
+  it('should initPunchoutSession opens pdp when selectedItem is present ', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
-    spyOn(connector, 'getPunchoutSession').and.returnValue(
+    spyOn(connector, 'initPunchoutSession').and.returnValue(
       of(mockPunchoutSessionResponse)
     );
 
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: () => {
         expect(routingService.go).toHaveBeenCalledWith({
           cxRoute: 'product',

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -244,7 +244,7 @@ export class PunchoutService implements PunchoutFacade {
     this.commandService.create((punchoutSessionId: string) => {
       return this.cachedPunchoutSessionResponse
         ? of(this.cachedPunchoutSessionResponse)
-        : this.punchoutConnector.getPunchoutSession(punchoutSessionId).pipe(
+        : this.punchoutConnector.initPunchoutSession(punchoutSessionId).pipe(
             map((punchoutSession) => {
               if (
                 !punchoutSession?.token?.accessToken ||
@@ -266,7 +266,7 @@ export class PunchoutService implements PunchoutFacade {
     return this.closePunchoutSessionCommand.execute(undefined);
   }
 
-  getPunchoutSession(
+  initPunchoutSession(
     punchoutSessionInput: PunchoutSessionInput
   ): Observable<PunchoutSession> {
     return this.getPunchoutSessionCommand.execute(punchoutSessionInput);

--- a/integration-libs/punchout/occ/adapters/occ-punchout.adapter.spec.ts
+++ b/integration-libs/punchout/occ/adapters/occ-punchout.adapter.spec.ts
@@ -88,12 +88,12 @@ describe('OccPunchoutAdapter', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should getPunchoutSession successfully', (done) => {
+  it('should initPunchoutSession successfully', (done) => {
     mockOccEndpointsService.buildUrl.and.returnValue(
       `/punchout/sessions/${mockSid}`
     );
 
-    service.getPunchoutSession(mockSid).subscribe({
+    service.initPunchoutSession(mockSid).subscribe({
       next: (result) => {
         expect(result).toEqual(mockPunchoutSessionResponse);
         done();
@@ -166,7 +166,7 @@ describe('OccPunchoutAdapter', () => {
       });
   });
 
-  it('should getPunchoutSession logs error when failing', (done) => {
+  it('should initPunchoutSession logs error when failing', (done) => {
     mockOccEndpointsService.buildUrl.and.returnValue(
       `/punchout/sessions/${mockSid}`
     );
@@ -174,7 +174,7 @@ describe('OccPunchoutAdapter', () => {
 
     const result = tryNormalizeHttpError(mockError, mockLogger);
     spyOn(httpClient, 'get').and.returnValue(throwError(() => mockError));
-    service.getPunchoutSession(mockSid).subscribe({
+    service.initPunchoutSession(mockSid).subscribe({
       error: (error) => {
         expect(error).toBe(result);
         done();

--- a/integration-libs/punchout/occ/adapters/occ-punchout.adapter.ts
+++ b/integration-libs/punchout/occ/adapters/occ-punchout.adapter.ts
@@ -31,7 +31,7 @@ export class OccPunchoutAdapter implements PunchoutAdapter {
   protected logger = inject(LoggerService);
   protected converter = inject(ConverterService);
 
-  getPunchoutSession(sessionId: string): Observable<PunchoutSession> {
+  initPunchoutSession(sessionId: string): Observable<PunchoutSession> {
     return this.http
       .get<PunchoutSession>(
         this.occEndpoints.buildUrl('punchoutSession', {

--- a/integration-libs/punchout/root/facade/punchout.facade.ts
+++ b/integration-libs/punchout/root/facade/punchout.facade.ts
@@ -19,7 +19,7 @@ export function punchoutFacadeFactory() {
     facade: PunchoutFacade,
     feature: PUNCHOUT_FEATURE,
     methods: [
-      'getPunchoutSession',
+      'initPunchoutSession',
       'getPunchoutSessionRequisition',
       'logoutPunchoutUser',
       'closePunchoutSession',
@@ -40,7 +40,7 @@ export abstract class PunchoutFacade {
    * occ api request, logout previous user, login punchout user, load cart
    * @param sessionId is the sesssion Id given by ARIBA via url param
    */
-  abstract getPunchoutSession(
+  abstract initPunchoutSession(
     punchoutSessionInput: PunchoutSessionInput
   ): Observable<PunchoutSession>;
 

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.spec.ts
@@ -44,7 +44,7 @@ class MockPunchoutDetectionService
 }
 
 class MockPunchoutFacade implements Partial<PunchoutFacade> {
-  getPunchoutSession = () => of(mockPunchoutSession);
+  initPunchoutSession = () => of(mockPunchoutSession);
 }
 
 describe('PunchoutStatePersistenceService', () => {
@@ -106,34 +106,34 @@ describe('PunchoutStatePersistenceService', () => {
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
       false
     );
-    spyOn(punchoutFacade, 'getPunchoutSession').and.returnValue(
+    spyOn(punchoutFacade, 'initPunchoutSession').and.returnValue(
       of(mockPunchoutSession)
     );
     service['onRead'](mockPunchoutState.punchoutSessionId);
 
-    expect(punchoutFacade.getPunchoutSession).toHaveBeenCalled();
+    expect(punchoutFacade.initPunchoutSession).toHaveBeenCalled();
   });
 
   it('should onRead do nothing when user on punchout session page', () => {
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
       true
     );
-    spyOn(punchoutFacade, 'getPunchoutSession').and.returnValue(
+    spyOn(punchoutFacade, 'initPunchoutSession').and.returnValue(
       of(mockPunchoutSession)
     );
     service['onRead'](mockPunchoutState.punchoutSessionId);
-    expect(punchoutFacade.getPunchoutSession).not.toHaveBeenCalled();
+    expect(punchoutFacade.initPunchoutSession).not.toHaveBeenCalled();
   });
 
   it('should onRead do nothing when no sessionId stored', () => {
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
       true
     );
-    spyOn(punchoutFacade, 'getPunchoutSession').and.returnValue(
+    spyOn(punchoutFacade, 'initPunchoutSession').and.returnValue(
       of(mockPunchoutSession)
     );
     service['onRead'](undefined);
-    expect(punchoutFacade.getPunchoutSession).not.toHaveBeenCalled();
+    expect(punchoutFacade.initPunchoutSession).not.toHaveBeenCalled();
   });
 
   it('should ngOnDestroy removes subscription', () => {

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
@@ -57,7 +57,7 @@ export class PunchoutStatePersistanceService implements OnDestroy {
    * Function called on each browser storage read.
    * Used to update state from browser -> state.
    * storage stores minimum data: only punchoutSessionId.
-   * Full PunchoutSession object is retrieved by calling punchoutFacade.getPunchoutSession
+   * Full PunchoutSession object is retrieved by calling punchoutFacade.initPunchoutSession
    */
   protected onRead(punchoutSessionId: string | undefined) {
     if (
@@ -66,7 +66,7 @@ export class PunchoutStatePersistanceService implements OnDestroy {
     ) {
       this.punchoutStoreService.setPunchoutState({ punchoutSessionId });
       this.punchoutFacade
-        .getPunchoutSession({
+        .initPunchoutSession({
           punchoutSessionId,
           isPageRefresh: true,
         })


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-9873

we decided to rename only the facade method `getPunchoutSession` to `initPunchoutSession`