### PR TITLE
fix: rename getPunchoutSession to initPunchoutSession

### DIFF
--- a/integration-libs/punchout/components/punchout-session/punchout-session.component.spec.ts
+++ b/integration-libs/punchout/components/punchout-session/punchout-session.component.spec.ts
@@ -35,7 +35,7 @@ describe('PunchoutSessionComponent', () => {
 
   beforeEach(() => {
     punchoutFacadeMock = jasmine.createSpyObj('PunchoutFacade', [
-      'getPunchoutSession',
+      'initPunchoutSession',
     ]);
     globalMessageServiceMock = jasmine.createSpyObj('GlobalMessageService', [
       'add',
@@ -51,7 +51,7 @@ describe('PunchoutSessionComponent', () => {
     });
     fixture = TestBed.createComponent(PunchoutSessionComponent);
     component = fixture.componentInstance;
-    punchoutFacadeMock.getPunchoutSession.and.returnValue(
+    punchoutFacadeMock.initPunchoutSession.and.returnValue(
       of(mockPunchoutSession)
     );
   });
@@ -60,9 +60,9 @@ describe('PunchoutSessionComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call getPunchoutSession on ngOnInit', () => {
+  it('should call initPunchoutSession on ngOnInit', () => {
     component.ngOnInit();
-    expect(punchoutFacadeMock.getPunchoutSession).toHaveBeenCalledWith({
+    expect(punchoutFacadeMock.initPunchoutSession).toHaveBeenCalledWith({
       punchoutSessionId: '123abc',
     });
     expect(globalMessageServiceMock.add).toHaveBeenCalledWith(

--- a/integration-libs/punchout/components/punchout-session/punchout-session.component.ts
+++ b/integration-libs/punchout/components/punchout-session/punchout-session.component.ts
@@ -36,7 +36,7 @@ export class PunchoutSessionComponent implements OnInit {
             },
             GlobalMessageType.MSG_TYPE_INFO
           );
-          return this.punchoutFacade.getPunchoutSession({
+          return this.punchoutFacade.initPunchoutSession({
             punchoutSessionId: param?.[PUNCHOUT_SESSION_KEY],
           });
         }),

--- a/integration-libs/punchout/core/facade/punchout.service.spec.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.spec.ts
@@ -159,7 +159,7 @@ describe('Punchoutservice', () => {
     spyOn(connector, 'getPunchoutSession').and.returnValue(
       of(mockPunchoutSessionResponse)
     );
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: (result) => {
         expect(result).toEqual(mockPunchoutSessionResponse);
         expect(connector.getPunchoutSession).toHaveBeenCalledWith(
@@ -192,7 +192,7 @@ describe('Punchoutservice', () => {
 
   it('should getPunchoutSession with empty param ends punchout session', (done) => {
     spyOn(routingService, 'go').and.returnValue(Promise.resolve(true));
-    service.getPunchoutSession({ punchoutSessionId: '' }).subscribe({
+    service.initPunchoutSession({ punchoutSessionId: '' }).subscribe({
       error: () => {
         expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
@@ -217,7 +217,7 @@ describe('Punchoutservice', () => {
       of(mockPunchoutRequisitionResponse)
     );
     service
-      .getPunchoutSession({ ...mockSessionInput, isPageRefresh: true })
+      .initPunchoutSession({ ...mockSessionInput, isPageRefresh: true })
       .subscribe({
         next: () => {
           expect(routingService.go).not.toHaveBeenCalled();
@@ -231,7 +231,7 @@ describe('Punchoutservice', () => {
     spyOn(connector, 'getPunchoutSession').and.returnValue(
       of({ ...mockPunchoutSessionResponse, token: undefined })
     );
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       error: () => {
         expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
@@ -245,7 +245,7 @@ describe('Punchoutservice', () => {
       of({ ...mockPunchoutSessionResponse, token: undefined })
     );
 
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       error: () => {
         expect(punchoutAuthService.endPunchoutSession).toHaveBeenCalledWith();
         done();
@@ -263,7 +263,7 @@ describe('Punchoutservice', () => {
       })
     );
 
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: () => {
         expect(routingService.go).toHaveBeenCalledWith('/');
         done();
@@ -281,7 +281,7 @@ describe('Punchoutservice', () => {
       })
     );
 
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: () => {
         expect(routingService.go).toHaveBeenCalledWith(
           PUNCHOUT_INSPECT_PAGE_URL
@@ -304,7 +304,7 @@ describe('Punchoutservice', () => {
       of(mockPunchoutInitialRequisition)
     );
     spyOn(punchoutStoreService, 'updatePunchoutState').and.callThrough();
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: () => {
         expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'cart' });
         expect(punchoutStoreService.updatePunchoutState).toHaveBeenCalledWith({
@@ -375,7 +375,7 @@ describe('Punchoutservice', () => {
       of(mockPunchoutSessionResponse)
     );
 
-    service.getPunchoutSession(mockSessionInput).subscribe({
+    service.initPunchoutSession(mockSessionInput).subscribe({
       next: () => {
         expect(routingService.go).toHaveBeenCalledWith({
           cxRoute: 'product',

--- a/integration-libs/punchout/core/facade/punchout.service.ts
+++ b/integration-libs/punchout/core/facade/punchout.service.ts
@@ -266,7 +266,7 @@ export class PunchoutService implements PunchoutFacade {
     return this.closePunchoutSessionCommand.execute(undefined);
   }
 
-  getPunchoutSession(
+  initPunchoutSession(
     punchoutSessionInput: PunchoutSessionInput
   ): Observable<PunchoutSession> {
     return this.getPunchoutSessionCommand.execute(punchoutSessionInput);

--- a/integration-libs/punchout/root/facade/punchout.facade.ts
+++ b/integration-libs/punchout/root/facade/punchout.facade.ts
@@ -19,7 +19,7 @@ export function punchoutFacadeFactory() {
     facade: PunchoutFacade,
     feature: PUNCHOUT_FEATURE,
     methods: [
-      'getPunchoutSession',
+      'initPunchoutSession',
       'getPunchoutSessionRequisition',
       'logoutPunchoutUser',
       'closePunchoutSession',
@@ -40,7 +40,7 @@ export abstract class PunchoutFacade {
    * occ api request, logout previous user, login punchout user, load cart
    * @param sessionId is the sesssion Id given by ARIBA via url param
    */
-  abstract getPunchoutSession(
+  abstract initPunchoutSession(
     punchoutSessionInput: PunchoutSessionInput
   ): Observable<PunchoutSession>;
 

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.spec.ts
@@ -44,7 +44,7 @@ class MockPunchoutDetectionService
 }
 
 class MockPunchoutFacade implements Partial<PunchoutFacade> {
-  getPunchoutSession = () => of(mockPunchoutSession);
+  initPunchoutSession = () => of(mockPunchoutSession);
 }
 
 describe('PunchoutStatePersistenceService', () => {
@@ -106,34 +106,34 @@ describe('PunchoutStatePersistenceService', () => {
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
       false
     );
-    spyOn(punchoutFacade, 'getPunchoutSession').and.returnValue(
+    spyOn(punchoutFacade, 'initPunchoutSession').and.returnValue(
       of(mockPunchoutSession)
     );
     service['onRead'](mockPunchoutState.punchoutSessionId);
 
-    expect(punchoutFacade.getPunchoutSession).toHaveBeenCalled();
+    expect(punchoutFacade.initPunchoutSession).toHaveBeenCalled();
   });
 
   it('should onRead do nothing when user on punchout session page', () => {
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
       true
     );
-    spyOn(punchoutFacade, 'getPunchoutSession').and.returnValue(
+    spyOn(punchoutFacade, 'initPunchoutSession').and.returnValue(
       of(mockPunchoutSession)
     );
     service['onRead'](mockPunchoutState.punchoutSessionId);
-    expect(punchoutFacade.getPunchoutSession).not.toHaveBeenCalled();
+    expect(punchoutFacade.initPunchoutSession).not.toHaveBeenCalled();
   });
 
   it('should onRead do nothing when no sessionId stored', () => {
     spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
       true
     );
-    spyOn(punchoutFacade, 'getPunchoutSession').and.returnValue(
+    spyOn(punchoutFacade, 'initPunchoutSession').and.returnValue(
       of(mockPunchoutSession)
     );
     service['onRead'](undefined);
-    expect(punchoutFacade.getPunchoutSession).not.toHaveBeenCalled();
+    expect(punchoutFacade.initPunchoutSession).not.toHaveBeenCalled();
   });
 
   it('should ngOnDestroy removes subscription', () => {

--- a/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
+++ b/integration-libs/punchout/root/services/punchout-state-persistence.service.ts
@@ -57,7 +57,7 @@ export class PunchoutStatePersistanceService implements OnDestroy {
    * Function called on each browser storage read.
    * Used to update state from browser -> state.
    * storage stores minimum data: only punchoutSessionId.
-   * Full PunchoutSession object is retrieved by calling punchoutFacade.getPunchoutSession
+   * Full PunchoutSession object is retrieved by calling punchoutFacade.initPunchoutSession
    */
   protected onRead(punchoutSessionId: string | undefined) {
     if (
@@ -66,7 +66,7 @@ export class PunchoutStatePersistanceService implements OnDestroy {
     ) {
       this.punchoutStoreService.setPunchoutState({ punchoutSessionId });
       this.punchoutFacade
-        .getPunchoutSession({
+        .initPunchoutSession({
           punchoutSessionId,
           isPageRefresh: true,
         })


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-9873

we decided to rename only the facade method getPunchoutSession to initPunchoutSession