### PR TITLE
chore: fix SSR tests in CI, after introducing new Angular application builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
       - name: Package installation
         run: npm ci
       - name: Build SSR Server
-        run: npm run build:libs && npm run build && npm run build:ssr:local-http-backend
+        run: npm run build:libs && npm run build:ssr:local-http-backend
       - name: Run SSR tests
         run: npm run test:ssr:ci --verbose
   build_conclusion:


### PR DESCRIPTION
followup of https://github.com/SAP/spartacus/pull/20242 
related to https://jira.tools.sap/browse/CXSPA-9318

Remove unnecessary build step from CI workflow. That build step was using wrong OCC base url. And the next build step (with correct OCC base url) was skipped then because of Nx cache kicking in.
And then SSR tests failed due to wrong OCC base url being used during the prior compilation.

btw. The double-build of the app is not necessary anymore!
In the past there were 2 different commands: `build` for building csr, and `build:ssr:...` for building ssr. Since merging the PR https://github.com/SAP/spartacus/pull/20242, the `build` and `build:ssr:...` builds both csr and ssr. So there is no need to run a build command twice.

Note: SSR tests are not running automatically on every PR pipeline, but only after merging to develop. So for this PR's branch, I've just run manually the SSR tests pipeline to confirm the problem is solved:
https://github.com/SAP/spartacus/actions/runs/15298611954
