### PR TITLE
fix: simplify punchout page paths

### DIFF
--- a/integration-libs/punchout/root/config/default-punchout-routing-config.ts
+++ b/integration-libs/punchout/root/config/default-punchout-routing-config.ts
@@ -10,18 +10,18 @@ export const defaultPunchoutRoutingConfig: RoutingConfig = {
   routing: {
     routes: {
       punchoutSession: {
-        paths: ['punchout/cxml/session'],
+        paths: ['punchout/session'],
         protected: false,
         authFlow: true,
       },
       punchoutRequisition: {
-        paths: ['punchout/cxml/requisition'],
+        paths: ['punchout/requisition'],
       },
       punchoutInspect: {
-        paths: ['punchout/cxml/inspect'],
+        paths: ['punchout/inspect'],
       },
       punchoutError: {
-        paths: ['punchout/cxml/error'],
+        paths: ['punchout/error'],
         protected: false,
         authFlow: true,
       },

--- a/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-detection.service.spec.ts
@@ -1,11 +1,11 @@
 import { Location } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
+import { SemanticPathService } from '@spartacus/core';
 import { PunchoutDetectionService } from './punchout-detection.service';
 import { PunchoutStoreService } from './punchout-store.service';
-import { SemanticPathService } from '@spartacus/core';
 
 const MOCK_URL = 'https://test';
-const MOCK_URL_WITH_PUNCHOUT = `https://spartacus/'punchout/cxml/session'?sid=abc123`;
+const MOCK_URL_WITH_PUNCHOUT = `https://spartacus/'punchout/session'?sid=abc123`;
 
 class MockLocation implements Partial<Location> {
   path() {
@@ -18,7 +18,7 @@ class MockPunchoutStoreService implements Partial<PunchoutStoreService> {
 }
 
 class MockSemanticPathService implements Partial<SemanticPathService> {
-  get = () => 'punchout/cxml/session';
+  get = () => 'punchout/session';
 }
 
 describe('PunchoutDetectionService', () => {

--- a/integration-libs/punchout/root/services/punchout-detection.service.ts
+++ b/integration-libs/punchout/root/services/punchout-detection.service.ts
@@ -6,8 +6,8 @@
 
 import { Location } from '@angular/common';
 import { inject, Injectable } from '@angular/core';
-import { PunchoutStoreService } from './punchout-store.service';
 import { SemanticPathService } from '@spartacus/core';
+import { PunchoutStoreService } from './punchout-store.service';
 
 @Injectable({ providedIn: 'root' })
 export class PunchoutDetectionService {
@@ -17,7 +17,7 @@ export class PunchoutDetectionService {
 
   /**
    * Check if browser url is the punchout initial session page.
-   * With default config, the expected url shape is '/punchout/cxml/session?abcd'.
+   * With default config, the expected url shape is '/punchout/session?abcd'.
    * @returns boolean
    */
   isPunchoutSessionPage(): boolean {


### PR DESCRIPTION
remove cxml segment that is useless and misleading, no cxml gets handle with those calls.