### PR TITLE
chore: remove ngZoneEventCoalescing option from bootstrapModule

### DIFF
--- a/projects/storefrontapp/src/main.ts
+++ b/projects/storefrontapp/src/main.ts
@@ -15,9 +15,7 @@ if (environment.production) {
 
 function bootstrap() {
   platformBrowserDynamic()
-    .bootstrapModule(AppModule, {
-      ngZoneEventCoalescing: true,
-    })
+    .bootstrapModule(AppModule)
     /* eslint-disable-next-line no-console
     --
     It's just an example application file. This message is not crucial


### PR DESCRIPTION
ngZoneEventCoalescing caused issues when certain events were not properly triggered, and that lead to failures in the following tests: 
- `replenishment/b2b-weekly-replenishment-checkout-flow.e2e.cy.ts`
- `regression/my-account/update-password.e2e.cy.ts`
The flag was temporarily removed to solve the situation.