### PR TITLE
fix: Dark theme not applied to the Punchout InspectCart page (CXSPA-10190)

### DIFF
--- a/integration-libs/punchout/_index.scss
+++ b/integration-libs/punchout/_index.scss
@@ -10,8 +10,8 @@ $punchout-components-allowlist:
 
 $skipComponentStyles: () !default;
 
-$page-template-allowlist: PunchoutTemplate;
-$page-template-blocklist: () !default;
+$page-template-allowlist-punchout: PunchoutTemplate !default;
+$page-template-blocklist-punchout: () !default;
 
 @each $selector in $punchout-components-allowlist {
   #{$selector} {
@@ -31,9 +31,9 @@ body {
   }
 }
 
-@each $selector in $page-template-allowlist {
+@each $selector in $page-template-allowlist-punchout {
   cx-page-layout.#{$selector} {
-    @if (index($page-template-blocklist, $selector) == null) {
+    @if (index($page-template-blocklist-punchout, $selector) == null) {
       @extend %#{$selector} !optional;
     }
   }

--- a/integration-libs/punchout/styles/_punchout-template.scss
+++ b/integration-libs/punchout/styles/_punchout-template.scss
@@ -41,6 +41,7 @@
       min-width: 0;
     }
   }
+  min-height: calc(100vh - 1px);
 }
 
 .cxPunchoutSessionActive {


### PR DESCRIPTION
Technically it is, but the page was not stretched
Closes [CXSPA-10190](https://jira.tools.sap/browse/CXSPA-10190)