### PR TITLE
feat: add media preconnect feature with toggle

### DIFF
--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -736,7 +736,7 @@ export interface FeatureTogglesInterface {
    * and that you'd like the process to start as soon as possible. Resources will load more quickly because the setup process
    * has already been completed by the time the browser requests them.
    */
-  createMediaPreconnectLinkInSsr?: boolean;
+  createMediaPreconnectLink?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -843,5 +843,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   reserveHorizontalSpaceStarRating: false,
   topProgressBarUseTransformAnimation: false,
   disableCxPageSlotMarginAnimation: false,
-  createMediaPreconnectLinkInSsr: false,
+  createMediaPreconnectLink: false,
 };

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -713,6 +713,19 @@ export interface FeatureTogglesInterface {
    * layout-independent operation that improves visual performance and avoids layout shifts.
    */
   topProgressBarUseTransformAnimation?: boolean;
+
+  /**
+   * Feature flag to enable using <link rel=preconnect> in the index.html.
+   *
+   * ## Why this flag exists
+   * 1. **Preconnecting is only effective for domains other than the origin domain, so you shouldn't use it for your site.
+   *
+   * ## When enabled:
+   * Adding rel=preconnect to a <link> informs the browser that your page intends to establish a connection to another domain,
+   * and that you'd like the process to start as soon as possible. Resources will load more quickly because the setup process
+   * has already been completed by the time the browser requests them.
+   */
+  createMediaPreconnectLinkInSsr?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -818,4 +831,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   defaultProductPageRouteAllowsNoProductName: false,
   reserveHorizontalSpaceStarRating: false,
   topProgressBarUseTransformAnimation: false,
+  createMediaPreconnectLinkInSsr: false,
 };

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -843,5 +843,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   reserveHorizontalSpaceStarRating: false,
   topProgressBarUseTransformAnimation: false,
   disableCxPageSlotMarginAnimation: false,
-  createMediaPreconnectLinkInSsr: false,
+  createMediaPreconnectLinkInSsr: false
 };

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -729,7 +729,7 @@ export interface FeatureTogglesInterface {
    * Feature flag to enable using <link rel=preconnect> in the index.html.
    *
    * ## Why this flag exists
-   * 1. **Preconnecting is only effective for domains other than the origin domain, so you shouldn't use it for your site.
+* 1. **Preconnecting is not needed (and won't be performed) if the domain of the media base url is the same as the storefront's domain.
    *
    * ## When enabled:
    * Adding rel=preconnect to a <link> informs the browser that your page intends to establish a connection to another domain,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -728,13 +728,12 @@ export interface FeatureTogglesInterface {
   /**
    * Feature flag to enable using <link rel=preconnect> in the index.html.
    *
-   * ## Why this flag exists
-   * 1. **Preconnecting is not needed (and won't be performed) if the domain of the media base url is the same as the storefront's domain.
-   *
    * ## When enabled:
    * Adding rel=preconnect to a <link> informs the browser that your page intends to establish a connection to another domain,
    * and that you'd like the process to start as soon as possible. Resources will load more quickly because the setup process
    * has already been completed by the time the browser requests them.
+   *
+   * Note: Preconnecting is not needed (and won't be performed) if the domain of the media base url is the same as the storefront's domain.
    */
   createMediaPreconnectLink?: boolean;
 }

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -843,5 +843,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   reserveHorizontalSpaceStarRating: false,
   topProgressBarUseTransformAnimation: false,
   disableCxPageSlotMarginAnimation: false,
-  createMediaPreconnectLinkInSsr: false
+  createMediaPreconnectLinkInSsr: false,
 };

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -729,7 +729,7 @@ export interface FeatureTogglesInterface {
    * Feature flag to enable using <link rel=preconnect> in the index.html.
    *
    * ## Why this flag exists
-* 1. **Preconnecting is not needed (and won't be performed) if the domain of the media base url is the same as the storefront's domain.
+   * 1. **Preconnecting is not needed (and won't be performed) if the domain of the media base url is the same as the storefront's domain.
    *
    * ## When enabled:
    * Adding rel=preconnect to a <link> informs the browser that your page intends to establish a connection to another domain,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -713,7 +713,7 @@ export interface FeatureTogglesInterface {
    * layout-independent operation that improves visual performance and avoids layout shifts.
    */
   topProgressBarUseTransformAnimation?: boolean;
-  
+
   /**
    * Feature flag to disable the margin animation for the cx-page-slot component.
    * Disables the CSS animation on the `margin` property in the `cx-page-slot` component.

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -400,7 +400,7 @@ if (environment.cpq) {
         reserveHorizontalSpaceStarRating: true,
         topProgressBarUseTransformAnimation: true,
         disableCxPageSlotMarginAnimation: true,
-        createMediaPreconnectLinkInSsr: true,
+        createMediaPreconnectLink: true,
       };
       return appFeatureToggles;
     }),

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -399,6 +399,7 @@ if (environment.cpq) {
         defaultProductPageRouteAllowsNoProductName: true,
         reserveHorizontalSpaceStarRating: true,
         topProgressBarUseTransformAnimation: true,
+        createMediaPreconnectLinkInSsr: true,
       };
       return appFeatureToggles;
     }),

--- a/projects/storefrontlib/cms-structure/seo/index.ts
+++ b/projects/storefrontlib/cms-structure/seo/index.ts
@@ -6,6 +6,7 @@
 
 export * from './page-meta-link.service';
 export * from './seo-meta.service';
+export * from './media-preconnect.service';
 export * from './seo.module';
 export * from './structured-data/index';
 export * from './config/index';

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
@@ -100,7 +100,9 @@ describe('MediaPreconnectService', () => {
   it('should handle invalid URL gracefully', () => {
     windowRef.location.origin = 'https://storefront.example.com';
     (globalThis as any)._originalURL = globalThis.URL;
-    globalThis.URL = function () { throw new Error('Invalid URL'); } as any;
+    globalThis.URL = function () {
+      throw new Error('Invalid URL');
+    } as any;
     expect(() => service.addPreconnectLink()).not.toThrow();
     expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
   });

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { MediaPreconnectService } from './media-preconnect.service';
 import { PageMetaLinkService } from './page-meta-link.service';
-import { MediaService } from '@spartacus/core';
+import { MediaService } from '../../shared/components/media/media.service';
 import { FeatureToggles } from '@spartacus/core';
 import { WindowRef } from '@spartacus/core';
 

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
@@ -45,28 +45,13 @@ describe('MediaPreconnectService', () => {
     windowRef = TestBed.inject(WindowRef) as any;
   });
 
-  afterEach(() => {
-    // Restore global URL if it was mocked
-    if ((globalThis as any)._originalURL) {
-      (globalThis as any).URL = (globalThis as any)._originalURL;
-      delete (globalThis as any)._originalURL;
-    }
-  });
-
-  function mockURLConstructor(origin: string) {
-    (globalThis as any)._originalURL = globalThis.URL;
-    globalThis.URL = function (_url: string) {
-      return { origin };
-    } as any;
-  }
-
   it('should inject service', () => {
     expect(service).toBeTruthy();
   });
 
   it('should add preconnect link if feature toggle is enabled and media domain is different', () => {
     windowRef.location.origin = 'https://storefront.example.com';
-    mockURLConstructor('https://media.example.com');
+    mediaService.getBaseUrl.and.returnValue('https://media.example.com');
     service.addPreconnectLink();
     expect(mediaService.getBaseUrl).toHaveBeenCalled();
     expect(pageMetaLinkService.addPreconnectLink).toHaveBeenCalledWith(
@@ -77,20 +62,21 @@ describe('MediaPreconnectService', () => {
   it('should not add preconnect link if feature toggle is disabled', () => {
     featureToggles.createMediaPreconnectLink = false;
     windowRef.location.origin = 'https://storefront.example.com';
+    mediaService.getBaseUrl.and.returnValue('https://media.example.com');
     service.addPreconnectLink();
     expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
   });
 
   it('should not add preconnect link if media domain is same as window origin', () => {
     windowRef.location.origin = 'https://storefront.example.com';
-    mockURLConstructor('https://storefront.example.com');
+    mediaService.getBaseUrl.and.returnValue('https://storefront.example.com');
     service.addPreconnectLink();
     expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
   });
 
   it('should add preconnect link if media domain is different from window origin', () => {
     windowRef.location.origin = 'https://another.example.com';
-    mockURLConstructor('https://media.example.com');
+    mediaService.getBaseUrl.and.returnValue('https://media.example.com');
     service.addPreconnectLink();
     expect(pageMetaLinkService.addPreconnectLink).toHaveBeenCalledWith(
       'https://media.example.com'
@@ -99,10 +85,7 @@ describe('MediaPreconnectService', () => {
 
   it('should handle invalid URL gracefully', () => {
     windowRef.location.origin = 'https://storefront.example.com';
-    (globalThis as any)._originalURL = globalThis.URL;
-    globalThis.URL = function () {
-      throw new Error('Invalid URL');
-    } as any;
+    mediaService.getBaseUrl.and.returnValue('not-a-valid-url');
     expect(() => service.addPreconnectLink()).not.toThrow();
     expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
   });

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
@@ -14,13 +14,10 @@ class MockMediaService {
     .and.returnValue('https://media.example.com');
 }
 class MockFeatureToggles {
-  createMediaPreconnectLinkInSsr = true;
+  createMediaPreconnectLink = true;
 }
 class MockWindowRef {
-  isBrowser() {
-    return true;
-  }
-  document = window.document;
+  location = { origin: 'https://storefront.example.com' };
 }
 
 describe('MediaPreconnectService', () => {
@@ -48,11 +45,28 @@ describe('MediaPreconnectService', () => {
     windowRef = TestBed.inject(WindowRef) as any;
   });
 
+  afterEach(() => {
+    // Restore global URL if it was mocked
+    if ((globalThis as any)._originalURL) {
+      (globalThis as any).URL = (globalThis as any)._originalURL;
+      delete (globalThis as any)._originalURL;
+    }
+  });
+
+  function mockURLConstructor(origin: string) {
+    (globalThis as any)._originalURL = globalThis.URL;
+    globalThis.URL = function (_url: string) {
+      return { origin };
+    } as any;
+  }
+
   it('should inject service', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should add preconnect link if feature toggle is enabled and in browser', () => {
+  it('should add preconnect link if feature toggle is enabled and media domain is different', () => {
+    windowRef.location.origin = 'https://storefront.example.com';
+    mockURLConstructor('https://media.example.com');
     service.addPreconnectLink();
     expect(mediaService.getBaseUrl).toHaveBeenCalled();
     expect(pageMetaLinkService.addPreconnectLink).toHaveBeenCalledWith(
@@ -61,14 +75,33 @@ describe('MediaPreconnectService', () => {
   });
 
   it('should not add preconnect link if feature toggle is disabled', () => {
-    featureToggles.createMediaPreconnectLinkInSsr = false;
+    featureToggles.createMediaPreconnectLink = false;
+    windowRef.location.origin = 'https://storefront.example.com';
     service.addPreconnectLink();
     expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
   });
 
-  it('should not add preconnect link if not in browser', () => {
-    spyOn(windowRef, 'isBrowser').and.returnValue(false);
+  it('should not add preconnect link if media domain is same as window origin', () => {
+    windowRef.location.origin = 'https://storefront.example.com';
+    mockURLConstructor('https://storefront.example.com');
     service.addPreconnectLink();
+    expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
+  });
+
+  it('should add preconnect link if media domain is different from window origin', () => {
+    windowRef.location.origin = 'https://another.example.com';
+    mockURLConstructor('https://media.example.com');
+    service.addPreconnectLink();
+    expect(pageMetaLinkService.addPreconnectLink).toHaveBeenCalledWith(
+      'https://media.example.com'
+    );
+  });
+
+  it('should handle invalid URL gracefully', () => {
+    windowRef.location.origin = 'https://storefront.example.com';
+    (globalThis as any)._originalURL = globalThis.URL;
+    globalThis.URL = function () { throw new Error('Invalid URL'); } as any;
+    expect(() => service.addPreconnectLink()).not.toThrow();
     expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
   });
 });

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { MediaPreconnectService } from './media-preconnect.service';
+import { PageMetaLinkService } from './page-meta-link.service';
+import { MediaService } from '@spartacus/core';
+import { FeatureToggles } from '@spartacus/core';
+import { WindowRef } from '@spartacus/core';
+
+class MockPageMetaLinkService {
+  addPreconnectLink = jasmine.createSpy('addPreconnectLink');
+}
+class MockMediaService {
+  getBaseUrl = jasmine
+    .createSpy('getBaseUrl')
+    .and.returnValue('https://media.example.com');
+}
+class MockFeatureToggles {
+  createMediaPreconnectLinkInSsr = true;
+}
+class MockWindowRef {
+  isBrowser() {
+    return true;
+  }
+  document = window.document;
+}
+
+describe('MediaPreconnectService', () => {
+  let service: MediaPreconnectService;
+  let pageMetaLinkService: MockPageMetaLinkService;
+  let mediaService: MockMediaService;
+  let featureToggles: MockFeatureToggles;
+  let windowRef: MockWindowRef;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MediaPreconnectService,
+        { provide: PageMetaLinkService, useClass: MockPageMetaLinkService },
+        { provide: MediaService, useClass: MockMediaService },
+        { provide: FeatureToggles, useClass: MockFeatureToggles },
+        { provide: WindowRef, useClass: MockWindowRef },
+      ],
+    });
+
+    service = TestBed.inject(MediaPreconnectService);
+    pageMetaLinkService = TestBed.inject(PageMetaLinkService) as any;
+    mediaService = TestBed.inject(MediaService) as any;
+    featureToggles = TestBed.inject(FeatureToggles) as any;
+    windowRef = TestBed.inject(WindowRef) as any;
+  });
+
+  it('should inject service', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should add preconnect link if feature toggle is enabled and in browser', () => {
+    service.addPreconnectLink();
+    expect(mediaService.getBaseUrl).toHaveBeenCalled();
+    expect(pageMetaLinkService.addPreconnectLink).toHaveBeenCalledWith(
+      'https://media.example.com'
+    );
+  });
+
+  it('should not add preconnect link if feature toggle is disabled', () => {
+    featureToggles.createMediaPreconnectLinkInSsr = false;
+    service.addPreconnectLink();
+    expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
+  });
+
+  it('should not add preconnect link if not in browser', () => {
+    spyOn(windowRef, 'isBrowser').and.returnValue(false);
+    service.addPreconnectLink();
+    expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
+  });
+});

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
@@ -33,8 +33,6 @@ export class MediaPreconnectService {
 
     if (domain && domain !== this.windowRef.location.origin) {
       this.pageMetaLinkService.addPreconnectLink(url);
-    } else if (domain) {
-      console.log('The media preconnect link URL matches the domain, so the preconnect URL has not been added.');
     }
   }
 }

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
@@ -19,14 +19,22 @@ export class MediaPreconnectService {
   private windowRef = inject(WindowRef);
 
   addPreconnectLink(): void {
-    if (!this.featureToggles.createMediaPreconnectLinkInSsr) {
+    if (!this.featureToggles.createMediaPreconnectLink) {
       return;
     }
 
-    if (!this.windowRef.isBrowser()) {
-      return;
-    }
     const url = this.mediaService.getBaseUrl();
-    this.pageMetaLinkService.addPreconnectLink(url);
+    let domain: string | undefined;
+    try {
+      domain = new URL(url).origin;
+    } catch {
+      domain = undefined;
+    }
+
+    if (domain && domain !== this.windowRef.location.origin) {
+      this.pageMetaLinkService.addPreconnectLink(url);
+    } else if (domain) {
+      console.log('The media preconnect link URL matches the domain, so the preconnect URL has not been added.');
+    }
   }
 }

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { inject, Injectable } from '@angular/core';
 import { PageMetaLinkService } from './page-meta-link.service';
 import { WindowRef, FeatureToggles } from '@spartacus/core';

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
@@ -31,6 +31,8 @@ export class MediaPreconnectService {
       domain = undefined;
     }
 
+    // Preconnecting is not needed (and won't be performed) if the domain of the media base url
+    // is the same as the storefront's domain
     if (domain && domain !== this.windowRef.location.origin) {
       this.pageMetaLinkService.addPreconnectLink(url);
     }

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
@@ -1,0 +1,26 @@
+import { inject, Injectable } from '@angular/core';
+import { PageMetaLinkService } from './page-meta-link.service';
+import { WindowRef, FeatureToggles } from '@spartacus/core';
+import { MediaService } from '../../shared/components/media/media.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MediaPreconnectService {
+  protected pageMetaLinkService = inject(PageMetaLinkService);
+  protected mediaService = inject(MediaService);
+  private featureToggles = inject(FeatureToggles);
+  private windowRef = inject(WindowRef);
+
+  addPreconnectLink(): void {
+    if (!this.featureToggles.createMediaPreconnectLinkInSsr) {
+      return;
+    }
+
+    if (!this.windowRef.isBrowser()) {
+      return;
+    }
+    const url = this.mediaService.getBaseUrl();
+    this.pageMetaLinkService.addPreconnectLink(url);
+  }
+}

--- a/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/media-preconnect.service.ts
@@ -16,7 +16,7 @@ export class MediaPreconnectService {
   protected pageMetaLinkService = inject(PageMetaLinkService);
   protected mediaService = inject(MediaService);
   private featureToggles = inject(FeatureToggles);
-  private windowRef = inject(WindowRef);
+  protected windowRef = inject(WindowRef);
 
   addPreconnectLink(): void {
     if (!this.featureToggles.createMediaPreconnectLink) {

--- a/projects/storefrontlib/cms-structure/seo/page-meta-link.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/page-meta-link.service.spec.ts
@@ -7,6 +7,7 @@ describe('PageMetaLinkService', () => {
   let winRef: WindowRef;
 
   const pageUrl = 'https://www.myurl.com/en/USD';
+  const preconnectUrl = 'https://media.example.com';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -15,6 +16,12 @@ describe('PageMetaLinkService', () => {
 
     service = TestBed.inject(PageMetaLinkService);
     winRef = TestBed.inject(WindowRef);
+  });
+
+  afterEach(() => {
+    // Clean up any preconnect links added to the document head
+    const links = Array.from(winRef.document.head.querySelectorAll('link[rel="preconnect"]'));
+    links.forEach(link => link.remove());
   });
 
   it('should inject service', () => {
@@ -45,5 +52,40 @@ describe('PageMetaLinkService', () => {
       'cxCanonical'
     ) as HTMLLinkElement;
     expect(linkElement).toBeNull();
+  });
+
+  it('should add a preconnect link to the document head', () => {
+    service.addPreconnectLink(preconnectUrl);
+    const linkElement = winRef.document.head.querySelector(
+      `link[rel="preconnect"][href="${preconnectUrl}"]`
+    ) as HTMLLinkElement;
+    expect(linkElement).toBeTruthy();
+    expect(linkElement.rel).toBe('preconnect');
+    //URL constructor is used for normalizing href
+    expect(new URL(linkElement.href).origin).toBe(preconnectUrl);
+  });
+
+  it('should not add duplicate preconnect links', () => {
+    service.addPreconnectLink(preconnectUrl);
+    service.addPreconnectLink(preconnectUrl);
+    const links = winRef.document.head.querySelectorAll(
+      `link[rel="preconnect"][href="${preconnectUrl}"]`
+    );
+    expect(links.length).toBe(1);
+  });
+
+  it('should insert the preconnect link at the top of the head', () => {
+    // Add another element to head first
+    const dummy = winRef.document.createElement('meta');
+    dummy.setAttribute('name', 'dummy');
+    winRef.document.head.appendChild(dummy);
+
+    service.addPreconnectLink(preconnectUrl);
+
+    const firstChild = winRef.document.head.firstChild as HTMLLinkElement;
+    expect(firstChild.tagName.toLowerCase()).toBe('link');
+    expect(firstChild.rel).toBe('preconnect');
+    //URL constructor is used for normalizing href
+    expect(new URL(firstChild.href).origin).toBe(preconnectUrl);
   });
 });

--- a/projects/storefrontlib/cms-structure/seo/page-meta-link.service.spec.ts
+++ b/projects/storefrontlib/cms-structure/seo/page-meta-link.service.spec.ts
@@ -20,8 +20,10 @@ describe('PageMetaLinkService', () => {
 
   afterEach(() => {
     // Clean up any preconnect links added to the document head
-    const links = Array.from(winRef.document.head.querySelectorAll('link[rel="preconnect"]'));
-    links.forEach(link => link.remove());
+    const links = Array.from(
+      winRef.document.head.querySelectorAll('link[rel="preconnect"]')
+    );
+    links.forEach((link) => link.remove());
   });
 
   it('should inject service', () => {

--- a/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
@@ -53,7 +53,6 @@ export class PageMetaLinkService {
       `link[rel="preconnect"][href="${url}"]`
     );
     if (existing) {
-      console.log("Existing link", url);
       return; // Preconnect link already exists, do nothing
     }
     const preconnect = this.renderer.createElement('link');

--- a/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, Renderer2, RendererFactory2, Inject } from '@angular/core';
+import { Injectable, Renderer2, RendererFactory2, Inject, inject } from '@angular/core';
 import { WindowRef } from '@spartacus/core';
 import { DOCUMENT } from '@angular/common';
 
@@ -12,10 +12,11 @@ import { DOCUMENT } from '@angular/common';
   providedIn: 'root',
 })
 export class PageMetaLinkService {
+  @Inject(DOCUMENT) protected document: Document = inject(DOCUMENT);
+
   constructor(
     protected winRef: WindowRef,
     protected rendererFactory: RendererFactory2,
-    @Inject(DOCUMENT) protected document: Document
   ) {}
 
   /**
@@ -47,6 +48,14 @@ export class PageMetaLinkService {
   }
 
   addPreconnectLink(url: string): void {
+    // Check if a preconnect link with the same href already exists
+    const existing = this.document.head.querySelector(
+      `link[rel="preconnect"][href="${url}"]`
+    );
+    if (existing) {
+      console.log("Existing link", url);
+      return; // Preconnect link already exists, do nothing
+    }
     const preconnect = this.renderer.createElement('link');
     this.renderer.setAttribute(preconnect, 'rel', 'preconnect');
     this.renderer.setAttribute(preconnect, 'href', url);

--- a/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, Renderer2, RendererFactory2, Inject, inject } from '@angular/core';
+import { Injectable, Renderer2, RendererFactory2, inject } from '@angular/core';
 import { WindowRef } from '@spartacus/core';
 import { DOCUMENT } from '@angular/common';
 
@@ -12,11 +12,11 @@ import { DOCUMENT } from '@angular/common';
   providedIn: 'root',
 })
 export class PageMetaLinkService {
-  @Inject(DOCUMENT) protected document: Document = inject(DOCUMENT);
+  protected document: Document = inject(DOCUMENT);
 
   constructor(
     protected winRef: WindowRef,
-    protected rendererFactory: RendererFactory2,
+    protected rendererFactory: RendererFactory2
   ) {}
 
   /**

--- a/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
+++ b/projects/storefrontlib/cms-structure/seo/page-meta-link.service.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
+import { Injectable, Renderer2, RendererFactory2, Inject } from '@angular/core';
 import { WindowRef } from '@spartacus/core';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable({
   providedIn: 'root',
@@ -13,7 +14,8 @@ import { WindowRef } from '@spartacus/core';
 export class PageMetaLinkService {
   constructor(
     protected winRef: WindowRef,
-    protected rendererFactory: RendererFactory2
+    protected rendererFactory: RendererFactory2,
+    @Inject(DOCUMENT) protected document: Document
   ) {}
 
   /**
@@ -42,6 +44,13 @@ export class PageMetaLinkService {
     } else {
       link?.setAttribute('href', url);
     }
+  }
+
+  addPreconnectLink(url: string): void {
+    const preconnect = this.renderer.createElement('link');
+    this.renderer.setAttribute(preconnect, 'rel', 'preconnect');
+    this.renderer.setAttribute(preconnect, 'href', url);
+    this.document.head.insertBefore(preconnect, this.document.head.firstChild); // we want the preconnect-link to be at the top of the <head> section
   }
 
   protected get renderer(): Renderer2 {

--- a/projects/storefrontlib/cms-structure/seo/seo.module.ts
+++ b/projects/storefrontlib/cms-structure/seo/seo.module.ts
@@ -10,7 +10,6 @@ import { defaultSeoConfig } from './config';
 import { htmlLangProvider } from './html-lang-provider';
 import { SeoMetaService } from './seo-meta.service';
 import { StructuredDataModule } from './structured-data/structured-data.module';
-import { MediaPreconnectService } from './media-preconnect.service';
 
 export function initSeoService(injector: Injector): () => void {
   const result = () => {
@@ -18,12 +17,6 @@ export function initSeoService(injector: Injector): () => void {
     service.init();
   };
   return result;
-}
-
-export function mediaPreconnectInitializer(
-  mediaPreconnectService: MediaPreconnectService
-): () => void {
-  return () => mediaPreconnectService.addPreconnectLink();
 }
 
 @NgModule({
@@ -34,12 +27,6 @@ export function mediaPreconnectInitializer(
       provide: APP_INITIALIZER,
       useFactory: initSeoService,
       deps: [Injector],
-      multi: true,
-    },
-    {
-      provide: APP_INITIALIZER,
-      useFactory: mediaPreconnectInitializer,
-      deps: [MediaPreconnectService],
       multi: true,
     },
     htmlLangProvider,

--- a/projects/storefrontlib/cms-structure/seo/seo.module.ts
+++ b/projects/storefrontlib/cms-structure/seo/seo.module.ts
@@ -10,6 +10,7 @@ import { defaultSeoConfig } from './config';
 import { htmlLangProvider } from './html-lang-provider';
 import { SeoMetaService } from './seo-meta.service';
 import { StructuredDataModule } from './structured-data/structured-data.module';
+import { MediaPreconnectService } from './media-preconnect.service';
 
 export function initSeoService(injector: Injector): () => void {
   const result = () => {
@@ -17,6 +18,12 @@ export function initSeoService(injector: Injector): () => void {
     service.init();
   };
   return result;
+}
+
+export function mediaPreconnectInitializer(
+  mediaPreconnectService: MediaPreconnectService
+): () => void {
+  return () => mediaPreconnectService.addPreconnectLink();
 }
 
 @NgModule({
@@ -27,6 +34,12 @@ export function initSeoService(injector: Injector): () => void {
       provide: APP_INITIALIZER,
       useFactory: initSeoService,
       deps: [Injector],
+      multi: true,
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: mediaPreconnectInitializer,
+      deps: [MediaPreconnectService],
       multi: true,
     },
     htmlLangProvider,

--- a/projects/storefrontlib/shared/components/media/media.module.ts
+++ b/projects/storefrontlib/shared/components/media/media.module.ts
@@ -33,7 +33,7 @@ export class MediaModule {
           deps: [MediaPreconnectService],
           multi: true,
         },
-      ]
+      ],
     };
   }
 }

--- a/projects/storefrontlib/shared/components/media/media.module.ts
+++ b/projects/storefrontlib/shared/components/media/media.module.ts
@@ -5,10 +5,17 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
 import { FeaturesConfigModule } from '@spartacus/core';
 import { MediaSourcesPipe } from './media-sources.pipe';
 import { MediaComponent } from './media.component';
+import { MediaPreconnectService } from '../../../cms-structure';
+
+export function mediaPreconnectInitializer(
+  mediaPreconnectService: MediaPreconnectService
+): () => void {
+  return () => mediaPreconnectService.addPreconnectLink();
+}
 
 @NgModule({
   imports: [CommonModule, FeaturesConfigModule],
@@ -19,6 +26,14 @@ export class MediaModule {
   static forRoot(): ModuleWithProviders<MediaModule> {
     return {
       ngModule: MediaModule,
+      providers: [
+        {
+          provide: APP_INITIALIZER,
+          useFactory: mediaPreconnectInitializer,
+          deps: [MediaPreconnectService],
+          multi: true,
+        },
+      ]
     };
   }
 }

--- a/projects/storefrontlib/shared/components/media/media.service.ts
+++ b/projects/storefrontlib/shared/components/media/media.service.ts
@@ -398,7 +398,7 @@ export class MediaService {
    *
    * Defaults to empty string in case no config is provided.
    */
-  protected getBaseUrl(): string {
+  public getBaseUrl(): string {
     return (
       this.config.backend?.media?.baseUrl ??
       this.config.backend?.occ?.baseUrl ??


### PR DESCRIPTION
closes [CXSPA-9613](https://jira.tools.sap/browse/CXSPA-9613)

The preconnect keyword for the [rel](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#rel) attribute of the [<link>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link) element is a hint to browsers that the user is likely to need resources from the target resource's origin, and therefore the browser can likely improve the user experience by preemptively initiating a connection to that origin. Preconnecting speeds up future loads from a given origin by preemptively performing part or all of the handshake (DNS+TCP for HTTP, and DNS+TCP+TLS for HTTPS origins). (source:[preconnect documentation]( https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preconnect))

Server-side rendered and CDN cached sites might benefit the most from the pre-connecting to media sites. 