### PR TITLE
chore: fix favicon.ico url in the storefrontapp

### DIFF
--- a/projects/storefrontapp/src/index.html
+++ b/projects/storefrontapp/src/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/x-icon" href="favicon.ico?v=2" />
+    <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <link rel="manifest" href="manifest.json" />
     <meta charset="utf-8" />
 


### PR DESCRIPTION
Currently 404 errors happen for this URL in SSR, and SSR logs are polutted.

This PR is just fixing our `storefrontapp` project. not affecting customers.
The fix was needed since we merged https://github.com/SAP/spartacus/pull/20242

Related to https://jira.tools.sap/browse/CXSPA-9318

QA steps:
- run `npm run dev:ssr`
- visit `http://localhost:4000` in the browser
- observe the browser's tab icon, and observe SSR logs:

BEFORE:
- Spartacus logo absent in the browser tab:
    ![image](https://github.com/user-attachments/assets/5c5658fd-a1c4-48dd-9793-29268d5035fd)
- SSR logs complain about missing favicon.ico
![image](https://github.com/user-attachments/assets/fed33ad5-a3f7-4c35-8005-6e7c4479d2c1)

AFTER:
- spartacus logo visible in the browser tab:
    ![image](https://github.com/user-attachments/assets/a5ad0b2f-b732-49b6-a2ba-83179dce98c4)
- no such error in the SSR logs

