### PR TITLE
fix: prevent downloading Product Carousel images twice

### DIFF
--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.html
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.html
@@ -8,6 +8,7 @@
   [title]="title$ | async"
   [template]="carouselItem"
   itemWidth="285px"
+  [trackByFn]="trackByFn"
 >
 </cx-carousel>
 

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
@@ -4,6 +4,7 @@ import {
   Pipe,
   PipeTransform,
   TemplateRef,
+  TrackByFunction,
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -36,6 +37,7 @@ class MockCarouselComponent {
   @Input() title: string;
   @Input() template: TemplateRef<any>;
   @Input() items: any[];
+  @Input() trackByFn: TrackByFunction<any>;
 }
 
 @Component({
@@ -399,5 +401,16 @@ describe('ProductCarouselComponent', () => {
         done();
       });
     });
+  });
+
+  it('should pass trackByFn to the carousel and return product.code', () => {
+    const carouselComponent = fixture.debugElement.query(
+      By.directive(MockCarouselComponent)
+    ).componentInstance;
+    expect(carouselComponent.trackByFn).toBeDefined();
+
+    const mockProduct = { code: 'test123', name: 'Test Product' };
+    const result = carouselComponent.trackByFn(999, mockProduct);
+    expect(result).toBe('test123');
   });
 });

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.ts
@@ -4,10 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import {
-  CmsProductCarouselComponent as model,
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  TrackByFunction,
+} from '@angular/core';
+import {
   FeatureConfigService,
+  CmsProductCarouselComponent as model,
   Product,
   ProductScope,
   ProductSearchByCategoryService,
@@ -78,6 +83,9 @@ export class ProductCarouselComponent {
         }
       })
     );
+
+  trackByFn: TrackByFunction<Product> = (_index: number, item: Product) =>
+    item?.code;
 
   constructor(
     protected componentData: CmsComponentData<model>,

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.html
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.html
@@ -20,14 +20,18 @@
       <cx-icon [type]="previousIcon"></cx-icon>
     </button>
     <div class="slides">
-      <ng-container *ngFor="let _ of items; let i = index">
+      <ng-container *ngFor="let _ of items; let i = index; trackBy: trackByFn">
         <div
           class="slide"
           *ngIf="i % size === 0"
           [class.active]="i === activeSlide"
         >
           <ng-container
-            *ngFor="let item of items | slice: i : i + size; let j = index"
+            *ngFor="
+              let item of items | slice: i : i + size;
+              let j = index;
+              trackBy: trackByFn
+            "
           >
             <div
               *ngIf="item | async as data"

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
@@ -642,20 +642,9 @@ describe('Carousel Component', () => {
   });
 
   describe('default @Input trackByFn', () => {
-    it('should handle property "id"', () => {
-      expect(component.trackByFn(0, { id: '123' })).toEqual('123');
-    });
-
-    it('should handle property "uid"', () => {
-      expect(component.trackByFn(0, { uid: '123' })).toEqual('123');
-    });
-
-    it('should handle property "code"', () => {
-      expect(component.trackByFn(0, { code: '123' })).toEqual('123');
-    });
-
-    it('should fallback to index', () => {
-      expect(component.trackByFn(123, { whatever: 'xxx' })).toEqual(123);
+    it('should return the item', () => {
+      const item = { id: '123' };
+      expect(component.trackByFn(123, item)).toBe(item);
     });
   });
 });
@@ -700,7 +689,7 @@ class TestParentComponent {
   carouselTrackByFn = (_index: number, item: any) => item.customID;
 }
 
-fdescribe('Carousel Component tested in TestParentComponent', () => {
+describe('Carousel Component tested in TestParentComponent', () => {
   let fixture: ComponentFixture<TestParentComponent>;
   let parent: TestParentComponent;
   let service: CarouselService;
@@ -736,7 +725,7 @@ fdescribe('Carousel Component tested in TestParentComponent', () => {
     expect(childEls[0].nativeElement.textContent).toContain('A');
   });
 
-  it('should not destroy child components when getting new array copy (thanks to trackBy)', () => {
+  it('should not destroy child components when getting a new deep copy of the array, while trackByFn is used', () => {
     fixture.detectChanges();
     const oldChildEls = fixture.debugElement.queryAll(By.css('cx-test-child'));
     // Replace with a new array (same objects/ids)

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Input, TemplateRef } from '@angular/core';
+import { Component, Input, OnDestroy, TemplateRef } from '@angular/core';
 import {
   ComponentFixture,
   fakeAsync,
@@ -639,5 +639,124 @@ describe('Carousel Component', () => {
         });
       }));
     });
+  });
+
+  describe('default @Input trackByFn', () => {
+    it('should handle property "id"', () => {
+      expect(component.trackByFn(0, { id: '123' })).toEqual('123');
+    });
+
+    it('should handle property "uid"', () => {
+      expect(component.trackByFn(0, { uid: '123' })).toEqual('123');
+    });
+
+    it('should handle property "code"', () => {
+      expect(component.trackByFn(0, { code: '123' })).toEqual('123');
+    });
+
+    it('should fallback to index', () => {
+      expect(component.trackByFn(123, { whatever: 'xxx' })).toEqual(123);
+    });
+  });
+});
+
+@Component({
+  selector: 'cx-test-child',
+  template: '<span class="child-content">{{ item.testProperty }}</span>',
+  standalone: false,
+})
+class TestChildComponent implements OnDestroy {
+  @Input() item: any;
+  static destroyedCount = 0;
+  ngOnDestroy() {
+    TestChildComponent.destroyedCount++;
+  }
+}
+
+@Component({
+  selector: 'cx-test-parent',
+  template: `
+    <cx-carousel
+      [items]="mockItems"
+      [title]="mockTitle"
+      [template]="carouselItem"
+      [trackByFn]="carouselTrackByFn"
+    ></cx-carousel>
+    <ng-template #carouselItem let-item="item">
+      <cx-test-child [item]="item"></cx-test-child>
+    </ng-template>
+  `,
+  standalone: false,
+})
+class TestParentComponent {
+  mockTitle = 'Test Carousel';
+  mockItems = [
+    of({ testProperty: 'A', customID: 1 }),
+    of({ testProperty: 'B', customID: 2 }),
+    of({ testProperty: 'C', customID: 3 }),
+    of({ testProperty: 'D', customID: 4 }),
+    of({ testProperty: 'E', customID: 5 }),
+  ];
+  carouselTrackByFn = (_index: number, item: any) => item.customID;
+}
+
+fdescribe('Carousel Component tested in TestParentComponent', () => {
+  let fixture: ComponentFixture<TestParentComponent>;
+  let parent: TestParentComponent;
+  let service: CarouselService;
+
+  beforeEach(waitForAsync(() => {
+    TestChildComponent.destroyedCount = 0;
+    TestBed.configureTestingModule({
+      imports: [I18nTestingModule],
+      declarations: [
+        CarouselComponent,
+        MockCxIconComponent,
+        MockTemplateComponent,
+        TestParentComponent,
+        TestChildComponent,
+      ],
+      providers: [{ provide: CarouselService, useClass: MockCarouselService }],
+    }).compileComponents();
+
+    service = TestBed.inject(CarouselService);
+    spyOn(service, 'getItemsPerSlide').and.returnValue(of(2));
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestParentComponent);
+    parent = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render child components for default input', () => {
+    fixture.detectChanges();
+    const childEls = fixture.debugElement.queryAll(By.css('cx-test-child'));
+    expect(childEls.length).toBe(5);
+    expect(childEls[0].nativeElement.textContent).toContain('A');
+  });
+
+  it('should not destroy child components when getting new array copy (thanks to trackBy)', () => {
+    fixture.detectChanges();
+    const oldChildEls = fixture.debugElement.queryAll(By.css('cx-test-child'));
+    // Replace with a new array (same objects/ids)
+    parent.mockItems = [
+      of({ testProperty: 'A', customID: 1 }),
+      of({ testProperty: 'B', customID: 2 }),
+      of({ testProperty: 'C', customID: 3 }),
+      of({ testProperty: 'D', customID: 4 }),
+      of({ testProperty: 'E', customID: 5 }),
+    ];
+    fixture.detectChanges();
+
+    expect(TestChildComponent.destroyedCount).toBe(0);
+
+    const newChildEls = fixture.debugElement.queryAll(By.css('cx-test-child'));
+    expect(newChildEls.length).toEqual(oldChildEls.length);
+    expect(newChildEls[0].nativeElement.textContent).toContain('A');
+    expect(newChildEls[1].nativeElement.textContent).toContain('B');
+    expect(newChildEls[2].nativeElement.textContent).toContain('C');
+    expect(newChildEls[3].nativeElement.textContent).toContain('D');
+    expect(newChildEls[4].nativeElement.textContent).toContain('E');
   });
 });

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
@@ -718,13 +718,6 @@ describe('Carousel Component tested in TestParentComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should render child components for default input', () => {
-    fixture.detectChanges();
-    const childEls = fixture.debugElement.queryAll(By.css('cx-test-child'));
-    expect(childEls.length).toBe(5);
-    expect(childEls[0].nativeElement.textContent).toContain('A');
-  });
-
   it('should not destroy child components when getting a new deep copy of the array, while trackByFn is used', () => {
     fixture.detectChanges();
     const oldChildEls = fixture.debugElement.queryAll(By.css('cx-test-child'));

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.spec.ts
@@ -644,7 +644,7 @@ describe('Carousel Component', () => {
   describe('default @Input trackByFn', () => {
     it('should return the item', () => {
       const item = { id: '123' };
-      expect(component.trackByFn(123, item)).toBe(item);
+      expect(component.trackByFn(999, item)).toBe(item);
     });
   });
 });

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.ts
@@ -15,6 +15,7 @@ import {
   OnInit,
   Output,
   TemplateRef,
+  TrackByFunction,
 } from '@angular/core';
 import { LoggerService, useFeatureStyles } from '@spartacus/core';
 import { BehaviorSubject, Observable } from 'rxjs';
@@ -102,8 +103,7 @@ export class CarouselComponent implements OnInit, OnChanges {
    * If the returned value is not unique, it may lead to unexpected behavior,
    * such as unwanted destroying and re-creating child templates on items array changes.
    */
-  @Input() trackByFn: (index: number, item: any) => any = (_index, item) =>
-    item;
+  @Input() trackByFn: TrackByFunction<any> = (_index, item) => item;
 
   activeSlide: number;
   size$: Observable<number>;

--- a/projects/storefrontlib/shared/components/carousel/carousel.component.ts
+++ b/projects/storefrontlib/shared/components/carousel/carousel.component.ts
@@ -92,6 +92,19 @@ export class CarouselComponent implements OnInit, OnChanges {
   @Input() previousIcon = ICON_TYPE.CARET_LEFT;
   @Input() nextIcon = ICON_TYPE.CARET_RIGHT;
 
+  /**
+   * Angular's trackBy function for iterating over carousel items.
+   *
+   * For a given item it should return an unique identifier.
+   * If not provided, it will fallback to returning the item directly
+   * (like Angular's naive default trackBy).
+   *
+   * If the returned value is not unique, it may lead to unexpected behavior,
+   * such as unwanted destroying and re-creating child templates on items array changes.
+   */
+  @Input() trackByFn: (index: number, item: any) => any = (_index, item) =>
+    item;
+
   activeSlide: number;
   size$: Observable<number>;
 


### PR DESCRIPTION
Added trackBy support for the carousel component. Used it in parent Product Carousel Component.

fixes https://jira.tools.sap/browse/CXSPA-10423

---

**QA steps:**

BEFORE: 
- in `product-carousel.component.html` remove the [line](https://github.com/SAP/spartacus/blob/54f407f2b351aa35191d6cfdfeccf1ecb6609159/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.html#L11) with the fix: `[trackByFn]="trackByFn"`
- run `npm run dev:ssr`
- in Chrome Dev Tools open Network tab and filter by the following string, which is an URL of one of the carousel items: `https://40.76.109.9:9002/medias/?context=bWFzdGVyfGltYWdlc3wxMjA3OHxpbWFnZS9qcGVnfGFXMWhaMlZ6TDJneE1DOW9OakF2T0RjNU56STNNamN3TXpBd05pNXFjR2N8ZDdjMTU2ZDhiMWI2NjIzOTJhYjNlNDNiZTBlZjcwNzRhZWE4NWRkYjlmZjFhMDAyNzliY2JlZTQzZWZmMDVhNA`
- visit SSR homepage http://localhost:4000/electronics-spa/en/USD/
- verify that the product image was downloaded twice (due to a destroy and re-create of the ProductCarouselItemComponent, due to a lack of trackBy)
    <img width="1001" alt="image" src="https://github.com/user-attachments/assets/28f9b512-5702-4fda-a428-f269ee2805ea" />



AFTER:
- in `product-carousel.component.html` bring back the removed [line](https://github.com/SAP/spartacus/blob/54f407f2b351aa35191d6cfdfeccf1ecb6609159/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.html#L11) with the fix: `[trackByFn]="trackByFn"`
- visit again SSR homepage http://localhost:4000/electronics-spa/en/USD/
- verify that the product image was downloaded only ONCE
    <img width="998" alt="image" src="https://github.com/user-attachments/assets/c9a54690-7613-4625-b0b3-0a43210ef783" />
