### PR TITLE
fix: (CXSPA-10471) config page - disable addToCart btn after first click

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.html
@@ -12,6 +12,7 @@
             </div>
             <button
               class="cx-btn btn btn-block btn-primary cx-add-to-cart-btn"
+              [disabled]="addToCartButtonDisabled"
               (click)="
                 onAddToCart(container.configuration, container.routerData)
               "

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
@@ -63,6 +63,7 @@ export class ConfiguratorAddToCartButtonComponent implements OnInit, OnDestroy {
   protected activeCartFacade = inject(ActiveCartFacade);
   quantityControl = new UntypedFormControl(1);
   iconType = ICON_TYPE;
+  addToCartButtonDisabled = false;
 
   container$: Observable<{
     routerData: ConfiguratorRouter.Data;
@@ -328,6 +329,7 @@ export class ConfiguratorAddToCartButtonComponent implements OnInit, OnDestroy {
     isOverview: boolean,
     productCode?: string
   ) {
+    this.addToCartButtonDisabled = true;
     const quantity = this.quantityControl.value;
     this.configuratorCartService.addToCart(
       owner.id,


### PR DESCRIPTION
When configuring a product and clicking on the "Add To Cart" button (quickly) twice, it is tried to create the cart entry with the same config two times. This causes an issue in the backend and the cart is in a undefined state.