### PR TITLE
fix: Workaround for Stylus library missing in NPM registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29423,7 +29423,8 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -31010,27 +31011,10 @@
       }
     },
     "node_modules/stylus": {
-      "version": "0.64.0",
-      "resolved": "https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz",
-      "integrity": "sha512-IQHf2BGsQuBppkq5/4BPf190n7tvYKUyeWeVtkaXHydq50Lv++06+JrkO7HbTPC86H7vwYWuD39SlwcgBZKD4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "~4.3.3",
-        "debug": "^4.3.2",
-        "glob": "^10.4.5",
-        "sax": "~1.4.1",
-        "source-map": "^0.7.3"
-      },
-      "bin": {
-        "stylus": "bin/stylus"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://opencollective.com/stylus"
-      }
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.0.1-security.tgz",
+      "integrity": "sha512-qTLX5NJwuj5dqdJyi1eAjXGE4HfjWDoPLbSIpYWn/rAEdiyZnsngS/Yj0BRjM7wC41e/+spK4QCXFqz7LM0fFQ==",
+      "dev": true
     },
     "node_modules/stylus-loader": {
       "version": "7.1.3",
@@ -31052,50 +31036,6 @@
       "peerDependencies": {
         "stylus": ">=0.52.4",
         "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/stylus/node_modules/@adobe/css-tools": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
-      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stylus/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/stylus/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31011,8 +31011,8 @@
     },
     "node_modules/stylus": {
       "version": "0.64.0",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.64.0.tgz",
-      "integrity": "sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==",
+      "resolved": "https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz",
+      "integrity": "sha512-IQHf2BGsQuBppkq5/4BPf190n7tvYKUyeWeVtkaXHydq50Lv++06+JrkO7HbTPC86H7vwYWuD39SlwcgBZKD4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -290,6 +290,6 @@
   },
   "overrides": {
     "vite": "5.4.19",
-    "stylus": "https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz"
+    "stylus": "0.0.1-security"
   }
 }

--- a/package.json
+++ b/package.json
@@ -289,6 +289,7 @@
     "webpack-cli": "^5.0.0"
   },
   "overrides": {
-    "vite": "5.4.19"
+    "vite": "5.4.19",
+    "stylus": "https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz"
   }
 }


### PR DESCRIPTION
This PR provides a workaround for downloading Stylus library, which has been removed from the NPM registry.

Cost:
- low implementation effort (1 line in package.json)
- no runtime impact (rather nothing breaks, as it's likely an optional and unused peer dep)
- later, remember to undo this, if/when not necessary

Benefits:
- unblocking tens of devs to work as usual without disruption


**IMPORTANT:** It is a workaround that should be reverted immediately, when the Stylus library is again available or the maintainer provides some official fixes

For more, see:
- stylus npm landing page with the message from npm authorities: https://www.npmjs.com/package/stylus
- stylus github issue where the library author says he wants to negotiate with npm officials: "[[Pinned] I am currently negotiating with the npmjs official. Please wait for the outcome.](https://github.com/stylus/stylus/issues/2938#top)"
- https://github.com/github/advisory-database/issues/5846