### PR TITLE
fix: [PoC] App redirected to homepage instead of checkout after logging via "code" flow 

### DIFF
--- a/feature-libs/cart/base/core/store/actions/cart.action.ts
+++ b/feature-libs/cart/base/core/store/actions/cart.action.ts
@@ -177,9 +177,11 @@ interface MergeCartPayload {
   tempCartId: string;
 }
 
-export class MergeCart implements Action {
+export class MergeCart extends StateUtils.EntityProcessesIncrementAction {
   readonly type = MERGE_CART;
-  constructor(public payload: MergeCartPayload) {}
+  constructor(public payload: MergeCartPayload) {
+    super(MULTI_CART_DATA, payload.cartId);
+  }
 }
 
 interface MergeCartSuccessPayload extends MergeCartPayload {


### PR DESCRIPTION
This partial PR adds `StateUtils.EntityProcessIncrementAction` to the `MergeCart` action required to increment the `processesCount` value that prevents loading an active cart when redirecting back after logging via "code" flow. Let's see the following code from active-cart.service.ts:
```ts
    const cartValue$ = this.cartEntity$.pipe(
      map((cartEntity) => {
        return {
          cart: cartEntity.value,
          isStable: !cartEntity.loading && cartEntity.processesCount === 0,  // <---- because we increase the value during `MergeCart` action, the cart is considered unstable
          loaded: Boolean(
            (cartEntity.error || cartEntity.success) && !cartEntity.loading
          ),
        };
      }),
      filter(({ isStable, cart }) => isStable || isEmpty(cart))
    );
    
    /* ... */
    
    const loading = cartValue$.pipe(
      withLatestFrom(this.activeCartId$, this.userIdService.getUserId()),
      tap(([{ cart, loaded, isStable }, cartId, userId]) => {
        if (
          isStable && <---  cart is unstable and won't be loaded until the merging cart is finished (`MergeCartSuccess` is called, anonymous cart with `processesCount` === 1 is destroyed and new active cart is set)
          isEmpty(cart) &&
          !loaded &&
          !isTempCartId(cartId) &&
          this.shouldLoadCartOnCodeFlow
        ) {
          this.load(cartId, userId);
        }
      })
    );
```

**Note:** Normally, `StateUtils.EntityProcessIncrementAction` requires calling `StateUtils.EntityProcessDecrementAction` in the related action called next, to set the actual state of `processesCount`. In this case, it might not be required because `processesCount` is set for the anonymous cart (that normally, would be loaded right after redirection, but won't be because processessCount !== 0), which will be deleted after successful merge. See the following screenshots:
<img width="1455" height="333" alt="Screenshot 2025-07-25 at 12 49 16" src="https://github.com/user-attachments/assets/2477ddf0-67d6-444a-9da3-3e1ee0b64ccb" />
<img width="1450" height="417" alt="Screenshot 2025-07-25 at 12 50 16" src="https://github.com/user-attachments/assets/6dbf54d2-a20a-4619-a97e-e014080e605d" />
<img width="1451" height="514" alt="Screenshot 2025-07-25 at 12 50 28" src="https://github.com/user-attachments/assets/c141acd3-bd8f-49ff-9c5c-89901e4de733" />

Nevertheless, unhappy path scenarios are required to be checked. When checked, and the above statement is true, it is worth adding a comment to the  `MergeCart` class describing why decrementing won't be necessary in that case, for future reference

QA:

1. run app and as an anonymous user, go to `http://localhost:4200/electronics-spa/en/USD/product/1934398/hdr-xr105e`
2. add product to cart and click `Proceed to checkout`
3. Provide credentials and verify if app was redirected to the checkout page, and if a product from the anonymous cart was added to the user's cart (merge was successful)
4. Proceed with checkout and finish the order
5. verify if cart is empty 

I had issues turning on password flow on this branch, but I tested the proposed solution on the `develop` branch against our default dev env, and it seems to be working as expected.


