### PR TITLE
fix: remove pageFold from the default layout config

### DIFF
--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -959,5 +959,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   unifiedDefaultHeaderSlotsAcrossBreakpoints: false,
   reserveSpaceForImagesOnPdpAndPlp: false,
   lazyLoadImagesByDefault: false,
-  defaultLayoutConfigWithoutPageFold: false
+  defaultLayoutConfigWithoutPageFold: false,
 };

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -827,6 +827,24 @@ export interface FeatureTogglesInterface {
    * Set to `true` to enable lazy loading by default.
    */
   lazyLoadImagesByDefault?: boolean;
+
+  /**
+   * Previously the default Spartacus layout config contained the property `pageFold`
+   * for the following layouts:
+   * - `LandingPage2Template`
+   * - `CategoryPageTemplate`
+   * - `ProductDetailsPageTemplate`
+   *
+   * When this feature toggle is enabled, the `pageFold` property is removed from those layout configs.
+   *
+   * It is to improve the CLS (Cumulative Layout Shift) metric. Previously the `pageFold` property
+   * caused the CMS components to be rendered only after a small delay even in SSR pages,
+   * which caused a layout shift.
+   *
+   * ⚠️ To fully enable this feature toggle, you need to also replace `provideConfig(layoutConfig)`
+   * in your codebase with `provideConfigFactory(layoutConfigFactory)`.
+   */
+  defaultLayoutConfigWithoutPageFold?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -941,4 +959,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   unifiedDefaultHeaderSlotsAcrossBreakpoints: false,
   reserveSpaceForImagesOnPdpAndPlp: false,
   lazyLoadImagesByDefault: false,
+  defaultLayoutConfigWithoutPageFold: false
 };

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -408,7 +408,7 @@ if (environment.cpq) {
         unifiedDefaultHeaderSlotsAcrossBreakpoints: true,
         reserveSpaceForImagesOnPdpAndPlp: true,
         lazyLoadImagesByDefault: true,
-        defaultLayoutConfigWithoutPageFold: true
+        defaultLayoutConfigWithoutPageFold: true,
       };
       return appFeatureToggles;
     }),

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -408,6 +408,7 @@ if (environment.cpq) {
         unifiedDefaultHeaderSlotsAcrossBreakpoints: true,
         reserveSpaceForImagesOnPdpAndPlp: true,
         lazyLoadImagesByDefault: true,
+        defaultLayoutConfigWithoutPageFold: true
       };
       return appFeatureToggles;
     }),

--- a/projects/storefrontlib/recipes/config/layout-config.ts
+++ b/projects/storefrontlib/recipes/config/layout-config.ts
@@ -176,7 +176,7 @@ export function layoutConfigFactory(): LayoutConfig {
       (config?.layoutSlots?.ProductDetailsPageTemplate as SlotConfig) ?? {};
     delete productDetailsPageConfig.pageFold;
     delete (
-      ((productDetailsPageConfig as SlotGroup).lg ?? {}) as SlotConfig
+      ((productDetailsPageConfig as SlotGroup).lg ?? {})
     ).pageFold;
   }
 

--- a/projects/storefrontlib/recipes/config/layout-config.ts
+++ b/projects/storefrontlib/recipes/config/layout-config.ts
@@ -175,9 +175,7 @@ export function layoutConfigFactory(): LayoutConfig {
     const productDetailsPageConfig =
       (config?.layoutSlots?.ProductDetailsPageTemplate as SlotConfig) ?? {};
     delete productDetailsPageConfig.pageFold;
-    delete (
-      ((productDetailsPageConfig as SlotGroup).lg ?? {})
-    ).pageFold;
+    delete ((productDetailsPageConfig as SlotGroup).lg ?? {}).pageFold;
   }
 
   return config;

--- a/projects/storefrontlib/recipes/config/layout-config.ts
+++ b/projects/storefrontlib/recipes/config/layout-config.ts
@@ -5,8 +5,12 @@
  */
 
 import { inject } from '@angular/core';
-import { LayoutConfig } from '../../layout/config/layout-config';
 import { FeatureToggles } from '@spartacus/core';
+import {
+  LayoutConfig,
+  SlotConfig,
+  SlotGroup,
+} from '../../layout/config/layout-config';
 
 /**
  * The layout configuration is used to define the overall layout of the storefront.
@@ -136,11 +140,10 @@ export const layoutConfig: LayoutConfig = {
  */
 export function layoutConfigFactory(): LayoutConfig {
   const config: LayoutConfig = JSON.parse(JSON.stringify(layoutConfig));
-  const unifiedDefaultHeaderSlotsAcrossBreakpoints =
-    inject(FeatureToggles).unifiedDefaultHeaderSlotsAcrossBreakpoints;
+  const featureToggles = inject(FeatureToggles);
 
   if (
-    unifiedDefaultHeaderSlotsAcrossBreakpoints &&
+    featureToggles.unifiedDefaultHeaderSlotsAcrossBreakpoints &&
     config.layoutSlots &&
     config.layoutSlots.header &&
     'slots' in config.layoutSlots.header
@@ -158,6 +161,23 @@ export function layoutConfigFactory(): LayoutConfig {
       'MiniCart',
       'NavigationBar',
     ];
+  }
+
+  if (featureToggles.defaultLayoutConfigWithoutPageFold) {
+    const homepageConfig =
+      (config?.layoutSlots?.LandingPage2Template as SlotConfig) ?? {};
+    delete homepageConfig.pageFold;
+
+    const categoryPageConfig =
+      (config?.layoutSlots?.CategoryPageTemplate as SlotConfig) ?? {};
+    delete categoryPageConfig.pageFold;
+
+    const productDetailsPageConfig =
+      (config?.layoutSlots?.ProductDetailsPageTemplate as SlotConfig) ?? {};
+    delete productDetailsPageConfig.pageFold;
+    delete (
+      ((productDetailsPageConfig as SlotGroup).lg ?? {}) as SlotConfig
+    ).pageFold;
   }
 
   return config;


### PR DESCRIPTION
Previously the default Spartacus layout config contained the property `pageFold`
for the following layouts:
- `LandingPage2Template`
- `CategoryPageTemplate`
- `ProductDetailsPageTemplate`

Now introduced a feature toggle for a fix: `defaultLayoutConfigWithoutPageFold`. When this feature toggle is enabled, the `pageFold` property is removed from those layout configs.

It is to improve the CLS (Cumulative Layout Shift) metric. Previously the `pageFold` property
caused the CMS components to be rendered only after a small delay even in SSR pages,
which caused a layout shift.

⚠️ To fully enable this feature toggle, you need to also replace `provideConfig(layoutConfig)`
in your codebase with `provideConfigFactory(layoutConfigFactory)`.

fixes https://jira.tools.sap/browse/CXSPA-10694


## QA steps:

1. Add the following workaround code snippet in app module to provide widht/height to banned images, which are missing in CMS response. If you don't provide it, the Lighthouse CLS will complain about it. And those banners CLS is out of scope for this ticket, so let's use the workaround.

Please scroll down to the very bottom of this PR description to the Appendix to copy-paste the code snippet to your app module. (I didn't want to put it here because it's huge)

2. run Dev SSR server: `npm run dev:ssr`

3. open homepage in chrome http://localhost:4000/electronics-spa/en/USD/

4. zoom out to 75%

5. In chrome devtools open Lighthouse tab and select "desktop". But don't run the Lighthouse audit yet!


**5) HOMEPAGE BEFORE:** 
👉 In `spartacus-features.module.ts` disable the new feature toggle: set `defaultLayoutConfigWithoutPageFold: false` and WAIT FOR THE APP FOR RECOMPILE

and in chrome devtools Lighthouse run "Analyze page load" 
<img width="837" height="239" alt="image" src="https://github.com/user-attachments/assets/86b7ee13-c235-4231-887f-6fd47965eb31" />

Result:
CLS is red

<img width="279" height="75" alt="image" src="https://github.com/user-attachments/assets/f69e8982-c2d5-4c16-9124-e4135fb7681b" />

please scroll a bit to bottom and select a small button [CLS] which filters only the CLS complaints:

<img width="574" height="687" alt="image" src="https://github.com/user-attachments/assets/306f392a-d9dd-490d-9258-b3ae3680e1c8" />

see it complains about the Section3


**5) HOMEPAGE AFTER:**
👉 In `spartacus-features.module.ts` enable the new feature toggle: set `defaultLayoutConfigWithoutPageFold: true` and WAIT FOR THE APP FOR RECOMPILE

and in chrome devtools Lighthouse run "Analyze page load" 

Result:
CLS is green

<img width="285" height="86" alt="image" src="https://github.com/user-attachments/assets/4c163011-6a15-4546-9e4b-d867883e371f" />


scroll a bit to bottom and select a small button [CLS] which filters only the CLS complaints:

<img width="574" height="657" alt="image" src="https://github.com/user-attachments/assets/0c9f77e4-5ca9-417a-ba04-3e864a9d184a" />

there is no complaint about the Section3 element 👍 



6. PDP: open PDP in chrome http://localhost:4000/electronics-spa/en/USD/

**6) PDP BEFORE:** 
👉 In `spartacus-features.module.ts` disable the new feature toggle: set `defaultLayoutConfigWithoutPageFold: false` and WAIT FOR THE APP FOR RECOMPILE

and in chrome devtools Lighthouse run "Analyze page load" 
<img width="837" height="239" alt="image" src="https://github.com/user-attachments/assets/86b7ee13-c235-4231-887f-6fd47965eb31" />

Result:
CLS is yellow

<img width="292" height="73" alt="image" src="https://github.com/user-attachments/assets/b830bf51-2b0e-4918-a990-3c7a06978f6d" />

please scroll a bit to bottom and select a small button [CLS] which filters only the CLS complaints:

<img width="597" height="678" alt="image" src="https://github.com/user-attachments/assets/45844263-ca10-4f5c-b876-7f61e2131192" />

see it complains about the Tabs element

**6) PDP AFTER:**
👉 In `spartacus-features.module.ts` enable the new feature toggle: set `defaultLayoutConfigWithoutPageFold: true` and WAIT FOR THE APP FOR RECOMPILE

and in chrome devtools Lighthouse run "Analyze page load" 

Result:
CLS is green

<img width="291" height="82" alt="image" src="https://github.com/user-attachments/assets/4ef1d52d-3b42-46c1-b074-92a4541a35ed" />

scroll a bit to bottom and select a small button [CLS] which filters only the CLS complaints:


there is no complaints about the Tabs element 👍 

<img width="587" height="594" alt="image" src="https://github.com/user-attachments/assets/9ac36cd0-7835-41cf-bdd9-cf20a8d4f619" />


7. There is no difference BEFORE vs AFTER for the Category page. CLS is green regardless of the feature toggle. But I decided to remove `pageFold` from this config for consistency.


## Appendix - workaround snippet to provide dimensions of banners:
```typescript

import { Injectable, Provider } from '@angular/core';
import {
  CmsBannerComponent,
  CmsBannerComponentMedia,
  CmsResponsiveBannerComponentMedia,
  CmsStructureModel,
  Occ,
  OccCmsPageNormalizer,
} from '@spartacus/core';

/**
 * This is a workaround to extract dimensions from a URL of a banner image, based on a filenames convention in our sample data
 * (yes it's a workaround! ideally dimensions should be defined in CMS!)
 */
@Injectable({ providedIn: 'root' })
export class CustomOccCmsPageNormalizer extends OccCmsPageNormalizer {
  override convert(
    source: Occ.CMSPage,
    target: CmsStructureModel = {}
  ): CmsStructureModel {
    let result = super.convert(source, target);

    result = this.populateBannerImagesDimensions(result);

    return result;
  }

  protected populateBannerImagesDimensions(
    result: CmsStructureModel
  ): CmsStructureModel {
    if (!result.components) {
      return result;
    }

    // Iterate through all components
    (result.components || []).forEach((component) => {
      // ignore components that are not banners
      if (
        !component.typeCode ||
        !['SimpleResponsiveBannerComponent', 'SimpleBannerComponent'].includes(
          component.typeCode
        )
      ) {
        return;
      }

      const copyDimensionsFromUrlToSeparateProperties = (
        media: CmsBannerComponentMedia
      ) => {
        if (media?.url) {
          const dimensions = this.extractDimensionsFromUrl(media.url);
          // Add dimensions to media object if found
          if (dimensions.width) {
            (media as any).width = dimensions.width; // although width is not defined in CMS, we add it here
          }
          if (dimensions.height) {
            (media as any).height = dimensions.height; // although height is not defined in CMS, we add it here
          }
          if(media.url.includes('Elec-1400x80-HomeDiscount-EN-01-1400W.jpg')){
            (media as any).height = 70; // there is wrong filename in our sample data
          }
        }
      };

      const bannerComponent = component as CmsBannerComponent;
      // Note:
      // - SimpleBannerComponent has "media" property with a single image
      // - SimpleResponsiveBannerComponent has "media" property with a object containing images
      //    for different media formats (in separate properties)

      if (!bannerComponent.media) {
        return;
      }
      if (bannerComponent.typeCode === 'SimpleBannerComponent') {
        copyDimensionsFromUrlToSeparateProperties(
          bannerComponent.media as CmsBannerComponentMedia
        );
      }
      if (bannerComponent.typeCode === 'SimpleResponsiveBannerComponent') {
        // Process each media format (mobile, tablet, desktop, widescreen)
        Object.values(
          bannerComponent.media as CmsResponsiveBannerComponentMedia
        ).forEach((media) => {
          copyDimensionsFromUrlToSeparateProperties(media);
        });
      }
    });

    return result;
  }

  /**
   * Extracts dimensions from a URL of a banner image, based on a filenames convention in our sample data
   * (yes it's a workaround! ideally dimensions should be defined in CMS!)
   */
  protected extractDimensionsFromUrl(url: string): {
    width?: number;
    height?: number;
  } {
    // Banner images in our sample data happen to follow the pattern `somename-WIDTHxHEIGHT-somename...`
    // so we can leverage it to extract the dimensions
    const pattern = /\/medias\/[^-]+-(\d+)x(\d+)-[^-]+/;
    const match = url.match(pattern);
    if (match) {
      const width = parseInt(match[1], 10);
      const height = parseInt(match[2], 10);
      return { width, height };
    } else {
      return {};
    }
  }
}

export const workaroundExtractBannerDimensionsFromUrl: Provider = {
  provide: OccCmsPageNormalizer,
  useExisting: CustomOccCmsPageNormalizer,
};

```

and then add to app.module providers:
```typescript
providers: [
  /*...*/
  workaroundExtractBannerDimensionsFromUrl
]
```
