### PR TITLE
fix: Expose OPF payment root components in a public_api

### DIFF
--- a/integration-libs/opf/payment/root/components/index.ts
+++ b/integration-libs/opf/payment/root/components/index.ts
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './opf-payment-verification/index';
+export * from './opf-payment-method-details/index';

--- a/integration-libs/opf/payment/root/public_api.ts
+++ b/integration-libs/opf/payment/root/public_api.ts
@@ -9,4 +9,5 @@ export * from './facade/index';
 export * from './feature-name';
 export * from './model/index';
 export * from './services/index';
+export * from './components/index';
 export * from './opf-payment-root.module';


### PR DESCRIPTION
Closes: CXSPA-10706