### PR TITLE
fix: CXSPA-10632: Auth issue when using CDC library along with JDK21

### DIFF
--- a/integration-libs/cdc/root/cdc-root.module.ts
+++ b/integration-libs/cdc/root/cdc-root.module.ts
@@ -12,7 +12,7 @@ import {
   provideDefaultConfig,
   provideDefaultConfigFactory,
 } from '@spartacus/core';
-import { LogoutGuard } from '@spartacus/storefront';
+import { LoginGuard, LogoutGuard } from '@spartacus/storefront';
 import { lastValueFrom } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { CdcConsentManagementModule } from './consent-management/cdc-consent.module';
@@ -20,6 +20,7 @@ import { defaultCdcRoutingConfig } from './config/default-cdc-routing-config';
 import { CDC_CORE_FEATURE, CDC_FEATURE } from './feature-name';
 import { CdcLogoutGuard } from './guards/cdc-logout.guard';
 import { CdcJsService } from './service/cdc-js.service';
+import { CdcLoginGuard } from './guards/cdc-login.guard';
 
 export function cdcJsFactory(
   cdcJsService: CdcJsService,
@@ -53,6 +54,7 @@ export function defaultCdcComponentsConfig(): CmsConfig {
   providers: [
     provideDefaultConfigFactory(defaultCdcComponentsConfig),
     { provide: LogoutGuard, useExisting: CdcLogoutGuard },
+    { provide: LoginGuard, useExisting: CdcLoginGuard },
     {
       provide: APP_INITIALIZER,
       useFactory: cdcJsFactory,

--- a/integration-libs/cdc/root/config/default-cdc-routing-config.ts
+++ b/integration-libs/cdc/root/config/default-cdc-routing-config.ts
@@ -22,6 +22,11 @@ export const cdcRoutesConfig: RoutesConfig = {
     protected: false,
     authFlow: true,
   },
+  login: {
+    paths: ['login'], //overriding default configuration
+    protected: false,
+    authFlow: true,
+  },
 };
 
 export const defaultCdcRoutingConfig: RoutingConfig = {

--- a/integration-libs/cdc/root/guards/cdc-login.guard.spec.ts
+++ b/integration-libs/cdc/root/guards/cdc-login.guard.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { CdcLoginGuard } from './cdc-login.guard';
+import { AuthService, AuthConfigService } from '@spartacus/core';
+import { CmsPageGuard } from '@spartacus/storefront';
+
+describe('CdcLoginGuard', () => {
+  let guard: CdcLoginGuard;
+  let mockAuthService: jasmine.SpyObj<AuthService>;
+  let mockCmsPageGuard: jasmine.SpyObj<CmsPageGuard>;
+
+  beforeEach(() => {
+    mockAuthService = jasmine.createSpyObj('AuthService', [
+      'loginWithRedirect',
+    ]);
+    mockCmsPageGuard = jasmine.createSpyObj('CmsPageGuard', ['canActivate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        CdcLoginGuard,
+        AuthConfigService,
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: CmsPageGuard, useValue: mockCmsPageGuard },
+      ],
+    });
+
+    guard = TestBed.inject(CdcLoginGuard);
+  });
+
+  it('shouldRenderCMSPage should return true', (done) => {
+    guard['shouldRenderCMSPage']().subscribe((result) => {
+      expect(result).toEqual(true);
+      done();
+    });
+  });
+});

--- a/integration-libs/cdc/root/guards/cdc-login.guard.ts
+++ b/integration-libs/cdc/root/guards/cdc-login.guard.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { AuthService, AuthConfigService } from '@spartacus/core';
+import { CmsPageGuard, LoginGuard } from '@spartacus/storefront';
+import { Observable, of } from 'rxjs';
+
+/**
+ * @override
+ *
+ * CDC version of login guard.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class CdcLoginGuard extends LoginGuard {
+  constructor(
+    protected authService: AuthService,
+    protected authConfigService: AuthConfigService,
+    protected cmsPageGuard: CmsPageGuard
+  ) {
+    super(authService, authConfigService, cmsPageGuard);
+  }
+
+  protected shouldRenderCMSPage(): Observable<Boolean> {
+    return of(true); // always load CMS Login Page
+  }
+}

--- a/integration-libs/cdc/root/guards/cdc-login.guard.ts
+++ b/integration-libs/cdc/root/guards/cdc-login.guard.ts
@@ -26,7 +26,7 @@ export class CdcLoginGuard extends LoginGuard {
     super(authService, authConfigService, cmsPageGuard);
   }
 
-  protected shouldRenderCMSPage(): Observable<Boolean> {
+  protected shouldRenderCMSPage(): Observable<boolean> {
     return of(true); // always load CMS Login Page
   }
 }

--- a/integration-libs/cdc/root/guards/cdc-login.guard.ts
+++ b/integration-libs/cdc/root/guards/cdc-login.guard.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable } from '@angular/core';
 import { AuthService, AuthConfigService } from '@spartacus/core';
 import { CmsPageGuard, LoginGuard } from '@spartacus/storefront';

--- a/integration-libs/cdc/root/guards/index.ts
+++ b/integration-libs/cdc/root/guards/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from './cdc-logout.guard';
+export * from './cdc-login.guard';

--- a/projects/storefrontlib/cms-components/user/login-route/login.guard.ts
+++ b/projects/storefrontlib/cms-components/user/login-route/login.guard.ts
@@ -37,8 +37,8 @@ export class LoginGuard {
   ): Observable<GuardResult> {
     return this.shouldRenderCMSPage().pipe(
       take(1),
-      switchMap((response) => {
-        if (response) {
+      switchMap((shouldRenderCMSPage) => {
+        if (shouldRenderCMSPage) {
           return this.cmsPageGuard.canActivate(route, state);
         } else {
           // This method can trigger redirect to OAuth server that's why we don't return anything in this case
@@ -52,7 +52,7 @@ export class LoginGuard {
     );
   }
 
-  protected shouldRenderCMSPage(): Observable<Boolean> {
+  protected shouldRenderCMSPage(): Observable<boolean> {
     return this.authService.isUserLoggedIn().pipe(
       take(1),
       map((isUserLoggedIn) => {

--- a/projects/storefrontlib/cms-components/user/login-route/login.guard.ts
+++ b/projects/storefrontlib/cms-components/user/login-route/login.guard.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/router';
 import { AuthConfigService, AuthService, OAuthFlow } from '@spartacus/core';
 import { EMPTY, Observable, of } from 'rxjs';
-import { switchMap, take } from 'rxjs/operators';
+import { map, switchMap, take } from 'rxjs/operators';
 import { CmsPageGuard } from '../../../cms-structure/guards/cms-page.guard';
 
 /**
@@ -35,14 +35,10 @@ export class LoginGuard {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<GuardResult> {
-    return this.authService.isUserLoggedIn().pipe(
+    return this.shouldRenderCMSPage().pipe(
       take(1),
-      switchMap((isUserLoggedIn) => {
-        if (
-          this.authConfigService.getOAuthFlow() ===
-            OAuthFlow.ResourceOwnerPasswordFlow ||
-          isUserLoggedIn
-        ) {
+      switchMap((response) => {
+        if (response) {
           return this.cmsPageGuard.canActivate(route, state);
         } else {
           // This method can trigger redirect to OAuth server that's why we don't return anything in this case
@@ -52,6 +48,18 @@ export class LoginGuard {
           }
           return EMPTY;
         }
+      })
+    );
+  }
+
+  protected shouldRenderCMSPage(): Observable<Boolean> {
+    return this.authService.isUserLoggedIn().pipe(
+      take(1),
+      map((isUserLoggedIn) => {
+        return (
+          this.authConfigService.getOAuthFlow() ===
+            OAuthFlow.ResourceOwnerPasswordFlow || isUserLoggedIn
+        );
       })
     );
   }


### PR DESCRIPTION
When CDC is enabled in storefront, always show CMS Login Page and not the Authorization server page