### PR TITLE
fix: Redundant Login action is dispatched on page refresh

### DIFF
--- a/projects/core/src/auth/user-auth/facade/auth.service.spec.ts
+++ b/projects/core/src/auth/user-auth/facade/auth.service.spec.ts
@@ -14,7 +14,10 @@ import { AuthActions } from '../store/actions';
 import { AuthService } from './auth.service';
 import { UserIdService } from './user-id.service';
 import createSpy = jasmine.createSpy;
-import { CrossSiteRequestForgeryService } from '@spartacus/core';
+import {
+  CrossSiteRequestForgeryService,
+  FeatureConfigService,
+} from '@spartacus/core';
 
 class MockUserIdService implements Partial<UserIdService> {
   getUserId(): Observable<string> {
@@ -80,6 +83,10 @@ class MockAuthMultisiteIsolationService {
   }
 }
 
+class MockFeatureConfigService implements Partial<FeatureConfigService> {
+  isEnabled = createSpy().and.returnValue(false);
+}
+
 describe('AuthService', () => {
   let service: AuthService;
   let routingService: RoutingService;
@@ -88,6 +95,7 @@ describe('AuthService', () => {
   let oAuthLibWrapperService: OAuthLibWrapperService;
   let authRedirectService: AuthRedirectService;
   let authMultisiteIsolationService: AuthMultisiteIsolationService;
+  let featureConfigService: FeatureConfigService;
   let store: Store;
 
   beforeEach(() => {
@@ -114,6 +122,10 @@ describe('AuthService', () => {
           provide: CrossSiteRequestForgeryService,
           useClass: MockCrossSiteRequestForgeryService,
         },
+        {
+          provide: FeatureConfigService,
+          useClass: MockFeatureConfigService,
+        },
       ],
     });
 
@@ -126,6 +138,7 @@ describe('AuthService', () => {
     authMultisiteIsolationService = TestBed.inject(
       AuthMultisiteIsolationService
     );
+    featureConfigService = TestBed.inject(FeatureConfigService);
     store = TestBed.inject(Store);
   });
 
@@ -134,58 +147,121 @@ describe('AuthService', () => {
   });
 
   describe('checkOAuthParamsInUrl()', () => {
-    it('should login user when token is present', async () => {
-      spyOn(oAuthLibWrapperService, 'tryLogin').and.callThrough();
-      spyOn(userIdService, 'setUserId').and.callThrough();
-      spyOn(store, 'dispatch').and.callThrough();
-      spyOn(authStorageService, 'getItem').and.returnValue('token');
-
-      await service.checkOAuthParamsInUrl();
-
-      expect(oAuthLibWrapperService.tryLogin).toHaveBeenCalled();
-      expect(userIdService.setUserId).toHaveBeenCalledWith(OCC_USER_ID_CURRENT);
-      expect(store.dispatch).toHaveBeenCalledWith(new AuthActions.Login());
-    });
-
-    describe('when the token is received', () => {
-      it('should redirect', async () => {
-        spyOn(authRedirectService, 'redirect').and.callThrough();
-
-        await service.checkOAuthParamsInUrl();
-
-        expect(authRedirectService.redirect).toHaveBeenCalled();
+    describe('when dispatchLoginActionOnlyWhenTokenReceived feature flag is DISABLED', () => {
+      beforeEach(() => {
+        (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(false);
       });
 
-      it('should dispatch login action', async () => {
+      it('should login user when token is present and dispatch login action', async () => {
+        spyOn(oAuthLibWrapperService, 'tryLogin').and.callThrough();
+        spyOn(userIdService, 'setUserId').and.callThrough();
         spyOn(store, 'dispatch').and.callThrough();
+        spyOn(authStorageService, 'getItem').and.returnValue('token');
 
         await service.checkOAuthParamsInUrl();
 
+        expect(oAuthLibWrapperService.tryLogin).toHaveBeenCalled();
+        expect(userIdService.setUserId).toHaveBeenCalledWith(
+          OCC_USER_ID_CURRENT
+        );
         expect(store.dispatch).toHaveBeenCalledWith(new AuthActions.Login());
       });
+
+      describe('when the token is received', () => {
+        it('should redirect', async () => {
+          spyOn(authRedirectService, 'redirect').and.callThrough();
+
+          await service.checkOAuthParamsInUrl();
+
+          expect(authRedirectService.redirect).toHaveBeenCalled();
+        });
+
+        it('should dispatch login action', async () => {
+          spyOn(store, 'dispatch').and.callThrough();
+
+          await service.checkOAuthParamsInUrl();
+
+          expect(store.dispatch).toHaveBeenCalledWith(new AuthActions.Login());
+        });
+      });
+
+      describe('when the token is NOT received', () => {
+        beforeEach(() => {
+          spyOn(oAuthLibWrapperService, 'tryLogin').and.returnValue(
+            Promise.resolve({ result: true, tokenReceived: false })
+          );
+        });
+
+        it('should NOT redirect', async () => {
+          spyOn(authRedirectService, 'redirect').and.stub();
+
+          await service.checkOAuthParamsInUrl();
+
+          expect(authRedirectService.redirect).not.toHaveBeenCalled();
+        });
+
+        it('should dispatch login action', async () => {
+          spyOn(store, 'dispatch').and.callThrough();
+
+          await service.checkOAuthParamsInUrl();
+
+          expect(store.dispatch).toHaveBeenCalledWith(new AuthActions.Login());
+        });
+      });
     });
 
-    describe('when the token is NOT received', () => {
+    describe('when dispatchLoginActionOnlyWhenTokenReceived feature flag is ENABLED', () => {
       beforeEach(() => {
-        spyOn(oAuthLibWrapperService, 'tryLogin').and.returnValue(
-          Promise.resolve({ result: true, tokenReceived: false })
-        );
+        (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(true);
       });
 
-      it('should NOT redirect', async () => {
-        spyOn(authRedirectService, 'redirect').and.stub();
+      describe('when the token is received', () => {
+        it('should login user and dispatch login action', async () => {
+          spyOn(oAuthLibWrapperService, 'tryLogin').and.callThrough();
+          spyOn(userIdService, 'setUserId').and.callThrough();
+          spyOn(store, 'dispatch').and.callThrough();
+          spyOn(authStorageService, 'getItem').and.returnValue('token');
 
-        await service.checkOAuthParamsInUrl();
+          await service.checkOAuthParamsInUrl();
 
-        expect(authRedirectService.redirect).not.toHaveBeenCalled();
+          expect(oAuthLibWrapperService.tryLogin).toHaveBeenCalled();
+          expect(userIdService.setUserId).toHaveBeenCalledWith(
+            OCC_USER_ID_CURRENT
+          );
+          expect(store.dispatch).toHaveBeenCalledWith(new AuthActions.Login());
+        });
+
+        it('should redirect', async () => {
+          spyOn(authRedirectService, 'redirect').and.callThrough();
+
+          await service.checkOAuthParamsInUrl();
+
+          expect(authRedirectService.redirect).toHaveBeenCalled();
+        });
       });
 
-      it('should NOT dispatch login action', async () => {
-        spyOn(store, 'dispatch').and.callThrough();
+      describe('when the token is NOT received', () => {
+        beforeEach(() => {
+          spyOn(oAuthLibWrapperService, 'tryLogin').and.returnValue(
+            Promise.resolve({ result: true, tokenReceived: false })
+          );
+        });
 
-        await service.checkOAuthParamsInUrl();
+        it('should NOT redirect', async () => {
+          spyOn(authRedirectService, 'redirect').and.stub();
 
-        expect(store.dispatch).not.toHaveBeenCalled();
+          await service.checkOAuthParamsInUrl();
+
+          expect(authRedirectService.redirect).not.toHaveBeenCalled();
+        });
+
+        it('should NOT dispatch login action', async () => {
+          spyOn(store, 'dispatch').and.callThrough();
+
+          await service.checkOAuthParamsInUrl();
+
+          expect(store.dispatch).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/projects/core/src/auth/user-auth/facade/auth.service.spec.ts
+++ b/projects/core/src/auth/user-auth/facade/auth.service.spec.ts
@@ -155,18 +155,37 @@ describe('AuthService', () => {
 
         expect(authRedirectService.redirect).toHaveBeenCalled();
       });
+
+      it('should dispatch login action', async () => {
+        spyOn(store, 'dispatch').and.callThrough();
+
+        await service.checkOAuthParamsInUrl();
+
+        expect(store.dispatch).toHaveBeenCalledWith(new AuthActions.Login());
+      });
     });
 
     describe('when the token is NOT received', () => {
-      it('should NOT redirect', async () => {
+      beforeEach(() => {
         spyOn(oAuthLibWrapperService, 'tryLogin').and.returnValue(
           Promise.resolve({ result: true, tokenReceived: false })
         );
+      });
+
+      it('should NOT redirect', async () => {
         spyOn(authRedirectService, 'redirect').and.stub();
 
         await service.checkOAuthParamsInUrl();
 
         expect(authRedirectService.redirect).not.toHaveBeenCalled();
+      });
+
+      it('should NOT dispatch login action', async () => {
+        spyOn(store, 'dispatch').and.callThrough();
+
+        await service.checkOAuthParamsInUrl();
+
+        expect(store.dispatch).not.toHaveBeenCalled();
       });
     });
   });

--- a/projects/core/src/auth/user-auth/facade/auth.service.ts
+++ b/projects/core/src/auth/user-auth/facade/auth.service.ts
@@ -8,6 +8,7 @@ import { inject, Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { BehaviorSubject, lastValueFrom, Observable } from 'rxjs';
 import { distinctUntilChanged, map, shareReplay, tap } from 'rxjs/operators';
+import { FeatureConfigService } from '../../../features-config/services/feature-config.service';
 import { OCC_USER_ID_CURRENT } from '../../../occ/utils/occ-constants';
 import { RoutingService } from '../../../routing/facade/routing.service';
 import { StateWithClientAuth } from '../../client-auth/store/client-auth-state';
@@ -43,6 +44,8 @@ export class AuthService {
    */
   logoutInProgress$: Observable<boolean> = new BehaviorSubject<boolean>(false);
 
+  private featureConfigService = inject(FeatureConfigService);
+
   constructor(
     protected store: Store<StateWithClientAuth>,
     protected userIdService: UserIdService,
@@ -69,12 +72,27 @@ export class AuthService {
       if (loginResult.result && token) {
         this.userIdService.setUserId(OCC_USER_ID_CURRENT);
 
+        if (
+          !this.featureConfigService.isEnabled(
+            'dispatchLoginActionOnlyWhenTokenReceived'
+          )
+        ) {
+          // When the feature flag is disabled, dispatch the login action even when the token
+          // is retrieved from storage (e.g., page refresh)
+          this.store.dispatch(new AuthActions.Login());
+        }
         // We check if the token was received during the `tryLogin()` attempt.
         // If so, we will redirect as we can deduce we are returning from the authentication server.
         // Redirection should not be done in cases we get the token from storage (eg. refreshing the page).
         // In this case we need to dispatch the login action to indicate that the user has just logged in.
         if (loginResult.tokenReceived) {
-          this.store.dispatch(new AuthActions.Login());
+          if (
+            this.featureConfigService.isEnabled(
+              'dispatchLoginActionOnlyWhenTokenReceived'
+            )
+          ) {
+            this.store.dispatch(new AuthActions.Login());
+          }
           this.authRedirectService.redirect();
         }
       }

--- a/projects/core/src/auth/user-auth/facade/auth.service.ts
+++ b/projects/core/src/auth/user-auth/facade/auth.service.ts
@@ -68,12 +68,13 @@ export class AuthService {
       // that why we also need to check if we have access_token
       if (loginResult.result && token) {
         this.userIdService.setUserId(OCC_USER_ID_CURRENT);
-        this.store.dispatch(new AuthActions.Login());
 
         // We check if the token was received during the `tryLogin()` attempt.
         // If so, we will redirect as we can deduce we are returning from the authentication server.
         // Redirection should not be done in cases we get the token from storage (eg. refreshing the page).
+        // In this case we need to dispatch the login action to indicate that the user has just logged in.
         if (loginResult.tokenReceived) {
+          this.store.dispatch(new AuthActions.Login());
           this.authRedirectService.redirect();
         }
       }

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -841,6 +841,20 @@ export interface FeatureTogglesInterface {
    * This is needed to prevent premature cart loading, that especially affects the authorization code flow that requires redirection to the auth server and back.
    */
   incrementProcessesCountForMergeCart?: boolean;
+
+  /**
+   * Controls when the Login action is dispatched during OAuth URL parameter checking.
+   *
+   * When set to `true`, enables the new behavior where the Login action is only dispatched when
+   * `tokenReceived` is true, meaning the token was received during the current `tryLogin()` attempt.
+   *
+   * When set to `false`, maintains the legacy behavior where the Login action will be dispatched in all
+   * successful login scenarios during `checkOAuthParamsInUrl()`, regardless of whether the token was
+   * received in the current attempt or retrieved from storage (e.g., page refresh).
+   *
+   * Affects: `AuthService`
+   */
+  dispatchLoginActionOnlyWhenTokenReceived?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -957,4 +971,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   authorizationCodeFlowByDefault: false,
   disableClientTokens: false,
   incrementProcessesCountForMergeCart: true,
+  dispatchLoginActionOnlyWhenTokenReceived: false,
 };

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -377,6 +377,7 @@ if (environment.cpq) {
         useSiteThemeService: true,
         enableConsecutiveCharactersPasswordRequirement: true,
         enablePasswordsCannotMatchInPasswordUpdateForm: true,
+        dispatchLoginActionOnlyWhenTokenReceived: true,
         allPageMetaResolversEnabledInCsr: true,
         a11yPdpGridArrangement: true,
         a11yHamburgerMenuTrapFocus: true,


### PR DESCRIPTION
# Fix: Prevent Login action dispatch on page refresh in OAuth code flow

## Problem

When using OAuth authorization code flow (required for JDK 21), the `AuthActions.Login()` action was being dispatched on every page refresh when a user was already logged in. This caused multiple issues:

- **Redundant API requests**: Effects listening to the Login action were triggered unnecessarily (e.g., `/pages` endpoint calls)
- **Tracking events fired incorrectly**: Login tracking events were sent on page refresh instead of actual login
- **Performance impact**: Multiple effects were re-executing business logic meant only for fresh logins
- **Semantic inconsistency**: The Login action should indicate a login event, not that a user is still logged in

## Root Cause

In `AuthService.checkOAuthParamsInUrl()`, the Login action was dispatched whenever both conditions were met:
1. `loginResult.result` was `true` 
2. An access token existed in storage

However, in code flow, `loginResult.result` returns `true` even on page refreshes when the user is already authenticated, leading to the Login action being dispatched incorrectly.

## Solution

The fix leverages the existing `tokenReceived` flag in `OAuthTryLoginResult` which accurately distinguishes between:
- **`tokenReceived: true`** - Fresh token received from auth server (actual login redirect)
- **`tokenReceived: false`** - Token retrieved from storage (page refresh)

This fix resolves the issue described in the team discussion where Login actions were being dispatched on every page refresh in the JDK 21 auth branch, causing unwanted side effects in tracking and other business logic.