### PR TITLE
feat: CXSPA-10708 Handle Guest Checkout indicator in code flow

### DIFF
--- a/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.spec.ts
+++ b/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.spec.ts
@@ -6,10 +6,13 @@ import {
   AuthRedirectService,
   AuthService,
   B2BUserRole,
+  FeatureConfigService,
   GlobalMessageService,
   GlobalMessageType,
   SemanticPathService,
+  WindowRef,
 } from '@spartacus/core';
+import { IS_GUEST_USER_CHECKOUT_KEY } from '@spartacus/storefront';
 import { User, UserAccountFacade } from '@spartacus/user/account/root';
 import { EMPTY, Observable, of } from 'rxjs';
 import { CheckoutB2BAuthGuard } from './checkout-b2b-auth.guard';
@@ -60,6 +63,16 @@ class MockGlobalMessageService implements Partial<GlobalMessageService> {
   add = createSpy();
 }
 
+class MockFeatureConfigService implements Partial<FeatureConfigService> {
+  isEnabled = createSpy();
+}
+
+const mockWindowRef = {
+  localStorage: {
+    setItem: createSpy(),
+  },
+};
+
 describe('CheckoutAuthGuard', () => {
   let checkoutGuard: CheckoutB2BAuthGuard;
   let authService: AuthService;
@@ -68,7 +81,8 @@ describe('CheckoutAuthGuard', () => {
   let checkoutConfigService: CheckoutConfigService;
   let userService: UserAccountFacade;
   let globalMessageService: GlobalMessageService;
-
+  let featureConfigService: FeatureConfigService;
+  let windowRef: WindowRef;
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -101,6 +115,14 @@ describe('CheckoutAuthGuard', () => {
           provide: GlobalMessageService,
           useClass: MockGlobalMessageService,
         },
+        {
+          provide: FeatureConfigService,
+          useClass: MockFeatureConfigService,
+        },
+        {
+          provide: WindowRef,
+          useValue: mockWindowRef,
+        },
       ],
     });
     checkoutGuard = TestBed.inject(CheckoutB2BAuthGuard);
@@ -110,6 +132,8 @@ describe('CheckoutAuthGuard', () => {
     checkoutConfigService = TestBed.inject(CheckoutConfigService);
     userService = TestBed.inject(UserAccountFacade);
     globalMessageService = TestBed.inject(GlobalMessageService);
+    featureConfigService = TestBed.inject(FeatureConfigService);
+    windowRef = TestBed.inject(WindowRef);
   });
 
   describe(', when user is NOT authorized,', () => {
@@ -123,23 +147,73 @@ describe('CheckoutAuthGuard', () => {
         spyOn(activeCartFacade, 'isGuestCart').and.returnValue(of(false));
       });
 
-      it('should return url to login with forced flag when guestCheckout feature enabled', () => {
-        spyOn(checkoutConfigService, 'isGuestCheckout').and.returnValue(true);
-        let result: boolean | UrlTree | RedirectCommand | undefined;
-        checkoutGuard
-          .canActivate()
-          .subscribe((value) => (result = value))
-          .unsubscribe();
-        expect(result?.toString()).toEqual(`/login?forced=true`);
+      describe('when authorizationCodeFlowByDefault feature flag is enabled', () => {
+        beforeEach(() => {
+          (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(true);
+        });
+
+        it('should return url to login without forced flag when guestCheckout feature disabled', () => {
+          let result: boolean | UrlTree | RedirectCommand | undefined;
+          checkoutGuard
+            .canActivate()
+            .subscribe((value) => (result = value))
+            .unsubscribe();
+          expect(result?.toString()).toEqual(`/login`);
+          expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+            'authorizationCodeFlowByDefault'
+          );
+          expect(windowRef.localStorage?.setItem).not.toHaveBeenCalled();
+        });
+
+        it('should return url to login with forced flag when guestCheckout feature enabled', () => {
+          spyOn(checkoutConfigService, 'isGuestCheckout').and.returnValue(true);
+          let result: boolean | UrlTree | RedirectCommand | undefined;
+          checkoutGuard
+            .canActivate()
+            .subscribe((value) => (result = value))
+            .unsubscribe();
+          expect(result?.toString()).toEqual(`/login`);
+          expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+            'authorizationCodeFlowByDefault'
+          );
+          expect(windowRef.localStorage?.setItem).toHaveBeenCalledWith(
+            IS_GUEST_USER_CHECKOUT_KEY,
+            'true'
+          );
+        });
       });
 
-      it('should return url to login without forced flag when guestCheckout feature disabled', () => {
-        let result: boolean | UrlTree | RedirectCommand | undefined;
-        checkoutGuard
-          .canActivate()
-          .subscribe((value) => (result = value))
-          .unsubscribe();
-        expect(result?.toString()).toEqual(`/login`);
+      describe('when authorizationCodeFlowByDefault feature flag is disabled', () => {
+        beforeEach(() => {
+          (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(
+            false
+          );
+        });
+
+        it('should return url to login without forced flag when guestCheckout feature disabled', () => {
+          let result: boolean | UrlTree | RedirectCommand | undefined;
+          checkoutGuard
+            .canActivate()
+            .subscribe((value) => (result = value))
+            .unsubscribe();
+          expect(result?.toString()).toEqual(`/login`);
+          expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+            'authorizationCodeFlowByDefault'
+          );
+        });
+
+        it('should return url to login without forced flag when guestCheckout feature enabled', () => {
+          spyOn(checkoutConfigService, 'isGuestCheckout').and.returnValue(true);
+          let result: boolean | UrlTree | RedirectCommand | undefined;
+          checkoutGuard
+            .canActivate()
+            .subscribe((value) => (result = value))
+            .unsubscribe();
+          expect(result?.toString()).toEqual(`/login?forced=true`);
+          expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+            'authorizationCodeFlowByDefault'
+          );
+        });
       });
 
       it('should notify AuthRedirectService with the current navigation', () => {

--- a/feature-libs/checkout/base/components/guards/checkout-auth.guard.spec.ts
+++ b/feature-libs/checkout/base/components/guards/checkout-auth.guard.spec.ts
@@ -4,9 +4,12 @@ import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {
   AuthRedirectService,
   AuthService,
+  FeatureConfigService,
   GlobalMessageService,
   SemanticPathService,
+  WindowRef,
 } from '@spartacus/core';
+import { IS_GUEST_USER_CHECKOUT_KEY } from '@spartacus/storefront';
 import { User } from '@spartacus/user/account/root';
 import { EMPTY, of } from 'rxjs';
 import { CheckoutConfigService } from '../services/checkout-config.service';
@@ -39,12 +42,22 @@ class MockGlobalMessageService implements Partial<GlobalMessageService> {
   add = createSpy();
 }
 
+class MockFeatureConfigService implements Partial<FeatureConfigService> {
+  isEnabled = createSpy();
+}
+
+const MockWindowRef = {
+  localStorage: { setItem: createSpy(), removeItem: createSpy() },
+};
+
 describe('CheckoutAuthGuard', () => {
   let checkoutGuard: CheckoutAuthGuard;
   let authService: AuthService;
   let authRedirectService: AuthRedirectService;
   let activeCartService: ActiveCartFacade;
   let checkoutConfigService: CheckoutConfigService;
+  let featureConfigService: FeatureConfigService;
+  let windowRef: WindowRef;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -74,6 +87,14 @@ describe('CheckoutAuthGuard', () => {
           provide: GlobalMessageService,
           useClass: MockGlobalMessageService,
         },
+        {
+          provide: FeatureConfigService,
+          useClass: MockFeatureConfigService,
+        },
+        {
+          provide: WindowRef,
+          useValue: MockWindowRef,
+        },
       ],
     });
     checkoutGuard = TestBed.inject(CheckoutAuthGuard);
@@ -81,6 +102,8 @@ describe('CheckoutAuthGuard', () => {
     authRedirectService = TestBed.inject(AuthRedirectService);
     activeCartService = TestBed.inject(ActiveCartFacade);
     checkoutConfigService = TestBed.inject(CheckoutConfigService);
+    featureConfigService = TestBed.inject(FeatureConfigService);
+    windowRef = TestBed.inject(WindowRef);
   });
 
   describe(', when user is NOT authorized,', () => {
@@ -94,30 +117,88 @@ describe('CheckoutAuthGuard', () => {
         activeCartService.isGuestCart = createSpy().and.returnValue(of(false));
       });
 
-      it('should return url to login with forced flag when guestCheckout feature enabled', () => {
-        checkoutConfigService.isGuestCheckout =
-          createSpy().and.returnValue(true);
-
-        let result: boolean | UrlTree | RedirectCommand | undefined;
-        checkoutGuard
-          .canActivate()
-          .subscribe((value) => (result = value))
-          .unsubscribe();
-        expect(result?.toString()).toEqual(`/login?forced=true`);
-      });
-
-      it('should return url to login without forced flag when guestCheckout feature disabled', () => {
-        let result: boolean | UrlTree | RedirectCommand | undefined;
-        checkoutGuard
-          .canActivate()
-          .subscribe((value) => (result = value))
-          .unsubscribe();
-        expect(result?.toString()).toEqual(`/login`);
-      });
-
       it('should notify AuthRedirectService with the current navigation', () => {
         checkoutGuard.canActivate().subscribe().unsubscribe();
         expect(authRedirectService.saveCurrentNavigationUrl).toHaveBeenCalled();
+      });
+
+      describe('when authorizationCodeFlowByDefault feature flag is enabled', () => {
+        beforeEach(() => {
+          (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(true);
+        });
+
+        it('should return url to login and not set IS_GUEST_USER_CHECKOUT_KEY when guestCheckout feature disabled', () => {
+          (
+            checkoutConfigService.isGuestCheckout as jasmine.Spy
+          ).and.returnValue(false);
+
+          let result: boolean | UrlTree | RedirectCommand | undefined;
+          checkoutGuard
+            .canActivate()
+            .subscribe((value) => (result = value))
+            .unsubscribe();
+          expect(result?.toString()).toEqual(`/login`);
+          expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+            'authorizationCodeFlowByDefault'
+          );
+          expect(windowRef.localStorage?.setItem).not.toHaveBeenCalled();
+        });
+
+        it('should return url to login and set IS_GUEST_USER_CHECKOUT_KEY when guestCheckout feature enabled', () => {
+          (
+            checkoutConfigService.isGuestCheckout as jasmine.Spy
+          ).and.returnValue(true);
+
+          let result: boolean | UrlTree | RedirectCommand | undefined;
+          checkoutGuard
+            .canActivate()
+            .subscribe((value) => (result = value))
+            .unsubscribe();
+          expect(result?.toString()).toEqual(`/login`);
+          expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+            'authorizationCodeFlowByDefault'
+          );
+          expect(windowRef.localStorage?.setItem).toHaveBeenCalledWith(
+            IS_GUEST_USER_CHECKOUT_KEY,
+            'true'
+          );
+        });
+      });
+
+      describe('when authorizationCodeFlowByDefault feature flag is disabled', () => {
+        beforeEach(() => {
+          (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(
+            false
+          );
+        });
+
+        it('should return url to login without forced flag when guestCheckout feature disabled', () => {
+          let result: boolean | UrlTree | RedirectCommand | undefined;
+          checkoutGuard
+            .canActivate()
+            .subscribe((value) => (result = value))
+            .unsubscribe();
+          expect(result?.toString()).toEqual(`/login`);
+          expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+            'authorizationCodeFlowByDefault'
+          );
+        });
+
+        it('should return url to login with forced flag when guestCheckout feature enabled', () => {
+          (
+            checkoutConfigService.isGuestCheckout as jasmine.Spy
+          ).and.returnValue(true);
+
+          let result: boolean | UrlTree | RedirectCommand | undefined;
+          checkoutGuard
+            .canActivate()
+            .subscribe((value) => (result = value))
+            .unsubscribe();
+          expect(result?.toString()).toEqual(`/login?forced=true`);
+          expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+            'authorizationCodeFlowByDefault'
+          );
+        });
       });
     });
 

--- a/feature-libs/checkout/base/components/guards/checkout-auth.guard.ts
+++ b/feature-libs/checkout/base/components/guards/checkout-auth.guard.ts
@@ -4,15 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { GuardResult, Router, UrlTree } from '@angular/router';
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import {
   AuthRedirectService,
   AuthService,
+  FeatureConfigService,
   SemanticPathService,
+  WindowRef,
 } from '@spartacus/core';
-import { Observable, combineLatest } from 'rxjs';
+import { IS_GUEST_USER_CHECKOUT_KEY } from '@spartacus/storefront';
+import { combineLatest, Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { CheckoutConfigService } from '../services/checkout-config.service';
 
@@ -20,6 +23,10 @@ import { CheckoutConfigService } from '../services/checkout-config.service';
   providedIn: 'root',
 })
 export class CheckoutAuthGuard {
+  // Name `featureConfig` instead of `featureConfigService` to avoid clash with `FeatureConfigService` in `OpfCheckoutAuthGuard`
+  private featureConfig = inject(FeatureConfigService);
+  protected windowRef = inject(WindowRef);
+
   constructor(
     protected authService: AuthService,
     protected authRedirectService: AuthRedirectService,
@@ -52,13 +59,25 @@ export class CheckoutAuthGuard {
 
   protected handleAnonymousUser(): boolean | UrlTree {
     this.authRedirectService.saveCurrentNavigationUrl();
-    if (this.checkoutConfigService.isGuestCheckout()) {
-      return this.router.createUrlTree(
-        [this.semanticPathService.get('login')],
-        { queryParams: { forced: true } }
-      );
-    } else {
+    if (this.featureConfig.isEnabled('authorizationCodeFlowByDefault')) {
+      if (this.checkoutConfigService.isGuestCheckout()) {
+        this.windowRef.localStorage?.setItem(
+          IS_GUEST_USER_CHECKOUT_KEY,
+          'true'
+        );
+      }
       return this.router.parseUrl(this.semanticPathService.get('login') ?? '');
+    } else {
+      if (this.checkoutConfigService.isGuestCheckout()) {
+        return this.router.createUrlTree(
+          [this.semanticPathService.get('login')],
+          { queryParams: { forced: true } }
+        );
+      } else {
+        return this.router.parseUrl(
+          this.semanticPathService.get('login') ?? ''
+        );
+      }
     }
   }
 }

--- a/feature-libs/user/account/components/guards/login-as-guest.guard.spec.ts
+++ b/feature-libs/user/account/components/guards/login-as-guest.guard.spec.ts
@@ -1,0 +1,113 @@
+//generate test for LoginAsGuestGuard
+
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import {
+  FeatureConfigService,
+  SemanticPathService,
+  WindowRef,
+} from '@spartacus/core';
+import { IS_GUEST_USER_CHECKOUT_KEY } from '@spartacus/storefront';
+import { LoginAsGuestGuard } from './login-as-guest.guard';
+
+const mockFeatureConfigService = {
+  isEnabled: jasmine.createSpy().and.returnValue(true),
+};
+
+const mockWindowRef = {
+  localStorage: {
+    getItem: jasmine.createSpy().and.returnValue('true'),
+    removeItem: jasmine.createSpy(),
+  },
+};
+
+const mockSemanticPathService = {
+  get: jasmine.createSpy().and.returnValue('loginForm'),
+};
+
+fdescribe('LoginAsGuestGuard', () => {
+  let guard: LoginAsGuestGuard;
+  let windowRef: WindowRef;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        Router,
+        {
+          provide: FeatureConfigService,
+          useValue: mockFeatureConfigService,
+        },
+        {
+          provide: SemanticPathService,
+          useValue: mockSemanticPathService,
+        },
+        {
+          provide: WindowRef,
+          useValue: mockWindowRef,
+        },
+      ],
+    });
+    guard = TestBed.inject(LoginAsGuestGuard);
+    windowRef = TestBed.inject(WindowRef);
+  });
+
+  beforeEach(() => {
+    mockWindowRef.localStorage.removeItem.calls.reset();
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  describe('when authorizationCodeFlowByDefault feature flag is not enabled', () => {
+    it('should return true', () => {
+      mockFeatureConfigService.isEnabled.and.returnValue(false);
+      guard.canActivate().subscribe((result) => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('when authorizationCodeFlowByDefault feature flag is enabled', () => {
+    it('should return url to login with `forced` query param when IS_GUEST_USER_CHECKOUT_KEY is set to true', () => {
+      mockFeatureConfigService.isEnabled.and.returnValue(true);
+      guard.canActivate().subscribe((result) => {
+        expect(result.toString()).toBe('/loginForm?forced=true');
+      });
+      expect(windowRef.localStorage?.getItem).toHaveBeenCalledWith(
+        IS_GUEST_USER_CHECKOUT_KEY
+      );
+      expect(windowRef.localStorage?.removeItem).toHaveBeenCalledWith(
+        IS_GUEST_USER_CHECKOUT_KEY
+      );
+    });
+
+    it('should return true if IS_GUEST_USER_CHECKOUT_KEY is not set to true', () => {
+      mockFeatureConfigService.isEnabled.and.returnValue(true);
+      (mockWindowRef.localStorage?.getItem as jasmine.Spy).and.returnValue(
+        'false'
+      );
+      guard.canActivate().subscribe((result) => {
+        expect(result).toBe(true);
+      });
+      expect(windowRef.localStorage?.getItem).toHaveBeenCalledWith(
+        IS_GUEST_USER_CHECKOUT_KEY
+      );
+      expect(windowRef.localStorage?.removeItem).not.toHaveBeenCalled();
+    });
+
+    it('should return true if IS_GUEST_USER_CHECKOUT_KEY is not set', () => {
+      mockFeatureConfigService.isEnabled.and.returnValue(true);
+      (mockWindowRef.localStorage?.getItem as jasmine.Spy).and.returnValue(
+        null
+      );
+      guard.canActivate().subscribe((result) => {
+        expect(result).toBe(true);
+      });
+      expect(windowRef.localStorage?.getItem).toHaveBeenCalledWith(
+        IS_GUEST_USER_CHECKOUT_KEY
+      );
+      expect(windowRef.localStorage?.removeItem).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/feature-libs/user/account/components/guards/login-as-guest.guard.spec.ts
+++ b/feature-libs/user/account/components/guards/login-as-guest.guard.spec.ts
@@ -25,7 +25,7 @@ const mockSemanticPathService = {
   get: jasmine.createSpy().and.returnValue('loginForm'),
 };
 
-fdescribe('LoginAsGuestGuard', () => {
+describe('LoginAsGuestGuard', () => {
   let guard: LoginAsGuestGuard;
   let windowRef: WindowRef;
 

--- a/feature-libs/user/account/components/guards/login-as-guest.guard.ts
+++ b/feature-libs/user/account/components/guards/login-as-guest.guard.ts
@@ -1,0 +1,36 @@
+import { Injectable, inject } from '@angular/core';
+import { GuardResult, Router } from '@angular/router';
+import {
+  FeatureConfigService,
+  SemanticPathService,
+  WindowRef,
+} from '@spartacus/core';
+import { IS_GUEST_USER_CHECKOUT_KEY } from '@spartacus/storefront';
+import { Observable, of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LoginAsGuestGuard {
+  private featureConfigService = inject(FeatureConfigService);
+  protected windowRef = inject(WindowRef);
+  protected router = inject(Router);
+  protected semanticPathService = inject(SemanticPathService);
+
+  canActivate(): Observable<GuardResult> {
+    if (
+      this.featureConfigService.isEnabled('authorizationCodeFlowByDefault') &&
+      this.windowRef.localStorage?.getItem(IS_GUEST_USER_CHECKOUT_KEY) ===
+        'true'
+    ) {
+      this.windowRef.localStorage.removeItem(IS_GUEST_USER_CHECKOUT_KEY);
+      return of(
+        this.router.createUrlTree([this.semanticPathService.get('loginForm')], {
+          queryParams: { forced: true },
+        })
+      );
+    }
+
+    return of(true);
+  }
+}

--- a/feature-libs/user/account/components/guards/login-as-guest.guard.ts
+++ b/feature-libs/user/account/components/guards/login-as-guest.guard.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { Injectable, inject } from '@angular/core';
 import { GuardResult, Router } from '@angular/router';
 import {

--- a/feature-libs/user/account/components/login-register/login-register.module.ts
+++ b/feature-libs/user/account/components/login-register/login-register.module.ts
@@ -15,6 +15,7 @@ import {
   UrlModule,
 } from '@spartacus/core';
 import { BtnLikeLinkModule, PageSlotModule } from '@spartacus/storefront';
+import { LoginAsGuestGuard } from '../guards/login-as-guest.guard';
 import { LoginRegisterComponent } from './login-register.component';
 
 @NgModule({
@@ -31,7 +32,7 @@ import { LoginRegisterComponent } from './login-register.component';
       cmsComponents: {
         ReturningCustomerRegisterComponent: {
           component: LoginRegisterComponent,
-          guards: [NotAuthGuard],
+          guards: [NotAuthGuard, LoginAsGuestGuard],
         },
       },
     }),

--- a/feature-libs/user/account/components/public_api.ts
+++ b/feature-libs/user/account/components/public_api.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export * from './guards/login-as-guest.guard';
 export * from './login-form/index';
 export * from './login-register/index';
 export * from './login/index';

--- a/integration-libs/opf/checkout/root/checkout-guard/opf-checkout-auth.guard.ts
+++ b/integration-libs/opf/checkout/root/checkout-guard/opf-checkout-auth.guard.ts
@@ -22,6 +22,9 @@ import { OpfCartUserEmailCheckerService } from '../services';
 export class OpfCheckoutAuthGuard extends CheckoutAuthGuard {
   protected userIdService = inject(UserIdService);
   protected opfCartUserEmailChecker = inject(OpfCartUserEmailCheckerService);
+  /**
+   * @deprecated since 2211.44
+   */
   protected featureConfigService = inject(FeatureConfigService);
 
   /**

--- a/projects/storefrontlib/cms-components/user/index.ts
+++ b/projects/storefrontlib/cms-components/user/index.ts
@@ -9,3 +9,4 @@ export * from './login-route/login.guard';
 export * from './logout/logout.guard';
 export * from './logout/logout.module';
 export * from './user.module';
+export * from './utils/user-constants';

--- a/projects/storefrontlib/cms-components/user/utils/user-constants.ts
+++ b/projects/storefrontlib/cms-components/user/utils/user-constants.ts
@@ -3,4 +3,5 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 export const IS_GUEST_USER_CHECKOUT_KEY = 'isGuestUserCheckout';

--- a/projects/storefrontlib/cms-components/user/utils/user-constants.ts
+++ b/projects/storefrontlib/cms-components/user/utils/user-constants.ts
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export const IS_GUEST_USER_CHECKOUT_KEY = 'isGuestUserCheckout';


### PR DESCRIPTION
This PR provides an alternative way of handling the guest checkout indicator. In password flow, it was done redarecting to the login page with queryParam `?forced=true`, triggered by the `CheckoutAuthGuard`. Due to redirections to the auth server that are part of the code flow, we need to keep the indicator in a different way. To solve it, the related flag that are kept in the local storage was used.

QA:

1. Authorization Code Flow
a.  run the app and go to http://localhost:4200/electronics-spa/en/USD/product/592506/av-cable-model-av-8
b. add to cart and click `Proceed To Checkout`
c. verify that login page has `Guest Checkout` option and click it
    <img width="605" height="485" alt="image" src="https://github.com/user-attachments/assets/451984ff-387b-4d61-b39a-5007e5c875e8" />
d. provide guest email (e.g. test@test.com) and go through the checkout process
e. repeat steps from a, b, c and when being on the `http://localhost:4200/electronics-spa/en/USD/login?forced=true` click on `Sign In/Register` in the top-right corner
f. verify that url has been changed to http://localhost:4200/electronics-spa/en/USD/login and instead of `Guest Checkout` the `Register` option is present.
   <img width="651" height="598" alt="image" src="https://github.com/user-attachments/assets/472eb2a4-9560-45de-8a77-d7a86cca6ec9" />

1. Resource Owner Password Flow
a. go to `spartacus-features.module.ts` and change `authorizationCodeFlowByDefault` to `false`
b. go to `environment.ts` and change `occBaseUrl:` to `https://40.76.109.9:9002` (jdk 17 commerce system where password flow is available) 
c.  run the app and go to http://localhost:4200/electronics-spa/en/USD/product/592506/av-cable-model-av-8
d. add to cart and click `Proceed To Checkout`
e. verify that login page has `Guest Checkout` option and click it
    <img width="605" height="485" alt="image" src="https://github.com/user-attachments/assets/451984ff-387b-4d61-b39a-5007e5c875e8" />
f. provide guest email (e.g. test@test.com) and go through the checkout process
g. repeat steps from a, b, c and when being on the `http://localhost:4200/electronics-spa/en/USD/login?forced=true` click on `Sign In/Register` in the top-right corner
h. verify that url has been changed to http://localhost:4200/electronics-spa/en/USD/login but the `Guest Checkout` option is still present - that's because only queryParam changes which does not reload the page (expected behavior)

Closes: https://jira.tools.sap/browse/CXSPA-10708

