### PR TITLE
fix: CXSPA-10742 Error during guest registration

### DIFF
--- a/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.spec.ts
+++ b/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.spec.ts
@@ -28,13 +28,17 @@ class MockRoutingService implements Partial<RoutingService> {
   go = jasmine.createSpy('go');
 }
 
+class MockFeatureConfigService implements Partial<FeatureConfigService> {
+  isEnabled = createSpy().and.returnValue(false);
+}
+
 describe('OrderGuestRegisterFormComponent', () => {
   let component: OrderGuestRegisterFormComponent;
   let fixture: ComponentFixture<OrderGuestRegisterFormComponent>;
 
   let userRegisterFacade: UserRegisterFacade;
   let routingService: RoutingService;
-
+  let featureConfigService: FeatureConfigService;
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -48,6 +52,7 @@ describe('OrderGuestRegisterFormComponent', () => {
         { provide: AuthService, useClass: MockAuthService },
         { provide: UserRegisterFacade, useClass: MockUserRegisterFacade },
         { provide: RoutingService, useClass: MockRoutingService },
+        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
       ],
     }).compileComponents();
   }));
@@ -57,7 +62,7 @@ describe('OrderGuestRegisterFormComponent', () => {
 
     userRegisterFacade = TestBed.inject(UserRegisterFacade);
     routingService = TestBed.inject(RoutingService);
-
+    featureConfigService = TestBed.inject(FeatureConfigService);
     component = fixture.componentInstance;
   });
 
@@ -65,26 +70,54 @@ describe('OrderGuestRegisterFormComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should register customer and redirect to homepage when submit', () => {
-    const password = 'StrongPass123!@#';
-    component.guestRegisterForm.controls['password'].setValue(password);
-    component.guestRegisterForm.controls['passwordconf'].setValue(password);
-    component.guid = 'guid';
-    component.submit();
+  describe('submit', () => {
+    describe('when authorizationCodeFlowByDefault is enabled', () => {
+      beforeEach(() => {
+        (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(true);
+      });
 
-    expect(userRegisterFacade.registerGuest).toHaveBeenCalledWith(
-      'guid',
-      password
-    );
-    expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'home' });
+      it('should register customer', () => {
+        const password = 'StrongPass123!@#';
+        component.guestRegisterForm.controls['password'].setValue(password);
+        component.guestRegisterForm.controls['passwordconf'].setValue(password);
+        component.guid = 'guid';
+        component.submit();
+
+        expect(userRegisterFacade.registerGuest).toHaveBeenCalledWith(
+          'guid',
+          password
+        );
+        expect(routingService.go).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when authorizationCodeFlowByDefault is disabled', () => {
+      beforeEach(() => {
+        (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(false);
+      });
+
+      it('should register customer and redirect to homepage when submit', () => {
+        const password = 'StrongPass123!@#';
+        component.guestRegisterForm.controls['password'].setValue(password);
+        component.guestRegisterForm.controls['passwordconf'].setValue(password);
+        component.guid = 'guid';
+        component.submit();
+
+        expect(userRegisterFacade.registerGuest).toHaveBeenCalledWith(
+          'guid',
+          password
+        );
+        expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'home' });
+        expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+          'authorizationCodeFlowByDefault'
+        );
+      });
+    });
   });
 
   describe('password validators', () => {
-    let featureConfigService: FeatureConfigService;
-
     it('should have new validators when feature flag is enabled', () => {
-      featureConfigService = TestBed.inject(FeatureConfigService);
-      spyOn(featureConfigService, 'isEnabled').and.returnValue(true);
+      (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(true);
 
       fixture = TestBed.createComponent(OrderGuestRegisterFormComponent);
       component = fixture.componentInstance;

--- a/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.ts
+++ b/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.ts
@@ -73,7 +73,10 @@ export class OrderGuestRegisterFormComponent implements OnDestroy {
         this.guid,
         this.guestRegisterForm.value.password
       );
-      if (!this.subscription) {
+      if (
+        !this.subscription &&
+        !this.featureConfigService.isEnabled('authorizationCodeFlowByDefault')
+      ) {
         this.subscription = this.authService
           .isUserLoggedIn()
           .subscribe((isLoggedIn) => {

--- a/feature-libs/user/profile/core/facade/user-register.service.spec.ts
+++ b/feature-libs/user/profile/core/facade/user-register.service.spec.ts
@@ -1,12 +1,18 @@
 import { inject, TestBed } from '@angular/core/testing';
-import { AuthService, OCC_USER_ID_CURRENT, User } from '@spartacus/core';
+import {
+  AuthService,
+  FeatureConfigService,
+  OCC_USER_ID_CURRENT,
+  RoutingService,
+  User,
+} from '@spartacus/core';
 
+import { Store } from '@ngrx/store';
+import { UserProfileConnector } from '@spartacus/user/profile/core';
+import { UserSignUp } from '@spartacus/user/profile/root';
 import { Observable, of } from 'rxjs';
 import { UserProfileService } from './user-profile.service';
 import { UserRegisterService } from './user-register.service';
-import { UserSignUp } from '@spartacus/user/profile/root';
-import { UserProfileConnector } from '@spartacus/user/profile/core';
-import { Store } from '@ngrx/store';
 import createSpy = jasmine.createSpy;
 
 class MockUserProfileService implements Partial<UserProfileService> {
@@ -25,10 +31,20 @@ class MockAuthService implements Partial<AuthService> {
   loginWithCredentials = createSpy().and.returnValue(Promise.resolve());
 }
 
+class MockRoutingService implements Partial<RoutingService> {
+  go = createSpy().and.returnValue(Promise.resolve());
+}
+
+class MockFeatureConfigService implements Partial<FeatureConfigService> {
+  isEnabled = createSpy().and.returnValue(false);
+}
+
 describe('UserRegisterService', () => {
   let service: UserRegisterService;
   let connector: UserProfileConnector;
-
+  let authService: AuthService;
+  let featureConfigService: FeatureConfigService;
+  let routingService: RoutingService;
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -39,12 +55,17 @@ describe('UserRegisterService', () => {
           useClass: MockUserProfileConnector,
         },
         { provide: UserProfileService, useClass: MockUserProfileService },
+        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
+        { provide: RoutingService, useClass: MockRoutingService },
         UserRegisterService,
       ],
     });
 
     service = TestBed.inject(UserRegisterService);
     connector = TestBed.inject(UserProfileConnector);
+    authService = TestBed.inject(AuthService);
+    featureConfigService = TestBed.inject(FeatureConfigService);
+    routingService = TestBed.inject(RoutingService);
   });
 
   it('should inject UserRegisterService', inject(
@@ -72,9 +93,44 @@ describe('UserRegisterService', () => {
     });
   });
 
-  it('should be able to register guest', () => {
-    service.registerGuest('guid', 'password');
-    expect(connector.registerGuest).toHaveBeenCalledWith('guid', 'password');
+  describe('registerGuest', () => {
+    describe('when authorizationCodeFlowByDefault is enabled', () => {
+      beforeEach(() => {
+        (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(true);
+      });
+      it('should be able to register guest and redirect to login', () => {
+        service.registerGuest('guid', 'password');
+        expect(connector.registerGuest).toHaveBeenCalledWith(
+          'guid',
+          'password'
+        );
+        expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'login' });
+        expect(authService.loginWithCredentials).not.toHaveBeenCalled();
+        expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+          'authorizationCodeFlowByDefault'
+        );
+      });
+    });
+    describe('when authorizationCodeFlowByDefault is disabled', () => {
+      beforeEach(() => {
+        (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(false);
+      });
+      it('should be able to register guest and login with credentials', () => {
+        service.registerGuest('guid', 'password');
+        expect(connector.registerGuest).toHaveBeenCalledWith(
+          'guid',
+          'password'
+        );
+        expect(authService.loginWithCredentials).toHaveBeenCalledWith(
+          'guid',
+          'password'
+        );
+        expect(routingService.go).not.toHaveBeenCalled();
+        expect(featureConfigService.isEnabled).toHaveBeenCalledWith(
+          'authorizationCodeFlowByDefault'
+        );
+      });
+    });
   });
 
   it('should get titles from profileService', () => {

--- a/feature-libs/user/profile/core/facade/user-register.service.ts
+++ b/feature-libs/user/profile/core/facade/user-register.service.ts
@@ -4,27 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
 import {
   AuthService,
   Command,
   CommandService,
+  FeatureConfigService,
+  RoutingService,
   UserActions,
 } from '@spartacus/core';
 import { User } from '@spartacus/user/account/root';
-import { Observable } from 'rxjs';
 import {
   Title,
   UserRegisterFacade,
   UserSignUp,
 } from '@spartacus/user/profile/root';
-import { UserProfileConnector } from '../connectors/user-profile.connector';
+import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { UserProfileConnector } from '../connectors/user-profile.connector';
 import { UserProfileService } from './user-profile.service';
-import { Store } from '@ngrx/store';
 
 @Injectable()
 export class UserRegisterService implements UserRegisterFacade {
+  private featureConfigService = inject(FeatureConfigService);
+  protected routingService = inject(RoutingService);
+
   protected registerCommand: Command<{ user: UserSignUp }, User> =
     this.command.create(({ user }) =>
       this.userConnector.register(user).pipe(
@@ -46,8 +51,14 @@ export class UserRegisterService implements UserRegisterFacade {
   > = this.command.create((payload) =>
     this.userConnector.registerGuest(payload.guid, payload.password).pipe(
       tap((user) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.authService.loginWithCredentials(user.uid!, payload.password);
+        if (
+          !this.featureConfigService.isEnabled('authorizationCodeFlowByDefault')
+        ) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          this.authService.loginWithCredentials(user.uid!, payload.password);
+        } else {
+          this.routingService.go({ cxRoute: 'login' });
+        }
       })
     )
   );


### PR DESCRIPTION
This PR provides fix for the guest registration after successful guest checkout. USer was created but due to usage of `authService.loginWithCredentials` regardless of configured auth flow, process produced errors for JDK 21, where is no support for the Resource Owner Password Flow (triggered under the hood of mentioned method)

QA steps:

1. Authorization Code Flow - happy path
a.  run the app and go to http://localhost:4200/electronics-spa/en/USD/product/592506/av-cable-model-av-8
b. add to cart and click `Proceed To Checkout`
c. proceed with the Guest Checkout
    <img width="605" height="485" alt="image" src="https://github.com/user-attachments/assets/451984ff-387b-4d61-b39a-5007e5c875e8" />
d. provide unique guest email and go through the checkout process. **CAUTION:** if user with provided email already exists, then guest registration won't pass.
e. Proceed with checkout. When land on guest order confirmation page, go through the Create an account process and click `Submit` button
   <img width="1188" height="1010" alt="image" src="https://github.com/user-attachments/assets/9c6f3445-fecd-4d4f-bf51-d8e44a9c644b" />
f. When user created, you should be redirected to the login page. Check if customer is created


1. Authorization Code Flow - unhappy path
a. go to `user-register.service.ts` file change the condition in line 55 to revert provided fix:
   ```ts
       if (
          this.featureConfigService.isEnabled('authorizationCodeFlowByDefault') // <--- RUN WHEN FEATURE FLAG ENABLED
        ) {
          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
          this.authService.loginWithCredentials(user.uid!, payload.password);
        } else {
          this.routingService.go({ cxRoute: 'login' });  <-- THIS ONE
        }
   ``` 
b.  run the app and go to http://localhost:4200/electronics-spa/en/USD/product/592506/av-cable-model-av-8
c. add to cart and click `Proceed To Checkout`
d. proceed with the Guest Checkout
    <img width="605" height="485" alt="image" src="https://github.com/user-attachments/assets/451984ff-387b-4d61-b39a-5007e5c875e8" />
e. provide unique guest email and go through the checkout process. **CAUTION:** if user with provided email already exists, then guest registration won't pass.
f. proceed with checkout - when land on guest order confirmation page, go through the Create an account process and click `Submit` button
   <img width="1188" height="1010" alt="image" src="https://github.com/user-attachments/assets/9c6f3445-fecd-4d4f-bf51-d8e44a9c644b" />
g. When submitted, user is not redirected to login page and the following error is visible in the console:
    <img width="1374" height="1092" alt="image" src="https://github.com/user-attachments/assets/fdc7b9cf-d24d-4bc2-b833-25e55a00ec90" />


1. Resource Owner Password Flow
a. Revert changes from `user-register.service.ts`, go to `spartacus-features.module.ts` and change `authorizationCodeFlowByDefault` to `false`
b. go to `environment.ts` and change `occBaseUrl:` to `https://40.76.109.9:9002` (jdk 17 commerce system where password flow is available) 
c.  run the app and go to http://localhost:4200/electronics-spa/en/USD/product/592506/av-cable-model-av-8
d. add to cart and click `Proceed To Checkout`
e. verify that login page has `Guest Checkout` option and click it
    <img width="605" height="485" alt="image" src="https://github.com/user-attachments/assets/451984ff-387b-4d61-b39a-5007e5c875e8" />
f. provide unique guest email and go through the checkout process. **CAUTION:** if user with provided email already exists, then guest registration won't pass.
g. proceed with checkout - when land on guest order confirmation page, go through the Create an account process and click `Submit` button
   <img width="1188" height="1010" alt="image" src="https://github.com/user-attachments/assets/9c6f3445-fecd-4d4f-bf51-d8e44a9c644b" />
h. When user created, you should be redirected to the home page (previous expected behaviour)

Closes [CXSPA-10742](https://jira.tools.sap/browse/CXSPA-10742)