### PR TITLE
chore: enable a11y feature toggle (CXSPA-10766)

### DIFF
--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -773,7 +773,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yImprovedErrorMessage: false,
   a11yLinkBtnsToTertiaryBtns: false,
   a11yNgSelectCloseDropdownOnEscape: true,
-  a11ySelectImprovementsCustomerTicketingCreateSelectbox: false,
+  a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   a11yNgSelectAriaLabelDropdownCustomized: true,
   a11yDeliveryMethodFieldset: true,
   a11yShowMoreReviewsBtnFocus: true,


### PR DESCRIPTION
For the September release, the following a11y toggle needs to be set to `true`:

- `a11ySelectImprovementsCustomerTicketingCreateSelectbox`

This toggle was introduced in the 2211.37 March release, which was six months ago, so for the September release, it is time to enable it by default.

Source of truth: [Composable Storefront Accessibility Rollout Phases](https://help.sap.com/docs/SAP_COMMERCE_COMPOSABLE_STOREFRONT/10a8bc7f635b4e3db6f6bb7880e58a7d/e84f624b79b74c07b199ac9a17d8f483.html?locale=en-US)