### PR TITLE
feat: CXSPA-10733 Handle authentication wrong credentials for Authorization Code Flow

### DIFF
--- a/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
@@ -231,6 +231,9 @@ describe('LoginFormComponentService', () => {
       }));
 
       beforeEach(() => {
+        globalMessageService = TestBed.inject(GlobalMessageService);
+        activatedRoute = TestBed.inject(ActivatedRoute);
+        router = TestBed.inject(Router);
         service = TestBed.inject(LoginFormComponentService);
         authService = TestBed.inject(AuthService);
         winRef = TestBed.inject(WindowRef);
@@ -291,28 +294,29 @@ describe('LoginFormComponentService', () => {
           expect(service.form.reset).not.toHaveBeenCalled();
         });
       });
-    });
-  });
 
-  describe('handleLoginError', () => {
-    it('should add error message to global message service', () => {
-      service.handleCustomLoginError();
-      expect(globalMessageService.add).toHaveBeenCalledWith(
-        {
-          key: 'customLoginPage.badRequest.bad_credentials',
-        },
-        GlobalMessageType.MSG_TYPE_ERROR
-      );
-      expect(router.navigate).toHaveBeenCalledWith([], {
-        queryParams: { error: null },
+      describe('handleCustomLoginError', () => {
+        it('should add error message to global message service', () => {
+          service.handleCustomLoginError();
+
+          expect(globalMessageService.add).toHaveBeenCalledWith(
+            {
+              key: 'customLoginPage.badRequest.bad_credentials',
+            },
+            GlobalMessageType.MSG_TYPE_ERROR
+          );
+          expect(router.navigate).toHaveBeenCalledWith([], {
+            queryParams: { error: null },
+          });
+        });
+
+        it('should not add error message to global message service if error is not present', () => {
+          activatedRoute.snapshot.queryParams = { error: null };
+          service.handleCustomLoginError();
+          expect(globalMessageService.add).not.toHaveBeenCalled();
+          expect(router.navigate).not.toHaveBeenCalled();
+        });
       });
-    });
-
-    it('should not add error message to global message service if error is not present', () => {
-      activatedRoute.snapshot.queryParams = { error: null };
-      service.handleCustomLoginError();
-      expect(globalMessageService.add).not.toHaveBeenCalled();
-      expect(router.navigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
@@ -1,10 +1,16 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import {
+  ActivatedRoute,
+  ActivatedRouteSnapshot,
+  Router,
+} from '@angular/router';
+import {
   AuthConfigService,
   AuthService,
   FeatureConfigService,
   GlobalMessageService,
+  GlobalMessageType,
   I18nTestingModule,
   WindowRef,
 } from '@spartacus/core';
@@ -42,6 +48,16 @@ class MockFeatureConfigService implements Partial<FeatureConfigService> {
   }
 }
 
+class MockActivatedRoute implements Partial<ActivatedRoute> {
+  snapshot = {
+    queryParams: { error: 'bad_credentials' },
+  } as unknown as ActivatedRouteSnapshot;
+}
+
+class MockRouter implements Partial<Router> {
+  navigate = createSpy().and.stub();
+}
+
 class MockAuthConfigService implements Partial<AuthConfigService> {
   getCustomLoginFormEndpoint() {
     return 'https://localhost:9002/authorizationserver/login';
@@ -77,6 +93,9 @@ describe('LoginFormComponentService', () => {
   let service: LoginFormComponentService;
   let authService: AuthService;
   let winRef: WindowRef;
+  let globalMessageService: GlobalMessageService;
+  let activatedRoute: ActivatedRoute;
+  let router: Router;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -89,6 +108,8 @@ describe('LoginFormComponentService', () => {
         { provide: GlobalMessageService, useClass: MockGlobalMessageService },
         { provide: AuthConfigService, useClass: MockAuthConfigService },
         { provide: FeatureConfigService, useClass: MockFeatureConfigService },
+        { provide: ActivatedRoute, useClass: MockActivatedRoute },
+        { provide: Router, useClass: MockRouter },
       ],
     }).compileComponents();
   }));
@@ -97,6 +118,9 @@ describe('LoginFormComponentService', () => {
     service = TestBed.inject(LoginFormComponentService);
     authService = TestBed.inject(AuthService);
     winRef = TestBed.inject(WindowRef);
+    activatedRoute = TestBed.inject(ActivatedRoute);
+    router = TestBed.inject(Router);
+    globalMessageService = TestBed.inject(GlobalMessageService);
   });
 
   it('should create service', () => {
@@ -194,6 +218,14 @@ describe('LoginFormComponentService', () => {
               provide: GlobalMessageService,
               useClass: MockGlobalMessageService,
             },
+            {
+              provide: ActivatedRoute,
+              useClass: MockActivatedRoute,
+            },
+            {
+              provide: Router,
+              useClass: MockRouter,
+            },
           ],
         }).compileComponents();
       }));
@@ -259,6 +291,28 @@ describe('LoginFormComponentService', () => {
           expect(service.form.reset).not.toHaveBeenCalled();
         });
       });
+    });
+  });
+
+  describe('handleLoginError', () => {
+    it('should add error message to global message service', () => {
+      service.handleLoginError();
+      expect(globalMessageService.add).toHaveBeenCalledWith(
+        {
+          key: 'customLoginPage.badRequest.bad_credentials',
+        },
+        GlobalMessageType.MSG_TYPE_ERROR
+      );
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        queryParams: { error: null },
+      });
+    });
+
+    it('should not add error message to global message service if error is not present', () => {
+      activatedRoute.snapshot.queryParams = { error: null };
+      service.handleLoginError();
+      expect(globalMessageService.add).not.toHaveBeenCalled();
+      expect(router.navigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
@@ -296,7 +296,7 @@ describe('LoginFormComponentService', () => {
 
   describe('handleLoginError', () => {
     it('should add error message to global message service', () => {
-      service.handleLoginError();
+      service.handleCustomLoginError();
       expect(globalMessageService.add).toHaveBeenCalledWith(
         {
           key: 'customLoginPage.badRequest.bad_credentials',
@@ -310,7 +310,7 @@ describe('LoginFormComponentService', () => {
 
     it('should not add error message to global message service if error is not present', () => {
       activatedRoute.snapshot.queryParams = { error: null };
-      service.handleLoginError();
+      service.handleCustomLoginError();
       expect(globalMessageService.add).not.toHaveBeenCalled();
       expect(router.navigate).not.toHaveBeenCalled();
     });

--- a/feature-libs/user/account/components/login-form/login-form-component.service.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.ts
@@ -101,17 +101,21 @@ export class LoginFormComponentService {
   }
 
   handleLoginError(): void {
+    const validErrors = ['bad_credentials', 'account_disabled'];
     const error = this.activatedRoute.snapshot.queryParams['error'];
     if (error) {
       this.globalMessage.add(
         {
-          key: `customLoginPage.badRequest.${error}`,
+          key: validErrors.includes(error)
+            ? `customLoginPage.badRequest.${error}`
+            : 'customLoginPage.badRequest.unknown_error',
         },
         GlobalMessageType.MSG_TYPE_ERROR
       );
       this.router.navigate([], {
         queryParams: { error: null },
       });
+    } else if (error) {
     }
   }
 

--- a/feature-libs/user/account/components/login-form/login-form-component.service.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.ts
@@ -115,7 +115,6 @@ export class LoginFormComponentService {
       this.router.navigate([], {
         queryParams: { error: null },
       });
-    } else if (error) {
     }
   }
 

--- a/feature-libs/user/account/components/login-form/login-form-component.service.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.ts
@@ -33,6 +33,10 @@ export class LoginFormComponentService {
   protected csrfStateService = inject(CsrfStateService);
   protected router = inject(Router);
   protected activatedRoute = inject(ActivatedRoute);
+  protected readonly customFormValidErrors = [
+    'bad_credentials',
+    'account_disabled',
+  ];
 
   action?: string;
   method?: string;
@@ -100,13 +104,17 @@ export class LoginFormComponentService {
     }
   }
 
-  handleLoginError(): void {
-    const validErrors = ['bad_credentials', 'account_disabled'];
+  handleCustomLoginError(): void {
+    if (
+      !this.featureConfigService.isEnabled('authorizationCodeFlowByDefault')
+    ) {
+      return;
+    }
     const error = this.activatedRoute.snapshot.queryParams['error'];
     if (error) {
       this.globalMessage.add(
         {
-          key: validErrors.includes(error)
+          key: this.customFormValidErrors.includes(error)
             ? `customLoginPage.badRequest.${error}`
             : 'customLoginPage.badRequest.unknown_error',
         },

--- a/feature-libs/user/account/components/login-form/login-form-component.service.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.ts
@@ -11,6 +11,7 @@ import {
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
 import {
   AuthConfigService,
   AuthService,
@@ -30,6 +31,8 @@ export class LoginFormComponentService {
   protected authConfigService = inject(AuthConfigService);
   private featureConfigService = inject(FeatureConfigService);
   protected csrfStateService = inject(CsrfStateService);
+  protected router = inject(Router);
+  protected activatedRoute = inject(ActivatedRoute);
 
   action?: string;
   method?: string;
@@ -94,6 +97,21 @@ export class LoginFormComponentService {
           tap(([_, isLoggedIn]) => this.onSuccess(isLoggedIn))
         )
         .subscribe();
+    }
+  }
+
+  handleLoginError(): void {
+    const error = this.activatedRoute.snapshot.queryParams['error'];
+    if (error) {
+      this.globalMessage.add(
+        {
+          key: `customLoginPage.badRequest.${error}`,
+        },
+        GlobalMessageType.MSG_TYPE_ERROR
+      );
+      this.router.navigate([], {
+        queryParams: { error: null },
+      });
     }
   }
 

--- a/feature-libs/user/account/components/login-form/login-form.component.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form.component.spec.ts
@@ -24,7 +24,7 @@ class MockLoginFormComponentService
   });
   isUpdating$ = isBusySubject;
   login = createSpy().and.stub();
-  handleLoginError = createSpy().and.stub();
+  handleCustomLoginError = createSpy().and.stub();
 }
 @Pipe({
   name: 'cxUrl',
@@ -71,7 +71,7 @@ describe('LoginFormComponent', () => {
   });
 
   it('should call handleLoginError() when component is created', () => {
-    expect(service.handleLoginError).toHaveBeenCalled();
+    expect(service.handleCustomLoginError).toHaveBeenCalled();
   });
 
   describe('busy', () => {

--- a/feature-libs/user/account/components/login-form/login-form.component.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form.component.spec.ts
@@ -24,6 +24,7 @@ class MockLoginFormComponentService
   });
   isUpdating$ = isBusySubject;
   login = createSpy().and.stub();
+  handleLoginError = createSpy().and.stub();
 }
 @Pipe({
   name: 'cxUrl',
@@ -67,6 +68,10 @@ describe('LoginFormComponent', () => {
 
   it('should create component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call handleLoginError() when component is created', () => {
+    expect(service.handleLoginError).toHaveBeenCalled();
   });
 
   describe('busy', () => {

--- a/feature-libs/user/account/components/login-form/login-form.component.ts
+++ b/feature-libs/user/account/components/login-form/login-form.component.ts
@@ -33,6 +33,7 @@ export class LoginFormComponent {
 
   constructor(protected service: LoginFormComponentService) {
     useFeatureStyles('a11yPasswordVisibliltyBtnValueOverflow');
+    this.service.handleLoginError();
   }
 
   onSubmit(): void {

--- a/feature-libs/user/account/components/login-form/login-form.component.ts
+++ b/feature-libs/user/account/components/login-form/login-form.component.ts
@@ -33,7 +33,7 @@ export class LoginFormComponent {
 
   constructor(protected service: LoginFormComponentService) {
     useFeatureStyles('a11yPasswordVisibliltyBtnValueOverflow');
-    this.service.handleLoginError();
+    this.service.handleCustomLoginError();
   }
 
   onSubmit(): void {

--- a/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.spec.ts
+++ b/integration-libs/cdc/user-account/login-form/cdc-login-form-component.service.spec.ts
@@ -1,5 +1,10 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import {
+  ActivatedRoute,
+  ActivatedRouteSnapshot,
+  Router,
+} from '@angular/router';
 import { Store } from '@ngrx/store';
 import { CdcJsService } from '@spartacus/cdc/root';
 import {
@@ -52,6 +57,18 @@ class MockLoginFormComponentService
   login = createSpy();
 }
 
+class MockActivatedRoute implements Partial<ActivatedRoute> {
+  snapshot = {
+    queryParams: {
+      error: 'bad_credentials',
+    },
+  } as unknown as ActivatedRouteSnapshot;
+}
+
+class MockRouter implements Partial<Router> {
+  navigate = createSpy().and.stub();
+}
+
 describe('CdcLoginComponentService', () => {
   let cdcLoginService: CdcLoginFormComponentService;
   let cdcJsService: CdcJsService;
@@ -71,6 +88,14 @@ describe('CdcLoginComponentService', () => {
         {
           provide: LoginFormComponentService,
           useClass: MockLoginFormComponentService,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: MockActivatedRoute,
+        },
+        {
+          provide: Router,
+          useClass: MockRouter,
         },
       ],
     });

--- a/projects/assets/src/translations/en/common.json
+++ b/projects/assets/src/translations/en/common.json
@@ -103,6 +103,11 @@
     "nextOrderDate": "Next Order Date",
     "pageViewUpdated": "Page view updated with your selected options."
   },
+  "customLoginPage": {
+    "badRequest": {
+      "bad_credentials": "Bad credentials. Please login again."
+    }
+  },
   "httpHandlers": {
     "badRequest": {
       "bad_credentials": "{{ errorMessage }}. Please login again.",

--- a/projects/assets/src/translations/en/common.json
+++ b/projects/assets/src/translations/en/common.json
@@ -105,7 +105,8 @@
   },
   "customLoginPage": {
     "badRequest": {
-      "bad_credentials": "Bad credentials. Please login again."
+      "bad_credentials": "Bad credentials. Please login again.",
+      "account_disabled": "User is disabled. Please contact administration."
     }
   },
   "httpHandlers": {

--- a/projects/assets/src/translations/en/common.json
+++ b/projects/assets/src/translations/en/common.json
@@ -106,7 +106,8 @@
   "customLoginPage": {
     "badRequest": {
       "bad_credentials": "Bad credentials. Please login again.",
-      "account_disabled": "User is disabled. Please contact administration."
+      "account_disabled": "User is disabled. Please contact administration.",
+      "unknown_error": "An unknown error occurred. Please try again later."
     }
   },
   "httpHandlers": {

--- a/projects/assets/src/translations/translations.ts
+++ b/projects/assets/src/translations/translations.ts
@@ -12,6 +12,7 @@ export const translationChunksConfig = {
     'navigation',
     'searchBox',
     'sorting',
+    'customLoginPage',
     'httpHandlers',
     'miniCart',
     'skipLink',

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/close-account.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/close-account.e2e.cy.ts
@@ -108,13 +108,7 @@ describe('My Account - Close Account', () => {
 
         cy.location('pathname').should('contain', '/login');
 
-        cy.whenJDK17(() => {
-          alerts.getErrorAlert().should('contain', 'User is disabled');
-        });
-
-        cy.whenJDK21(() => {
-          cy.url().should('contain', '/login?error=account_disabled');
-        });
+        alerts.getErrorAlert().should('contain', 'User is disabled');
       });
     });
   });

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-email.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/my-account/update-email.e2e.cy.ts
@@ -5,13 +5,13 @@
  */
 
 import { login } from '../../../helpers/auth-forms';
+import * as alerts from '../../../helpers/global-message';
 import { checkBanner } from '../../../helpers/homepage';
 import { signOut } from '../../../helpers/register';
 import * as updateEmail from '../../../helpers/update-email';
 import { registerAndLogin } from '../../../helpers/update-email';
 import { viewportContext } from '../../../helpers/viewport-context';
 import { standardUser } from '../../../sample-data/shared-users';
-import * as alerts from '../../../helpers/global-message';
 
 describe('My Account - Update Email', () => {
   viewportContext(['mobile', 'desktop'], () => {
@@ -49,12 +49,8 @@ describe('My Account - Update Email', () => {
           standardUser.registrationData.email,
           standardUser.registrationData.password
         );
-        cy.whenJDK17(() => {
-          alerts.getErrorAlert().should('contain', 'Bad credentials');
-        });
-        cy.whenJDK21(() => {
-          cy.url().should('contain', '/login?error=bad_credentials');
-        });
+
+        alerts.getErrorAlert().should('contain', 'Bad credentials');
       });
     });
   });


### PR DESCRIPTION
This PR contains changes required to handle wrong credential error on the custom login page used for Authorization Code Flow.

QA:

- run the app and go to http://localhost:4200/electronics-spa/en/USD/login
- try to login as existing user but pass wrong credentials and submit
- verify that for a moment the following query param is visible in the browser bar: `?error=bad_request`
- verify if the global message about the error is visible:
   <img width="843" height="563" alt="image" src="https://github.com/user-attachments/assets/75747bd5-b589-46fe-bf05-7e7f8b612114" />
- go to http://localhost:4200/electronics-spa/en/USD/product/2063624/avc-dc400, add product and proceed to checkout
- on the page with login form, try to login as existing user but pass wrong credentials and submit
- verify that for a moment the following query param is visible in the browser bar: `?error=bad_request`
- verify if the global message about the error is present

Closes [CXSPA-10733](https://jira.tools.sap/browse/CXSPA-10733)
