### PR TITLE
fix: added button for returning physical products in S4ServiceOrderDetailActionsComponent

### DIFF
--- a/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.html
+++ b/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.html
@@ -1,10 +1,45 @@
 <ng-container *ngIf="order$ | async as order">
-  <div
-    class="cx-order-details-actions row mt-3"
-    *ngIf="displayActions$ | async"
-  >
+  <div class="cx-order-details-actions row mt-3">
     <div class="col-12 d-flex justify-content-end">
       <span class="cx-action-button ml-2">
+        <a
+          id="cancel-items-btn"
+          *ngIf="order.cancellable"
+          [routerLink]="
+            {
+              cxRoute: 'orderCancel',
+              params: order,
+            } | cxUrl
+          "
+          [attr.aria-label]="
+            'myAccountV2OrderDetails.cancelItems' | cxTranslate
+          "
+          class="btn btn-secondary"
+          cxBtnLikeLink
+        >
+          {{ 'myAccountV2OrderDetails.cancelItems' | cxTranslate }}
+        </a>
+      </span>
+      <span class="cx-action-button ml-2">
+        <a
+          id="return-items-btn"
+          *ngIf="order.returnable"
+          [routerLink]="
+            {
+              cxRoute: 'orderReturn',
+              params: order,
+            } | cxUrl
+          "
+          [attr.aria-label]="
+            'myAccountV2OrderDetails.returnItems' | cxTranslate
+          "
+          class="btn btn-secondary"
+          cxBtnLikeLink
+        >
+          {{ 'myAccountV2OrderDetails.returnItems' | cxTranslate }}
+        </a>
+      </span>
+      <span class="cx-action-button cancel-service-btn-container ml-2">
         <a
           id="cancel-service-btn"
           *ngIf="order.serviceCancellable"
@@ -21,7 +56,7 @@
           {{ 'cancelService.action' | cxTranslate }}
         </a>
       </span>
-      <span class="cx-action-button ml-2">
+      <span class="cx-action-button reschedule-service-btn-container ml-2">
         <a
           id="reschedule-service-btn"
           *ngIf="order.serviceReschedulable"

--- a/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.spec.ts
+++ b/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.spec.ts
@@ -118,38 +118,35 @@ describe('S4ServiceOrderDetailActionsComponent', () => {
       expect(component).toBeTruthy();
     });
     it('should show Cancel button when service is serviceCancellable', () => {
-      component.displayActions$ = of(true);
       fixture.detectChanges();
-      expect(el.query(By.css('.cx-order-details-actions'))).toBeTruthy();
+      expect(el.query(By.css('.cancel-service-btn-container'))).toBeTruthy();
       const elements = el.queryAll(By.css('#cancel-service-btn'));
       expect(elements.length).toEqual(1);
     });
     it('should show Reschedule button when service is reschedulable', () => {
-      component.displayActions$ = of(true);
       fixture.detectChanges();
-      expect(el.query(By.css('.cx-order-details-actions'))).toBeTruthy();
+      expect(
+        el.query(By.css('.reschedule-service-btn-container'))
+      ).toBeTruthy();
       const elements = el.queryAll(By.css('#reschedule-service-btn'));
       expect(elements.length).toEqual(1);
     });
-    it('should display action buttons when time to service is more than 24 hours', () => {
+    it('should not display a notification when time to service is more than 24 hours', () => {
       spyOn(
         checkoutServiceSchedulePickerService,
         'getHoursFromServiceSchedule'
       ).and.returnValue(40);
+      (component as any).displayServiceMessage(mockOrder1);
       fixture.detectChanges();
-      component.displayActions$.subscribe((res) => {
-        expect(res).toBe(true);
-      });
+      expect(globalMessageService.add).toHaveBeenCalledTimes(0);
     });
-    it('should not display action buttons when time to service is within 24 hours', () => {
+    it('should display a notification when time to service is within 24 hours', () => {
       spyOn(
         checkoutServiceSchedulePickerService,
         'getHoursFromServiceSchedule'
       ).and.returnValue(10);
+      (component as any).displayServiceMessage(mockOrder1);
       fixture.detectChanges();
-      component.displayActions$.subscribe((res) => {
-        expect(res).toBe(false);
-      });
       expect(globalMessageService.add).toHaveBeenCalledWith(
         { key: 'rescheduleService.serviceNotAmendable' },
         GlobalMessageType.MSG_TYPE_INFO
@@ -163,7 +160,6 @@ describe('S4ServiceOrderDetailActionsComponent', () => {
     });
 
     it('should not show Reschedule button when service is not reschedulable', () => {
-      component.displayActions$ = of(true);
       fixture.detectChanges();
       const elements = fixture.debugElement.queryAll(By.css('a'));
       expect(elements.length).toEqual(0);
@@ -177,7 +173,7 @@ describe('S4ServiceOrderDetailActionsComponent', () => {
     });
   });
 
-  describe('displayActions', () => {
+  describe('displayServiceActions', () => {
     beforeEach(() => {
       beforeEachFn(mockOrder3);
     });

--- a/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.ts
+++ b/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.ts
@@ -32,7 +32,7 @@ export class S4ServiceOrderDetailActionsComponent
   protected globalMessageService = inject(GlobalMessageService);
 
   /**
-   * @deprecated since 2211.44 - Displaying the individual action buttons will depend on their boolean flags from API response.
+   * @deprecated since 221121.1 - Displaying the individual action buttons will depend on their boolean flags from API response.
    */
   displayActions$: Observable<boolean> = this.order$.pipe(
     map((order) => this.checkServiceStatus(order))
@@ -43,7 +43,7 @@ export class S4ServiceOrderDetailActionsComponent
   }
 
   /**
-   * @deprecated since 2211.44 - Displaying the individual action buttons will depend on their boolean flags from API response.
+   * @deprecated since 221121.1 - Displaying the individual action buttons will depend on their boolean flags from API response.
    * Displaying notification for a service not amendable will be carried out by 'displayServiceMessage' instead.
    */
   protected checkServiceStatus(order: Order): boolean {

--- a/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.ts
+++ b/integration-libs/s4-service/order/components/s4-service-order-detail-actions/s4-service-order-detail-actions.component.ts
@@ -4,12 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit,
+} from '@angular/core';
 import { GlobalMessageService, GlobalMessageType } from '@spartacus/core';
 import { OrderDetailActionsComponent } from '@spartacus/order/components';
 import { Order } from '@spartacus/order/root';
 import { CheckoutServiceSchedulePickerService } from '@spartacus/s4-service/root';
-import { map, Observable } from 'rxjs';
+import { map, Observable, tap } from 'rxjs';
 
 @Component({
   selector: 'cx-s4-service-order-detail-actions',
@@ -17,16 +22,30 @@ import { map, Observable } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
-export class S4ServiceOrderDetailActionsComponent extends OrderDetailActionsComponent {
+export class S4ServiceOrderDetailActionsComponent
+  extends OrderDetailActionsComponent
+  implements OnInit
+{
   protected checkoutServiceSchedulePickerService = inject(
     CheckoutServiceSchedulePickerService
   );
   protected globalMessageService = inject(GlobalMessageService);
 
+  /**
+   * @deprecated since 2211.44 - Displaying the individual action buttons will depend on their boolean flags from API response.
+   */
   displayActions$: Observable<boolean> = this.order$.pipe(
     map((order) => this.checkServiceStatus(order))
   );
 
+  ngOnInit(): void {
+    this.order$.pipe(tap((order) => this.displayServiceMessage(order)));
+  }
+
+  /**
+   * @deprecated since 2211.44 - Displaying the individual action buttons will depend on their boolean flags from API response.
+   * Displaying notification for a service not amendable will be carried out by 'displayServiceMessage' instead.
+   */
   protected checkServiceStatus(order: Order): boolean {
     if (order && order.status === 'CANCELLED') {
       return false;
@@ -46,5 +65,20 @@ export class S4ServiceOrderDetailActionsComponent extends OrderDetailActionsComp
       }
     }
     return true;
+  }
+
+  protected displayServiceMessage(order: Order): void {
+    if (order.status !== 'CANCELLED' && !!order.servicedAt) {
+      const hoursFromSchedule =
+        this.checkoutServiceSchedulePickerService.getHoursFromServiceSchedule(
+          order.servicedAt
+        );
+      if (hoursFromSchedule > 0 && hoursFromSchedule <= 24) {
+        this.globalMessageService.add(
+          { key: 'rescheduleService.serviceNotAmendable' },
+          GlobalMessageType.MSG_TYPE_INFO
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
Return button is not visible for physical products when s4-service library is installed because `S4ServiceOrderDetailActionsComponent` overrides `MyAccountV2OrderDetailsActionsComponent`.

Added return button in `S4ServiceOrderDetailActionsComponent` as a fix.