### PR TITLE
chore: Change deprecation version to 221121.1

### DIFF
--- a/feature-libs/cart/base/core/store/actions/cart.action.ts
+++ b/feature-libs/cart/base/core/store/actions/cart.action.ts
@@ -178,7 +178,9 @@ interface MergeCartPayload {
   tempCartId: string;
 }
 /**
- * @deprecated since 2211.44. Use the new MergeCartAndIncrementProcessesCount instead.
+ * @deprecated since 221121.1
+ * Use the new MergeCartAndIncrementProcessesCount instead.
+ * @see MergeCartAndIncrementProcessesCount
  */
 export class MergeCart implements Action {
   readonly type = MERGE_CART;

--- a/integration-libs/opf/checkout/root/checkout-guard/opf-checkout-auth.guard.ts
+++ b/integration-libs/opf/checkout/root/checkout-guard/opf-checkout-auth.guard.ts
@@ -23,7 +23,7 @@ export class OpfCheckoutAuthGuard extends CheckoutAuthGuard {
   protected userIdService = inject(UserIdService);
   protected opfCartUserEmailChecker = inject(OpfCartUserEmailCheckerService);
   /**
-   * @deprecated since 2211.44
+   * @deprecated since 221121.1
    */
   protected featureConfigService = inject(FeatureConfigService);
 

--- a/projects/core/src/auth/user-auth/config/default-auth-config.ts
+++ b/projects/core/src/auth/user-auth/config/default-auth-config.ts
@@ -9,7 +9,8 @@ import { FeatureToggles } from '../../../features-config/feature-toggles';
 import { AuthConfig } from './auth-config';
 
 /**
- * @deprecated since 2211.44. Please use the `authorizationCodeFlowByDefault` feature toggle instead.
+ * @deprecated since 221121.1
+ * Please use the `authorizationCodeFlowByDefault` feature toggle instead.
  */
 export const USE_AUTHORIZATION_CODE_FLOW_BY_DEFAULT =
   new InjectionToken<boolean>('USE_AUTHORIZATION_CODE_FLOW_BY_DEFAULT', {


### PR DESCRIPTION
This PR updates the version mentioned in `@deprecated` JSDoc section to a proper one.