### PR TITLE
chore: CXSPA-10755 Add missing Slack Token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,11 +323,10 @@ jobs:
           echo "  Branch = ${{ github.ref_name }}"
           echo "  Default branch = ${{ github.event.repository.default_branch }}"
       - name: Notify the slack channel of when build conclusion failed
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
         uses: slackapi/slack-github-action@v2.1.1
         with:
           method: chat.postMessage
+          token: ${{ secrets.SLACK_TOKEN }}
           payload: |
             {
               "channel": "${{ secrets.SLACK_NOTIFICATION_CHANNEL }}",


### PR DESCRIPTION
According to the documentation:
> A token must be provided with other inputs
> This Action expects a [token](https://api.slack.com/concepts/token-types) as a step input value.
> 
> Prior to updating: Bot tokens were provided with the SLACK_BOT_TOKEN environment variable.
> 
> Recommended change: Provide the token scoped for the method as a step input, as shown above. The SLACK_TOKEN environment variable can also be used.

It is required to adjust how the token is provided.

Closes [CXSPA-10755](https://jira.tools.sap/browse/CXSPA-10755)