### PR TITLE
test: product_configurator_e2e test suite fail on S2 and S3 (CXSPA-10752)

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-mobile.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-mobile.e2e.cy.ts
@@ -8,6 +8,7 @@ import { clickAllowAllFromBanner } from '../../../helpers/anonymous-consents';
 import * as configuration from '../../../helpers/product-configurator';
 import * as configurationVc from '../../../helpers/product-configurator-vc';
 import { viewportContext } from '../../../helpers/viewport-context';
+import { clearAllStorage } from '../../../support/utils/clear-all-storage';
 
 const electronicsShop = 'electronics-spa';
 const testProduct = 'CONF_CAMERA_SL';
@@ -20,11 +21,17 @@ const CAMERA_MODE = 'CAMERA_MODE';
 
 viewportContext(['mobile'], () => {
   describe('Group Handling', () => {
-    it('should navigate using the group menu in mobile resolution', () => {
+    beforeEach(() => {
+      clearAllStorage();
+    });
+
+    beforeEach(() => {
       configurationVc.registerConfigurationRoute();
-      cy.window().then((win) => win.sessionStorage.clear());
       cy.visit('/');
       clickAllowAllFromBanner();
+    });
+
+    it('should navigate using the group menu in mobile resolution', () => {
       configurationVc.goToConfigurationPage(electronicsShop, testProduct);
       configuration.checkHamburgerDisplayed();
       configuration.checkAttributeDisplayed(CAMERA_MODE, radioGroup);

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-textfield.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-textfield.e2e.cy.ts
@@ -8,6 +8,9 @@ import * as cart from '../../../helpers/cart';
 import * as configuration from '../../../helpers/product-configurator';
 import * as textfieldConfiguration from '../../../helpers/textfield-configuration';
 import * as common from '../../../helpers/common';
+import { clickAllowAllFromBanner } from '../../../helpers/anonymous-consents';
+import { viewportContext } from '../../../helpers/viewport-context';
+import { clearAllStorage } from '../../../support/utils/clear-all-storage';
 
 const electronicsShop = 'electronics-spa';
 const testProduct = '1934793';
@@ -15,67 +18,76 @@ const ENGRAVED_TEXT = 'Engraved Text';
 const HALLO = 'Hallo';
 
 context('Textfield Configuration', () => {
-  before(() => {
-    cy.visit('/');
-  });
-  describe('Navigate to textfield configuration page', () => {
-    it('should be able to navigate from the product search result', () => {
-      configuration.searchForProduct(testProduct);
-      textfieldConfiguration.clickOnConfigureButton();
+  viewportContext(['desktop'], () => {
+    beforeEach(() => {
+      clearAllStorage();
     });
 
-    it('should be able to navigate from the product details page', () => {
-      textfieldConfiguration.goToProductDetailsPage(
-        electronicsShop,
-        testProduct
-      );
-      textfieldConfiguration.clickOnConfigureButton();
+    before(() => {
+      cy.visit('/');
+      clickAllowAllFromBanner();
     });
 
-    it('should be able to navigate from the cart', () => {
-      textfieldConfiguration.goToConfigurationPage(
-        electronicsShop,
-        testProduct
-      );
-      textfieldConfiguration.checkConfigurationPageIsDisplayed();
-      textfieldConfiguration.addToCartAndVerify(electronicsShop, testProduct);
-      textfieldConfiguration.clickOnEditConfigurationLink(0);
+    describe('Navigate to textfield configuration page', () => {
+      it('should be able to navigate from the product search result', () => {
+        configuration.searchForProduct(testProduct);
+        textfieldConfiguration.clickOnConfigureButton();
+      });
+
+      it('should be able to navigate from the product details page', () => {
+        textfieldConfiguration.goToProductDetailsPage(
+          electronicsShop,
+          testProduct
+        );
+        textfieldConfiguration.clickOnConfigureButton();
+      });
+
+      it('should be able to navigate from the cart', () => {
+        textfieldConfiguration.goToConfigurationPage(
+          electronicsShop,
+          testProduct
+        );
+        textfieldConfiguration.checkConfigurationPageIsDisplayed();
+        textfieldConfiguration.addToCartAndVerify(electronicsShop, testProduct);
+        textfieldConfiguration.clickOnEditConfigurationLink(0);
+      });
+
+      it('should be able to navigate from the cart after adding product directly to the cart', () => {
+        textfieldConfiguration.goToProductDetailsPage(
+          electronicsShop,
+          testProduct
+        );
+        common.clickOnAddToCartBtnOnPD();
+        common.clickOnViewCartBtnOnPD();
+        cart.verifyCartNotEmpty();
+        textfieldConfiguration.clickOnEditConfigurationLink(0);
+      });
     });
 
-    it('should be able to navigate from the cart after adding product directly to the cart', () => {
-      textfieldConfiguration.goToProductDetailsPage(
-        electronicsShop,
-        testProduct
-      );
-      common.clickOnAddToCartBtnOnPD();
-      common.clickOnViewCartBtnOnPD();
-      cart.verifyCartNotEmpty();
-      textfieldConfiguration.clickOnEditConfigurationLink(0);
-    });
-  });
-  describe('Configure product and add to cart', () => {
-    it('should enter value and add product to cart', () => {
-      textfieldConfiguration.goToConfigurationPage(
-        electronicsShop,
-        testProduct
-      );
-      textfieldConfiguration.checkConfigurationPageIsDisplayed();
-      textfieldConfiguration.checkAttributeDisplayed(ENGRAVED_TEXT);
-      textfieldConfiguration.selectAttribute(ENGRAVED_TEXT, HALLO);
-      textfieldConfiguration.addToCartAndVerify(electronicsShop, testProduct);
-    });
+    describe('Configure product and add to cart', () => {
+      it('should enter value and add product to cart', () => {
+        textfieldConfiguration.goToConfigurationPage(
+          electronicsShop,
+          testProduct
+        );
+        textfieldConfiguration.checkConfigurationPageIsDisplayed();
+        textfieldConfiguration.checkAttributeDisplayed(ENGRAVED_TEXT);
+        textfieldConfiguration.selectAttribute(ENGRAVED_TEXT, HALLO);
+        textfieldConfiguration.addToCartAndVerify(electronicsShop, testProduct);
+      });
 
-    it('should be able to update a configured product from the cart', () => {
-      textfieldConfiguration.goToConfigurationPage(
-        electronicsShop,
-        testProduct
-      );
-      textfieldConfiguration.checkConfigurationPageIsDisplayed();
-      textfieldConfiguration.addToCartAndVerify(electronicsShop, testProduct);
-      textfieldConfiguration.clickOnEditConfigurationLink(0);
-      textfieldConfiguration.checkAttributeDisplayed(ENGRAVED_TEXT);
-      textfieldConfiguration.selectAttribute(ENGRAVED_TEXT, HALLO);
-      textfieldConfiguration.addToCartAndVerify(electronicsShop, testProduct);
+      it('should be able to update a configured product from the cart', () => {
+        textfieldConfiguration.goToConfigurationPage(
+          electronicsShop,
+          testProduct
+        );
+        textfieldConfiguration.checkConfigurationPageIsDisplayed();
+        textfieldConfiguration.addToCartAndVerify(electronicsShop, testProduct);
+        textfieldConfiguration.clickOnEditConfigurationLink(0);
+        textfieldConfiguration.checkAttributeDisplayed(ENGRAVED_TEXT);
+        textfieldConfiguration.selectAttribute(ENGRAVED_TEXT, HALLO);
+        textfieldConfiguration.addToCartAndVerify(electronicsShop, testProduct);
+      });
     });
   });
 });

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-interactive.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/product_configurator/product-configurator-vc-interactive.e2e.cy.ts
@@ -8,6 +8,8 @@ import * as configuration from '../../../helpers/product-configurator';
 import { clickAllowAllFromBanner } from '../../../helpers/anonymous-consents';
 import * as configurationOverviewVc from '../../../helpers/product-configurator-overview-vc';
 import * as configurationVc from '../../../helpers/product-configurator-vc';
+import { viewportContext } from '../../../helpers/viewport-context';
+import { clearAllStorage } from '../../../support/utils/clear-all-storage';
 
 const electronicsShop = 'electronics-spa';
 const testProduct = 'CONF_CAMERA_SL';
@@ -53,206 +55,209 @@ const Conflict_msg_gaming_console =
   'Gaming console cannot be selected with LCD projector';
 
 context('Product Configuration', () => {
-  const commerceRelease: configurationVc.CommerceRelease = {};
+  viewportContext(['desktop'], () => {
+    const commerceRelease: configurationVc.CommerceRelease = {};
 
-  before(() => {
-    configurationVc.checkCommerceRelease(
-      electronicsShop,
-      testProduct,
-      commerceRelease
-    );
-  });
-
-  beforeEach(() => {
-    configurationVc.registerConfigurationRoute();
-    configurationVc.registerConfigurationUpdateRoute();
-    configurationOverviewVc.registerConfigurationOverviewRoute();
-    cy.visit('/');
-  });
-
-  describe('Configure product', () => {
-    it('should support image attribute type - single selection', () => {
-      clickAllowAllFromBanner();
-      configurationVc.goToConfigurationPage(
-        electronicsShop,
-        testProductMultiLevel
-      );
-      configuration.checkAttributeDisplayed(ROOM_SIZE, radioGroup);
-      configurationVc.selectAttributeAndWait(
-        COLOUR_HT,
-        single_selection_image,
-        WHITE,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.checkImageSelected(
-        single_selection_image,
-        COLOUR_HT,
-        WHITE
-      );
-      configurationVc.selectAttributeAndWait(
-        COLOUR_HT,
-        single_selection_image,
-        TITAN,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.checkImageSelected(
-        single_selection_image,
-        COLOUR_HT,
-        TITAN
-      );
-    });
-
-    it('should keep checkboxes selected after group change', () => {
-      clickAllowAllFromBanner();
-      configurationVc.goToConfigurationPage(
+    before(() => {
+      clearAllStorage();
+      configurationVc.checkCommerceRelease(
         electronicsShop,
         testProduct,
-        commerceRelease.isPricingEnabled
+        commerceRelease
       );
-      configuration.checkAttributeDisplayed(CAMERA_MODE, radioGroup);
-      configurationVc.clickOnNextBtnAndWait(
-        SPECIFICATION,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.selectAttributeAndWait(
-        CAMERA_SD_CARD,
-        checkBoxList,
-        SDHC,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.clickOnPreviousBtnAndWait(
-        BASICS,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.clickOnNextBtnAndWait(
-        SPECIFICATION,
-        commerceRelease.isPricingEnabled
-      );
-      configuration.checkValueSelected(checkBoxList, CAMERA_SD_CARD, SDHC);
     });
-  });
 
-  describe('Conflict solver', () => {
     beforeEach(() => {
+      configurationVc.registerConfigurationRoute();
+      configurationVc.registerConfigurationUpdateRoute();
+      configurationOverviewVc.registerConfigurationOverviewRoute();
       cy.visit('/');
+      clickAllowAllFromBanner();
     });
 
-    it('should support the conflict solving process', () => {
-      configurationVc.goToConfigurationPage(
-        electronicsShop,
-        testProductMultiLevel,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.clickOnNextBtnAndWait(
-        PROJECTOR,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.selectAttributeAndWait(
-        PROJECTOR_TYPE,
-        radioGroup,
-        PROJECTOR_LCD,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.clickOnPreviousBtnAndWait(
-        GENERAL,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.clickOnGroupAndWait(3, commerceRelease.isPricingEnabled);
+    describe('Configure product', () => {
+      it('should support image attribute type - single selection', () => {
+        configurationVc.goToConfigurationPage(
+          electronicsShop,
+          testProductMultiLevel,
+          commerceRelease.isPricingEnabled
+        );
+        configuration.checkAttributeDisplayed(ROOM_SIZE, radioGroup);
+        configurationVc.selectAttributeAndWait(
+          COLOUR_HT,
+          single_selection_image,
+          WHITE,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.checkImageSelected(
+          single_selection_image,
+          COLOUR_HT,
+          WHITE
+        );
+        configurationVc.selectAttributeAndWait(
+          COLOUR_HT,
+          single_selection_image,
+          TITAN,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.checkImageSelected(
+          single_selection_image,
+          COLOUR_HT,
+          TITAN
+        );
+      });
 
-      configurationVc.selectConflictingValueAndWait(
-        GAMING_CONSOLE,
-        radioGroup,
-        GAMING_CONSOLE_YES,
-        1,
-        commerceRelease.isPricingEnabled
-      );
+      it('should keep checkboxes selected after group change', () => {
+        configurationVc.goToConfigurationPage(
+          electronicsShop,
+          testProduct,
+          commerceRelease.isPricingEnabled
+        );
+        configuration.checkAttributeDisplayed(CAMERA_MODE, radioGroup);
+        configurationVc.clickOnNextBtnAndWait(
+          SPECIFICATION,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.selectAttributeAndWait(
+          CAMERA_SD_CARD,
+          checkBoxList,
+          SDHC,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.clickOnPreviousBtnAndWait(
+          BASICS,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.clickOnNextBtnAndWait(
+          SPECIFICATION,
+          commerceRelease.isPricingEnabled
+        );
+        configuration.checkValueSelected(checkBoxList, CAMERA_SD_CARD, SDHC);
+      });
+    });
 
-      configurationVc.checkStatusIconDisplayed(SOURCE_COMPONENTS, WARNING);
-      configurationVc.checkStatusIconDisplayed(VIDEO_SYSTEM, WARNING);
-      configurationVc.deselectConflictingValueAndWait(
-        GAMING_CONSOLE,
-        radioGroup,
-        GAMING_CONSOLE_NO,
-        commerceRelease.isPricingEnabled
-      );
+    describe('Conflict solver', () => {
+      beforeEach(() => {
+        configurationVc.goToConfigurationPage(
+          electronicsShop,
+          testProductMultiLevel,
+          commerceRelease.isPricingEnabled
+        );
+      });
 
-      configurationVc.checkStatusIconNotDisplayed(SOURCE_COMPONENTS);
-      configurationVc.checkStatusIconNotDisplayed(VIDEO_SYSTEM);
-      configurationVc.selectConflictingValueAndWait(
-        GAMING_CONSOLE,
-        radioGroup,
-        GAMING_CONSOLE_YES,
-        1,
-        commerceRelease.isPricingEnabled
-      );
-
-      // Navigate to a conflict group via clicking on 'Conflict Detected' link
-
-      configurationVc.checkViewInConfigurationLinkDisplayed(GAMING_CONSOLE);
-      // Only perform this piece if backend allows to bavigate from attribute group to conflict group
-      if (commerceRelease.isAtLeast2211) {
-        configurationVc.clickOnConflictDetectedAndWait(GAMING_CONSOLE);
-        configuration.checkCurrentGroupActive(CONFLICT_FOR_GAMING_CONSOLE);
-        configurationVc.checkConflictDescriptionDisplayed(
-          Conflict_msg_gaming_console
+      it('should support the conflict solving process', () => {
+        configurationVc.clickOnNextBtnAndWait(
+          PROJECTOR,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.selectAttributeAndWait(
+          PROJECTOR_TYPE,
+          radioGroup,
+          PROJECTOR_LCD,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.clickOnPreviousBtnAndWait(
+          GENERAL,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.clickOnGroupAndWait(
+          3,
+          commerceRelease.isPricingEnabled
         );
 
-        // Navigate to a group that contains an attribute which is involved in a conflict via clicking on 'View in Configuration' link
+        configurationVc.selectConflictingValueAndWait(
+          GAMING_CONSOLE,
+          radioGroup,
+          GAMING_CONSOLE_YES,
+          1,
+          commerceRelease.isPricingEnabled
+        );
+
+        configurationVc.checkStatusIconDisplayed(SOURCE_COMPONENTS, WARNING);
+        configurationVc.checkStatusIconDisplayed(VIDEO_SYSTEM, WARNING);
+        configurationVc.deselectConflictingValueAndWait(
+          GAMING_CONSOLE,
+          radioGroup,
+          GAMING_CONSOLE_NO,
+          commerceRelease.isPricingEnabled
+        );
+
+        configurationVc.checkStatusIconNotDisplayed(SOURCE_COMPONENTS);
+        configurationVc.checkStatusIconNotDisplayed(VIDEO_SYSTEM);
+        configurationVc.selectConflictingValueAndWait(
+          GAMING_CONSOLE,
+          radioGroup,
+          GAMING_CONSOLE_YES,
+          1,
+          commerceRelease.isPricingEnabled
+        );
+
+        // Navigate to a conflict group via clicking on 'Conflict Detected' link
+
         configurationVc.checkViewInConfigurationLinkDisplayed(GAMING_CONSOLE);
-        configurationVc.clickOnViewInConfigurationAndWait(GAMING_CONSOLE);
-        configuration.checkCurrentGroupActive(SOURCE_COMPONENTS);
-        configuration.checkAttributeDisplayed(GAMING_CONSOLE, radioGroup);
+        // Only perform this piece if backend allows to bavigate from attribute group to conflict group
+        if (commerceRelease.isAtLeast2211) {
+          configurationVc.clickOnConflictDetectedAndWait(GAMING_CONSOLE);
+          configuration.checkCurrentGroupActive(CONFLICT_FOR_GAMING_CONSOLE);
+          configurationVc.checkConflictDescriptionDisplayed(
+            Conflict_msg_gaming_console
+          );
 
-        // finally navigate to overview page and check conflict behavior on it
-        configurationVc.clickAddToCartBtn();
-        configurationOverviewVc.verifyNotificationBannerOnOP(0, 1); // 0 issues, 1 conflict
-        configurationOverviewVc.clickOnResolveConflictsLinkOnOP();
-        configuration.checkCurrentGroupActive(CONFLICT_FOR_GAMING_CONSOLE);
-        configurationVc.checkConflictDescriptionDisplayed(
-          Conflict_msg_gaming_console
+          // Navigate to a group that contains an attribute which is involved in a conflict via clicking on 'View in Configuration' link
+          configurationVc.checkViewInConfigurationLinkDisplayed(GAMING_CONSOLE);
+          configurationVc.clickOnViewInConfigurationAndWait(GAMING_CONSOLE);
+          configuration.checkCurrentGroupActive(SOURCE_COMPONENTS);
+          configuration.checkAttributeDisplayed(GAMING_CONSOLE, radioGroup);
+
+          // finally navigate to overview page and check conflict behavior on it
+          configurationVc.clickAddToCartBtn();
+          configurationOverviewVc.verifyNotificationBannerOnOP(0, 1); // 0 issues, 1 conflict
+          configurationOverviewVc.clickOnResolveConflictsLinkOnOP();
+          configuration.checkCurrentGroupActive(CONFLICT_FOR_GAMING_CONSOLE);
+          configurationVc.checkConflictDescriptionDisplayed(
+            Conflict_msg_gaming_console
+          );
+        }
+      });
+
+      it('should display a success message on conflict resolution (CXSPA-2374)', () => {
+        configurationVc.clickOnNextBtnAndWait(
+          PROJECTOR,
+          commerceRelease.isPricingEnabled
         );
-      }
-    });
+        configurationVc.selectAttributeAndWait(
+          PROJECTOR_TYPE,
+          radioGroup,
+          PROJECTOR_LCD,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.clickOnPreviousBtnAndWait(
+          GENERAL,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.clickOnGroupAndWait(
+          3,
+          commerceRelease.isPricingEnabled
+        );
 
-    it('should display a success message on conflict resolution (CXSPA-2374)', () => {
-      configurationVc.goToConfigurationPage(
-        electronicsShop,
-        testProductMultiLevel,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.clickOnNextBtnAndWait(
-        PROJECTOR,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.selectAttributeAndWait(
-        PROJECTOR_TYPE,
-        radioGroup,
-        PROJECTOR_LCD,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.clickOnPreviousBtnAndWait(
-        GENERAL,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.clickOnGroupAndWait(3, commerceRelease.isPricingEnabled);
-
-      configurationVc.selectConflictingValueAndWait(
-        GAMING_CONSOLE,
-        radioGroup,
-        GAMING_CONSOLE_YES,
-        1,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.checkGlobalMessageNotDisplayed();
-      configurationVc.deselectConflictingValueAndWait(
-        GAMING_CONSOLE,
-        radioGroup,
-        GAMING_CONSOLE_NO,
-        commerceRelease.isPricingEnabled
-      );
-      configurationVc.checkGlobalMessageContains(
-        `Conflicts have been resolved`
-      );
+        configurationVc.selectConflictingValueAndWait(
+          GAMING_CONSOLE,
+          radioGroup,
+          GAMING_CONSOLE_YES,
+          1,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.checkGlobalMessageNotDisplayed();
+        configurationVc.deselectConflictingValueAndWait(
+          GAMING_CONSOLE,
+          radioGroup,
+          GAMING_CONSOLE_NO,
+          commerceRelease.isPricingEnabled
+        );
+        configurationVc.checkGlobalMessageContains(
+          `Conflicts have been resolved`
+        );
+      });
     });
   });
 });

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
@@ -50,8 +50,8 @@ export function goToConfigurationPage(
   registerCreateConfigurationRoute();
   const location = `/${shopName}/en/USD/configure/vc/product/entityKey/${productId}`;
   cy.visit(location);
-  this.checkConfigPageDisplayed();
   waitForRequest(CREATE_CONFIG_ALIAS, isPricingEnabled);
+  this.checkConfigPageDisplayed();
 }
 
 /**
@@ -157,11 +157,50 @@ export function clickOnShowDetailsBtn(): void {
 }
 
 /**
+ * Verifies whether the ghost form animation is not displayed.
+ */
+export function checkGhostFormAnimationNotDisplayed(): void {
+  cy.log('Wait until the ghost form animation is not displayed anymore');
+  cy.get('.cx-ghost-attribute').should('not.exist');
+}
+
+/**
+ * Verifies whether the ghost group menu animation is not displayed.
+ */
+export function checkGhostGroupMenuAnimationNotDisplayed(): void {
+  cy.log('Wait until the ghost group menu animation is not displayed anymore');
+  cy.get('.cx-ghost-group-menu').should('not.exist');
+}
+
+/**
+ * Verifies whether the ghost tab bar animation is not displayed.
+ */
+export function checkGhostTabBarAnimationNotDisplayed(): void {
+  cy.log('Wait until the ghost tab bar animation is not displayed anymore');
+  cy.get('.cx-ghost-tab-bar').should('not.exist');
+}
+
+/**
+ * Verifies whether the ghost product title animation is not displayed.
+ */
+export function checkGhostProductTitleAnimationNotDisplayed(): void {
+  cy.log(
+    'Wait until the ghost product title animation is not displayed anymore'
+  );
+  cy.get('.cx-ghost-general-product-info').should('not.exist');
+}
+
+/**
  * Verifies whether the ghost animation is not displayed.
  */
 export function checkGhostAnimationNotDisplayed(): void {
   cy.log('Wait until the ghost animation is not displayed anymore');
   cy.get('.ghost').should('not.exist');
+
+  checkGhostFormAnimationNotDisplayed();
+  checkGhostGroupMenuAnimationNotDisplayed();
+  checkGhostTabBarAnimationNotDisplayed();
+  checkGhostProductTitleAnimationNotDisplayed();
 }
 
 /**
@@ -590,6 +629,7 @@ export function clickOnGroupAndWait(
 ): void {
   clickOnGroup(groupIndex);
   waitForRequest(GET_CONFIG_ALIAS, isPricingEnabled);
+  checkGhostAnimationNotDisplayed();
 }
 
 /**
@@ -650,6 +690,7 @@ export function selectAttributeAndWait(
 ): void {
   configuration.selectAttribute(attributeName, uiType, valueName, false);
   waitForRequest(UPDATE_CONFIG_ALIAS, isPricingEnabled);
+  checkGhostAnimationNotDisplayed();
 }
 
 /**
@@ -685,6 +726,7 @@ export function clickOnNextBtnAndWait(
 ): void {
   configuration.clickOnNextBtn(nextGroup);
   waitForRequest(GET_CONFIG_ALIAS, isPricingEnabled);
+  checkGhostAnimationNotDisplayed();
 }
 
 /**
@@ -699,6 +741,7 @@ export function clickOnPreviousBtnAndWait(
 ): void {
   configuration.clickOnPreviousBtn(previousGroup);
   waitForRequest(GET_CONFIG_ALIAS, isPricingEnabled);
+  checkGhostAnimationNotDisplayed();
 }
 
 export class CommerceRelease {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
@@ -23,6 +23,8 @@ const quantityStepperSelector =
 
 const quantitySelector = '.cx-add-to-cart-btn-container .cx-quantity-value';
 
+const variantCarouselSelector = '.cx-variant-carousel-container';
+
 /**
  * ui types
  */
@@ -47,9 +49,10 @@ export function defineAliases(backendUrl: string) {
  * Verifies whether the updating configuration message is not displayed on the top of the configuration.
  */
 export function checkUpdatingMessageNotDisplayed(): void {
-  cy.get('cx-configurator-update-message div.cx-update-msg').should(
-    'not.be.visible'
-  );
+  const updatingMsgSelector =
+    'cx-configurator-update-message div.cx-update-msg';
+  cy.get(updatingMsgSelector).scrollIntoView();
+  cy.get(updatingMsgSelector).should('not.be.visible');
 }
 
 /**
@@ -78,9 +81,10 @@ export function checkCurrentGroupActive(currentGroup: string): void {
   cy.get(
     'cx-configurator-group-title:contains(' + `${currentGroup}` + ')'
   ).should('be.visible');
-  cy.get('button.active:contains(' + `${currentGroup}` + ')').should(
-    'be.visible'
-  );
+  const activeGroupSelector =
+    'button.active:contains(' + `${currentGroup}` + ')';
+  cy.get(activeGroupSelector).scrollIntoView();
+  cy.get(activeGroupSelector).should('be.visible');
 }
 
 /**
@@ -93,9 +97,10 @@ function clickOnPreviousOrNextBtn(
   btnSelector: string,
   activeGroup?: string
 ): void {
+  cy.get(btnSelector).scrollIntoView();
   cy.get(btnSelector)
-    .scrollIntoView()
-    .click({ force: true })
+    .should('be.visible')
+    .click()
     .then(() => {
       checkUpdatingMessageNotDisplayed();
       if (activeGroup) {
@@ -128,7 +133,9 @@ export function clickOnPreviousBtn(previousGroup?: string): void {
  */
 export function checkShowMoreLinkAtProductTitleDisplayed(): void {
   checkUpdatingMessageNotDisplayed();
-  cy.get('button:contains("show more")').should('be.visible');
+  const showMoreLinkSelector = 'button:contains("show more")';
+  cy.get(showMoreLinkSelector).scrollIntoView();
+  cy.get(showMoreLinkSelector).should('be.visible');
 }
 
 /**
@@ -136,13 +143,16 @@ export function checkShowMoreLinkAtProductTitleDisplayed(): void {
  */
 export function checkTabBarDisplayed(): void {
   checkUpdatingMessageNotDisplayed();
-  cy.get('cx-configurator-tab-bar').should('be.visible');
+  const tabBarSelector = 'cx-configurator-tab-bar';
+  cy.get(tabBarSelector).scrollIntoView();
+  cy.get(tabBarSelector).should('be.visible');
 }
 
 /**
  * Verifies whether the 'previous' button is enabled.
  */
 export function checkPreviousBtnEnabled(): void {
+  cy.get(previousBtnSelector).scrollIntoView();
   cy.get(previousBtnSelector).should('be.not.disabled');
 }
 
@@ -150,6 +160,7 @@ export function checkPreviousBtnEnabled(): void {
  * Verifies whether the 'previous' button is disabled.
  */
 export function checkPreviousBtnDisabled(): void {
+  cy.get(previousBtnSelector).scrollIntoView();
   cy.get(previousBtnSelector).should('be.disabled');
 }
 
@@ -157,6 +168,7 @@ export function checkPreviousBtnDisabled(): void {
  * Verifies whether the 'next' button is enabled.
  */
 export function checkNextBtnEnabled(): void {
+  cy.get(nextBtnSelector).scrollIntoView();
   cy.get(nextBtnSelector).should('be.not.disabled');
 }
 
@@ -164,6 +176,7 @@ export function checkNextBtnEnabled(): void {
  * Verifies whether the 'next' button is disabled.
  */
 export function checkNextBtnDisabled(): void {
+  cy.get(nextBtnSelector).scrollIntoView();
   cy.get(nextBtnSelector).should('be.disabled');
 }
 
@@ -178,7 +191,8 @@ export function checkAttributeDisplayed(
   uiType: uiType
 ): void {
   const attributeId = getAttributeId(attributeName, uiType);
-  cy.get(`#${attributeId}`).scrollIntoView().should('be.visible');
+  cy.get(`#${attributeId}`).scrollIntoView();
+  cy.get(`#${attributeId}`).should('be.visible');
 }
 
 /**
@@ -225,6 +239,7 @@ export function checkAttrValueDisplayed(
     valueLocator = `#${attributeId}--${valueName}`;
   }
   cy.log('value locator: ' + valueLocator);
+  cy.get(`${valueLocator}`).scrollIntoView();
   cy.get(`${valueLocator}`).should('be.visible');
 }
 
@@ -251,11 +266,12 @@ export function checkAttrValueNotDisplayed(
 }
 
 export function checkVariantCarouselDisplayed(): void {
-  cy.get('.cx-variant-carousel-container').should('be.visible');
+  cy.get(variantCarouselSelector).scrollIntoView();
+  cy.get(variantCarouselSelector).should('be.visible');
 }
 
 export function checkVariantCarouselNotDisplayed(): void {
-  cy.get('.cx-variant-carousel-container').should('not.exist');
+  cy.get(variantCarouselSelector).should('not.exist');
 }
 
 /**
@@ -303,13 +319,16 @@ export function selectAttribute(
     case 'radioGroup':
     case 'checkBoxList':
     case 'multi_selection_image':
-      cy.get(`#${valueId}`).scrollIntoView().click({ force: true });
+      cy.get(`#${valueId}`).scrollIntoView();
+      cy.get(`#${valueId}`).should('be.visible').click();
       break;
     case 'single_selection_image':
       const labelId = `cx-configurator--label--${attributeName}--${valueName}`;
       cy.log('labelId: ' + labelId);
+      cy.get(`#${labelId}`).scrollIntoView();
       cy.get(`#${labelId}`)
-        .click({ force: true })
+        .should('be.visible')
+        .click()
         .then(() => {
           if (waitForUpdateMsg) {
             checkUpdatingMessageNotDisplayed();
@@ -329,9 +348,10 @@ export function selectAttribute(
     case 'checkBoxListProduct':
       const btnLoc = `#${valueId} .cx-product-card-action button`;
       cy.get(btnLoc).then((el) => cy.log(`text before click: '${el.text()}'`));
+      cy.get(btnLoc).scrollIntoView();
       cy.get(btnLoc)
-        .scrollIntoView()
-        .click({ force: true })
+        .should('be.visible')
+        .click()
         .then(() => {
           if (waitForUpdateMsg) {
             checkUpdatingMessageNotDisplayed();
@@ -395,7 +415,9 @@ export function checkValueSelected(
  * Verifies whether the group menu is displayed.
  */
 export function checkGroupMenuDisplayed(): void {
-  cy.get('cx-configurator-group-menu').should('be.visible');
+  const groupMenuSelector = 'cx-configurator-group-menu';
+  cy.get(groupMenuSelector).scrollIntoView();
+  cy.get(groupMenuSelector).should('be.visible');
 }
 
 /**
@@ -403,7 +425,9 @@ export function checkGroupMenuDisplayed(): void {
  */
 export function checkGroupTitleDisplayed(): void {
   checkUpdatingMessageNotDisplayed();
-  cy.get('cx-configurator-group-title').should('be.visible');
+  const groupTitleSelector = 'cx-configurator-group-title';
+  cy.get(groupTitleSelector).scrollIntoView();
+  cy.get(groupTitleSelector).should('be.visible');
 }
 
 /**
@@ -411,7 +435,9 @@ export function checkGroupTitleDisplayed(): void {
  */
 export function checkGroupFormDisplayed(): void {
   checkUpdatingMessageNotDisplayed();
-  cy.get('cx-configurator-form').should('be.visible');
+  const groupFormSelector = 'cx-configurator-form';
+  cy.get(groupFormSelector).scrollIntoView();
+  cy.get(groupFormSelector).should('be.visible');
 }
 
 /**
@@ -419,7 +445,9 @@ export function checkGroupFormDisplayed(): void {
  */
 export function checkPreviousAndNextBtnsDispalyed(): void {
   checkUpdatingMessageNotDisplayed();
-  cy.get('cx-configurator-previous-next-buttons').should('be.visible');
+  const previousNextButtonsSelector = 'cx-configurator-previous-next-buttons';
+  cy.get(previousNextButtonsSelector).scrollIntoView();
+  cy.get(previousNextButtonsSelector).should('be.visible');
 }
 
 /**
@@ -427,7 +455,9 @@ export function checkPreviousAndNextBtnsDispalyed(): void {
  */
 export function checkPriceSummaryDisplayed(): void {
   checkUpdatingMessageNotDisplayed();
-  cy.get('cx-configurator-price-summary').should('be.visible');
+  const priceSummarySelector = 'cx-configurator-price-summary';
+  cy.get(priceSummarySelector).scrollIntoView();
+  cy.get(priceSummarySelector).should('be.visible');
 }
 
 /**
@@ -435,7 +465,9 @@ export function checkPriceSummaryDisplayed(): void {
  */
 export function checkAddToCartBtnDisplayed(): void {
   checkUpdatingMessageNotDisplayed();
-  cy.get('cx-configurator-add-to-cart-button').should('be.visible');
+  const addToCartBtnSelector = 'cx-configurator-add-to-cart-button';
+  cy.get(addToCartBtnSelector).scrollIntoView();
+  cy.get(addToCartBtnSelector).should('be.visible');
 }
 
 /**
@@ -455,9 +487,9 @@ export function checkTotalPrice(formattedPrice: string): void {
  * Navigates to the overview page via the overview tab.
  */
 export function navigateToOverviewPage(): void {
-  cy.get('cx-configurator-tab-bar a:contains("Overview")').click({
-    force: true,
-  });
+  const overviewPageSelector = 'cx-configurator-tab-bar a:contains("Overview")';
+  cy.get(overviewPageSelector).scrollIntoView();
+  cy.get(overviewPageSelector).should('be.visible').click();
 }
 
 /**
@@ -469,16 +501,20 @@ export function clickOnGroupByGroupIndex(groupIndex: number): void {
   cy.get('cx-configurator-group-menu .cx-menu-item')
     .not('.cx-menu-conflict')
     .eq(groupIndex)
-    .click({ force: true });
+    .should('be.visible')
+    .click();
 }
 
 /**
  * Clicks the group menu.
  */
 export function clickHamburger(): void {
-  cy.get('cx-configurator-group-title cx-hamburger-menu button')
-    .scrollIntoView()
-    .click({ force: true })
+  const hamburgerMenuSelector =
+    'cx-configurator-group-title cx-hamburger-menu button';
+  cy.get(hamburgerMenuSelector).scrollIntoView();
+  cy.get(hamburgerMenuSelector)
+    .should('be.visible')
+    .click()
     .then(() => {
       checkUpdatingMessageNotDisplayed();
     });
@@ -488,9 +524,10 @@ export function clickHamburger(): void {
  * Verifies whether the group menu is displayed.
  */
 export function checkHamburgerDisplayed(): void {
-  cy.get('cx-configurator-group-title cx-hamburger-menu button').should(
-    'be.visible'
-  );
+  const hamburgerMenuSelector =
+    'cx-configurator-group-title cx-hamburger-menu button';
+  cy.get(hamburgerMenuSelector).scrollIntoView();
+  cy.get(hamburgerMenuSelector).should('be.visible');
 }
 
 /**


### PR DESCRIPTION
- I've changed the order of the **waits**. For example, it first waits for a **GET** response and then checks whether the configuration has rendered the corresponding elements.
- I've also adjusted most of the **check**..() methods to scroll to the respective element first. This was because the generated video during the test execution might not have clearly indicated which element was currently in focus. Then, the element's visibility is checked.
- For methods that trigger a click, a click event is triggered as soon as the element is visible.
- **viewportContext** is set explicitly for each test suite because there were resolution issues in the pipeline.