### PR TITLE
fix: Deprecate a11y toggles for October 2025 release

### DIFF
--- a/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.ts
+++ b/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.ts
@@ -272,9 +272,7 @@ export class AddToCartComponent implements OnInit, OnDestroy {
     newEvent.quantity = quantity;
     newEvent.numberOfEntriesBeforeAdd = numberOfEntriesBeforeAdd;
     newEvent.pickupStoreName = storeName;
-    if (this.featureConfigService.isEnabled('a11yDialogTriggerRefocus')) {
-      newEvent.triggerElementRef = this.addToCartDialogTriggerEl;
-    }
+    newEvent.triggerElementRef = this.addToCartDialogTriggerEl;
     return newEvent;
   }
 

--- a/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.ts
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.ts
@@ -94,7 +94,6 @@ export class AddedToCartDialogComponent implements OnInit, OnDestroy {
     protected routingService: RoutingService,
     protected el: ElementRef
   ) {
-    useFeatureStyles('a11yPreventHorizontalScroll');
     useFeatureStyles('a11yUpdatingCartNoNarration');
   }
 

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.ts
@@ -99,7 +99,6 @@ export class CartItemListComponent implements OnInit, OnDestroy {
     protected cd: ChangeDetectorRef,
     @Optional() protected outlet?: OutletContextData<ItemListContext>
   ) {
-    useFeatureStyles('a11yPreventHorizontalScroll');
     useFeatureStyles('a11yQTY2Quantity');
     useFeatureStyles('a11yPickupOptionsTabs');
     useFeatureStyles('a11yCroppedFocusRing');

--- a/feature-libs/cart/base/styles/components/_added-to-cart-dialog.scss
+++ b/feature-libs/cart/base/styles/components/_added-to-cart-dialog.scss
@@ -84,13 +84,11 @@
         }
       }
 
-      @include forFeature('a11yPreventHorizontalScroll') {
-        .cx-quantity {
-          @include media-breakpoint-down(xs) {
-            flex-direction: column;
-            align-items: start;
-            gap: 5px;
-          }
+      .cx-quantity {
+        @include media-breakpoint-down(xs) {
+          flex-direction: column;
+          align-items: start;
+          gap: 5px;
         }
       }
 

--- a/feature-libs/cart/base/styles/components/_cart-item-list.scss
+++ b/feature-libs/cart/base/styles/components/_cart-item-list.scss
@@ -67,10 +67,7 @@
   .cx-code {
     color: var(--cx-color-secondary);
     margin-top: 0.5em;
-
-    @include forFeature('a11yPreventHorizontalScroll') {
-      overflow-wrap: anywhere;
-    }
+    overflow-wrap: anywhere;
   }
 
   .cx-link {

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-form/import-entries-form.component.html
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-form/import-entries-form.component.html
@@ -3,7 +3,7 @@
   [formGroup]="form"
   (submit)="formSubmitSubject$.next(undefined)"
 >
-  <ng-container *cxFeature="'a11yCartImportConfirmationMessage'">
+  <ng-container>
     <div aria-live="assertive" aria-atomic="true">
       <cx-message
         *ngIf="form.get('file')?.value && form.get('file')?.valid"

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-form/import-entries-form.component.html
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-form/import-entries-form.component.html
@@ -3,17 +3,15 @@
   [formGroup]="form"
   (submit)="formSubmitSubject$.next(undefined)"
 >
-  <ng-container>
-    <div aria-live="assertive" aria-atomic="true">
-      <cx-message
-        *ngIf="form.get('file')?.value && form.get('file')?.valid"
-        [text]="'importEntriesDialog.selectedSuccessfully' | cxTranslate"
-        [type]="globalMessageType.MSG_TYPE_CONFIRMATION"
-        [isVisibleCloseButton]="false"
-        [cxFocus]="{ autofocus: '.cx-message' }"
-      ></cx-message>
-    </div>
-  </ng-container>
+  <div aria-live="assertive" aria-atomic="true">
+    <cx-message
+      *ngIf="form.get('file')?.value && form.get('file')?.valid"
+      [text]="'importEntriesDialog.selectedSuccessfully' | cxTranslate"
+      [type]="globalMessageType.MSG_TYPE_CONFIRMATION"
+      [isVisibleCloseButton]="false"
+      [cxFocus]="{ autofocus: '.cx-message' }"
+    ></cx-message>
+  </div>
   <p class="cx-import-entries-subtitle">
     {{ 'importEntriesDialog.importProductsSubtitle' | cxTranslate }}
   </p>

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-to-new-saved-cart-form/import-to-new-saved-cart-form.component.html
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-to-new-saved-cart-form/import-to-new-saved-cart-form.component.html
@@ -3,7 +3,7 @@
   [formGroup]="form"
   (submit)="formSubmitSubject$.next(undefined)"
 >
-  <ng-container *cxFeature="'a11yCartImportConfirmationMessage'">
+  <ng-container>
     <div aria-live="assertive" aria-atomic="true">
       <cx-message
         *ngIf="form.get('file')?.value && form.get('file')?.valid"

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-to-new-saved-cart-form/import-to-new-saved-cart-form.component.html
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-to-new-saved-cart-form/import-to-new-saved-cart-form.component.html
@@ -3,17 +3,15 @@
   [formGroup]="form"
   (submit)="formSubmitSubject$.next(undefined)"
 >
-  <ng-container>
-    <div aria-live="assertive" aria-atomic="true">
-      <cx-message
-        *ngIf="form.get('file')?.value && form.get('file')?.valid"
-        [text]="'importEntriesDialog.selectedSuccessfully' | cxTranslate"
-        [type]="globalMessageType.MSG_TYPE_CONFIRMATION"
-        [isVisibleCloseButton]="false"
-        [cxFocus]="{ autofocus: '.cx-message' }"
-      ></cx-message>
-    </div>
-  </ng-container>
+  <div aria-live="assertive" aria-atomic="true">
+    <cx-message
+      *ngIf="form.get('file')?.value && form.get('file')?.valid"
+      [text]="'importEntriesDialog.selectedSuccessfully' | cxTranslate"
+      [type]="globalMessageType.MSG_TYPE_CONFIRMATION"
+      [isVisibleCloseButton]="false"
+      [cxFocus]="{ autofocus: '.cx-message' }"
+    ></cx-message>
+  </div>
   <cx-form-required-legend />
   <p class="cx-import-entries-subtitle">
     {{ 'importEntriesDialog.importProductsNewSavedCartSubtitle' | cxTranslate }}

--- a/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.ts
+++ b/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.ts
@@ -64,17 +64,13 @@ export class AddToWishListComponent {
   add(product: Product): void {
     if (product.code) {
       this.wishListFacade.addEntry(product.code);
-      if (this.featureConfigService.isEnabled('a11yAddToWishlistFocus')) {
-        this.restoreFocus();
-      }
+      this.restoreFocus();
     }
   }
 
   remove(entry: OrderEntry): void {
     this.wishListFacade.removeEntry(entry);
-    if (this.featureConfigService.isEnabled('a11yAddToWishlistFocus')) {
-      this.restoreFocus();
-    }
+    this.restoreFocus();
   }
 
   getProductInWishList(

--- a/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.ts
+++ b/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.ts
@@ -8,17 +8,11 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  inject,
   ViewChild,
 } from '@angular/core';
 import { OrderEntry } from '@spartacus/cart/base/root';
 import { WishListFacade } from '@spartacus/cart/wish-list/root';
-import {
-  AuthService,
-  FeatureConfigService,
-  isNotNullable,
-  Product,
-} from '@spartacus/core';
+import { AuthService, Product, isNotNullable } from '@spartacus/core';
 import { CurrentProductService, ICON_TYPE } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
 import { filter, map, take, tap } from 'rxjs/operators';
@@ -40,8 +34,6 @@ export class AddToWishListComponent {
 
   @ViewChild('addToWishlistButton') addToWishlistButton: ElementRef;
   @ViewChild('removeFromWishlistButton') removeFromWishlistButton: ElementRef;
-
-  private featureConfigService = inject(FeatureConfigService);
 
   userLoggedIn$: Observable<boolean> = this.authService.isUserLoggedIn().pipe(
     tap((isLogin) => {

--- a/feature-libs/order/components/order-history/order-history.component.ts
+++ b/feature-libs/order/components/order-history/order-history.component.ts
@@ -7,10 +7,9 @@
 import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
 import { Params } from '@angular/router';
 import {
-  isNotUndefined,
   RoutingService,
   TranslationService,
-  useFeatureStyles,
+  isNotUndefined,
 } from '@spartacus/core';
 import {
   Order,
@@ -18,7 +17,7 @@ import {
   OrderHistoryList,
   ReplenishmentOrderHistoryFacade,
 } from '@spartacus/order/root';
-import { combineLatest, Observable } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
 import { filter, map, take, tap } from 'rxjs/operators';
 
 @Component({
@@ -33,9 +32,7 @@ export class OrderHistoryComponent implements OnDestroy {
     protected orderHistoryFacade: OrderHistoryFacade,
     protected translation: TranslationService,
     protected replenishmentOrderHistoryFacade: ReplenishmentOrderHistoryFacade
-  ) {
-    useFeatureStyles('a11yTabComponent');
-  }
+  ) {}
 
   private PAGE_SIZE = 5;
   sortType: string;

--- a/feature-libs/order/styles/components/order-history/_order-history.scss
+++ b/feature-libs/order/styles/components/order-history/_order-history.scss
@@ -1,8 +1,6 @@
 %cx-order-history {
   .cx-order-history-container {
-    @include forFeature('a11yTabComponent') {
-      padding: 0 20px;
-    }
+    padding: 0 20px;
   }
 
   .cx-order-history {
@@ -66,7 +64,7 @@
   }
 
   .cx-order-history-header {
-    padding: 40px 0 0 0;
+    padding: 0;
     color: var(--cx-color-text);
 
     @include media-breakpoint-down(sm) {
@@ -74,10 +72,6 @@
       padding-inline-end: 20px;
       padding-bottom: 0;
       padding-inline-start: 20px;
-    }
-
-    @include forFeature('a11yTabComponent') {
-      padding: 0;
     }
   }
 

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.ts
@@ -11,7 +11,6 @@ import {
   OnDestroy,
   OnInit,
   Optional,
-  ViewChild,
   ViewContainerRef,
 } from '@angular/core';
 import {
@@ -81,14 +80,6 @@ export function orderEntryWithRequiredFields(
   standalone: false,
 })
 export class CartPickupOptionsContainerComponent implements OnInit, OnDestroy {
-  // TODO: Remove element reference once 'a11yDialogTriggerRefocus' feature flag is removed.
-  /**
-   * @deprecated since 2211.28.0
-   * This reference does not point to any element and will be removed at earliest convinience.
-   * The 'triggerElement' is passed through 'PickupOptionChange' event instead.
-   */
-  @ViewChild('open') element: ElementRef;
-
   pickupOption$: Observable<PickupOption | undefined>;
   disableControls$: Observable<boolean>;
   storeDetails$: Observable<{
@@ -262,98 +253,47 @@ export class CartPickupOptionsContainerComponent implements OnInit, OnDestroy {
       tap((_) => (this.displayNameIsSet = true))
     );
   }
-  // TODO: Remove 'PickupOption' argument type once 'a11yDialogTriggerRefocus' feature flag is removed.
-  /**
-   * @deprecated since 2211.28.0 - Use event param instead of option.
-   * @param event - Object containing the selected option and the element that triggered the change.
-   */
-  onPickupOptionChange(pickupOption: PickupOption): void;
-  // eslint-disable-next-line @typescript-eslint/unified-signatures
+
   onPickupOptionChange(event: {
     option: PickupOption;
     triggerElement: ElementRef;
-  }): void;
-  onPickupOptionChange(
-    event: { option: PickupOption; triggerElement: ElementRef } | PickupOption
-  ): void {
+  }): void {
     /* istanbul ignore else */
+    this.pickupOptionFacade.setPickupOption(this.entryNumber, event.option);
+    if (event.option === 'delivery') {
+      this.activeCartFacade.updateEntry(
+        this.entryNumber,
+        this.quantity,
+        undefined,
+        true
+      );
+      return;
+    }
+    [event.option]
+      .filter((option) => option === 'pickup')
+      .forEach(() => {
+        this.subscription.add(
+          this.storeDetails$
+            .pipe(
+              filter(({ name }) => !!name),
+              tap(({ name }) =>
+                this.activeCartFacade.updateEntry(
+                  this.entryNumber,
+                  this.quantity,
+                  name,
+                  true
+                )
+              )
+            )
+            .subscribe()
+        );
+      });
+
     if (
-      this.featureConfigService.isEnabled('a11yDialogTriggerRefocus') &&
-      typeof event === 'object'
+      !this.featureConfigService.isEnabled('a11yPickupOptionsTabs') &&
+      !this.displayNameIsSet
     ) {
-      this.pickupOptionFacade.setPickupOption(this.entryNumber, event.option);
-      if (event.option === 'delivery') {
-        this.activeCartFacade.updateEntry(
-          this.entryNumber,
-          this.quantity,
-          undefined,
-          true
-        );
-        return;
-      }
-      [event.option]
-        .filter((option) => option === 'pickup')
-        .forEach(() => {
-          this.subscription.add(
-            this.storeDetails$
-              .pipe(
-                filter(({ name }) => !!name),
-                tap(({ name }) =>
-                  this.activeCartFacade.updateEntry(
-                    this.entryNumber,
-                    this.quantity,
-                    name,
-                    true
-                  )
-                )
-              )
-              .subscribe()
-          );
-        });
-
-      if (
-        !this.featureConfigService.isEnabled('a11yPickupOptionsTabs') &&
-        !this.displayNameIsSet
-      ) {
-        this.openDialog(event.triggerElement);
-      }
-    } else if (typeof event === 'string') {
-      this.pickupOptionFacade.setPickupOption(this.entryNumber, event);
-      if (event === 'delivery') {
-        this.activeCartFacade.updateEntry(
-          this.entryNumber,
-          this.quantity,
-          undefined,
-          true
-        );
-        return;
-      }
-      [event]
-        .filter((option) => option === 'pickup')
-        .forEach(() => {
-          this.subscription.add(
-            this.storeDetails$
-              .pipe(
-                filter(({ name }) => !!name),
-                tap(({ name }) =>
-                  this.activeCartFacade.updateEntry(
-                    this.entryNumber,
-                    this.quantity,
-                    name,
-                    true
-                  )
-                )
-              )
-              .subscribe()
-          );
-        });
-
-      if (
-        !this.featureConfigService.isEnabled('a11yPickupOptionsTabs') &&
-        !this.displayNameIsSet
-      ) {
-        this.openDialog();
-      }
+      this.openDialog(event.triggerElement);
     }
   }
 
@@ -361,15 +301,10 @@ export class CartPickupOptionsContainerComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
-  // TODO: Make argument required once 'a11yDialogTriggerRefocus' feature flag is removed.
-  /**
-   * @deprecated since 2211.28.0 - The use of TriggerElement param will become mandatory.
-   * @param triggerElement - The reference of element that triggered the dialog. Used to refocus on it after the dialog is closed.
-   */
-  openDialog(triggerElement?: ElementRef): void {
+  openDialog(triggerElement: ElementRef): void {
     const dialog = this.launchDialogService.openDialog(
       LAUNCH_CALLER.PICKUP_IN_STORE,
-      triggerElement ? triggerElement : this.element,
+      triggerElement,
       this.vcr,
       {
         productCode: this.productCode,

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.spec.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.spec.ts
@@ -2,11 +2,7 @@ import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import {
-  FeatureConfigService,
-  I18nTestingModule,
-  Product,
-} from '@spartacus/core';
+import { I18nTestingModule, Product } from '@spartacus/core';
 
 import {
   AugmentedPointOfService,
@@ -17,10 +13,9 @@ import {
 } from '@spartacus/pickup-in-store/root';
 import {
   CurrentProductService,
-  LAUNCH_CALLER,
   LaunchDialogService,
 } from '@spartacus/storefront';
-import { firstValueFrom, Observable, of, Subscription } from 'rxjs';
+import { Observable, Subscription, firstValueFrom, of } from 'rxjs';
 import { PdpPickupOptionsContainerComponent } from './pdp-pickup-options-container.component';
 
 import { MockIntendedPickupLocationService } from '../../../core/facade/intended-pickup-location.service.spec';
@@ -88,12 +83,6 @@ class MockCurrentLocationService {
   }
 }
 
-class MockFeatureConfigService {
-  isEnabled() {
-    return true;
-  }
-}
-
 describe('PdpPickupOptionsComponent', () => {
   let component: PdpPickupOptionsContainerComponent;
   let fixture: ComponentFixture<PdpPickupOptionsContainerComponent>;
@@ -101,7 +90,6 @@ describe('PdpPickupOptionsComponent', () => {
   let intendedPickupLocationService: IntendedPickupLocationFacade;
   let currentProductService: CurrentProductService;
   let preferredStoreFacade: PreferredStoreFacade;
-  let featureConfigService: FeatureConfigService;
 
   const configureTestingModule = () =>
     TestBed.configureTestingModule({
@@ -133,10 +121,6 @@ describe('PdpPickupOptionsComponent', () => {
           provide: CurrentLocationService,
           useClass: MockCurrentLocationService,
         },
-        {
-          provide: FeatureConfigService,
-          useClass: MockFeatureConfigService,
-        },
       ],
     });
 
@@ -150,7 +134,6 @@ describe('PdpPickupOptionsComponent', () => {
     preferredStoreFacade = TestBed.inject(PreferredStoreFacade);
 
     currentProductService = TestBed.inject(CurrentProductService);
-    featureConfigService = TestBed.inject(FeatureConfigService);
 
     spyOn(currentProductService, 'getProduct').and.callThrough();
     spyOn(launchDialogService, 'openDialog').and.callThrough();
@@ -176,16 +159,6 @@ describe('PdpPickupOptionsComponent', () => {
       expect(component).toBeDefined();
     });
 
-    it('should trigger and open dialog', () => {
-      component.openDialog();
-      expect(launchDialogService.openDialog).toHaveBeenCalledWith(
-        LAUNCH_CALLER.PICKUP_IN_STORE,
-        component.element,
-        component['vcr'],
-        { productCode: 'productCode' }
-      );
-    });
-
     it('should unsubscribe from any subscriptions when destroyed', () => {
       component.subscription = new Subscription();
       spyOn(component.subscription, 'unsubscribe');
@@ -205,23 +178,6 @@ describe('PdpPickupOptionsComponent', () => {
         intendedPickupLocationService.getIntendedLocation
       ).toHaveBeenCalledWith('productCode');
       expect(component.availableForPickup).toBe(true);
-    });
-
-    it('should call setPickupOption on pickup option change ', () => {
-      spyOn(intendedPickupLocationService, 'setPickupOption');
-      const option = 'pickup';
-      const productCode = 'productCode';
-      component.onPickupOptionChange(option);
-      expect(
-        intendedPickupLocationService.setPickupOption
-      ).toHaveBeenCalledWith(productCode, option);
-    });
-
-    it('should return nothing if pickup option is delivery ', () => {
-      spyOn(component, 'openDialog');
-      const option = 'delivery';
-      component.onPickupOptionChange(option);
-      expect(component.openDialog).not.toHaveBeenCalled();
     });
 
     it('should return undefined if intendedLocation.displayName is not defined', async () => {
@@ -250,24 +206,6 @@ describe('PdpPickupOptionsComponent', () => {
         name: 'London School',
         pickupOption: 'delivery',
       });
-    });
-
-    it('should open dialog if displayName is not set and a11yPickupOptionsTabs disabled', () => {
-      spyOn(featureConfigService, 'isEnabled').and.returnValue(false);
-      spyOn(component, 'openDialog');
-      component['displayNameIsSet'] = false;
-      const option = 'pickup';
-      component.onPickupOptionChange(option);
-      expect(component.openDialog).toHaveBeenCalled();
-    });
-
-    it('should NOT open dialog if displayName is not set and a11yPickupOptionsTabs enabled', () => {
-      spyOn(featureConfigService, 'isEnabled').and.returnValue(true);
-      spyOn(component, 'openDialog');
-      component['displayNameIsSet'] = false;
-      const option = 'pickup';
-      component.onPickupOptionChange(option);
-      expect(component.openDialog).not.toHaveBeenCalled();
     });
   });
   describe('without current product', () => {

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.spec.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.spec.ts
@@ -18,6 +18,7 @@ import {
 import { Observable, Subscription, firstValueFrom, of } from 'rxjs';
 import { PdpPickupOptionsContainerComponent } from './pdp-pickup-options-container.component';
 
+import { ElementRef } from '@angular/core';
 import { MockIntendedPickupLocationService } from '../../../core/facade/intended-pickup-location.service.spec';
 import { MockPreferredStoreService } from '../../../core/services/preferred-store.service.spec';
 import { PickupOptionsStubComponent } from '../../presentational/pickup-options/pickup-options.component.spec';
@@ -159,6 +160,55 @@ describe('PdpPickupOptionsComponent', () => {
       expect(component).toBeDefined();
     });
 
+    it('should not open dialog when feature flag is enabled', () => {
+      spyOn(component['featureConfigService'], 'isEnabled').and.returnValue(
+        true
+      );
+      spyOn(component, 'openDialog');
+      component['displayNameIsSet'] = false;
+      component.onPickupOptionChange({
+        option: 'pickup',
+        triggerElement: {} as ElementRef,
+      });
+      expect(component.openDialog).not.toHaveBeenCalled();
+    });
+
+    it('should not open dialog when option is delivery and feature flag is disabled', () => {
+      spyOn(component['featureConfigService'], 'isEnabled').and.returnValue(
+        false
+      );
+      spyOn(component, 'openDialog');
+      component.onPickupOptionChange({
+        option: 'delivery',
+        triggerElement: {} as ElementRef,
+      });
+      expect(component.openDialog).not.toHaveBeenCalled();
+    });
+
+    it('should not open dialog when displayName is set', () => {
+      spyOn(component['featureConfigService'], 'isEnabled').and.returnValue(
+        false
+      );
+      spyOn(component, 'openDialog');
+      component['displayNameIsSet'] = true;
+      component.onPickupOptionChange({
+        option: 'pickup',
+        triggerElement: {} as ElementRef,
+      });
+      expect(component.openDialog).not.toHaveBeenCalled();
+    });
+
+    it('should handle invalid intended location on init', async () => {
+      spyOn(
+        intendedPickupLocationService,
+        'getIntendedLocation'
+      ).and.returnValue(of({ pickupOption: 'pickup', displayName: undefined }));
+      const displayLocation = await firstValueFrom(
+        component.displayPickupLocation$
+      );
+      expect(displayLocation).toBeUndefined();
+    });
+
     it('should unsubscribe from any subscriptions when destroyed', () => {
       component.subscription = new Subscription();
       spyOn(component.subscription, 'unsubscribe');
@@ -231,6 +281,31 @@ describe('PdpPickupOptionsComponent', () => {
         intendedPickupLocationService.getIntendedLocation
       ).not.toHaveBeenCalled();
       expect(component.availableForPickup).toBe(false);
+    });
+
+    it('should not open dialog when option is delivery and feature flag is disabled', () => {
+      spyOn(component['featureConfigService'], 'isEnabled').and.returnValue(
+        false
+      );
+      spyOn(component, 'openDialog');
+      component.onPickupOptionChange({
+        option: 'delivery',
+        triggerElement: {} as ElementRef,
+      });
+      expect(component.openDialog).not.toHaveBeenCalled();
+    });
+
+    it('should not open dialog when displayName is set', () => {
+      spyOn(component['featureConfigService'], 'isEnabled').and.returnValue(
+        false
+      );
+      spyOn(component, 'openDialog');
+      component['displayNameIsSet'] = true;
+      component.onPickupOptionChange({
+        option: 'pickup',
+        triggerElement: {} as ElementRef,
+      });
+      expect(component.openDialog).not.toHaveBeenCalled();
     });
 
     it('should not display the form', () => {

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
@@ -7,12 +7,11 @@
 import {
   Component,
   ElementRef,
-  inject,
   EventEmitter,
+  inject,
   OnDestroy,
   OnInit,
   Output,
-  ViewChild,
   ViewContainerRef,
 } from '@angular/core';
 import { FeatureConfigService, Product } from '@spartacus/core';
@@ -59,13 +58,6 @@ function isProductWithCode(
   standalone: false,
 })
 export class PdpPickupOptionsContainerComponent implements OnInit, OnDestroy {
-  // TODO: Remove element reference once 'a11yDialogTriggerRefocus' feature flag is removed.
-  /**
-   * @deprecated since 2211.28.0
-   * This reference does not point to any element and will be removed at earliest convinience.
-   * The 'triggerElement' is passed through 'PickupOptionChange' event instead.
-   */
-  @ViewChild('open') element: ElementRef;
   @Output() intendedPickupChange = new EventEmitter<
     AugmentedPointOfService | undefined
   >();
@@ -182,17 +174,10 @@ export class PdpPickupOptionsContainerComponent implements OnInit, OnDestroy {
     );
   }
 
-  // TODO: Make argument required once 'a11yDialogTriggerRefocus' feature flag is removed.
-  /**
-   * @deprecated since 2211.28.0 - The use of TriggerElement param will become mandatory.
-   * @param triggerElement - The reference of element that triggered the dialog. Used to refocus on it after the dialog is closed.
-   */
-  openDialog(triggerElement?: ElementRef): void {
+  openDialog(triggerElement: ElementRef): void {
     const dialog = this.launchDialogService.openDialog(
       LAUNCH_CALLER.PICKUP_IN_STORE,
-      this.featureConfigService.isEnabled('a11yDialogTriggerRefocus')
-        ? triggerElement
-        : this.element,
+      triggerElement,
       this.vcr,
       { productCode: this.productCode }
     );
@@ -202,24 +187,11 @@ export class PdpPickupOptionsContainerComponent implements OnInit, OnDestroy {
     }
   }
 
-  // TODO: Remove 'PickupOption' argument type once 'a11yDialogTriggerRefocus' feature flag is removed.
-  /**
-   * @deprecated since 2211.28.0 - Use event param instead of option.
-   * @param event - Object containing the selected option and the element that triggered the change.
-   */
-  onPickupOptionChange(option: PickupOption): void;
-  // eslint-disable-next-line @typescript-eslint/unified-signatures
   onPickupOptionChange(event: {
     option: PickupOption;
     triggerElement: ElementRef;
-  }): void;
-  onPickupOptionChange(
-    event: { option: PickupOption; triggerElement: ElementRef } | PickupOption
-  ): void {
-    const handleChange = (
-      option: PickupOption,
-      triggerElement?: ElementRef
-    ) => {
+  }): void {
+    const handleChange = (option: PickupOption, triggerElement: ElementRef) => {
       if (!this.featureConfigService.isEnabled('a11yPickupOptionsTabs')) {
         if (option === 'delivery') {
           return;
@@ -229,22 +201,11 @@ export class PdpPickupOptionsContainerComponent implements OnInit, OnDestroy {
         }
       }
     };
-    if (
-      this.featureConfigService.isEnabled('a11yDialogTriggerRefocus') &&
-      typeof event === 'object'
-    ) {
-      const { option, triggerElement = undefined } = event;
-      this.intendedPickupLocationService.setPickupOption(
-        this.productCode,
-        option
-      );
-      handleChange(option, triggerElement);
-    } else if (typeof event === 'string') {
-      this.intendedPickupLocationService.setPickupOption(
-        this.productCode,
-        event
-      );
-      handleChange(event);
-    }
+    const { option, triggerElement } = event;
+    this.intendedPickupLocationService.setPickupOption(
+      this.productCode,
+      option
+    );
+    handleChange(option, triggerElement);
   }
 }

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.ts
@@ -191,7 +191,9 @@ export class PdpPickupOptionsContainerComponent implements OnInit, OnDestroy {
     option: PickupOption;
     triggerElement: ElementRef;
   }): void {
-    const handleChange = (option: PickupOption, triggerElement: ElementRef) => {
+    const { option, triggerElement } = event;
+
+    const handleChange = () => {
       if (!this.featureConfigService.isEnabled('a11yPickupOptionsTabs')) {
         if (option === 'delivery') {
           return;
@@ -201,11 +203,11 @@ export class PdpPickupOptionsContainerComponent implements OnInit, OnDestroy {
         }
       }
     };
-    const { option, triggerElement } = event;
+
     this.intendedPickupLocationService.setPickupOption(
       this.productCode,
       option
     );
-    handleChange(option, triggerElement);
+    handleChange();
   }
 }

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.ts
@@ -59,13 +59,9 @@ export class PickupOptionDialogComponent implements OnInit, OnDestroy {
   private featureConfigService = inject(FeatureConfigService);
 
   get focusConfig(): FocusConfig {
-    const useTrapTab = this.featureConfigService.isEnabled(
-      'a11yUseTrapTabInsteadOfTrapInDialogs'
-    );
-
     return {
-      trap: !useTrapTab,
-      trapTabOnly: useTrapTab,
+      trap: false,
+      trapTabOnly: true,
       block: true,
       autofocus: 'input',
       focusOnEscape: true,

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.html
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.html
@@ -1,6 +1,6 @@
 <ng-container *cxFeature="'!a11yPickupOptionsTabs'">
   <form [formGroup]="pickupOptionsForm">
-    <fieldset *cxFeature="'a11yDeliveryMethodFieldset'">
+    <fieldset>
       <legend>{{ 'pickupOptions.legend' | cxTranslate }}</legend>
       <div class="form-check">
         <input
@@ -63,68 +63,6 @@
         </label>
       </div>
     </fieldset>
-    <ng-container *cxFeature="'!a11yDeliveryMethodFieldset'">
-      <div class="form-check">
-        <input
-          type="radio"
-          role="radio"
-          [attr.id]="deliveryId"
-          data-pickup="delivery"
-          value="delivery"
-          (click)="onPickupOptionChange('delivery')"
-          formControlName="pickupOption"
-          [attr.aria-label]="'pickupOptions.delivery' | cxTranslate"
-          [attr.aria-checked]="
-            pickupOptionsForm.value.pickupOption === 'delivery'
-          "
-        />
-        <label [attr.for]="deliveryId">
-          {{ 'pickupOptions.delivery' | cxTranslate }}
-        </label>
-      </div>
-      <div class="form-check">
-        <input
-          type="radio"
-          role="radio"
-          [attr.id]="pickupId"
-          data-pickup="pickup"
-          value="pickup"
-          (click)="onPickupOptionChange('pickup')"
-          formControlName="pickupOption"
-          [attr.aria-label]="'pickupOptions.pickup' | cxTranslate"
-          [attr.aria-checked]="
-            pickupOptionsForm.value.pickupOption === 'pickup'
-          "
-        />
-        <label [attr.for]="pickupId">
-          <p>
-            {{ 'pickupOptions.pickup' | cxTranslate
-            }}<ng-container *ngIf="displayPickupLocation"
-              >:
-              <strong [attr.data-pickup-location]="displayPickupLocation">{{
-                displayPickupLocation
-              }}</strong>
-            </ng-container>
-            |
-            <button
-              #dialogTriggerEl
-              [attr.data-store-location-link]="
-                displayPickupLocation ? 'change' : 'select'
-              "
-              class="link cx-action-link"
-              (click)="onPickupLocationChange()"
-            >
-              {{
-                (displayPickupLocation
-                  ? 'pickupOptions.changeStore'
-                  : 'pickupOptions.selectStore'
-                ) | cxTranslate
-              }}
-            </button>
-          </p>
-        </label>
-      </div>
-    </ng-container>
   </form>
 </ng-container>
 <ng-container *cxFeature="'a11yPickupOptionsTabs'">

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.spec.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.spec.ts
@@ -101,15 +101,6 @@ describe('PickupOptionsComponent', () => {
       );
     });
 
-    it('should emit the new pickup option on onPickupOptionChange', () => {
-      spyOn(component.pickupOptionChange, 'emit');
-      component.onPickupOptionChange('delivery');
-
-      expect(component.pickupOptionChange.emit).toHaveBeenCalledWith(
-        'delivery'
-      );
-    });
-
     it('should emit on onPickupLocationChange', () => {
       spyOn(component.pickupLocationChange, 'emit');
       component.onPickupLocationChange();

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
@@ -87,7 +87,6 @@ export class PickupOptionsComponent
   }
 
   constructor() {
-    useFeatureStyles('a11yDeliveryMethodFieldset');
     useFeatureStyles('a11yPickupOptionsTabs');
   }
 

--- a/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-options/pickup-options.component.ts
@@ -49,14 +49,13 @@ export class PickupOptionsComponent
   @Input() disableControls = false;
 
   /** Emitted when the selected option is changed. */
-  // TODO: Remove the 'PickupOption' type when the `a11yDialogTriggerRefocus` feature flag is removed.
-  @Output() pickupOptionChange = new EventEmitter<
-    { option: PickupOption; triggerElement: ElementRef } | PickupOption
-  >();
+  @Output() pickupOptionChange = new EventEmitter<{
+    option: PickupOption;
+    triggerElement: ElementRef;
+  }>();
 
   /** Emitted when a new store should be selected. */
-  // TODO: Remove the undefined type when the `a11yDialogTriggerRefocus` feature flag is removed.
-  @Output() pickupLocationChange = new EventEmitter<ElementRef | undefined>();
+  @Output() pickupLocationChange = new EventEmitter<ElementRef>();
 
   @ViewChild('dialogTriggerEl') triggerElement: ElementRef;
 
@@ -121,23 +120,16 @@ export class PickupOptionsComponent
 
   /** Emit a new selected option. */
   onPickupOptionChange(option: PickupOption): void {
-    if (this.featureConfigService.isEnabled('a11yDialogTriggerRefocus')) {
-      this.pickupOptionChange.emit({
-        option,
-        triggerElement: this.triggerElement,
-      });
-    } else {
-      this.pickupOptionChange.emit(option);
-    }
+    this.pickupOptionChange.emit({
+      option,
+      triggerElement: this.triggerElement,
+    });
   }
 
   /** Emit to indicate a new store should be selected. */
   onPickupLocationChange(): boolean {
-    if (this.featureConfigService.isEnabled('a11yDialogTriggerRefocus')) {
-      this.pickupLocationChange.emit(this.triggerElement);
-    } else {
-      this.pickupLocationChange.emit();
-    }
+    this.pickupLocationChange.emit(this.triggerElement);
+
     // Return false to stop `onPickupOptionChange` being called after this
     return false;
   }

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.html
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.html
@@ -48,17 +48,7 @@
 
 <ng-template #thumb let-item="item">
   <cx-media
-    *cxFeature="'a11yCarouselArrowKeysNavigation'"
     cxFocusableCarouselItem
-    [container]="item.container"
-    tabindex="0"
-    (focus)="openImage(item.container)"
-    [class.is-active]="isActive(item.container) | async"
-    format="product"
-  >
-  </cx-media>
-  <cx-media
-    *cxFeature="'!a11yCarouselArrowKeysNavigation'"
     [container]="item.container"
     tabindex="0"
     (focus)="openImage(item.container)"

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.html
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.html
@@ -11,16 +11,7 @@
 
 <ng-template #thumb let-item="item">
   <cx-media
-    *cxFeature="'a11yCarouselArrowKeysNavigation'"
     cxFocusableCarouselItem
-    [container]="item.container"
-    tabindex="0"
-    (focus)="openImage(item.container)"
-    [class.is-active]="isActive(item.container) | async"
-  >
-  </cx-media>
-  <cx-media
-    *cxFeature="'!a11yCarouselArrowKeysNavigation'"
     [container]="item.container"
     tabindex="0"
     (focus)="openImage(item.container)"

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.spec.ts
@@ -199,6 +199,7 @@ describe('CompactAddToCartComponent', () => {
     uiEvent.numberOfEntriesBeforeAdd = 1;
     uiEvent.quantity = 1;
     uiEvent.pickupStoreName = undefined;
+    uiEvent.triggerElementRef = undefined;
 
     addToCartComponent.addToCart();
 

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -163,11 +163,6 @@ export interface FeatureTogglesInterface {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox?: boolean;
 
   /**
-   * When enabled, the form in 'PickupOptionsComponent' will be wrapped in a fieldset and contain a legend.
-   */
-  a11yDeliveryMethodFieldset?: boolean;
-
-  /**
    * In 'ProductReviewsComponent' the 'show more/less reviews' button will no longer loose focus on activation.
    */
   a11yShowMoreReviewsBtnFocus?: boolean;
@@ -794,7 +789,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yNgSelectCloseDropdownOnEscape: true,
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   a11yNgSelectAriaLabelDropdownCustomized: true,
-  a11yDeliveryMethodFieldset: true,
   a11yShowMoreReviewsBtnFocus: true,
   a11yDialogTriggerRefocus: true,
   a11yAddToWishlistFocus: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -59,11 +59,6 @@ export interface FeatureTogglesInterface {
   a11yAnonymousConsentMessageInDialog?: boolean;
 
   /**
-   * `StorefrontComponent` focuses on the first navigation item after hamburger menu expansion
-   */
-  a11yMobileFocusOnFirstNavigationItem?: boolean;
-
-  /**
    * `QuickOrderFormComponent` - disable navigation with Tab/Shift+Tab for search results list
    */
   a11yQuickOrderSearchListKeyboardNavigation?: boolean;
@@ -802,7 +797,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yPopoverHighContrast: true,
   a11yTabsManualActivation: true,
   a11yAnonymousConsentMessageInDialog: true,
-  a11yMobileFocusOnFirstNavigationItem: true,
   a11yQuickOrderSearchListKeyboardNavigation: true,
   a11yStyleExternalLinksAsLinks: true,
   a11ySearchboxLabel: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -83,13 +83,6 @@ export interface FeatureTogglesInterface {
   a11ySelectLabelWithContextForSelectedAddrOrPayment?: boolean;
 
   /**
-   * Enables only Tab/Shift+Tab keyboard navigation in dialogs and preserved default scrolling behaviour of up/down keys.
-   * Components:
-   * - `PickupOptionDialogComponent`
-   */
-  a11yUseTrapTabInsteadOfTrapInDialogs?: boolean;
-
-  /**
    * Adds a keyboard accessible zoom button to the `ProductImageZoomViewComponent`.
    */
   a11yKeyboardAccessibleZoom?: boolean;
@@ -801,7 +794,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yStyleExternalLinksAsLinks: true,
   a11ySearchboxLabel: true,
   a11ySelectLabelWithContextForSelectedAddrOrPayment: true,
-  a11yUseTrapTabInsteadOfTrapInDialogs: true,
   a11yKeyboardAccessibleZoom: false,
   a11yTruncatedTextStoreFinder: true,
   a11yTruncatedTextUnitLevelOrderHistory: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -105,13 +105,6 @@ export interface FeatureTogglesInterface {
   a11yPreventCartItemsFormRedundantRecreation?: boolean;
 
   /**
-   * Enables the use of TabComponent in the PLP and PDP page to replace some functionality
-   * of the FacetListComponent and TabParagraphComponent to make then keyboard accessible
-   * and responsive in tab and accordion stles.
-   */
-  a11yTabComponent?: boolean;
-
-  /**
    * `ProductImageZoomProductImagesComponent`, `ProductImageZoomThumbnailsComponent` - enable
    * arrow keys navigation for the carousel
    */
@@ -798,7 +791,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yTruncatedTextStoreFinder: true,
   a11yTruncatedTextUnitLevelOrderHistory: true,
   a11yPreventCartItemsFormRedundantRecreation: false,
-  a11yTabComponent: true,
   a11yCarouselArrowKeysNavigation: true,
   a11yPickupOptionsTabs: true,
   a11yResetFocusAfterNavigating: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -54,12 +54,6 @@ export interface FeatureTogglesInterface {
   a11yTabsManualActivation?: boolean;
 
   /**
-   * In `ImportToNewSavedCartFormComponent`,`ImportEntriesFormComponent` after selecting a file
-   * confirmation message is displayed and read out
-   */
-  a11yCartImportConfirmationMessage?: boolean;
-
-  /**
    * In `AnonymousConsentDialogComponent` display notifications inside the modal without closing it
    */
   a11yAnonymousConsentMessageInDialog?: boolean;
@@ -807,7 +801,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yUseProperTextColorForFutureStockAccordion: true,
   a11yPopoverHighContrast: true,
   a11yTabsManualActivation: true,
-  a11yCartImportConfirmationMessage: true,
   a11yAnonymousConsentMessageInDialog: true,
   a11yMobileFocusOnFirstNavigationItem: true,
   a11yQuickOrderSearchListKeyboardNavigation: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -105,12 +105,6 @@ export interface FeatureTogglesInterface {
   a11yPreventCartItemsFormRedundantRecreation?: boolean;
 
   /**
-   * `ProductImageZoomProductImagesComponent`, `ProductImageZoomThumbnailsComponent` - enable
-   * arrow keys navigation for the carousel
-   */
-  a11yCarouselArrowKeysNavigation?: boolean;
-
-  /**
    * Use tabs instead of radio group for pickup options. Improves SR narration and keyboard navigation pattern.
    * Modified components:
    *  - `PickupOptionsComponent`
@@ -791,7 +785,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yTruncatedTextStoreFinder: true,
   a11yTruncatedTextUnitLevelOrderHistory: true,
   a11yPreventCartItemsFormRedundantRecreation: false,
-  a11yCarouselArrowKeysNavigation: true,
   a11yPickupOptionsTabs: true,
   a11yResetFocusAfterNavigating: true,
   headerLayoutForSmallerViewports: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -163,11 +163,6 @@ export interface FeatureTogglesInterface {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox?: boolean;
 
   /**
-   * In 'ProductReviewsComponent' the 'show more/less reviews' button will no longer loose focus on activation.
-   */
-  a11yShowMoreReviewsBtnFocus?: boolean;
-
-  /**
    * When enabled, the focus will be returned to the trigger element after the dialog is closed.
    * Affected components: 'AddtoCartComponent', 'PickupOptionsComponent', CartPickupOptionsContainerComponent, PDPPickupOptionsContainerComponent
    */
@@ -789,7 +784,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yNgSelectCloseDropdownOnEscape: true,
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   a11yNgSelectAriaLabelDropdownCustomized: true,
-  a11yShowMoreReviewsBtnFocus: true,
   a11yDialogTriggerRefocus: true,
   a11yAddToWishlistFocus: true,
   a11ySearchBoxFocusOnEscape: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -44,11 +44,6 @@ export interface FeatureTogglesInterface {
   a11yUseProperTextColorForFutureStockAccordion?: boolean;
 
   /**
-   * Prevent horizontal scroll appearing on smaller screens for `CartItemListComponent`, `AddedToCartDialogComponent`
-   */
-  a11yPreventHorizontalScroll?: boolean;
-
-  /**
    * Fix popover appearance when a High Contrast Theme is applied.
    */
   a11yPopoverHighContrast?: boolean;
@@ -810,7 +805,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   propagateErrorsToServer: true,
   ssrStrictErrorHandlingForHttpAndNgrx: true,
   a11yUseProperTextColorForFutureStockAccordion: true,
-  a11yPreventHorizontalScroll: true,
   a11yPopoverHighContrast: true,
   a11yTabsManualActivation: true,
   a11yCartImportConfirmationMessage: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -163,11 +163,6 @@ export interface FeatureTogglesInterface {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox?: boolean;
 
   /**
-   * `SearchBoxComponent` should no longer lose focus after closing the popup the esc key.
-   */
-  a11ySearchBoxFocusOnEscape?: boolean;
-
-  /**
    * In `AddedToCartDialogComponent`, `Updating cart...` should no longer read by a screen reader.
    */
   a11yUpdatingCartNoNarration?: boolean;
@@ -773,7 +768,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yNgSelectCloseDropdownOnEscape: true,
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   a11yNgSelectAriaLabelDropdownCustomized: true,
-  a11ySearchBoxFocusOnEscape: true,
   a11yUpdatingCartNoNarration: true,
   a11yPasswordVisibliltyBtnValueOverflow: true,
   a11yItemCounterFocus: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -163,12 +163,6 @@ export interface FeatureTogglesInterface {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox?: boolean;
 
   /**
-   * When enabled, the focus will be returned to the trigger element after the dialog is closed.
-   * Affected components: 'AddtoCartComponent', 'PickupOptionsComponent', CartPickupOptionsContainerComponent, PDPPickupOptionsContainerComponent
-   */
-  a11yDialogTriggerRefocus?: boolean;
-
-  /**
    * The 'AddToWishListComponent' will restore focus to the button after adding or removing an item from the wishlist.
    */
   a11yAddToWishlistFocus?: boolean;
@@ -784,7 +778,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yNgSelectCloseDropdownOnEscape: true,
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   a11yNgSelectAriaLabelDropdownCustomized: true,
-  a11yDialogTriggerRefocus: true,
   a11yAddToWishlistFocus: true,
   a11ySearchBoxFocusOnEscape: true,
   a11yUpdatingCartNoNarration: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -163,11 +163,6 @@ export interface FeatureTogglesInterface {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox?: boolean;
 
   /**
-   * The 'AddToWishListComponent' will restore focus to the button after adding or removing an item from the wishlist.
-   */
-  a11yAddToWishlistFocus?: boolean;
-
-  /**
    * `SearchBoxComponent` should no longer lose focus after closing the popup the esc key.
    */
   a11ySearchBoxFocusOnEscape?: boolean;
@@ -778,7 +773,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yNgSelectCloseDropdownOnEscape: true,
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   a11yNgSelectAriaLabelDropdownCustomized: true,
-  a11yAddToWishlistFocus: true,
   a11ySearchBoxFocusOnEscape: true,
   a11yUpdatingCartNoNarration: true,
   a11yPasswordVisibliltyBtnValueOverflow: true,

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/epd-visualization/visualization-lookup/visualization-lookup.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/epd-visualization/visualization-lookup/visualization-lookup.e2e.cy.ts
@@ -11,11 +11,6 @@ describe('in Spare Parts Tab', () => {
     });
 
     beforeEach(() => {
-      cy.cxConfig({
-        features: {
-          a11yTabComponent: false,
-        },
-      } as any);
       cy.intercept(
         'GET',
         `${Cypress.env('OCC_PREFIX')}/${Cypress.env(

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -308,7 +308,6 @@ if (environment.cpq) {
         a11yTruncatedTextStoreFinder: true,
         a11yTruncatedTextUnitLevelOrderHistory: true,
         a11yPreventCartItemsFormRedundantRecreation: true,
-        a11yCarouselArrowKeysNavigation: true,
         a11yPickupOptionsTabs: true,
         a11yResetFocusAfterNavigating: true,
         headerLayoutForSmallerViewports: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -300,7 +300,6 @@ if (environment.cpq) {
         a11yPopoverHighContrast: true,
         a11yTabsManualActivation: true,
         a11yAnonymousConsentMessageInDialog: true,
-        a11yMobileFocusOnFirstNavigationItem: true,
         a11yQuickOrderSearchListKeyboardNavigation: false,
         a11ySearchboxLabel: true,
         a11yStyleExternalLinksAsLinks: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -322,7 +322,6 @@ if (environment.cpq) {
         a11yNgSelectCloseDropdownOnEscape: true,
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         a11yNgSelectAriaLabelDropdownCustomized: true,
-        a11yShowMoreReviewsBtnFocus: true,
         a11yDialogTriggerRefocus: true,
         a11yAddToWishlistFocus: true,
         a11ySearchBoxFocusOnEscape: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -308,7 +308,6 @@ if (environment.cpq) {
         a11yTruncatedTextStoreFinder: true,
         a11yTruncatedTextUnitLevelOrderHistory: true,
         a11yPreventCartItemsFormRedundantRecreation: true,
-        a11yTabComponent: true,
         a11yCarouselArrowKeysNavigation: true,
         a11yPickupOptionsTabs: true,
         a11yResetFocusAfterNavigating: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -304,7 +304,6 @@ if (environment.cpq) {
         a11ySearchboxLabel: true,
         a11yStyleExternalLinksAsLinks: true,
         a11ySelectLabelWithContextForSelectedAddrOrPayment: true,
-        a11yUseTrapTabInsteadOfTrapInDialogs: true,
         a11yKeyboardAccessibleZoom: true,
         a11yTruncatedTextStoreFinder: true,
         a11yTruncatedTextUnitLevelOrderHistory: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -322,7 +322,6 @@ if (environment.cpq) {
         a11yNgSelectCloseDropdownOnEscape: true,
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         a11yNgSelectAriaLabelDropdownCustomized: true,
-        a11yDeliveryMethodFieldset: true,
         a11yShowMoreReviewsBtnFocus: true,
         a11yDialogTriggerRefocus: true,
         a11yAddToWishlistFocus: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -299,7 +299,6 @@ if (environment.cpq) {
         a11yUseProperTextColorForFutureStockAccordion: true,
         a11yPopoverHighContrast: true,
         a11yTabsManualActivation: true,
-        a11yCartImportConfirmationMessage: true,
         a11yAnonymousConsentMessageInDialog: true,
         a11yMobileFocusOnFirstNavigationItem: true,
         a11yQuickOrderSearchListKeyboardNavigation: false,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -322,7 +322,6 @@ if (environment.cpq) {
         a11yNgSelectCloseDropdownOnEscape: true,
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         a11yNgSelectAriaLabelDropdownCustomized: true,
-        a11ySearchBoxFocusOnEscape: true,
         a11yUpdatingCartNoNarration: true,
         a11yPasswordVisibliltyBtnValueOverflow: true,
         a11yItemCounterFocus: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -322,7 +322,6 @@ if (environment.cpq) {
         a11yNgSelectCloseDropdownOnEscape: true,
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         a11yNgSelectAriaLabelDropdownCustomized: true,
-        a11yDialogTriggerRefocus: true,
         a11yAddToWishlistFocus: true,
         a11ySearchBoxFocusOnEscape: true,
         a11yUpdatingCartNoNarration: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -322,7 +322,6 @@ if (environment.cpq) {
         a11yNgSelectCloseDropdownOnEscape: true,
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         a11yNgSelectAriaLabelDropdownCustomized: true,
-        a11yAddToWishlistFocus: true,
         a11ySearchBoxFocusOnEscape: true,
         a11yUpdatingCartNoNarration: true,
         a11yPasswordVisibliltyBtnValueOverflow: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -297,7 +297,6 @@ if (environment.cpq) {
         propagateErrorsToServer: true,
         ssrStrictErrorHandlingForHttpAndNgrx: true,
         a11yUseProperTextColorForFutureStockAccordion: true,
-        a11yPreventHorizontalScroll: true,
         a11yPopoverHighContrast: true,
         a11yTabsManualActivation: true,
         a11yCartImportConfirmationMessage: true,

--- a/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.html
+++ b/projects/storefrontlib/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.html
@@ -1,62 +1,14 @@
 <ng-container *ngIf="components$ | async as components">
-  <div
-    *cxFeature="'!a11yTabComponent'"
-    role="region"
-    tabindex="-1"
-    [attr.aria-label]="ariaLabel | cxTranslate"
-    class="container"
-  >
-    <ng-container *ngFor="let component of components; let i = index">
-      <ng-container *ngIf="component">
-        <button
-          [class.active]="i === activeTabNum"
-          (click)="select(i, $event)"
-          [attr.aria-expanded]="i === activeTabNum"
-        >
-          {{
-            component.title | cxTranslate: { param: tabTitleParams[i] | async }
-          }}
-
-          <span
-            title="{{
-              i === activeTabNum
-                ? ('common.collapse' | cxTranslate)
-                : ('common.expand' | cxTranslate)
-            }}"
-            class="accordion-icon"
-            aria-hidden="true"
-          ></span>
-        </button>
-
-        <div
-          [class.active]="i === activeTabNum"
-          class="cx-tab-paragraph-content"
-          tabindex="0"
-          role="presentation"
-        >
-          <ng-template [cxOutlet]="component.flexType" [cxOutletContext]="{}">
-            <ng-container
-              [cxComponentWrapper]="component"
-              (cxComponentRef)="tabCompLoaded($event)"
-            ></ng-container>
-          </ng-template>
-        </div>
-      </ng-container>
-    </ng-container>
-  </div>
-
-  <ng-container *cxFeature="'a11yTabComponent'">
-    <cx-tab [tabs]="tabs$ | async" [config]="tabConfig$ | async">
-      <ng-template
-        *ngFor="let component of components; let i = index"
-        [cxOutlet]="component.flexType"
-        #tabRef
-      >
-        <ng-container
-          [cxComponentWrapper]="component"
-          (cxComponentRef)="tabCompLoaded($event, component.uid)"
-        ></ng-container>
-      </ng-template>
-    </cx-tab>
-  </ng-container>
+  <cx-tab [tabs]="tabs$ | async" [config]="tabConfig$ | async">
+    <ng-template
+      *ngFor="let component of components; let i = index"
+      [cxOutlet]="component.flexType"
+      #tabRef
+    >
+      <ng-container
+        [cxComponentWrapper]="component"
+        (cxComponentRef)="tabCompLoaded($event, component.uid)"
+      ></ng-container>
+    </ng-template>
+  </cx-tab>
 </ng-container>

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.ts
@@ -105,9 +105,8 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
   @HostListener('keydown.escape')
   onEscape() {
     if (
-      (this.featureConfigService?.isEnabled('a11ySearchBoxFocusOnEscape') &&
-        this.winRef.document.activeElement !==
-          this.searchInputEl?.nativeElement) ||
+      this.winRef.document.activeElement !==
+        this.searchInputEl?.nativeElement ||
       this.searchBoxActive
     ) {
       setTimeout(() => {

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.html
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.html
@@ -24,32 +24,11 @@
       Here we'd like to introduce configurable facet components,
       either by using specific configuration or generic sproutlets
   -->
-  <ng-container *cxFeature="'a11yTabComponent'">
-    <cx-tab [tabs$]="tabs$" [config]="tabConfig"></cx-tab>
+  <cx-tab [tabs$]="tabs$" [config]="tabConfig"></cx-tab>
 
-    <ng-template #facetsRef *ngFor="let facet of facets">
-      <cx-facet
-        [facet]="facet"
-        role="group"
-        attr.aria-label="{{
-          'productFacetNavigation.ariaLabelItemsAvailable'
-            | cxTranslate
-              : {
-                  name: facet.name,
-                  count: facet?.values?.length,
-                }
-        }}"
-      ></cx-facet>
-    </ng-template>
-  </ng-container>
-
-  <ng-container *cxFeature="'!a11yTabComponent'">
+  <ng-template #facetsRef *ngFor="let facet of facets">
     <cx-facet
-      *ngFor="let facet of facets"
-      #facetRef
       [facet]="facet"
-      [class.expanded]="isExpanded(facet) | async"
-      [class.collapsed]="isCollapsed(facet) | async"
       role="group"
       attr.aria-label="{{
         'productFacetNavigation.ariaLabelItemsAvailable'
@@ -60,7 +39,7 @@
               }
       }}"
     ></cx-facet>
-  </ng-container>
+  </ng-template>
 
   <div *ngIf="isDialog" class="cx-facet-list-footer">
     <button

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.ts
@@ -23,7 +23,7 @@ import {
   ViewChildren,
   inject,
 } from '@angular/core';
-import { Facet, FeatureConfigService, useFeatureStyles } from '@spartacus/core';
+import { Facet, FeatureConfigService } from '@spartacus/core';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 import {
@@ -102,9 +102,7 @@ export class FacetListComponent implements OnInit, OnDestroy, AfterViewInit {
     protected facetService: FacetService,
     protected elementRef: ElementRef,
     protected renderer: Renderer2
-  ) {
-    useFeatureStyles('a11yTabComponent');
-  }
+  ) {}
 
   ngOnInit(): void {
     this.enableFocusHandlingOnFacetListChanges();

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.html
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.html
@@ -1,29 +1,4 @@
 <ng-container *ngIf="state$ | async as state">
-  <button
-    class="heading"
-    #facetHeader
-    (click)="toggleGroup($event)"
-    (keydown)="onKeydown($event)"
-    [attr.aria-expanded]="isExpanded"
-    [attr.aria-label]="
-      'productFacetNavigation.filterBy.name' | cxTranslate: { name: facet.name }
-    "
-    [cxFocus]="{ key: facet.name }"
-    *cxFeature="'!a11yTabComponent'"
-  >
-    {{ facet.name }}
-    <cx-icon
-      title="{{ 'common.collapse' | cxTranslate }}"
-      class="collapse-icon"
-      [type]="collapseIcon"
-    ></cx-icon>
-    <cx-icon
-      title="{{ 'common.expand' | cxTranslate }}"
-      class="expand-icon"
-      [type]="expandIcon"
-    ></cx-icon>
-  </button>
-
   <div>
     <!-- TODO: (CXSPA-6892) - Remove feature flag next major release. -->
     <a

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.spec.ts
@@ -173,12 +173,6 @@ describe('FacetComponent', () => {
       key: 'ArrowDown',
     });
     const mockArrowUpEvent = new KeyboardEvent('keydown', { key: 'ArrowUp' });
-    const mockArrowRightEvent = new KeyboardEvent('keydown', {
-      key: 'ArrowRight',
-    });
-    const mockArrowLeftEvent = new KeyboardEvent('keydown', {
-      key: 'ArrowLeft',
-    });
     Object.defineProperty(mockArrowDownOnHeaderEvent, 'target', {
       value: facetHeaderElement,
     });
@@ -211,16 +205,8 @@ describe('FacetComponent', () => {
     });
 
     it('should initialize keyboard controls and find tiggered values index', () => {
-      spyOn(component, 'onArrowLeft');
-      spyOn(component, 'onArrowRight');
       spyOn(component, 'onArrowDown');
       spyOn(component, 'onArrowUp');
-
-      component.onKeydown(mockArrowLeftEvent);
-      expect(component.onArrowLeft).toHaveBeenCalledWith(mockArrowLeftEvent);
-
-      component.onKeydown(mockArrowRightEvent);
-      expect(component.onArrowRight).toHaveBeenCalledWith(mockArrowRightEvent);
 
       component.onKeydown(mockArrowUpEvent);
       expect(component.onArrowUp).toHaveBeenCalledWith(mockArrowUpEvent, 1);

--- a/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.ts
+++ b/projects/storefrontlib/cms-components/product/product-list/product-facet-navigation/facet/facet.component.ts
@@ -130,15 +130,7 @@ export class FacetComponent implements AfterViewInit {
     const targetIndex = this.values.toArray().findIndex((el) => {
       return el.nativeElement === event.target;
     });
-    // TODO: Left and Right arrow keys are disabled when setting a11yTabComponent.
-    // We can remove these in the future.
     switch (event.key) {
-      case 'ArrowLeft':
-        this.onArrowLeft(event);
-        break;
-      case 'ArrowRight':
-        this.onArrowRight(event);
-        break;
       case 'ArrowDown':
         this.onArrowDown(event, targetIndex);
         break;
@@ -152,71 +144,22 @@ export class FacetComponent implements AfterViewInit {
   }
 
   /**
-   * If a11yTabComponent is enabled, we temporarily disable tabbing for the facet values.
+   * We temporarily disable tabbing for the facet values.
    * This is to use proper keyboard navigation keys(ArrowUp/ArrowDown) for navigating through the facet values.
    */
   protected onTabNavigation(): void {
-    if (!this.featureConfigService?.isEnabled('a11yTabComponent')) {
-      return;
-    }
     disableTabbingForTick(this.values.map((el) => el.nativeElement));
   }
 
-  /**
-   * @deprecated: Arrow key functions will be removed in favour of using the TabComponent.
-   */
-  onArrowRight(event: Event): void {
-    if (this.featureConfigService?.isEnabled('a11yTabComponent')) {
-      return;
-    }
-
-    if (!this.isExpanded) {
-      this.toggleGroup(event as UIEvent);
-    }
-  }
-
-  /**
-   * @deprecated: Arrow key functions will be removed in favour of using the TabComponent.
-   */
-  onArrowLeft(event: Event): void {
-    // Navigate to tab buttons when tab component enabled
-    if (this.featureConfigService?.isEnabled('a11yTabComponent')) {
-      return;
-    }
-
-    if (this.isExpanded) {
-      this.toggleGroup(event as UIEvent);
-      this.facetHeader.nativeElement.focus();
-    }
-  }
-
   onArrowDown(event: Event, targetIndex: number): void {
-    if (this.featureConfigService?.isEnabled('a11yTabComponent')) {
-      event.preventDefault();
-      this.values.get(targetIndex + 1)?.nativeElement.focus();
-      return;
-    }
-
-    if (this.isExpanded) {
-      event.preventDefault();
-      if (event.target === this.facetHeader.nativeElement) {
-        this.values?.first?.nativeElement.focus();
-        return;
-      }
-      this.values.get(targetIndex + 1)?.nativeElement.focus();
-    }
+    event.preventDefault();
+    this.values.get(targetIndex + 1)?.nativeElement.focus();
+    return;
   }
 
   onArrowUp(event: Event, targetIndex: number): void {
-    if (this.featureConfigService?.isEnabled('a11yTabComponent')) {
-      event.preventDefault();
-      this.values.get(targetIndex - 1)?.nativeElement.focus();
-      return;
-    }
-
-    if (this.isExpanded) {
-      event.preventDefault();
-      this.values.get(targetIndex - 1)?.nativeElement.focus();
-    }
+    event.preventDefault();
+    this.values.get(targetIndex - 1)?.nativeElement.focus();
+    return;
   }
 }

--- a/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.component.html
+++ b/projects/storefrontlib/cms-components/product/product-tabs/product-reviews/product-reviews.component.html
@@ -46,7 +46,6 @@
         </div>
         <div *ngIf="reviews.length > initialMaxListItems">
           <button
-            *cxFeature="'a11yShowMoreReviewsBtnFocus'"
             aria-live="polite"
             class="btn btn-primary"
             (click)="
@@ -62,22 +61,6 @@
               ) | cxTranslate
             }}
           </button>
-          <ng-container *cxFeature="'!a11yShowMoreReviewsBtnFocus'">
-            <button
-              class="btn btn-primary"
-              (click)="maxListItems = reviews.length"
-              *ngIf="maxListItems === initialMaxListItems"
-            >
-              {{ 'productReview.more' | cxTranslate }}
-            </button>
-            <button
-              class="btn btn-primary"
-              (click)="maxListItems = initialMaxListItems"
-              *ngIf="maxListItems !== initialMaxListItems"
-            >
-              {{ 'productReview.less' | cxTranslate }}
-            </button>
-          </ng-container>
         </div>
       </ng-container>
     </ng-container>

--- a/projects/storefrontlib/layout/main/storefront.component.ts
+++ b/projects/storefrontlib/layout/main/storefront.component.ts
@@ -99,19 +99,14 @@ export class StorefrontComponent implements OnInit, OnDestroy {
     this.navigateSubscription = this.routingService
       .isNavigating()
       .subscribe((val) => this.onNavigation(val));
-    if (
-      this.featureConfigService.isEnabled(
-        'a11yMobileFocusOnFirstNavigationItem'
-      )
-    ) {
-      this.isExpanded$ = this.hamburgerMenuService.isExpanded.pipe(
-        tap((isExpanded) => {
-          if (isExpanded) {
-            this.focusOnFirstNavigationItem();
-          }
-        })
-      );
-    }
+
+    this.isExpanded$ = this.hamburgerMenuService.isExpanded.pipe(
+      tap((isExpanded) => {
+        if (isExpanded) {
+          this.focusOnFirstNavigationItem();
+        }
+      })
+    );
 
     if (this.featureConfigService.isEnabled('a11yHamburgerMenuTrapFocus')) {
       this.trapFocusOnMenuIfExpanded();

--- a/projects/storefrontstyles/scss/components/product/list/_facet-list.scss
+++ b/projects/storefrontstyles/scss/components/product/list/_facet-list.scss
@@ -112,44 +112,42 @@ body.modal-open {
       margin-bottom: 1rem;
     }
 
-    @include forFeature('a11yTabComponent') {
-      cx-tab {
-        .tab-btn {
-          @include type('6');
-          background: none;
+    cx-tab {
+      .tab-btn {
+        @include type('6');
+        background: none;
 
-          &:after {
-            display: none;
-          }
-          border-bottom: 1px solid var(--cx-color-medium);
-          border-top: none;
-          padding-top: 1rem;
-          height: unset;
+        &:after {
+          display: none;
+        }
+        border-bottom: 1px solid var(--cx-color-medium);
+        border-top: none;
+        padding-top: 1rem;
+        height: unset;
 
-          &:hover,
-          &:focus {
-            color: var(--cx-color-primary);
-            .tab-icon {
-              color: var(--cx-color-primary);
-            }
-          }
-
+        &:hover,
+        &:focus {
+          color: var(--cx-color-primary);
           .tab-icon {
-            font-size: 25px;
-            font-weight: normal;
-            bottom: 6px;
+            color: var(--cx-color-primary);
           }
         }
 
-        .accordian {
-          div {
-            padding: 0;
-          }
+        .tab-icon {
+          font-size: 25px;
+          font-weight: normal;
+          bottom: 6px;
+        }
+      }
 
-          cx-tab-panel {
-            .active {
-              padding: 8px 0;
-            }
+      .accordian {
+        div {
+          padding: 0;
+        }
+
+        cx-tab-panel {
+          .active {
+            padding: 8px 0;
           }
         }
       }

--- a/projects/storefrontstyles/scss/components/product/list/_facet.scss
+++ b/projects/storefrontstyles/scss/components/product/list/_facet.scss
@@ -53,11 +53,7 @@ $intialExpandedFacetsLarge: 3 !default;
         .collapse-icon,
         a,
         button:not(.heading) {
-          display: none;
-
-          @include forFeature('a11yTabComponent') {
-            display: flex;
-          }
+          display: flex;
         }
       }
       &.expanded .expand-icon {


### PR DESCRIPTION
Removes the following accessibility toggles, as part of the deprecation plan for the October 2025:

- a11yPreventHorizontalScroll
- a11yCartImportConfirmationMessage
- a11yMobileFocusOnFirstNavigationItem
- a11yUseTrapTabInsteadOfTrapInDialogs
- a11yTabComponent
- a11yCarouselArrowKeysNavigation
- a11yDeliveryMethodFieldset
- a11yShowMoreReviewsBtnFocus
- a11yDialogTriggerRefocus
- a11yAddToWishlistFocus
- a11ySearchBoxFocusOnEscape