### PR TITLE
chore: Add B2B Client ID

### DIFF
--- a/projects/storefrontapp/src/app/spartacus/spartacus-b2b-configuration.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-b2b-configuration.module.ts
@@ -7,6 +7,7 @@
 import { NgModule } from '@angular/core';
 import { defaultB2BCheckoutConfig } from '@spartacus/checkout/b2b/root';
 import {
+  AuthConfig,
   provideConfig,
   provideConfigFactory,
   SiteContextConfig,
@@ -45,6 +46,11 @@ if (environment.epdVisualization) {
       pwa: {
         enabled: true,
         addToHomeScreen: true,
+      },
+    }),
+    provideConfig(<AuthConfig>{
+      authentication: {
+        client_id: 'mobile_android_public_b2b',
       },
     }),
   ],


### PR DESCRIPTION
Allow B2C and B2B storefronts in same CX JDK21 instance. 