### PR TITLE
(partial PR) revert typescript version constraints for customers to original ^5.6.2, but keep using internally 5.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
         "ts-jest": "^29.4.1",
         "ts-morph": "^26.0.0",
         "ts-node": "^10.6.0",
-        "typescript": "~5.8.3",
+        "typescript": "^5.6.3",
         "webpack": "~5.101.0",
         "webpack-cli": "^6.0.0"
       },
@@ -33407,7 +33407,7 @@
         "@schematics/angular": "^19.2.15",
         "jsonc-parser": "^3.3.1",
         "parse5": "^7.2.1",
-        "typescript": "~5.8.3"
+        "typescript": "^5.6.3"
       },
       "peerDependenciesMeta": {
         "canvas": {

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "ts-jest": "^29.4.1",
     "ts-morph": "^26.0.0",
     "ts-node": "^10.6.0",
-    "typescript": "~5.8.3",
+    "typescript": "^5.6.3",
     "webpack": "~5.101.0",
     "webpack-cli": "^6.0.0"
   }

--- a/projects/schematics/package.json
+++ b/projects/schematics/package.json
@@ -30,7 +30,7 @@
     "@schematics/angular": "^19.2.15",
     "jsonc-parser": "^3.3.1",
     "parse5": "^7.2.1",
-    "typescript": "~5.8.3"
+    "typescript": "^5.6.3"
   },
   "peerDependenciesMeta": {
     "canvas": {


### PR DESCRIPTION
...so it doesn't conflict with Angular's OOTB TS ~5.7.2, but internally we must use 5.8.3 to avoid compilation issues in our @spartacus/schematics logic which depends on @schematics/angular@19.2.15 utils that have hardcoded internalized version 5.8