### PR TITLE
chore: [port to release/221121.2.x] missing update of peerDeps listed in package-lock.json after updating Angular CLI 19.2.15 to 19.2.16 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,7 +165,7 @@
       },
       "peerDependencies": {
         "@angular/core": "^19.2.15",
-        "@angular/ssr": "^19.2.15",
+        "@angular/ssr": "^19.2.16",
         "@spartacus/cart": "2211.43.0",
         "@spartacus/core": "2211.43.0",
         "@spartacus/order": "2211.43.0",
@@ -183,7 +183,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -212,7 +212,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -239,7 +239,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -267,7 +267,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -292,7 +292,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@spartacus/cart": "2211.43.0",
@@ -315,7 +315,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -344,7 +344,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -373,7 +373,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -395,7 +395,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -424,7 +424,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/router": "^19.2.15",
@@ -446,7 +446,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -475,7 +475,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -499,7 +499,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@spartacus/core": "2211.43.0",
@@ -519,7 +519,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -544,7 +544,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -569,7 +569,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@spartacus/core": "2211.43.0",
@@ -588,7 +588,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -613,7 +613,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@spartacus/core": "2211.43.0",
@@ -632,7 +632,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -657,7 +657,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -685,7 +685,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/core": "^19.2.15",
         "@spartacus/customer-ticketing": "2211.43.0",
         "@spartacus/schematics": "2211.43.0",
@@ -703,7 +703,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/router": "^19.2.15",
@@ -728,7 +728,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@spartacus/cart": "2211.43.0",
@@ -749,7 +749,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -774,7 +774,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -799,7 +799,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/router": "^19.2.15",
@@ -821,7 +821,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -850,7 +850,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/router": "^19.2.15",
@@ -868,7 +868,7 @@
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -893,7 +893,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@angular/forms": "^19.2.15",
@@ -918,7 +918,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@spartacus/cart": "2211.43.0",
@@ -942,7 +942,7 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/common": "^19.2.15",
         "@angular/core": "^19.2.15",
         "@spartacus/core": "2211.43.0",
@@ -33517,7 +33517,7 @@
       "license": "MIT",
       "dependencies": {
         "@angular/pwa": "^19.2.15",
-        "@angular/ssr": "^19.2.15",
+        "@angular/ssr": "^19.2.16",
         "semver": "^7.5.2",
         "ts-morph": "^26.0.0",
         "tslib": "^2.8.1"
@@ -33526,8 +33526,8 @@
         "node": "^22.0.0"
       },
       "peerDependencies": {
-        "@angular-devkit/core": "^19.2.15",
-        "@angular-devkit/schematics": "^19.2.15",
+        "@angular-devkit/core": "^19.2.16",
+        "@angular-devkit/schematics": "^19.2.16",
         "@angular/compiler": "^19.2.15",
         "@schematics/angular": "^19.2.15",
         "jsonc-parser": "^3.3.1",


### PR DESCRIPTION
(Port to release/221121.2.x branch the PR https://github.com/SAP/spartacus/pull/20744)

> In the previous PR https://github.com/SAP/spartacus/pull/20741 we've updated Angular version and updated package-lock.json, and updated peerDeps for our libs.
> 
> However, the previous PR doesn't contain changes in package-lock generated by the next run on npm install. It's just copied definitions of our peerDeps to package-lock.
> 
> Until this PR is merged, every developer will generate those package-lock.json changes locally, unintentionally.
> 
> Note: this change doesn't affect customers, but only our developers
> 
> related to CXSPA-10974