### PR TITLE
chore: update registerUser to wait for success in jdk21 mode

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -121,9 +121,7 @@ export function registerUser(
 
   register(sampleUser, giveRegistrationConsent);
 
-  cy.whenJDK17(() => {
-    cy.get('cx-breadcrumb').contains('Login');
-  });
+  cy.get('cx-breadcrumb').contains('Login');
   return sampleUser;
 }
 


### PR DESCRIPTION
When in JDK21 mode, the "register complete" logic would enter a race condition with the next cypress command.  Whichever was slower to execute would win out.  When the "register compete" won, it would change the page on the next cypress command, causing expected HTML elements to not be found.

With custom login page enabled as default, we can use the same JDK17 logic because we expect to go to the login page in either context.