### PR TITLE
chore: deprecate epd-visualization integration library

### DIFF
--- a/integration-libs/epd-visualization/README.md
+++ b/integration-libs/epd-visualization/README.md
@@ -1,3 +1,21 @@
-# SAP Enterprise Product Development Visualization integration
+# DEPRECATED - SAP Enterprise Product Development Visualization integration
 
 This library is deprecated and will be removed in the future.
+
+This library provides capabilities for viewing 2D and 3D content served from the SAP Enterprise Product Development Visualization services:
+<https://www.sap.com/sea/products/enterprise-product-development.html>.
+
+To add sample data for this integration library, please update your SAP Commerce Cloud installation to include the `epdvisualizationspartacussampledata` extension which can be found here:
+<https://github.tools.sap/cx-commerce/epdvisualizationspartacussampledata>
+
+This integration library can be added to the existing Spartacus application by running `ng add @spartacus/schematics@latest` and including the `EPD Visualization Integration` module.
+
+Use the following to use the sample data created the `epdvisualizationspartacussampledata` extension:
+`ng add @spartacus/schematics@latest --base-site powertools-epdvisualization-spa`
+
+For more information about Spartacus schematics, visit the [official Spartacus schematics documentation page](https://sap.github.io/spartacus-docs/schematics/).
+
+The `epdvisualizationspartacussampledata` extension creates the following products in the `powertools-epdvisualization-spa` site which have spare part product references that can be linked to corresponding visualization data:
+
+- VSS_CX704
+- VSS_CX704_2D

--- a/integration-libs/epd-visualization/README.md
+++ b/integration-libs/epd-visualization/README.md
@@ -1,19 +1,3 @@
 # SAP Enterprise Product Development Visualization integration
 
-This library provides capabilities for viewing 2D and 3D content served from the SAP Enterprise Product Development Visualization services:
-<https://www.sap.com/sea/products/enterprise-product-development.html>.
-
-To add sample data for this integration library, please update your SAP Commerce Cloud installation to include the `epdvisualizationspartacussampledata` extension which can be found here:
-<https://github.tools.sap/cx-commerce/epdvisualizationspartacussampledata>
-
-This integration library can be added to the existing Spartacus application by running `ng add @spartacus/schematics@latest` and including the `EPD Visualization Integration` module.
-
-Use the following to use the sample data created the `epdvisualizationspartacussampledata` extension:
-`ng add @spartacus/schematics@latest --base-site powertools-epdvisualization-spa`
-
-For more information about Spartacus schematics, visit the [official Spartacus schematics documentation page](https://sap.github.io/spartacus-docs/schematics/).
-
-The `epdvisualizationspartacussampledata` extension creates the following products in the `powertools-epdvisualization-spa` site which have spare part product references that can be linked to corresponding visualization data:
-
-- VSS_CX704
-- VSS_CX704_2D
+This library is deprecated and will be removed in the future.

--- a/integration-libs/epd-visualization/assets/translations/cs/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/cs/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const cs = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/de/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/de/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const de = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/en/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/en/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const en = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/es/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/es/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const es = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/es_CO/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/es_CO/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const es_CO = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/fr/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/fr/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const fr = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/hi/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/hi/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const hi = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/hu/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/hu/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const hu = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/id/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/id/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const id = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/it/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/it/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const it = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/ja/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/ja/index.ts
@@ -5,6 +5,11 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const ja = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/ja/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/ja/index.ts
@@ -6,7 +6,6 @@
 
 import epdVisualization from './epdVisualization.json';
 
-
 /**
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */

--- a/integration-libs/epd-visualization/assets/translations/ko/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/ko/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const ko = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/pl/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/pl/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const pl = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/pt/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/pt/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const pt = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/ru/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/ru/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const ru = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/translations.ts
+++ b/integration-libs/epd-visualization/assets/translations/translations.ts
@@ -6,6 +6,9 @@
 
 import { TranslationChunksConfig } from '@spartacus/core';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const epdVisualizationTranslationChunksConfig: TranslationChunksConfig =
   {
     epdVisualization: ['epdVisualization'],

--- a/integration-libs/epd-visualization/assets/translations/zh/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/zh/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const zh = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/assets/translations/zh_TW/index.ts
+++ b/integration-libs/epd-visualization/assets/translations/zh_TW/index.ts
@@ -5,6 +5,10 @@
  */
 
 import epdVisualization from './epdVisualization.json';
+
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const zh_TW = {
   epdVisualization,
 };

--- a/integration-libs/epd-visualization/components/epd-visualization-components.module.ts
+++ b/integration-libs/epd-visualization/components/epd-visualization-components.module.ts
@@ -8,6 +8,9 @@ import { NgModule } from '@angular/core';
 import { VisualPickingTabModule } from './visual-picking/visual-picking-tab/visual-picking-tab.module';
 import { VisualViewerModule } from './visual-viewer/visual-viewer.module';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   declarations: [],
   imports: [VisualPickingTabModule, VisualViewerModule],

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.component.ts
@@ -8,6 +8,9 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { VisualPickingProductFilterService } from './visual-picking-product-filter.service';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Component({
   selector: 'cx-epd-visualization-product-filter',
   templateUrl: './visual-picking-product-filter.component.html',

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.module.ts
@@ -12,6 +12,9 @@ import { IconModule } from '@spartacus/storefront';
 import { VisualPickingProductFilterComponent } from './visual-picking-product-filter.component';
 import { VisualPickingProductFilterService } from './visual-picking-product-filter.service';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   imports: [CommonModule, FormsModule, IconModule, UrlModule, I18nModule],
   providers: [VisualPickingProductFilterService],

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.service.ts
@@ -9,6 +9,9 @@ import { Product, ProductReference } from '@spartacus/core';
 import { combineLatest, concat, Observable, of } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.ts
@@ -7,6 +7,9 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { AddToCartComponent } from '@spartacus/cart/base/components/add-to-cart';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Component({
   selector: 'cx-epd-visualization-compact-add-to-cart',
   templateUrl: './compact-add-to-cart.component.html',

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.module.ts
@@ -17,6 +17,9 @@ import {
 } from '@spartacus/storefront';
 import { CompactAddToCartComponent } from './compact-add-to-cart.component';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   imports: [
     CommonModule,

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/model/visual-picking-product-list-item.model.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/model/visual-picking-product-list-item.model.ts
@@ -7,7 +7,7 @@
 import { Product } from '@spartacus/core';
 
 /**
- * A model object representing a product item in the visual picking product list.
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export interface VisualPickingProductListItem {
   /**

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/model/visual-picking-product-list-item.model.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/model/visual-picking-product-list-item.model.ts
@@ -7,6 +7,8 @@
 import { Product } from '@spartacus/core';
 
 /**
+ * A model object representing a product item in the visual picking product list.
+ *
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export interface VisualPickingProductListItem {

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.ts
@@ -18,13 +18,9 @@ import {
 import { LoggerService } from '@spartacus/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
+
 /**
- * Generic in-memory paged list component that can be used to render arbitrary items in
- * a vertical orientation.
- * Previous/next buttons as well as indicator-buttons can used to navigate the slides (pages).
- *
- * To allow for flexible rendering of items, the rendering is delegated to the
- * given `template` and `headerTemplate`.
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 @Component({
   selector: 'cx-epd-visualization-paged-list',

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.ts
@@ -20,6 +20,13 @@ import { ICON_TYPE } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
 
 /**
+ * Generic in-memory paged list component that can be used to render arbitrary items in
+ * a vertical orientation.
+ * Previous/next buttons as well as indicator-buttons can used to navigate the slides (pages).
+ *
+ * To allow for flexible rendering of items, the rendering is delegated to the
+ * given `template` and `headerTemplate`.
+ *
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 @Component({

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.module.ts
@@ -11,6 +11,9 @@ import { UrlModule } from '@spartacus/core';
 import { IconModule, MediaModule } from '@spartacus/storefront';
 import { PagedListComponent } from './paged-list.component';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   imports: [CommonModule, RouterModule, IconModule, MediaModule, UrlModule],
   declarations: [PagedListComponent],

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.ts
@@ -15,6 +15,9 @@ import { Observable } from 'rxjs';
 import { VisualPickingProductListItem } from './model/visual-picking-product-list-item.model';
 import { VisualPickingProductListService } from './visual-picking-product-list.service';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Component({
   selector: 'cx-epd-visualization-product-list',
   templateUrl: './visual-picking-product-list.component.html',

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.module.ts
@@ -18,6 +18,9 @@ import { CompactAddToCartModule } from './compact-add-to-cart/compact-add-to-car
 import { PagedListModule } from './paged-list/paged-list.module';
 import { VisualPickingProductListComponent } from './visual-picking-product-list.component';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   imports: [
     CommonModule,

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.service.ts
@@ -28,6 +28,9 @@ import {
 import { VisualPickingProductFilterService } from '../product-filter/visual-picking-product-filter.service';
 import { VisualPickingProductListItem } from './model/visual-picking-product-list-item.model';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.ts
@@ -16,6 +16,9 @@ import { VisualPickingProductListComponent } from './product-list/visual-picking
 import { VisualPickingProductListService } from './product-list/visual-picking-product-list.service';
 import { VisualPickingTabService } from './visual-picking-tab.service';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Component({
   selector: 'cx-epd-visualization-visual-picking-tab',
   templateUrl: './visual-picking-tab.component.html',

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.module.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.module.ts
@@ -13,6 +13,9 @@ import { VisualPickingProductFilterModule } from './product-filter/visual-pickin
 import { VisualPickingProductListModule } from './product-list/visual-picking-product-list.module';
 import { VisualPickingTabComponent } from './visual-picking-tab.component';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   imports: [
     CommonModule,

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.service.ts
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.service.ts
@@ -24,6 +24,9 @@ import {
 import { VisualViewerService } from '../../visual-viewer/visual-viewer.service';
 import { VisualPickingProductListService } from './product-list/visual-picking-product-list.service';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/integration-libs/epd-visualization/components/visual-viewer/models/navigation-mode.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/navigation-mode.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export enum NavigationMode {
   /**
    * Left mouse button drag causes turntable rotation.

--- a/integration-libs/epd-visualization/components/visual-viewer/models/node-content-type.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/node-content-type.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export enum NodeContentType {
   Annotation = 'Annotation',
   Background = 'Background',

--- a/integration-libs/epd-visualization/components/visual-viewer/models/scene-load-info.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/scene-load-info.ts
@@ -7,11 +7,17 @@
 import { ContentType } from '@spartacus/epd-visualization/root';
 import { SceneLoadState } from './scene-load-state';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface LoadedSceneInfo {
   sceneId: string;
   contentType: ContentType;
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface SceneLoadInfo {
   sceneLoadState: SceneLoadState;
   loadedSceneInfo?: LoadedSceneInfo;

--- a/integration-libs/epd-visualization/components/visual-viewer/models/scene-load-state.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/scene-load-state.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export enum SceneLoadState {
   NotStarted,
   Loading,

--- a/integration-libs/epd-visualization/components/visual-viewer/models/selection-display-mode.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/selection-display-mode.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * The way that selections are displayed in 3D content.
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export enum SelectionDisplayMode {
   /**

--- a/integration-libs/epd-visualization/components/visual-viewer/models/selection-display-mode.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/selection-display-mode.ts
@@ -5,6 +5,8 @@
  */
 
 /**
+ * The way that selections are displayed in 3D content.
+ *
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export enum SelectionDisplayMode {

--- a/integration-libs/epd-visualization/components/visual-viewer/models/selection-mode.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/selection-mode.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Defines the selection behaviour.
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export enum SelectionMode {
   /**

--- a/integration-libs/epd-visualization/components/visual-viewer/models/selection-mode.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/selection-mode.ts
@@ -5,6 +5,8 @@
  */
 
 /**
+ * Defines the selection behaviour.
+ *
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export enum SelectionMode {

--- a/integration-libs/epd-visualization/components/visual-viewer/models/visualization-load-info.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/visualization-load-info.ts
@@ -6,6 +6,9 @@
 
 import { VisualizationInfo } from '@spartacus/epd-visualization/root';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export enum VisualizationLookupResult {
   UniqueMatchFound = 'UniqueMatchFound',
   NoMatchFound = 'NoMatchFound',
@@ -13,6 +16,9 @@ export enum VisualizationLookupResult {
   UnexpectedError = 'UnexpectedError',
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export enum VisualizationLoadStatus {
   NotStarted = 'NotStarted',
   Loading = 'Loading',
@@ -21,7 +27,7 @@ export enum VisualizationLoadStatus {
 }
 
 /**
- * Information relating to an attempt to resolve and load a visualization.
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export interface VisualizationLoadInfo {
   lookupResult: VisualizationLookupResult;

--- a/integration-libs/epd-visualization/components/visual-viewer/models/visualization-load-info.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/visualization-load-info.ts
@@ -27,6 +27,8 @@ export enum VisualizationLoadStatus {
 }
 
 /**
+ * Information relating to an attempt to resolve and load a visualization.
+ *
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export interface VisualizationLoadInfo {

--- a/integration-libs/epd-visualization/components/visual-viewer/models/zoom-to.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/models/zoom-to.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export enum ZoomTo {
   All = 'all',
   Node = 'node',

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.component.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.component.ts
@@ -16,6 +16,9 @@ import {
 } from '@angular/core';
 import { VisualViewerAnimationSliderService } from './visual-viewer-animation-slider.service';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Component({
   selector: 'cx-epd-visualization-animation-slider',
   templateUrl: './visual-viewer-animation-slider.component.html',

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.module.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.module.ts
@@ -9,6 +9,9 @@ import { NgModule } from '@angular/core';
 import { I18nModule } from '@spartacus/core';
 import { VisualViewerAnimationSliderComponent } from './visual-viewer-animation-slider.component';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   imports: [CommonModule, I18nModule],
   declarations: [VisualViewerAnimationSliderComponent],

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.service.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-animation-slider/visual-viewer-animation-slider.service.ts
@@ -14,6 +14,9 @@ import {
 import { WindowRef } from '@spartacus/core';
 import { EventListenerUtils } from '@spartacus/epd-visualization/root';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.component.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.component.ts
@@ -6,6 +6,9 @@
 
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Component({
   selector: 'cx-epd-visualization-viewer-toolbar-button',
   templateUrl: './visual-viewer-toolbar-button.component.html',

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.module.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.module.ts
@@ -9,6 +9,9 @@ import { NgModule } from '@angular/core';
 import { IconModule } from '@spartacus/storefront';
 import { VisualViewerToolbarButtonComponent } from './visual-viewer-toolbar-button.component';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   imports: [CommonModule, IconModule],
   declarations: [VisualViewerToolbarButtonComponent],

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.spec.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.spec.ts
@@ -210,6 +210,9 @@ class MockVisualViewerService {
   public sceneLoadInfo$ = new Subject<SceneLoadInfo>();
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Component({
   selector: 'cx-epd-visualization-animation-slider',
   template: '',

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.ts
@@ -16,6 +16,9 @@ import { SelectionMode } from './models/selection-mode';
 import { VisualizationLoadInfo } from './models/visualization-load-info';
 import { VisualViewerService } from './visual-viewer.service';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Component({
   selector: 'cx-epd-visualization-viewer',
   templateUrl: './visual-viewer.component.html',

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.module.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.module.ts
@@ -13,6 +13,9 @@ import { VisualViewerAnimationSliderModule } from './toolbar/visual-viewer-anima
 import { VisualViewerToolbarButtonModule } from './toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.module';
 import { VisualViewerComponent } from './visual-viewer.component';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   imports: [
     CommonModule,

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.service.ts
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.service.ts
@@ -68,6 +68,9 @@ interface VisualContentChangesFinishedEvent {
 
 interface VisualContentLoadFinishedEvent {}
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/integration-libs/epd-visualization/core/connectors/scene/converters.ts
+++ b/integration-libs/epd-visualization/core/connectors/scene/converters.ts
@@ -8,6 +8,9 @@ import { InjectionToken } from '@angular/core';
 import { Converter } from '@spartacus/core';
 import { NodesResponse } from './nodes-response';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const NODES_RESPONSE_NORMALIZER = new InjectionToken<
   Converter<any, NodesResponse>
 >('NodesResponseNormalizer');

--- a/integration-libs/epd-visualization/core/connectors/scene/nodes-response.ts
+++ b/integration-libs/epd-visualization/core/connectors/scene/nodes-response.ts
@@ -4,20 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface NodesResponse {
   nodes?: TreeNode[];
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface TreeNode {
   sid: string;
   usageIds?: UsageId[];
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface UsageId {
   name: string;
   keys: UsageIdKey[];
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface UsageIdKey {
   name: string;
   value: string;

--- a/integration-libs/epd-visualization/core/connectors/scene/scene.adapter.ts
+++ b/integration-libs/epd-visualization/core/connectors/scene/scene.adapter.ts
@@ -7,6 +7,9 @@
 import { Observable } from 'rxjs';
 import { NodesResponse } from './nodes-response';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export abstract class SceneAdapter {
   /**
    * Used for invoking the EPD Visualization API for retrieving scene node information.

--- a/integration-libs/epd-visualization/core/connectors/scene/scene.connector.ts
+++ b/integration-libs/epd-visualization/core/connectors/scene/scene.connector.ts
@@ -9,6 +9,9 @@ import { Observable } from 'rxjs';
 import { NodesResponse } from './nodes-response';
 import { SceneAdapter } from './scene.adapter';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/integration-libs/epd-visualization/core/connectors/visualization/converters.ts
+++ b/integration-libs/epd-visualization/core/connectors/visualization/converters.ts
@@ -8,6 +8,9 @@ import { InjectionToken } from '@angular/core';
 import { Converter } from '@spartacus/core';
 import { LookupVisualizationsResponse } from './lookup-visualizations-response';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const LOOKUP_VISUALIZATIONS_RESPONSE_NORMALIZER = new InjectionToken<
   Converter<any, LookupVisualizationsResponse>
 >('LookupVisualizationsResponseNormalizer');

--- a/integration-libs/epd-visualization/core/connectors/visualization/lookup-visualizations-response.ts
+++ b/integration-libs/epd-visualization/core/connectors/visualization/lookup-visualizations-response.ts
@@ -6,6 +6,9 @@
 
 import { VisualizationInfo } from '@spartacus/epd-visualization/root';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface LookupVisualizationsResponse {
   visualizations?: VisualizationInfo[];
 }

--- a/integration-libs/epd-visualization/core/connectors/visualization/visualization.adapter.ts
+++ b/integration-libs/epd-visualization/core/connectors/visualization/visualization.adapter.ts
@@ -8,6 +8,9 @@ import { UsageId } from '@spartacus/epd-visualization/root';
 import { Observable } from 'rxjs';
 import { LookupVisualizationsResponse } from './lookup-visualizations-response';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export abstract class VisualizationAdapter {
   /**
    * Used for finding a visualization by Usage ID that has anonymous (unauthenticated) read access enabled.

--- a/integration-libs/epd-visualization/core/connectors/visualization/visualization.connector.ts
+++ b/integration-libs/epd-visualization/core/connectors/visualization/visualization.connector.ts
@@ -10,6 +10,9 @@ import { Observable } from 'rxjs';
 import { LookupVisualizationsResponse } from './lookup-visualizations-response';
 import { VisualizationAdapter } from './visualization.adapter';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/integration-libs/epd-visualization/core/epd-visualization-core.module.ts
+++ b/integration-libs/epd-visualization/core/epd-visualization-core.module.ts
@@ -9,6 +9,9 @@ import { SceneConnector, VisualizationConnector } from './connectors';
 import { SceneNodeToProductLookupService } from './services/scene-node-to-product-lookup/scene-node-to-product-lookup.service';
 import { VisualizationLookupService } from './services/visualization-lookup/visualization-lookup.service';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   providers: [
     SceneConnector,

--- a/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/scene-node-to-product-lookup.service.ts
+++ b/integration-libs/epd-visualization/core/services/scene-node-to-product-lookup/scene-node-to-product-lookup.service.ts
@@ -17,11 +17,17 @@ import { first, map } from 'rxjs/operators';
 import { NodesResponse, TreeNode } from '../../connectors/scene/nodes-response';
 import { SceneConnector } from '../../connectors/scene/scene.connector';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface NodeIdProductCodes {
   nodeId: string;
   productCodes: string[];
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/integration-libs/epd-visualization/core/services/visualization-lookup/visualization-lookup.service.ts
+++ b/integration-libs/epd-visualization/core/services/visualization-lookup/visualization-lookup.service.ts
@@ -18,6 +18,9 @@ import { map } from 'rxjs/operators';
 import { LookupVisualizationsResponse } from '../../connectors/visualization/lookup-visualizations-response';
 import { VisualizationConnector } from '../../connectors/visualization/visualization.connector';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
@@ -25,6 +25,11 @@ import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /**
+ * This adapter references an API that is expected to be deprecated and relocated
+ * since multiple microservice APIs are being combined into a single namespace.
+ * A new adapter implementation will be added and this one will be deprecated
+ * when the new endpoint is available.
+ *
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 @Injectable()

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/storage-v1/storage-v1.adapter.ts
@@ -25,10 +25,7 @@ import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /**
- * This adapter references an API that is expected to be deprecated and relocated
- * since multiple microservice APIs are being combined into a single namespace.
- * A new adapter implementation will be added and this one will be deprecated
- * when the new endpoint is available.
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 @Injectable()
 export class StorageV1Adapter implements SceneAdapter {

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
@@ -26,10 +26,7 @@ import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /**
- * This adapter references an API that is expected to be deprecated and relocated
- * since multiple microservice APIs are being combined into a single namespace.
- * A new adapter implementation will be added and this one will be deprecated
- * when the new endpoint is available.
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 @Injectable()
 export class VisualizationV1Adapter implements VisualizationAdapter {

--- a/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/adapters/visualization-v1/visualization-v1.adapter.ts
@@ -26,6 +26,11 @@ import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /**
+ * This adapter references an API that is expected to be deprecated and relocated
+ * since multiple microservice APIs are being combined into a single namespace.
+ * A new adapter implementation will be added and this one will be deprecated
+ * when the new endpoint is available.
+ *
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 @Injectable()

--- a/integration-libs/epd-visualization/epd-visualization-api/epd-visualization-api.module.ts
+++ b/integration-libs/epd-visualization/epd-visualization-api/epd-visualization-api.module.ts
@@ -12,6 +12,9 @@ import {
 import { StorageV1Adapter } from './adapters/storage-v1/storage-v1.adapter';
 import { VisualizationV1Adapter } from './adapters/visualization-v1/visualization-v1.adapter';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   providers: [
     { provide: SceneAdapter, useClass: StorageV1Adapter },

--- a/integration-libs/epd-visualization/epd-visualization.module.ts
+++ b/integration-libs/epd-visualization/epd-visualization.module.ts
@@ -9,6 +9,9 @@ import { EpdVisualizationComponentsModule } from '@spartacus/epd-visualization/c
 import { EpdVisualizationCoreModule } from '@spartacus/epd-visualization/core';
 import { EpdVisualizationApiModule } from '@spartacus/epd-visualization/epd-visualization-api';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   imports: [
     EpdVisualizationComponentsModule,

--- a/integration-libs/epd-visualization/package.json
+++ b/integration-libs/epd-visualization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spartacus/epd-visualization",
   "version": "221121.2.0",
-  "description": "SAP Enterprise Product Development Visualization integration library for Spartacus",
+  "description": "DEPRECATED - SAP Enterprise Product Development Visualization integration library for Spartacus",
   "keywords": [
     "spartacus",
     "framework",

--- a/integration-libs/epd-visualization/root/config/epd-visualization-config-validator.ts
+++ b/integration-libs/epd-visualization/root/config/epd-visualization-config-validator.ts
@@ -10,6 +10,9 @@ import {
   EpdVisualizationInnerConfig,
 } from './epd-visualization-config';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export function epdVisualizationConfigValidator(
   epdVisualizationConfig: EpdVisualizationConfig
 ): string | void {

--- a/integration-libs/epd-visualization/root/config/epd-visualization-config.ts
+++ b/integration-libs/epd-visualization/root/config/epd-visualization-config.ts
@@ -9,6 +9,9 @@ import { Config } from '@spartacus/core';
 import { UsageId } from '../models/usage-ids/usage-id';
 import { UsageIdDefinition } from '../models/usage-ids/usage-id-definition';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @Injectable({
   providedIn: 'root',
   useExisting: Config,
@@ -20,6 +23,9 @@ export abstract class EpdVisualizationConfig implements Config {
   public epdVisualization?: EpdVisualizationInnerConfig;
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface EpdVisualizationInnerConfig {
   /**
    * UI5 configuration
@@ -39,6 +45,9 @@ export interface EpdVisualizationInnerConfig {
   visualPicking?: VisualPickingConfig;
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface Ui5Config {
   /**
    * This is the URL that SAPUI5 is bootstrapped from.
@@ -50,6 +59,9 @@ export interface Ui5Config {
   bootstrapUrl: string;
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface VisualizationApiConfig {
   /**
    * This is the base URL that is used to access the EPD Visualization APIs.
@@ -59,6 +71,9 @@ export interface VisualizationApiConfig {
   baseUrl: string;
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface UsageIdConfig {
   /**
    * Folders in the configured SAP EPD Visualization tenant that have anonymous access enabled and have this Usage ID
@@ -78,6 +93,9 @@ export interface UsageIdConfig {
   productUsageId: UsageIdDefinition;
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface VisualPickingConfig {
   /**
    * This is the type of product reference to list for the active product (typically SPAREPART)
@@ -85,6 +103,9 @@ export interface VisualPickingConfig {
   productReferenceType: string;
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 declare module '@spartacus/core' {
   interface Config extends EpdVisualizationConfig {}
 }

--- a/integration-libs/epd-visualization/root/config/epd-visualization-default-config.ts
+++ b/integration-libs/epd-visualization/root/config/epd-visualization-default-config.ts
@@ -6,6 +6,9 @@
 
 import { EpdVisualizationConfig } from '../config/epd-visualization-config';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export function getEpdVisualizationDefaultConfig(): EpdVisualizationConfig {
   return {
     epdVisualization: {

--- a/integration-libs/epd-visualization/root/epd-visualization-root.module.ts
+++ b/integration-libs/epd-visualization/root/epd-visualization-root.module.ts
@@ -25,6 +25,9 @@ export function defaultEpdVisualizationComponentsConfig(): CmsConfig {
   return config;
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 @NgModule({
   providers: [
     provideDefaultConfigFactory(defaultEpdVisualizationComponentsConfig),

--- a/integration-libs/epd-visualization/root/feature-name.ts
+++ b/integration-libs/epd-visualization/root/feature-name.ts
@@ -4,4 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export const EPD_VISUALIZATION_FEATURE = 'epd-visualization';

--- a/integration-libs/epd-visualization/root/models/usage-ids/usage-id-definition.ts
+++ b/integration-libs/epd-visualization/root/models/usage-ids/usage-id-definition.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface UsageIdDefinition {
   name: string;
   keyName: string;

--- a/integration-libs/epd-visualization/root/models/usage-ids/usage-id.ts
+++ b/integration-libs/epd-visualization/root/models/usage-ids/usage-id.ts
@@ -4,11 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface UsageId {
   name: string;
   keys: UsageIdKey[];
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface UsageIdKey {
   name: string;
   value: string;

--- a/integration-libs/epd-visualization/root/models/visualizations/content-type.ts
+++ b/integration-libs/epd-visualization/root/models/visualizations/content-type.ts
@@ -5,6 +5,10 @@
  */
 
 /**
+ * A subset of the content types that may be returned by the EPD Visualization service.
+ * We use filtering to ensure that we only get visualizations of the types below returned.
+ * Some values start with numbers, so the identifiers do not match the values
+ *
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export enum ContentType {

--- a/integration-libs/epd-visualization/root/models/visualizations/content-type.ts
+++ b/integration-libs/epd-visualization/root/models/visualizations/content-type.ts
@@ -5,9 +5,7 @@
  */
 
 /**
- * A subset of the content types that may be returned by the EPD Visualization service.
- * We use filtering to ensure that we only get visualizations of the types below returned.
- * Some values start with numbers, so the identifiers do not match the values
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export enum ContentType {
   /**

--- a/integration-libs/epd-visualization/root/models/visualizations/visualization-info.ts
+++ b/integration-libs/epd-visualization/root/models/visualizations/visualization-info.ts
@@ -7,7 +7,7 @@
 import { ContentType } from './content-type';
 
 /**
- * Information about a visualization stored in an EPD Visualization service.
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export interface VisualizationInfo {
   /**

--- a/integration-libs/epd-visualization/root/models/visualizations/visualization-info.ts
+++ b/integration-libs/epd-visualization/root/models/visualizations/visualization-info.ts
@@ -7,6 +7,8 @@
 import { ContentType } from './content-type';
 
 /**
+ * Information about a visualization stored in an EPD Visualization service.
+ *
  * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
  */
 export interface VisualizationInfo {

--- a/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
+++ b/integration-libs/epd-visualization/root/testing/epd-visualization-test-config.ts
@@ -6,6 +6,9 @@
 
 import { EpdVisualizationConfig } from '../config/epd-visualization-config';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export function getTestConfig(): EpdVisualizationConfig {
   return {
     epdVisualization: {

--- a/integration-libs/epd-visualization/root/util/event-listener-utils.ts
+++ b/integration-libs/epd-visualization/root/util/event-listener-utils.ts
@@ -6,12 +6,18 @@
 
 import { Renderer2 } from '@angular/core';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export interface Listener {
   nativeElement: any;
   eventName: string;
   endListener: () => void;
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export class EventListenerUtils {
   initialize(renderer: Renderer2) {
     this.renderer = renderer;

--- a/integration-libs/epd-visualization/root/util/url-utils.ts
+++ b/integration-libs/epd-visualization/root/util/url-utils.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export function getUrl(urlString: string): URL | null {
   try {
     return new URL(urlString);
@@ -12,6 +15,9 @@ export function getUrl(urlString: string): URL | null {
   }
 }
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export function isHttpOrHttps(url: URL) {
   return url.protocol === 'http:' || url.protocol === 'https:';
 }

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/index.ts
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/index.ts
@@ -22,6 +22,9 @@ import {
 } from '@spartacus/schematics';
 import { peerDependencies } from '../../package.json';
 
+/**
+ * @deprecated since v221121.3.0 - The epd-visualization integration library will be removed in the future.
+ */
 export function addEpdVisualizationFeature(
   options: SpartacusEpdVisualizationOptions
 ): Rule {


### PR DESCRIPTION
The integration between Spartacus/Commerce Cloud and IPD Visualization is now deprecated.

CXSPA-11273