### PR TITLE
feat: Add new builder addressing ng-packagr issues

### DIFF
--- a/feature-libs/cart/project.json
+++ b/feature-libs/cart/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/cart/tsconfig.lib.json",
         "project": "feature-libs/cart/ng-package.json"

--- a/feature-libs/checkout/project.json
+++ b/feature-libs/checkout/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/checkout/tsconfig.lib.json",
         "project": "feature-libs/checkout/ng-package.json"

--- a/feature-libs/customer-ticketing/project.json
+++ b/feature-libs/customer-ticketing/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/customer-ticketing/tsconfig.lib.json",
         "project": "feature-libs/customer-ticketing/ng-package.json"

--- a/feature-libs/estimated-delivery-date/project.json
+++ b/feature-libs/estimated-delivery-date/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/estimated-delivery-date/tsconfig.lib.json",
         "project": "feature-libs/estimated-delivery-date/ng-package.json"

--- a/feature-libs/order/project.json
+++ b/feature-libs/order/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/order/tsconfig.lib.json",
         "project": "feature-libs/order/ng-package.json"

--- a/feature-libs/organization/project.json
+++ b/feature-libs/organization/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/organization/tsconfig.lib.json",
         "project": "feature-libs/organization/ng-package.json"

--- a/feature-libs/pdf-invoices/project.json
+++ b/feature-libs/pdf-invoices/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/pdf-invoices/tsconfig.lib.json",
         "project": "feature-libs/pdf-invoices/ng-package.json"

--- a/feature-libs/pickup-in-store/project.json
+++ b/feature-libs/pickup-in-store/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/pickup-in-store/tsconfig.lib.json",
         "project": "feature-libs/pickup-in-store/ng-package.json"

--- a/feature-libs/product-configurator/project.json
+++ b/feature-libs/product-configurator/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/product-configurator/tsconfig.lib.json",
         "project": "feature-libs/product-configurator/ng-package.json"

--- a/feature-libs/quote/project.json
+++ b/feature-libs/quote/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/quote/tsconfig.lib.json",
         "project": "feature-libs/quote/ng-package.json"

--- a/feature-libs/requested-delivery-date/project.json
+++ b/feature-libs/requested-delivery-date/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/requested-delivery-date/tsconfig.lib.json",
         "project": "feature-libs/requested-delivery-date/ng-package.json"

--- a/feature-libs/subscription-billing/project.json
+++ b/feature-libs/subscription-billing/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/subscription-billing/tsconfig.lib.json",
         "project": "feature-libs/subscription-billing/ng-package.json"

--- a/feature-libs/tracking/project.json
+++ b/feature-libs/tracking/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/tracking/tsconfig.lib.json",
         "project": "feature-libs/tracking/ng-package.json"

--- a/feature-libs/user/project.json
+++ b/feature-libs/user/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "feature-libs/user/tsconfig.lib.json",
         "project": "feature-libs/user/ng-package.json"

--- a/integration-libs/cpq-quote/project.json
+++ b/integration-libs/cpq-quote/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "integration-libs/cpq-quote/tsconfig.lib.json",
         "project": "integration-libs/cpq-quote/ng-package.json"

--- a/integration-libs/punchout/project.json
+++ b/integration-libs/punchout/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "integration-libs/punchout/tsconfig.lib.json",
         "project": "integration-libs/punchout/ng-package.json"

--- a/projects/core/project.json
+++ b/projects/core/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "projects/core/tsconfig.lib.json",
         "project": "projects/core/ng-package.json"

--- a/projects/storefrontlib/project.json
+++ b/projects/storefrontlib/project.json
@@ -6,7 +6,7 @@
   "prefix": "cx",
   "targets": {
     "build": {
-      "executor": "./tools/build-lib:augmented-types",
+      "executor": "./tools/build-lib:declaration-merging",
       "options": {
         "tsConfig": "projects/storefrontlib/tsconfig.lib.json",
         "project": "projects/storefrontlib/ng-package.json"

--- a/tools/build-lib/builders.json
+++ b/tools/build-lib/builders.json
@@ -4,6 +4,11 @@
       "implementation": "./augmented-types",
       "schema": "./augmented-types/schema.json",
       "description": "Propagate typing exports to main d.ts file to make them augmentable."
+    },
+    "declaration-merging": {
+      "implementation": "./declaration-merging",
+      "schema": "./declaration-merging/schema.json",
+      "description": "Fix relative paths used for declaration merging in flattened .d.ts file"
     }
   }
 }

--- a/tools/build-lib/declaration-merging/index.js
+++ b/tools/build-lib/declaration-merging/index.js
@@ -1,0 +1,104 @@
+"use strict";
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const architect_1 = require("@angular-devkit/architect");
+const fs_1 = require("fs");
+const glob_1 = require("glob");
+const path = require("path");
+const rxjs_1 = require("rxjs");
+const operators_1 = require("rxjs/operators");
+exports.default = (0, architect_1.createBuilder)(declarationMergingBuilder);
+/**
+ * Builder that runs default ng-packagr builder ('@angular-devkit/build-angular:ng-packagr')
+ * and performs additional post step to fix paths in declaration merges.
+ *
+ * It's a workaround to fix paths in declaration merges, reference issues:
+ *   - https://github.com/ng-packagr/ng-packagr/issues/3085
+ */
+function declarationMergingBuilder(options, context) {
+    return (0, rxjs_1.from)(ngPackagrBuild(context, options)).pipe((0, operators_1.switchMap)((result) => result.success
+        ? (0, rxjs_1.from)(declarationMergingPostStep(context, options))
+        : (0, rxjs_1.of)(result)));
+}
+/**
+ * Run ng packager build step as is
+ */
+function ngPackagrBuild(context, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const builderRun = yield context.scheduleBuilder('@angular-devkit/build-angular:ng-packagr', options, { target: context.target });
+        return yield builderRun.result;
+    });
+}
+/**
+ * Post build step
+ */
+function declarationMergingPostStep(context, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const outputPath = yield getNgPackgrLibOutputPath(options.project);
+        yield propagateDeclarationMerging(outputPath, context.logger);
+        return { success: true };
+    });
+}
+/**
+ * Get output directory for ng packager job
+ * @param ngPackagerFile
+ */
+function getNgPackgrLibOutputPath(ngPackagerFile) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const ngPackageData = JSON.parse(yield fs_1.promises.readFile(ngPackagerFile, 'utf8'));
+        return path.join(path.dirname(ngPackagerFile), ngPackageData.dest);
+    });
+}
+/**
+ * Propagate declaration merging for every package.json file in the built in library
+ */
+function propagateDeclarationMerging(libPath, logger) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // grab all package.json files
+        const files = (0, glob_1.globSync)(libPath + '/**/package.json', { nodir: true });
+        for (const packageJsonFile of files) {
+            try {
+                // get typings file from package.json
+                const packageData = JSON.parse(yield fs_1.promises.readFile(packageJsonFile, 'utf8'));
+                const typingsFile = packageData.typings;
+                if (!typingsFile) {
+                    continue;
+                }
+                const packageJsonDir = path.dirname(packageJsonFile);
+                const typingsFilePath = path.join(packageJsonDir, typingsFile);
+                let typingsFileSource = yield fs_1.promises.readFile(typingsFilePath, 'utf8');
+                // find all places where `declare module '../foo/bar'` and list them in an array
+                const declarationMerges = typingsFileSource.match(/declare module \'([^\@spartacus].+)\'/g);
+                if (!declarationMerges) {
+                    continue;
+                }
+                logger.info(`Found ${declarationMerges.length} declaration merges`);
+                for (const declarationMerge of declarationMerges) {
+                    // replace declare module `../foo/bar` with typingsFile without `.d.ts`
+                    const typingsFileWithoutDts = typingsFile.replace('.d.ts', '');
+                    typingsFileSource = typingsFileSource.replace(declarationMerge, `declare module './${typingsFileWithoutDts}'`);
+                    logger.info(`Updated declaration merge for ${declarationMerge}, new value: ${typingsFileWithoutDts}`);
+                }
+                yield fs_1.promises.writeFile(typingsFilePath, typingsFileSource, 'utf8');
+                logger.info('Fixed paths in declaration merges for ' + typingsFilePath);
+            }
+            catch (e) {
+                logger.error('Error when fixing paths in declaration merges for ' + packageJsonFile);
+            }
+        }
+    });
+}
+//# sourceMappingURL=index.js.map

--- a/tools/build-lib/declaration-merging/index.ts
+++ b/tools/build-lib/declaration-merging/index.ts
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder,
+} from '@angular-devkit/architect';
+import { NgPackagrBuilderOptions } from '@angular-devkit/build-angular';
+import { JsonObject, logging } from '@angular-devkit/core';
+import { promises as fs } from 'fs';
+import { globSync } from 'glob';
+import * as path from 'path';
+import { from, Observable, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+
+export default createBuilder(declarationMergingBuilder);
+
+/**
+ * Builder that runs default ng-packagr builder ('@angular-devkit/build-angular:ng-packagr')
+ * and performs additional post step to fix paths in declaration merges.
+ *
+ * It's a workaround to fix paths in declaration merges, reference issues:
+ *   - https://github.com/ng-packagr/ng-packagr/issues/3085
+ */
+function declarationMergingBuilder(
+  options: NgPackagrBuilderOptions & JsonObject,
+  context: BuilderContext
+): Observable<BuilderOutput> {
+  return from(ngPackagrBuild(context, options)).pipe(
+    switchMap((result) =>
+      result.success
+        ? from(
+            declarationMergingPostStep(
+              context,
+              options as NgPackagrBuilderOptions
+            )
+          )
+        : of(result)
+    )
+  );
+}
+
+/**
+ * Run ng packager build step as is
+ */
+async function ngPackagrBuild(
+  context: BuilderContext,
+  options: NgPackagrBuilderOptions & JsonObject
+): Promise<BuilderOutput> {
+  const builderRun = await context.scheduleBuilder(
+    '@angular-devkit/build-angular:ng-packagr',
+    options,
+    { target: context.target }
+  );
+  return await builderRun.result;
+}
+
+/**
+ * Post build step
+ */
+async function declarationMergingPostStep(
+  context: BuilderContext,
+  options: NgPackagrBuilderOptions
+): Promise<BuilderOutput> {
+  const outputPath = await getNgPackgrLibOutputPath(options.project);
+  await propagateDeclarationMerging(outputPath, context.logger);
+  return { success: true };
+}
+
+/**
+ * Get output directory for ng packager job
+ * @param ngPackagerFile
+ */
+async function getNgPackgrLibOutputPath(ngPackagerFile: string) {
+  const ngPackageData = JSON.parse(await fs.readFile(ngPackagerFile, 'utf8'));
+  return path.join(path.dirname(ngPackagerFile), ngPackageData.dest);
+}
+
+/**
+ * Propagate declaration merging for every package.json file in the built in library
+ */
+async function propagateDeclarationMerging(
+  libPath: string,
+  logger: logging.LoggerApi
+) {
+  // grab all package.json files
+  const files = globSync(libPath + '/**/package.json', { nodir: true });
+
+  for (const packageJsonFile of files) {
+    try {
+      // get typings file from package.json
+      const packageData = JSON.parse(
+        await fs.readFile(packageJsonFile, 'utf8')
+      );
+      const typingsFile = packageData.typings;
+
+      if (!typingsFile) {
+        continue;
+      }
+      const packageJsonDir = path.dirname(packageJsonFile);
+      const typingsFilePath = path.join(packageJsonDir, typingsFile);
+      let typingsFileSource = await fs.readFile(typingsFilePath, 'utf8');
+
+      // find all places where `declare module '../foo/bar'` and list them in an array
+      const declarationMerges = typingsFileSource.match(
+        /declare module \'([^\@spartacus].+)\'/g
+      );
+      if (!declarationMerges) {
+        continue;
+      }
+      logger.info(`Found ${declarationMerges.length} declaration merges`);
+      for (const declarationMerge of declarationMerges) {
+        // replace declare module `../foo/bar` with typingsFile without `.d.ts`
+        const typingsFileWithoutDts = typingsFile.replace('.d.ts', '');
+        typingsFileSource = typingsFileSource.replace(
+          declarationMerge,
+          `declare module './${typingsFileWithoutDts}'`
+        );
+        logger.info(
+          `Updated declaration merge for ${declarationMerge}, new value: ${typingsFileWithoutDts}`
+        );
+      }
+
+      await fs.writeFile(typingsFilePath, typingsFileSource, 'utf8');
+
+      logger.info('Fixed paths in declaration merges for ' + typingsFilePath);
+    } catch (e) {
+      logger.error(
+        'Error when fixing paths in declaration merges for ' + packageJsonFile
+      );
+    }
+  }
+}

--- a/tools/build-lib/declaration-merging/schema.json
+++ b/tools/build-lib/declaration-merging/schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "type": "object"
+}


### PR DESCRIPTION
This PR provides a temporary workaround for [ng-packagr issue](https://github.com/ng-packagr/ng-packagr/issues/3085) introduced in v20.
The ng-packagr library introduces new functionality: [Flatten type definitions to a single *.d.ts file](https://github.com/ng-packagr/ng-packagr/issues/139#top)
Due to a bug in its dependency, the `rollup-plugin-dts` library, flattened `.d.ts` file still uses relative paths in declaration merging, but after flattening, there are no other directories in the built libs, where types are located.

BEFORE:
<img width="627" height="248" alt="image" src="https://github.com/user-attachments/assets/a28150eb-44b4-4350-a3b9-63f057714b42" />

AFTER:
<img width="632" height="242" alt="image" src="https://github.com/user-attachments/assets/c0d8c7ae-f994-466b-855f-38b8381068e9" />

Note: It is just a workaround and hopefully the issue is going to be fixed in the root cause. 
Apart from that, there might be a case the builder was used in libraries which does not require it - let's check it later, to unblock the build.

closes sub-task: [CXSPA-11393](https://jira.tools.sap/browse/CXSPA-11393)