### PR TITLE
fix: Workaround for 'ariaLabelDropdown' input signal

### DIFF
--- a/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
+++ b/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
@@ -228,7 +228,7 @@ export class NgSelectA11yDirective implements AfterViewInit {
         // workaround for known issue with setting value of the input signal programmatically: https://github.com/angular/angular/issues/54782
         // since ng-select@20.x changed ariaLabelDropdown to be an input signal, we can't set its value directly
         // NOTE: SIGNAL is not a part of the public API of @angular/core and may change without notice
-        // TODO: find a way to apply customizeNgSelectAriaLabelDropdown in a different way
+        // TODO: CXSPA-11443 find a way to apply customizeNgSelectAriaLabelDropdown in a different way
         const ariaLabelDropdownSignal =
           this.selectComponent.ariaLabelDropdown[SIGNAL];
         ariaLabelDropdownSignal.applyValueToInputSignal(

--- a/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
+++ b/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
@@ -19,6 +19,7 @@ import {
   Renderer2,
   SecurityContext,
 } from '@angular/core';
+import { SIGNAL } from '@angular/core/primitives/signals';
 import {
   outputToObservable,
   takeUntilDestroyed,
@@ -224,7 +225,16 @@ export class NgSelectA11yDirective implements AfterViewInit {
       .translate('common.ngSelectDropdownOptionsList')
       .pipe(take(1))
       .subscribe((translation) => {
-        this.selectComponent.ariaLabelDropdown = translation;
+        // workaround for known issue with setting value of the input signal programmatically: https://github.com/angular/angular/issues/54782
+        // since ng-select@20.x changed ariaLabelDropdown to be an input signal, we can't set its value directly
+        // NOTE: SIGNAL is not a part of the public API of @angular/core and may change without notice
+        // TODO: find a way to apply customizeNgSelectAriaLabelDropdown in a different way
+        const ariaLabelDropdownSignal =
+          this.selectComponent.ariaLabelDropdown[SIGNAL];
+        ariaLabelDropdownSignal.applyValueToInputSignal(
+          ariaLabelDropdownSignal,
+          translation
+        );
       });
   }
 }


### PR DESCRIPTION
- in ng-select@20 ariaLabelDropdown has been changed to [input signal](https://github.com/ng-select/ng-select/pull/2656/files#diff-4e0502e4dc19d676826005eb8878a23f9daec09195ecd896a44ebf3772f78a63)
- used SIGNAL symbol to get access to change value of the input signal
- known problem: https://github.com/angular/angular/issues/54782