### PR TITLE
chore: update documentation of cacheSize property

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -42,7 +42,7 @@ export interface SsrOptimizationOptions {
    *
    * Default value is set to 3000.
    *
-   * @deprecated since v2211.42. Use `cacheSizeBytes` option instead.
+   * @deprecated since v2211.42. Use `cacheSizeMemory` option instead.
    *             The `cacheSize` option will be removed eventually together with the feature toggle `ssrFeatureToggles.limitCacheByMemory`.
    */
   cacheSize?: number;


### PR DESCRIPTION
I think 'cacheSizeMemory' is meant here...