### PR TITLE
fix: disable CustomLoginGuard in SSR

### DIFF
--- a/projects/core/src/auth/user-auth/guards/custom-login.guard.spec.ts
+++ b/projects/core/src/auth/user-auth/guards/custom-login.guard.spec.ts
@@ -124,7 +124,7 @@ describe('CustomLoginGuard', () => {
     });
   });
 
-  describe('wehn SSR mode is running', () => {
+  describe('when SSR mode is running', () => {
     beforeEach(() => {
       spyOn(mockWindowRef, 'isBrowser').and.returnValue(false);
     });

--- a/projects/core/src/auth/user-auth/guards/custom-login.guard.spec.ts
+++ b/projects/core/src/auth/user-auth/guards/custom-login.guard.spec.ts
@@ -31,6 +31,9 @@ class MockSemanticPathService {
 }
 class MockWindowRef {
   localStorage = mockStorage();
+  isBrowser(): boolean {
+    return true;
+  }
 }
 class MockGlobalMessageService {
   add = jasmine.createSpy();
@@ -59,6 +62,7 @@ describe('CustomLoginGuard', () => {
   let csrfStateService: CsrfStateService;
   let storage: Storage;
   let authConfigService: AuthConfigService;
+  let mockWindowRef: MockWindowRef;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -92,6 +96,7 @@ describe('CustomLoginGuard', () => {
     spyOn(csrfStateService, 'set').and.callThrough();
     storage = TestBed.inject(WindowRef).localStorage as Storage;
     spyOn(storage, 'setItem').and.callThrough();
+    mockWindowRef = TestBed.inject(WindowRef) as MockWindowRef;
     authConfigService = TestBed.inject(AuthConfigService);
 
     jasmine.clock().install();
@@ -113,9 +118,19 @@ describe('CustomLoginGuard', () => {
       );
     });
 
-    it('should resolve to true when custom login is enabled', async () => {
+    it('should resolve to true when custom login is disabled', async () => {
       const actual = await lastValueFrom(guard.canActivate());
+      expect(actual).toBe(true);
+    });
+  });
 
+  describe('wehn SSR mode is running', () => {
+    beforeEach(() => {
+      spyOn(mockWindowRef, 'isBrowser').and.returnValue(false);
+    });
+
+    it('should resolve to true when SSR mode is running', async () => {
+      const actual = await lastValueFrom(guard.canActivate());
       expect(actual).toBe(true);
     });
   });

--- a/projects/core/src/auth/user-auth/guards/custom-login.guard.ts
+++ b/projects/core/src/auth/user-auth/guards/custom-login.guard.ts
@@ -57,9 +57,11 @@ export class CustomLoginGuard implements CanActivate {
   protected csrfStateService = inject(CsrfStateService);
 
   canActivate(): Observable<GuardResult> {
-    if (!this.authConfigService.customLoginEnabled()) {
-      // disable guard when custom login page is not enabled
-      return of(true);
+    if (
+      !this.authConfigService.customLoginEnabled() ||
+      !this.windowRef.isBrowser()
+    ) {
+      // disable guard when custom login page is not enabled or when the application is running in SSR mode.
     }
 
     return this.authService.getCsrfToken().pipe(

--- a/projects/core/src/auth/user-auth/guards/custom-login.guard.ts
+++ b/projects/core/src/auth/user-auth/guards/custom-login.guard.ts
@@ -62,6 +62,7 @@ export class CustomLoginGuard implements CanActivate {
       !this.windowRef.isBrowser()
     ) {
       // disable guard when custom login page is not enabled or when the application is running in SSR mode.
+      return of(true);
     }
 
     return this.authService.getCsrfToken().pipe(


### PR DESCRIPTION
CXSPA-11484
when the app run in SSR
- /login is called then fails with error 500 -> due to /CSRF called on server side

Guard is now skipped in SSR.
The guard will then run when fallback into CSR gets triggered.