### PR TITLE
fix: CXSPA-11400 Fix schematics unit tests

### DIFF
--- a/feature-libs/asm/schematics/add-asm/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/asm/schematics/add-asm/__snapshots__/index_spec.ts.snap
@@ -86,10 +86,8 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -106,7 +104,6 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
               "src/styles.scss",
               "src/styles/spartacus/asm.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -143,7 +140,7 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -155,10 +152,10 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -176,7 +173,6 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
               "src/styles.scss",
               "src/styles/spartacus/asm.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/cart/schematics/add-cart/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/cart/schematics/add-cart/__snapshots__/index_spec.ts.snap
@@ -109,10 +109,8 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -129,7 +127,6 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -166,7 +163,7 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -178,10 +175,10 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -199,7 +196,6 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -302,10 +298,8 @@ exports[`Spartacus Cart schematics: ng-add Cart Import Export feature general se
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -322,7 +316,6 @@ exports[`Spartacus Cart schematics: ng-add Cart Import Export feature general se
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -359,7 +352,7 @@ exports[`Spartacus Cart schematics: ng-add Cart Import Export feature general se
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -371,10 +364,10 @@ exports[`Spartacus Cart schematics: ng-add Cart Import Export feature general se
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -392,7 +385,6 @@ exports[`Spartacus Cart schematics: ng-add Cart Import Export feature general se
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -495,10 +487,8 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -515,7 +505,6 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -552,7 +541,7 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -564,10 +553,10 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -585,7 +574,6 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -688,10 +676,8 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -708,7 +694,6 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -745,7 +730,7 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -757,10 +742,10 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -778,7 +763,6 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -891,10 +875,8 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -911,7 +893,6 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -948,7 +929,7 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -960,10 +941,10 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -981,7 +962,6 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
               "src/styles.scss",
               "src/styles/spartacus/cart.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/checkout/schematics/add-checkout/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/checkout/schematics/add-checkout/__snapshots__/index_spec.ts.snap
@@ -161,10 +161,8 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -181,7 +179,6 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
               "src/styles.scss",
               "src/styles/spartacus/checkout.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -218,7 +215,7 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -230,10 +227,10 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -251,7 +248,6 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
               "src/styles.scss",
               "src/styles/spartacus/checkout.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -354,10 +350,8 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -374,7 +368,6 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
               "src/styles.scss",
               "src/styles/spartacus/checkout.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -411,7 +404,7 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -423,10 +416,10 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -444,7 +437,6 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
               "src/styles.scss",
               "src/styles/spartacus/checkout.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -641,10 +633,8 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -661,7 +651,6 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
               "src/styles.scss",
               "src/styles/spartacus/checkout.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -698,7 +687,7 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -710,10 +699,10 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -731,7 +720,6 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
               "src/styles.scss",
               "src/styles/spartacus/checkout.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/customer-ticketing/schematics/add-customer-ticketing/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/customer-ticketing/schematics/add-customer-ticketing/__snapshots__/index_spec.ts.snap
@@ -86,10 +86,8 @@ exports[`Spartacus Customer Ticketing schematics: ng-add Customer Ticketing feat
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -106,7 +104,6 @@ exports[`Spartacus Customer Ticketing schematics: ng-add Customer Ticketing feat
               "src/styles.scss",
               "src/styles/spartacus/customer-ticketing.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -143,7 +140,7 @@ exports[`Spartacus Customer Ticketing schematics: ng-add Customer Ticketing feat
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -155,10 +152,10 @@ exports[`Spartacus Customer Ticketing schematics: ng-add Customer Ticketing feat
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -176,7 +173,6 @@ exports[`Spartacus Customer Ticketing schematics: ng-add Customer Ticketing feat
               "src/styles.scss",
               "src/styles/spartacus/customer-ticketing.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/__snapshots__/index_spec.ts.snap
@@ -70,10 +70,8 @@ exports[`Spartacus Estimated-Delivery-Date schematics: ng-add Estimated-Delivery
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -91,7 +89,6 @@ exports[`Spartacus Estimated-Delivery-Date schematics: ng-add Estimated-Delivery
               "src/styles/spartacus/cart.scss",
               "src/styles/spartacus/estimated-delivery-date.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -128,7 +125,7 @@ exports[`Spartacus Estimated-Delivery-Date schematics: ng-add Estimated-Delivery
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -140,10 +137,10 @@ exports[`Spartacus Estimated-Delivery-Date schematics: ng-add Estimated-Delivery
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -162,7 +159,6 @@ exports[`Spartacus Estimated-Delivery-Date schematics: ng-add Estimated-Delivery
               "src/styles/spartacus/cart.scss",
               "src/styles/spartacus/estimated-delivery-date.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/order/schematics/add-order/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/order/schematics/add-order/__snapshots__/index_spec.ts.snap
@@ -86,10 +86,8 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -106,7 +104,6 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
               "src/styles.scss",
               "src/styles/spartacus/order.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -143,7 +140,7 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -155,10 +152,10 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -176,7 +173,6 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
               "src/styles.scss",
               "src/styles/spartacus/order.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/organization/schematics/add-organization/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/organization/schematics/add-organization/__snapshots__/index_spec.ts.snap
@@ -124,10 +124,8 @@ exports[`Spartacus Organization schematics: ng-add Account summary feature gener
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -144,7 +142,6 @@ exports[`Spartacus Organization schematics: ng-add Account summary feature gener
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -181,7 +178,7 @@ exports[`Spartacus Organization schematics: ng-add Account summary feature gener
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -193,10 +190,10 @@ exports[`Spartacus Organization schematics: ng-add Account summary feature gener
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -214,7 +211,6 @@ exports[`Spartacus Organization schematics: ng-add Account summary feature gener
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -352,10 +348,8 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -372,7 +366,6 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -409,7 +402,7 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -421,10 +414,10 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -442,7 +435,6 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -580,10 +572,8 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -600,7 +590,6 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -637,7 +626,7 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -649,10 +638,10 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -670,7 +659,6 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -808,10 +796,8 @@ exports[`Spartacus Organization schematics: ng-add Unit order feature general se
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -828,7 +814,6 @@ exports[`Spartacus Organization schematics: ng-add Unit order feature general se
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -865,7 +850,7 @@ exports[`Spartacus Organization schematics: ng-add Unit order feature general se
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -877,10 +862,10 @@ exports[`Spartacus Organization schematics: ng-add Unit order feature general se
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -898,7 +883,6 @@ exports[`Spartacus Organization schematics: ng-add Unit order feature general se
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -1036,10 +1020,8 @@ exports[`Spartacus Organization schematics: ng-add User registration feature gen
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -1056,7 +1038,6 @@ exports[`Spartacus Organization schematics: ng-add User registration feature gen
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -1093,7 +1074,7 @@ exports[`Spartacus Organization schematics: ng-add User registration feature gen
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -1105,10 +1086,10 @@ exports[`Spartacus Organization schematics: ng-add User registration feature gen
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -1126,7 +1107,6 @@ exports[`Spartacus Organization schematics: ng-add User registration feature gen
               "src/styles.scss",
               "src/styles/spartacus/organization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/pdf-invoices/schematics/add-pdf-invoices/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/pdf-invoices/schematics/add-pdf-invoices/__snapshots__/index_spec.ts.snap
@@ -35,10 +35,8 @@ exports[`Spartacus PDF Invoices schematics: ng-add PDF Invoices feature general 
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -55,7 +53,6 @@ exports[`Spartacus PDF Invoices schematics: ng-add PDF Invoices feature general 
               "src/styles.scss",
               "src/styles/spartacus/pdf-invoices.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -92,7 +89,7 @@ exports[`Spartacus PDF Invoices schematics: ng-add PDF Invoices feature general 
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -104,10 +101,10 @@ exports[`Spartacus PDF Invoices schematics: ng-add PDF Invoices feature general 
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -125,7 +122,6 @@ exports[`Spartacus PDF Invoices schematics: ng-add PDF Invoices feature general 
               "src/styles.scss",
               "src/styles/spartacus/pdf-invoices.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/pickup-in-store/schematics/add-pickup-in-store/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/pickup-in-store/schematics/add-pickup-in-store/__snapshots__/index_spec.ts.snap
@@ -89,10 +89,8 @@ exports[`Spartacus Pickup in Store schematics: ng-add Pick Up In Store feature g
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -109,7 +107,6 @@ exports[`Spartacus Pickup in Store schematics: ng-add Pick Up In Store feature g
               "src/styles.scss",
               "src/styles/spartacus/pickup-in-store.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -146,7 +143,7 @@ exports[`Spartacus Pickup in Store schematics: ng-add Pick Up In Store feature g
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -158,10 +155,10 @@ exports[`Spartacus Pickup in Store schematics: ng-add Pick Up In Store feature g
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -179,7 +176,6 @@ exports[`Spartacus Pickup in Store schematics: ng-add Pick Up In Store feature g
               "src/styles.scss",
               "src/styles/spartacus/pickup-in-store.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/product-configurator/schematics/add-product-configurator/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product-configurator/schematics/add-product-configurator/__snapshots__/index_spec.ts.snap
@@ -155,10 +155,8 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -175,7 +173,6 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               "src/styles.scss",
               "src/styles/spartacus/product-configurator.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -212,7 +209,7 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -224,10 +221,10 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -245,7 +242,6 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               "src/styles.scss",
               "src/styles/spartacus/product-configurator.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -400,10 +396,8 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -420,7 +414,6 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               "src/styles.scss",
               "src/styles/spartacus/product-configurator.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -457,7 +450,7 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -469,10 +462,10 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -490,7 +483,6 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               "src/styles.scss",
               "src/styles/spartacus/product-configurator.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -624,10 +616,8 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -644,7 +634,6 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               "src/styles.scss",
               "src/styles/spartacus/product-configurator.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -681,7 +670,7 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -693,10 +682,10 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -714,7 +703,6 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               "src/styles.scss",
               "src/styles/spartacus/product-configurator.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -814,10 +802,8 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -834,7 +820,6 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               "src/styles.scss",
               "src/styles/spartacus/product-configurator.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -871,7 +856,7 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -883,10 +868,10 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -904,7 +889,6 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
               "src/styles.scss",
               "src/styles/spartacus/product-configurator.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/__snapshots__/index_spec.ts.snap
@@ -39,10 +39,8 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add list feature gen
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -58,7 +56,6 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add list feature gen
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -95,7 +92,7 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add list feature gen
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -107,10 +104,10 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add list feature gen
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -127,7 +124,6 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add list feature gen
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -230,10 +226,8 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add selector feature
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -250,7 +244,6 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add selector feature
               "src/styles.scss",
               "src/styles/spartacus/product-multi-dimensional.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -287,7 +280,7 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add selector feature
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -299,10 +292,10 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add selector feature
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -320,7 +313,6 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add selector feature
               "src/styles.scss",
               "src/styles/spartacus/product-multi-dimensional.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/product/schematics/add-product/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product/schematics/add-product/__snapshots__/index_spec.ts.snap
@@ -124,10 +124,8 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -144,7 +142,6 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
               "src/styles.scss",
               "src/styles/spartacus/product.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -181,7 +178,7 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -193,10 +190,10 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -214,7 +211,6 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
               "src/styles.scss",
               "src/styles/spartacus/product.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -352,10 +348,8 @@ exports[`Spartacus Product schematics: ng-add FutureStock feature general setup 
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -372,7 +366,6 @@ exports[`Spartacus Product schematics: ng-add FutureStock feature general setup 
               "src/styles.scss",
               "src/styles/spartacus/product.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -409,7 +402,7 @@ exports[`Spartacus Product schematics: ng-add FutureStock feature general setup 
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -421,10 +414,10 @@ exports[`Spartacus Product schematics: ng-add FutureStock feature general setup 
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -442,7 +435,6 @@ exports[`Spartacus Product schematics: ng-add FutureStock feature general setup 
               "src/styles.scss",
               "src/styles/spartacus/product.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -545,10 +537,8 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -565,7 +555,6 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
               "src/styles.scss",
               "src/styles/spartacus/product.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -602,7 +591,7 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -614,10 +603,10 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -635,7 +624,6 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
               "src/styles.scss",
               "src/styles/spartacus/product.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -738,10 +726,8 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -758,7 +744,6 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
               "src/styles.scss",
               "src/styles/spartacus/product.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -795,7 +780,7 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -807,10 +792,10 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -828,7 +813,6 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
               "src/styles.scss",
               "src/styles/spartacus/product.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/qualtrics/schematics/add-qualtrics/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/qualtrics/schematics/add-qualtrics/__snapshots__/index_spec.ts.snap
@@ -73,10 +73,8 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -93,7 +91,6 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
               "src/styles.scss",
               "src/styles/spartacus/qualtrics-embedded-feedback.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -130,7 +127,7 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -142,10 +139,10 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -163,7 +160,6 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
               "src/styles.scss",
               "src/styles/spartacus/qualtrics-embedded-feedback.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/quote/schematics/add-quote/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/quote/schematics/add-quote/__snapshots__/index_spec.ts.snap
@@ -144,10 +144,8 @@ exports[`Spartacus Quote schematics: ng-add Quote feature general setup styling 
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -164,7 +162,6 @@ exports[`Spartacus Quote schematics: ng-add Quote feature general setup styling 
               "src/styles.scss",
               "src/styles/spartacus/quote.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -201,7 +198,7 @@ exports[`Spartacus Quote schematics: ng-add Quote feature general setup styling 
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -213,10 +210,10 @@ exports[`Spartacus Quote schematics: ng-add Quote feature general setup styling 
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -234,7 +231,6 @@ exports[`Spartacus Quote schematics: ng-add Quote feature general setup styling 
               "src/styles.scss",
               "src/styles/spartacus/quote.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/__snapshots__/index_spec.ts.snap
@@ -35,10 +35,8 @@ exports[`Spartacus Requested Delivery Date schematics: ng-add Requested Delivery
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -55,7 +53,6 @@ exports[`Spartacus Requested Delivery Date schematics: ng-add Requested Delivery
               "src/styles.scss",
               "src/styles/spartacus/requested-delivery-date.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -92,7 +89,7 @@ exports[`Spartacus Requested Delivery Date schematics: ng-add Requested Delivery
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -104,10 +101,10 @@ exports[`Spartacus Requested Delivery Date schematics: ng-add Requested Delivery
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -125,7 +122,6 @@ exports[`Spartacus Requested Delivery Date schematics: ng-add Requested Delivery
               "src/styles.scss",
               "src/styles/spartacus/requested-delivery-date.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/smartedit/schematics/add-smartedit/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/smartedit/schematics/add-smartedit/__snapshots__/index_spec.ts.snap
@@ -48,10 +48,8 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -72,7 +70,6 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -109,7 +106,7 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -121,10 +118,10 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -146,7 +143,6 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/storefinder/schematics/add-storefinder/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/storefinder/schematics/add-storefinder/__snapshots__/index_spec.ts.snap
@@ -89,10 +89,8 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -109,7 +107,6 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
               "src/styles.scss",
               "src/styles/spartacus/storefinder.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -146,7 +143,7 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -158,10 +155,10 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -179,7 +176,6 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
               "src/styles.scss",
               "src/styles/spartacus/storefinder.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/feature-libs/user/schematics/add-user/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/user/schematics/add-user/__snapshots__/index_spec.ts.snap
@@ -117,10 +117,8 @@ exports[`Spartacus User schematics: ng-add User Profile feature general setup st
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -137,7 +135,6 @@ exports[`Spartacus User schematics: ng-add User Profile feature general setup st
               "src/styles.scss",
               "src/styles/spartacus/user.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -174,7 +171,7 @@ exports[`Spartacus User schematics: ng-add User Profile feature general setup st
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -186,10 +183,10 @@ exports[`Spartacus User schematics: ng-add User Profile feature general setup st
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -207,7 +204,6 @@ exports[`Spartacus User schematics: ng-add User Profile feature general setup st
               "src/styles.scss",
               "src/styles/spartacus/user.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -307,10 +303,8 @@ exports[`Spartacus User schematics: ng-add User-Account feature general setup st
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -327,7 +321,6 @@ exports[`Spartacus User schematics: ng-add User-Account feature general setup st
               "src/styles.scss",
               "src/styles/spartacus/user.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -364,7 +357,7 @@ exports[`Spartacus User schematics: ng-add User-Account feature general setup st
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -376,10 +369,10 @@ exports[`Spartacus User schematics: ng-add User-Account feature general setup st
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -397,7 +390,6 @@ exports[`Spartacus User schematics: ng-add User-Account feature general setup st
               "src/styles.scss",
               "src/styles/spartacus/user.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
@@ -148,10 +148,8 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -168,7 +166,6 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
               "src/styles.scss",
               "src/styles/spartacus/epd-visualization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -205,7 +202,7 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -217,10 +214,10 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -238,7 +235,6 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
               "src/styles.scss",
               "src/styles/spartacus/epd-visualization.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/integration-libs/opf/schematics/add-opf/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/opf/schematics/add-opf/__snapshots__/index_spec.ts.snap
@@ -82,10 +82,8 @@ exports[`Spartacus SAP OPF integration schematics: ng-add SAP OPF feature genera
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -102,7 +100,6 @@ exports[`Spartacus SAP OPF integration schematics: ng-add SAP OPF feature genera
               "src/styles.scss",
               "src/styles/spartacus/opf.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -139,7 +136,7 @@ exports[`Spartacus SAP OPF integration schematics: ng-add SAP OPF feature genera
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -151,10 +148,10 @@ exports[`Spartacus SAP OPF integration schematics: ng-add SAP OPF feature genera
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -172,7 +169,6 @@ exports[`Spartacus SAP OPF integration schematics: ng-add SAP OPF feature genera
               "src/styles.scss",
               "src/styles/spartacus/opf.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/projects/schematics/src/add-cms-component/index_spec.ts
+++ b/projects/schematics/src/add-cms-component/index_spec.ts
@@ -223,6 +223,7 @@ describe('add-cms-component', () => {
       const moduleOptions = {
         name: moduleName,
         project: defaultOptions.project,
+        typeSeparator: '.',
       };
       const dummyComponentOptions = {
         project: defaultOptions.project,
@@ -230,6 +231,7 @@ describe('add-cms-component', () => {
         module: moduleName,
         export: true,
         standalone: false,
+        type: 'component',
       };
       const modifiedOptions: CxCmsComponentSchema = {
         ...commonCmsOptions,
@@ -521,11 +523,13 @@ describe('add-cms-component', () => {
       const moduleOptions = {
         name: moduleName,
         project: defaultOptions.project,
+        typeSeparator: '.',
       };
       const modifiedOptions: CxCmsComponentSchema = {
         ...commonCmsOptions,
         module: 'app',
         declareCmsModule: moduleName,
+        type: 'component',
       };
 
       appTree = await schematicRunner.runExternalSchematic(

--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -8,7 +8,7 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
     "schematics-test": {
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "configurations": {
             "development": {
               "extractLicenses": false,
@@ -44,14 +44,11 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
               },
             ],
             "browser": "src/main.ts",
-            "index": "src/index.html",
             "inlineStyleLanguage": "scss",
-            "outputPath": "dist/schematics-test",
             "polyfills": [
               "zone.js",
             ],
             "prerender": false,
-            "scripts": [],
             "server": "src/main.server.ts",
             "ssr": {
               "entry": "src/server.ts",
@@ -73,10 +70,10 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
           },
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "builder": "@angular/build:extract-i18n",
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "development": {
               "buildTarget": "schematics-test:build:development,noSsr",
@@ -88,7 +85,7 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
           "defaultConfiguration": "development",
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "assets": [
               {
@@ -101,7 +98,6 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
               "zone.js",
               "zone.js/testing",
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/",
@@ -138,38 +134,38 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
 
 exports[`add-ssr app.module.server.ts should be updated 1`] = `
 "import { NgModule } from '@angular/core';
-import { ServerModule } from '@angular/platform-server';
-import { AppComponent } from './app.component';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
+import { App } from './app.component';
 import { AppModule } from './app.module';
+import { serverRoutes } from './app.routes.server';
 import { provideServer } from '@spartacus/setup/ssr';
 
 @NgModule({
-  imports: [AppModule, ServerModule],
-  bootstrap: [AppComponent],
-  providers: [
-    ...provideServer({
-       serverRequestOrigin: process.env['SERVER_REQUEST_ORIGIN'],
-     }),
-  ],
+  imports: [AppModule],
+  providers: [provideServerRendering(withRoutes(serverRoutes)), 
+     ...provideServer({
+        serverRequestOrigin: process.env['SERVER_REQUEST_ORIGIN'],
+      }),],
+  bootstrap: [App],
 })
 export class AppServerModule {}
 "
 `;
 
 exports[`add-ssr app.module.ts should be updated 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { BrowserModule, provideClientHydration, withEventReplay, withNoHttpTransferCache } from '@angular/platform-browser';
 
 import { provideHttpClient, withFetch, withInterceptorsFromDi } from "@angular/common/http";
 import { EffectsModule } from "@ngrx/effects";
 import { StoreModule } from "@ngrx/store";
 import { AppRoutingModule } from "@spartacus/storefront";
-import { AppComponent } from './app.component';
+import { App } from './app.component';
 import { SpartacusModule } from './spartacus/spartacus.module';
 
 @NgModule({
   declarations: [
-    AppComponent
+    App
   ],
   imports: [
     BrowserModule,
@@ -178,8 +174,12 @@ import { SpartacusModule } from './spartacus/spartacus.module';
     EffectsModule.forRoot([]),
     SpartacusModule
   ],
-  providers: [provideHttpClient(withFetch(), withInterceptorsFromDi()), provideClientHydration(withEventReplay(), withNoHttpTransferCache())],
-  bootstrap: [AppComponent]
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideHttpClient(withFetch(), withInterceptorsFromDi()),
+    provideClientHydration(withEventReplay(), withNoHttpTransferCache())
+  ],
+  bootstrap: [App]
 })
 export class AppModule { }
 "
@@ -244,14 +244,14 @@ export function app(): express.Express {
 
   // Serve static files from /browser
   server.get(
-    '*.*',
+    /.*\\..*/,
     express.static(browserDistFolder, {
       maxAge: '1y',
     })
   );
 
   // All regular routes use the Universal engine
-  server.get('*', (req, res) => {
+  server.get(/.*/, (req, res) => {
     res.render(indexHtml, {
       req,
       providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],

--- a/projects/schematics/src/migrations/mechanism/scaffold-app-structure/scaffold-app-structure_spec.ts
+++ b/projects/schematics/src/migrations/mechanism/scaffold-app-structure/scaffold-app-structure_spec.ts
@@ -1,11 +1,4 @@
 /// <reference types="jest" />
-
-/*
- * We'll be able to import `firstValueFrom` directly from 'rxjs' only after we bump `@angular-devkit/schematics`,
- * because typings of `@angular-devkit/schematics/node_modules/rxjs@7.8.1` are not compatible with
- * typings of the `rxjs@7.8.2` globally installed in our repo.
- */
-import { firstValueFrom } from '@angular-devkit/schematics/node_modules/rxjs';
 import {
   SchematicTestRunner,
   UnitTestTree,
@@ -15,6 +8,7 @@ import {
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
+import { firstValueFrom } from 'rxjs';
 import { spartacusFeaturesModulePath } from '../../../shared/utils/test-utils';
 import { scaffoldAppStructure } from './scaffold-app-structure';
 

--- a/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 1`] = `
-"import { NgModule } from '@angular/core';
+"import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { BrowserModule, provideClientHydration, withEventReplay, withNoHttpTransferCache } from '@angular/platform-browser';
 
 import { provideHttpClient, withFetch, withInterceptorsFromDi } from "@angular/common/http";
 import { EffectsModule } from "@ngrx/effects";
 import { StoreModule } from "@ngrx/store";
 import { AppRoutingModule } from "@spartacus/storefront";
-import { AppComponent } from './app.component';
+import { App } from './app.component';
 import { SpartacusModule } from './spartacus/spartacus.module';
 
 @NgModule({
   declarations: [
-    AppComponent
+    App
   ],
   imports: [
     BrowserModule,
@@ -22,8 +22,12 @@ import { SpartacusModule } from './spartacus/spartacus.module';
     EffectsModule.forRoot([]),
     SpartacusModule
   ],
-  providers: [provideHttpClient(withFetch(), withInterceptorsFromDi()), provideClientHydration(withEventReplay(), withNoHttpTransferCache())],
-  bootstrap: [AppComponent]
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideHttpClient(withFetch(), withInterceptorsFromDi()),
+    provideClientHydration(withEventReplay(), withNoHttpTransferCache())
+  ],
+  bootstrap: [App]
 })
 export class AppModule { }
 "
@@ -42,51 +46,62 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "serve:ssr:schematics-test": "node dist/schematics-test/server/server.mjs",
     "build:ssr": "ng build"
   },
+  "prettier": {
+    "printWidth": 100,
+    "singleQuote": true,
+    "overrides": [
+      {
+        "files": "*.html",
+        "options": {
+          "parser": "angular"
+        }
+      }
+    ]
+  },
   "private": true,
   "dependencies": {
-    "@angular/common": "^19.2.0",
-    "@angular/compiler": "^19.2.0",
-    "@angular/core": "^19.2.0",
-    "@angular/forms": "^19.2.0",
-    "@angular/platform-browser": "^19.2.0",
-    "@angular/platform-browser-dynamic": "^19.2.0",
-    "@angular/platform-server": "^19.2.0",
-    "@angular/router": "^19.2.0",
-    "@angular/service-worker": "^19.2.15",
-    "@angular/ssr": "^19.2.15",
+    "@angular/common": "^20.3.0",
+    "@angular/compiler": "^20.3.0",
+    "@angular/core": "^20.3.0",
+    "@angular/forms": "^20.3.0",
+    "@angular/platform-browser": "^20.3.0",
+    "@angular/platform-server": "^20.3.0",
+    "@angular/router": "^20.3.0",
+    "@angular/service-worker": "^20.3.7",
+    "@angular/ssr": "^20.3.7",
     "@fontsource/open-sans": "^5.1.0",
     "@fortawesome/fontawesome-free": "6.7.2",
-    "@ng-select/ng-select": "^14.1.0",
-    "@ngrx/effects": "^19.0.0",
-    "@ngrx/router-store": "^19.0.0",
-    "@ngrx/store": "^19.0.0",
+    "@ng-select/ng-select": "^20.4.3",
+    "@ngrx/effects": "^20.1.0",
+    "@ngrx/router-store": "^20.1.0",
+    "@ngrx/store": "^20.1.0",
     "@spartacus/assets": "~221121.4.0",
     "@spartacus/core": "~221121.4.0",
     "@spartacus/setup": "~221121.4.0",
     "@spartacus/storefront": "~221121.4.0",
     "@spartacus/styles": "~221121.4.0",
-    "angular-oauth2-oidc": "19.0.0",
-    "express": "^4.18.2",
+    "angular-oauth2-oidc": "^20.0.2",
+    "express": "^5.1.0",
     "i18next": "^24.2.1",
     "i18next-http-backend": "^3.0.1",
     "i18next-resources-to-backend": "^1.2.1",
-    "ngx-infinite-scroll": "^19.0.0",
+    "ngx-infinite-scroll": "^20.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^19.2.15",
-    "@angular-devkit/core": "^19.2.16",
-    "@angular-devkit/schematics": "^19.2.16",
+    "@angular-devkit/core": "^20.3.7",
+    "@angular-devkit/schematics": "^20.3.7",
+    "@angular/build": "^20.3.7",
     "@angular/cli": "^0.5.0",
-    "@angular/compiler": "^19.2.15",
-    "@angular/compiler-cli": "^19.2.0",
-    "@schematics/angular": "^19.2.15",
-    "@types/express": "^4.17.17",
+    "@angular/compiler": "^20.3.7",
+    "@angular/compiler-cli": "^20.3.0",
+    "@schematics/angular": "^20.3.7",
+    "@types/express": "^5.0.1",
     "@types/jasmine": "~5.1.0",
-    "@types/node": "^18.18.0",
-    "jasmine-core": "~5.6.0",
+    "@types/node": "^20.17.19",
+    "jasmine-core": "~5.9.0",
     "jsonc-parser": "^3.3.1",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
@@ -94,26 +109,26 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "parse5": "^7.2.1",
-    "typescript": "~5.7.2"
+    "typescript": "~5.9.2"
   }
 }"
 `;
 
 exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 3`] = `
 "import { NgModule } from '@angular/core';
-import { ServerModule } from '@angular/platform-server';
-import { AppComponent } from './app.component';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
+import { App } from './app.component';
 import { AppModule } from './app.module';
+import { serverRoutes } from './app.routes.server';
 import { provideServer } from '@spartacus/setup/ssr';
 
 @NgModule({
-  imports: [AppModule, ServerModule],
-  bootstrap: [AppComponent],
-  providers: [
-    ...provideServer({
-       serverRequestOrigin: process.env['SERVER_REQUEST_ORIGIN'],
-     }),
-  ],
+  imports: [AppModule],
+  providers: [provideServerRendering(withRoutes(serverRoutes)), 
+     ...provideServer({
+        serverRequestOrigin: process.env['SERVER_REQUEST_ORIGIN'],
+      }),],
+  bootstrap: [App],
 })
 export class AppServerModule {}
 "

--- a/projects/schematics/src/shared/utils/__snapshots__/lib-utils_spec.ts.snap
+++ b/projects/schematics/src/shared/utils/__snapshots__/lib-utils_spec.ts.snap
@@ -153,10 +153,8 @@ exports[`Lib utils assets options should update angular.json file with assets 1`
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -172,7 +170,6 @@ exports[`Lib utils assets options should update angular.json file with assets 1`
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -209,7 +206,7 @@ exports[`Lib utils assets options should update angular.json file with assets 1`
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -221,10 +218,10 @@ exports[`Lib utils assets options should update angular.json file with assets 1`
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -241,7 +238,6 @@ exports[`Lib utils assets options should update angular.json file with assets 1`
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -280,10 +276,8 @@ exports[`Lib utils assets options should update angular.json file with assets 2`
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/schematics-test",
-            "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
@@ -305,7 +299,6 @@ exports[`Lib utils assets options should update angular.json file with assets 2`
               "src/styles.scss",
               "src/styles/spartacus/xxx.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"
@@ -342,7 +335,7 @@ exports[`Lib utils assets options should update angular.json file with assets 2`
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "schematics-test:build:production"
@@ -354,10 +347,10 @@ exports[`Lib utils assets options should update angular.json file with assets 2`
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular-devkit/build-angular:karma",
+          "builder": "@angular/build:karma",
           "options": {
             "polyfills": [
               "zone.js",
@@ -380,7 +373,6 @@ exports[`Lib utils assets options should update angular.json file with assets 2`
               "src/styles.scss",
               "src/styles/spartacus/xxx.scss"
             ],
-            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "node_modules/"

--- a/projects/schematics/src/shared/utils/__snapshots__/workspace-utils_spec.ts.snap
+++ b/projects/schematics/src/shared/utils/__snapshots__/workspace-utils_spec.ts.snap
@@ -4,7 +4,7 @@ exports[`Workspace utils getProject should return project 1`] = `
 {
   "architect": {
     "build": {
-      "builder": "@angular-devkit/build-angular:application",
+      "builder": "@angular/build:application",
       "configurations": {
         "development": {
           "extractLicenses": false,
@@ -36,13 +36,10 @@ exports[`Workspace utils getProject should return project 1`] = `
           },
         ],
         "browser": "src/main.ts",
-        "index": "src/index.html",
         "inlineStyleLanguage": "scss",
-        "outputPath": "dist/schematics-test",
         "polyfills": [
           "zone.js",
         ],
-        "scripts": [],
         "stylePreprocessorOptions": {
           "includePaths": [
             "node_modules/",
@@ -60,10 +57,10 @@ exports[`Workspace utils getProject should return project 1`] = `
       },
     },
     "extract-i18n": {
-      "builder": "@angular-devkit/build-angular:extract-i18n",
+      "builder": "@angular/build:extract-i18n",
     },
     "serve": {
-      "builder": "@angular-devkit/build-angular:dev-server",
+      "builder": "@angular/build:dev-server",
       "configurations": {
         "development": {
           "buildTarget": "schematics-test:build:development",
@@ -75,7 +72,7 @@ exports[`Workspace utils getProject should return project 1`] = `
       "defaultConfiguration": "development",
     },
     "test": {
-      "builder": "@angular-devkit/build-angular:karma",
+      "builder": "@angular/build:karma",
       "options": {
         "assets": [
           {
@@ -88,7 +85,6 @@ exports[`Workspace utils getProject should return project 1`] = `
           "zone.js",
           "zone.js/testing",
         ],
-        "scripts": [],
         "stylePreprocessorOptions": {
           "includePaths": [
             "node_modules/",
@@ -123,7 +119,7 @@ exports[`Workspace utils getProject should return project 1`] = `
 exports[`Workspace utils getProjectTargets should return project targets 1`] = `
 {
   "build": {
-    "builder": "@angular-devkit/build-angular:application",
+    "builder": "@angular/build:application",
     "configurations": {
       "development": {
         "extractLicenses": false,
@@ -155,13 +151,10 @@ exports[`Workspace utils getProjectTargets should return project targets 1`] = `
         },
       ],
       "browser": "src/main.ts",
-      "index": "src/index.html",
       "inlineStyleLanguage": "scss",
-      "outputPath": "dist/schematics-test",
       "polyfills": [
         "zone.js",
       ],
-      "scripts": [],
       "stylePreprocessorOptions": {
         "includePaths": [
           "node_modules/",
@@ -179,10 +172,10 @@ exports[`Workspace utils getProjectTargets should return project targets 1`] = `
     },
   },
   "extract-i18n": {
-    "builder": "@angular-devkit/build-angular:extract-i18n",
+    "builder": "@angular/build:extract-i18n",
   },
   "serve": {
-    "builder": "@angular-devkit/build-angular:dev-server",
+    "builder": "@angular/build:dev-server",
     "configurations": {
       "development": {
         "buildTarget": "schematics-test:build:development",
@@ -194,7 +187,7 @@ exports[`Workspace utils getProjectTargets should return project targets 1`] = `
     "defaultConfiguration": "development",
   },
   "test": {
-    "builder": "@angular-devkit/build-angular:karma",
+    "builder": "@angular/build:karma",
     "options": {
       "assets": [
         {
@@ -207,7 +200,6 @@ exports[`Workspace utils getProjectTargets should return project targets 1`] = `
         "zone.js",
         "zone.js/testing",
       ],
-      "scripts": [],
       "stylePreprocessorOptions": {
         "includePaths": [
           "node_modules/",

--- a/projects/schematics/src/shared/utils/feature-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/feature-utils_spec.ts
@@ -1,10 +1,3 @@
-/*
- * We'll be able to import `firstValueFrom` directly from 'rxjs' only after we bump `@angular-devkit/schematics`,
- * because typings of `@angular-devkit/schematics/node_modules/rxjs@7.8.1` are not compatible with
- * typings of the `rxjs@7.8.2` globally installed in our repo.
- */
-import { firstValueFrom } from '@angular-devkit/schematics/node_modules/rxjs';
-
 import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import {
@@ -13,6 +6,7 @@ import {
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
 import * as path from 'path';
+import { firstValueFrom } from 'rxjs';
 import { Schema as SpartacusOptions } from '../../add-spartacus/schema';
 import { UTF_8 } from '../constants';
 import {

--- a/projects/schematics/src/shared/utils/file-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/file-utils_spec.ts
@@ -1032,7 +1032,7 @@ describe('File utils', () => {
       it('should return the InsertChanges', async () => {
         const filePath = '/src/app/app.component.ts';
         const source = getTsSourceFile(appTree, filePath);
-        const identifierName = 'AppComponent';
+        const identifierName = 'App';
         const commentToInsert = 'comment';
 
         const changes = insertCommentAboveIdentifier(
@@ -1042,7 +1042,7 @@ describe('File utils', () => {
           commentToInsert
         );
         expect(changes).toEqual([
-          new InsertChange(filePath, 179, commentToInsert),
+          new InsertChange(filePath, 187, commentToInsert),
         ]);
       });
     });
@@ -1051,7 +1051,7 @@ describe('File utils', () => {
       it('should return the ReplaceChange', async () => {
         const filePath = '/src/app/app.component.ts';
         const source = getTsSourceFile(appTree, filePath);
-        const oldName = 'AppComponent';
+        const oldName = 'App';
         const newName = 'NewAppComponent';
 
         const changes = renameIdentifierNode(
@@ -1061,7 +1061,7 @@ describe('File utils', () => {
           newName
         );
         expect(changes).toEqual([
-          new ReplaceChange(filePath, 192, oldName, newName),
+          new ReplaceChange(filePath, 200, oldName, newName),
         ]);
       });
     });

--- a/projects/schematics/src/shared/utils/import-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/import-utils_spec.ts
@@ -1,9 +1,4 @@
-/*
- * We'll be able to import `firstValueFrom` directly from 'rxjs' only after we bump `@angular-devkit/schematics`,
- * because typings of `@angular-devkit/schematics/node_modules/rxjs@7.8.1` are not compatible with
- * typings of the `rxjs@7.8.2` globally installed in our repo.
- */
-import { firstValueFrom } from '@angular-devkit/schematics/node_modules/rxjs';
+import { firstValueFrom } from 'rxjs';
 
 import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';

--- a/projects/schematics/src/shared/utils/lib-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/lib-utils_spec.ts
@@ -1,17 +1,12 @@
 import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-/*
- * We'll be able to import `firstValueFrom` directly from 'rxjs' only after we bump `@angular-devkit/schematics`,
- * because typings of `@angular-devkit/schematics/node_modules/rxjs@7.8.1` are not compatible with
- * typings of the `rxjs@7.8.2` globally installed in our repo.
- */
-import { firstValueFrom } from '@angular-devkit/schematics/node_modules/rxjs';
 import {
   Schema as ApplicationOptions,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
 import * as path from 'path';
+import { firstValueFrom } from 'rxjs';
 import { Schema as SpartacusOptions } from '../../add-spartacus/schema';
 import { CDS_CONFIG, UTF_8 } from '../constants';
 import {

--- a/projects/schematics/src/shared/utils/new-module-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/new-module-utils_spec.ts
@@ -1,9 +1,4 @@
-/*
- * We'll be able to import `firstValueFrom` directly from 'rxjs' only after we bump `@angular-devkit/schematics`,
- * because typings of `@angular-devkit/schematics/node_modules/rxjs@7.8.1` are not compatible with
- * typings of the `rxjs@7.8.2` globally installed in our repo.
- */
-import { firstValueFrom } from '@angular-devkit/schematics/node_modules/rxjs';
+import { firstValueFrom } from 'rxjs';
 
 import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';


### PR DESCRIPTION
- adjusted import statements to use firstValueFrom directly from 'rxjs'.
- updated snapshots
- added `typeSeparator: "."` for module schematics and `type: "component"` for component chematics
- the name of the searched component has been changed from `AppComponent` to `App` to be in line with name from the fresh ng20 app