### PR TITLE
fix: CXSPA-11548 Installation script

### DIFF
--- a/scripts/install/functions.sh
+++ b/scripts/install/functions.sh
@@ -95,6 +95,10 @@ function create_shell_app {
         EXTRA_ANGULAR_CLI_FLAGS="--standalone=false --ssr=false" # SSR can be added later by running other schematics (e.g. Spartacus installation schematics with its flag --ssr).
         echo "Angular CLI version >= 17.0.0, so applying extra flags to the command 'ng new': ${EXTRA_ANGULAR_CLI_FLAGS}"
     fi
+    if [ "$(compareSemver "$ANGULAR_CLI_VERSION" "20.0.0")" -ge 0 ]; then
+        EXTRA_ANGULAR_CLI_FLAGS="${EXTRA_ANGULAR_CLI_FLAGS} --zoneless=false --ai-config=none"
+        echo "Angular CLI version >= 20.0.0, so applying extra flag --zoneless=false"
+    fi
 
     ( cd ${INSTALLATION_DIR} && \
         ng new ${1} \


### PR DESCRIPTION
- adjust installation script to add  and  flags when scaffolding fresh app

QA:
- cp config.default.sh config.sh
- change the following variables:
  ```bash
  BACKEND_URL="https://40.76.109.9:9002"
  ANGULAR_CLI_VERSION='^20.3.0'
  BRANCH='spike/angular-20-upgrade'
  ```
- `cd scripts/install`
- run `bash run.sh install`
- run `bash run.sh start` to run Spartacus in CSR and SSR
- verify that started apps work as expected