### PR TITLE
fix: Loading homepage content on logout

### DIFF
--- a/projects/core/src/routing/store/reducers/router.reducer.ts
+++ b/projects/core/src/routing/store/reducers/router.reducer.ts
@@ -140,7 +140,7 @@ export class CustomSerializer
           state.routeConfig?.canActivate?.find(
             (x) =>
               x &&
-              typeof x === 'object' &&
+              typeof x === 'function' &&
               'guardName' in x &&
               x.guardName === 'CmsPageGuard'
           ))


### PR DESCRIPTION
fix typing. 

caused skipping setting a flag `cmsRequired`  to `true`
and that caused skipping triggering `refreshPage$` in `page.effect.ts` on logout.