### PR TITLE
docs: CXSPA-11547 Installation and migration docs

### DIFF
--- a/docs/migration/221121_ng20/installation.md
+++ b/docs/migration/221121_ng20/installation.md
@@ -38,7 +38,7 @@ The schematics will:
 - Install required Spartacus libraries
 - Configure your application for Spartacus
 
-## Step 4: SSR-Specific Configuration (If Using SSR)
+## Step 3: SSR-Specific Configuration (If Using SSR)
 
 For Spartacus with Server-Side Rendering (SSR), run the following command:
 

--- a/docs/migration/221121_ng20/installation.md
+++ b/docs/migration/221121_ng20/installation.md
@@ -1,0 +1,76 @@
+# Installing Spartacus 2211.21 with Angular 20
+
+This guide provides step-by-step instructions for creating a fresh Angular 20 application and installing Spartacus 2211.21.
+
+## Prerequisites
+
+Before starting, ensure you have the following installed:
+
+- **Node.js**: Version 22 or higher
+- **npm**: Version 10 or higher
+- **Angular CLI**: Version 20
+
+Install or update Angular CLI globally:
+
+```bash
+npm install -g @angular/cli@20
+```
+
+## Step 1: Create a New Angular 20 Application
+
+Create a new Angular 20 application:
+
+```bash
+ng new my-spartacus-app --style=scss --ssr=false --zoneless=false --standalone=false
+cd my-spartacus-app
+```
+
+## Step 2: Install Spartacus
+
+Run the Spartacus schematics to add Spartacus to your project:
+
+```bash
+ng add @spartacus/schematics@221121.<latest>
+```
+
+The schematics will:
+- rename files in the project to use classic file name style guide (e.g., `app.component.ts` instead of `app.ts`)
+- Install required Spartacus libraries
+- Configure your application for Spartacus
+
+## Step 4: SSR-Specific Configuration (If Using SSR)
+
+For Spartacus with Server-Side Rendering (SSR), run the following command:
+
+```bash
+ng add @spartacus/schematics@221121.<latest> --ssr
+```
+This will set up SSR-specific configurations.
+
+### Manual Changes for SSR with `application` builder
+
+If you enabled SSR during project creation, you need to make an additional manual changes in the project files:
+
+1. remove `app.routes.server.ts` file as it is not supported by Spartacus SSR.
+2. remove `provideServerRendering` from `app.server.module.ts` file:
+
+```diff
+import { NgModule } from '@angular/core';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
+import { provideServer } from '@spartacus/setup/ssr';
+import { App } from './app.component';
+import { AppModule } from './app.module';
+import { serverRoutes } from './app.routes.server';
+
+@NgModule({
+  imports: [AppModule],
+  providers: [
+-   provideServerRendering(withRoutes(serverRoutes)),
+    ...provideServer({
+      serverRequestOrigin: process.env['SERVER_REQUEST_ORIGIN'],
+    }),
+  ],
+  bootstrap: [App],
+})
+export class AppServerModule {}
+```

--- a/docs/migration/221121_ng20/migration.md
+++ b/docs/migration/221121_ng20/migration.md
@@ -2,7 +2,7 @@
 
 Before upgrading Spartacus to the new version with Angular 20, you need to first:
 
-- upgrade Spartacus to version 2211.36 (with Angular 19)
+- upgrade Spartacus to version 221121.4.0 (with Angular 19)
 - install Node 22 version
 - if your project uses SSR (Server-Side Rendering), please upgrade `@types/node` to version 22
 
@@ -21,7 +21,7 @@ git add .
 git commit -m "update angular 20 and 3rd party deps angular 20 compatible"
 ```
 
-While migrating to Angular 18, you'll be asked whether to run the `use-application-builder` migration:
+While migrating to Angular 20, you'll be asked whether to run the `use-application-builder` migration:
 
 `❯◯ [use-application-builder] Migrate application projects to the new build system.`
 

--- a/docs/migration/221121_ng20/migration.md
+++ b/docs/migration/221121_ng20/migration.md
@@ -1,0 +1,234 @@
+# Migrating a custom app to use Spartacus with Angular 20
+
+Before upgrading Spartacus to the new version with Angular 20, you need to first:
+
+- upgrade Spartacus to version 2211.36 (with Angular 19)
+- install Node 22 version
+- if your project uses SSR (Server-Side Rendering), please upgrade `@types/node` to version 22
+
+  ```bash
+  npm i @types/node@22 -D
+  ```
+- upgrade Angular to version v20
+
+## Update Angular to 20 and 3rd party deps to be compatible with Angular 20
+
+Follow the [Angular guidelines for upgrading from v19 to v20](https://angular.dev/update-guide?v=19.0-20.0&l=3) and bump the Angular version locally, and update other 3rd party dependencies from Angular ecosystem to versions compatible with Angular 20 (e.g. `@ng-select/ng-select@latest`, `@ngrx/store@20`, `angular-oauth2-oidc@20`, `ngx-infinite-scroll@latest`):
+
+```bash
+ng update @angular/core@20 @angular/cli@20 @ngrx/store@20 angular-oauth2-oidc@20 @ng-select/ng-select@20 ngx-infinite-scroll@20 --force
+git add .
+git commit -m "update angular 20 and 3rd party deps angular 20 compatible"
+```
+
+While migrating to Angular 18, you'll be asked whether to run the `use-application-builder` migration:
+
+`❯◯ [use-application-builder] Migrate application projects to the new build system.`
+
+Let's select this migration to replace old builders located under `@angular-devkit/build-angular` with new ones under `@angular/build`.
+
+The result of migration should be following:
+
+```diff
+ "projects": {
+    <your-project-name>: {
+      "projectType": "application",
++      "root": "",
++      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+-          "builder": "@angular-devkit/build-angular:application",
++          "builder": "@angular/build:application",
+            ...
+        },
+        "serve": {
+-          "builder": "@angular-devkit/build-angular:dev-server",
++          "builder": "@angular/build:dev-server",
+          ...
+        },
+        "extract-i18n": {
+-          "builder": "@angular-devkit/build-angular:extract-i18n"
++          "builder": "@angular/build:extract-i18n"
+        },
+        "test": {
+-          "builder": "@angular-devkit/build-angular:karma",
++          "builder": "@angular/build:karma",
+        }
+      }
+    },
++   "schematics": {
++    "@schematics/angular:component": {
++      "type": "component"
++    },
++    "@schematics/angular:directive": {
++      "type": "directive"
++    },
++    "@schematics/angular:service": {
++      "type": "service"
++    },
++    "@schematics/angular:guard": {
++      "typeSeparator": "."
++    },
++    "@schematics/angular:interceptor": {
++      "typeSeparator": "."
++    },
++    "@schematics/angular:module": {
++      "typeSeparator": "."
++    },
++    "@schematics/angular:pipe": {
++      "typeSeparator": "."
++    },
++    "@schematics/angular:resolver": {
++      "typeSeparator": "."    }
++  }
+```
+
+Angular migration also takes care of adding `"typeSeparator": "."` to and proper type (suffix) to relevant schematics.
+
+## Run Spartacus update
+
+After successfully updating the application to Angular 20 and Express 5, execute this command to initiate the Spartacus update process.
+
+```bash
+ng update @spartacus/schematics@2211.21
+```
+
+### Manual changes
+
+Let's make following manual changes to modernize so it's similar to a new Angular 20 application.
+
+1. In `angular.json`, remove redundant `index` property. For more, see: https://github.com/angular/angular-cli/commit/901ab60d9f63fcff17213dbf7fe17e4a46835974
+
+```diff
+ "projects": {
+    <your-project-name>: {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "options": {
+            "outputPath": "dist/<your-project-name>",
+-            "index": "src/index.html",
+            "browser": "src/main.ts",
+            "polyfills": [
+              "zone.js"
+            ],
+            ...
+        }
+      }
+    }
+```
+
+2. In `tsconfig.json`, update the `types` array to include `"node20"` instead of `"node"`:
+
+```diff
+/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+-    "outDir": "./dist/out-tsc",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+-    "esModuleInterop": true,
+    "experimentalDecorators": true,
+-    "moduleResolution": "bundler",
+    "importHelpers": true,
+    "target": "ES2022",
+-    "module": "ES2022"
++    "module": "preserve"
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
++    "typeCheckHostBindings": true,
+    "strictTemplates": true
+  },
++  "files": [],
++  "references": [
++    {
++      "path": "./tsconfig.app.json"
++    },
++    {
++      "path": "./tsconfig.spec.json"
++    }
++  ]
++}
+```
+
+1. In `app.module.ts`, add the `provideBrowserGlobalErrorListeners` to the `providers` array. For more, see: https://angular.dev/best-practices/error-handling#client-side-rendering
+
+```diff
+-import { NgModule } from '@angular/core';
++import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { provideHttpClient, withFetch, withInterceptorsFromDi } from "@angular/common/http";
+import { EffectsModule } from "@ngrx/effects";
+import { StoreModule } from "@ngrx/store";
+import { AppRoutingModule } from "@spartacus/storefront";
+import { App } from './app.component';
+import { SpartacusModule } from './spartacus/spartacus.module';
+
+@NgModule({
+  declarations: [
+    App
+  ],
+  imports: [
+    BrowserModule,
+    StoreModule.forRoot({}),
+    AppRoutingModule,
+    EffectsModule.forRoot([]),
+    SpartacusModule
+  ],
+  providers: [
++    provideBrowserGlobalErrorListeners(),
+    provideHttpClient(withFetch(), withInterceptorsFromDi())
+  ],
+  bootstrap: [App]
+})
+export class AppModule { }
+```
+
+## If using Server Side Rendering (SSR)
+
+### Upgrade Express to Version 5
+
+Spartacus 221121.<latest> requires Express 5.x. Upgrade Express:
+
+```bash
+npm install express@^5.1.0
+git add .
+git commit -m "chore: upgrade Express to v5"
+```
+
+### Manual changes
+1. In `server.ts`, update wildcard strings with regular expressions for Express 5 compatibility:
+
+```diff
+  // Serve static files from /browser
+  server.get(
+-    '*.*',
++    /.*\..*/,
+    express.static(browserDistFolder, {
+      maxAge: '1y',
+    })
+  );
+
+  // All regular routes use the Universal engine
+-  server.get('*', (req, res) => {
++  server.get(/.*/, (req, res) => {
+    res.render(indexHtml, {
+      req,
+      providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],
+    });
+  });


### PR DESCRIPTION
This PR introduces installation and migration docs containing required manual steps necessary to perform in fresh and migrated apps, with and without SSR.

Ideally, we'd like to automate most of these steps in the future.

QA steps:

Prerequisites:
- change version of all libs from `221121.4.0` to a bigger number (e.g `221121.5.0`) and run `npm run build:libs`
  - we need to change version to higher than the one availoable on RBSC, for migration purposes
- in the root folder, run `npx ts-node ./tools/schematics/testing`
- in a wizard, select `publish`
   **NOTE:** terminal needs to be open until testing is finished
- open [Verdaccio](http://localhost:4873/) and verify if all all packages are published and have expected version. 

1. Installation:
  - CSR:
    - open `[docs/migration/221121_ng20/installation.md](https://github.com/SAP/spartacus/compare/epic/angular-20-upgrade...docs/CXSPA-11547-installation-and-migration-docs?expand=1#diff-d4bfb8110dbbb7ded448c7a4b021862f875007f287eb0031679f6b13b535b184) and follow steps 1 and 2
    - run `npm run start` to verify if app works in dev mode
    - run `npm run build` to verify the build
  - SSR
    - open `[docs/migration/221121_ng20/installation.md](https://github.com/SAP/spartacus/compare/epic/angular-20-upgrade...docs/CXSPA-11547-installation-and-migration-docs?expand=1#diff-d4bfb8110dbbb7ded448c7a4b021862f875007f287eb0031679f6b13b535b184) and follow all steps, including the 3rd
    - run `npm run start` to verify if app works in dev mode
    - run `npm run build`
    - run `NODE_TLS_REJECT_UNAUTHORIZED=0 run serve:ssr:<your-app-name>` to verify if prod build with SSR works
 
 2. Migration
   - CSR
     - create fresh Angular 19 app:
       ```bash
       npx @angular/cli@19 new my-app --standalone=false --ssr=false
       ```
     - in created location, create file `.npmrc`
        ```
        cd my app && touch .npmrc
        ```
     - paste the following snippet inside `.npmrc` to make installation from RBSC possible: 
        ```bash
        always-auth=true
        @spartacus:registry=https://73554900100900004337.dev.npmsrv.base.repositories.cloud.sap/
        //73554900100900004337.dev.npmsrv.base.repositories.cloud.sap/:_auth=<YOUR_TOKEN>
        ```
        Pur your RBSC token instead of `<YOUR_TOKEN>`. For generating the token, see: https://wiki.one.int.sap/wiki/display/spar/How+to+Get+the+Access+Tokens+Required+to+Download+RBSC+Packages
     - install Spartacus in fresh app:
        ```bash
        npx ng add @spartacus/schematics --debug
        ```
     - open [docs/migration/221121_ng20/migration.md](https://github.com/SAP/spartacus/compare/epic/angular-20-upgrade...docs/CXSPA-11547-installation-and-migration-docs?expand=1#diff-0b4d558a20d726dfd3be3f9fb8d61352ac16650b1e2a9ec51934d1d9dfc65877) and follow migration steps for CSR
     **NOTE:** remove local `.npmrc` file from the project so Spartacus for migration is taken from the Verdaccio (step required in prerequisites)
     - run `npm run start` to verify if app works in dev mode
     - run `npm run build` to verify the build
     - compare files to fresh Angular 20 with Spartacus
   
  - SSR
    - create fresh Angular 19 app:
       ```bash
        npx @angular/cli@19 new my-app --standalone=false --ssr=false
       ```
    - in created location, create file `.npmrc`
      ```
      cd my app && touch .npmrc
      ```
    - paste the following snippet inside `.npmrc` to make installation from RBSC possible: 
      ```bash
      always-auth=true
      @spartacus:registry=https://73554900100900004337.dev.npmsrv.base.repositories.cloud.sap/
      //73554900100900004337.dev.npmsrv.base.repositories.cloud.sap/:_auth=<YOUR_TOKEN>
      ```
      Pur your RBSC token instead of `<YOUR_TOKEN>`. For generating the token, see: https://wiki.one.int.sap/wiki/display/spar/How+to+Get+the+Access+Tokens+Required+to+Download+RBSC+Packages
    - install Spartacus in fresh app:
      ```bash
      npx ng add @spartacus/schematics --ssr --debug
      ```
    - open [docs/migration/221121_ng20/migration.md](https://github.com/SAP/spartacus/compare/epic/angular-20-upgrade...docs/CXSPA-11547-installation-and-migration-docs?expand=1#diff-0b4d558a20d726dfd3be3f9fb8d61352ac16650b1e2a9ec51934d1d9dfc65877) and follow migration steps for CSR+SSR
    **NOTE:** remove local `.npmrc` file from the project so Spartacus for migration is taken from the Verdaccio (step required in prerequisites)
     - run `npm run start` to verify if app works in dev mode
     - run `npm run build`
     - run `NODE_TLS_REJECT_UNAUTHORIZED=0 run serve:ssr:<your-app-name>` to verify if prod build with SSR works
     - compare files to fresh Angular 20 with Spartacus with SSR