### PR TITLE
fix: use sanitizer pipe instead of calling method in cms-paragraph

### DIFF
--- a/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.html
+++ b/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.html
@@ -1,4 +1,4 @@
 <div
   *ngIf="component.data$ | async as data"
-  [innerHTML]="bypassSecurityTrustHtml(data.content | cxSupplementHashAnchors)"
+  [innerHTML]="data.content | cxSupplementHashAnchors | cxBypassSecurityTrustHtml"
 ></div>

--- a/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.spec.ts
+++ b/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.spec.ts
@@ -17,12 +17,21 @@ export class MockAnchorPipe implements PipeTransform {
   }
 }
 
+@Pipe({
+  name: 'cxBypassSecurityTrustHtml',
+  standalone: false,
+})
+export class MockTrustPipe implements PipeTransform {
+  public transform(html: string): string {
+    return html;
+  }
+}
+
 describe('CmsParagraphComponent in CmsLib', () => {
   let paragraphComponent: ParagraphComponent;
   let fixture: ComponentFixture<ParagraphComponent>;
   let el: DebugElement;
   let router: Router;
-  let domSanitizer: DomSanitizer;
 
   const componentData: CmsParagraphComponent = {
     uid: '001',
@@ -48,7 +57,7 @@ describe('CmsParagraphComponent in CmsLib', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [MockAnchorPipe, ParagraphComponent],
+      declarations: [MockAnchorPipe, ParagraphComponent, MockTrustPipe],
       providers: [
         {
           provide: CmsComponentData,
@@ -63,7 +72,6 @@ describe('CmsParagraphComponent in CmsLib', () => {
     fixture = TestBed.createComponent(ParagraphComponent);
     paragraphComponent = fixture.componentInstance;
     router = TestBed.inject(Router);
-    domSanitizer = TestBed.inject(DomSanitizer);
 
     el = fixture.debugElement;
   });
@@ -77,17 +85,6 @@ describe('CmsParagraphComponent in CmsLib', () => {
     fixture.detectChanges();
     expect(el.query(By.css('div')).nativeElement.textContent).toEqual(
       componentData.content
-    );
-  });
-
-  it('should sanitize unsafe html', () => {
-    const unsafeData = Object.assign({}, componentData);
-    unsafeData.content = `<img src="" onerror='alert(1)'>`;
-    data$.next(unsafeData);
-    spyOn(console, 'warn').and.stub(); // Prevent warning to be showed by Angular when sanitizing
-    fixture.detectChanges();
-    expect(el.query(By.css('div')).nativeElement.innerHTML).toEqual(
-      `<img src="">`
     );
   });
 
@@ -128,18 +125,6 @@ describe('CmsParagraphComponent in CmsLib', () => {
       const link = setupLink(url);
       link.click();
       expect(router.navigateByUrl).toHaveBeenCalledWith(url);
-    });
-
-    it('should call DOM sanitizer', () => {
-      const bypassSecurityTrustHtmlSpy = spyOn(
-        domSanitizer,
-        'bypassSecurityTrustHtml'
-      ).and.callThrough();
-
-      data$.next(componentData);
-      fixture.detectChanges();
-
-      expect(bypassSecurityTrustHtmlSpy).toHaveBeenCalled();
     });
 
     it('should not pass root url to router navigation for internal links ', () => {

--- a/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.ts
+++ b/projects/storefrontlib/cms-components/content/paragraph/paragraph.component.ts
@@ -7,10 +7,8 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  HostListener,
-  inject,
+  HostListener
 } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { CmsParagraphComponent } from '@spartacus/core';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
@@ -22,8 +20,6 @@ import { CmsComponentData } from '../../../cms-structure/page/model/cms-componen
   standalone: false,
 })
 export class ParagraphComponent {
-  protected sanitizer = inject(DomSanitizer);
-
   @HostListener('click', ['$event'])
   public handleClick(event: Event): void {
     if (event.target instanceof HTMLAnchorElement) {
@@ -43,8 +39,4 @@ export class ParagraphComponent {
     public component: CmsComponentData<CmsParagraphComponent>,
     protected router: Router
   ) {}
-
-  public bypassSecurityTrustHtml(html: string = ''): SafeHtml {
-    return this.sanitizer.bypassSecurityTrustHtml(html);
-  }
 }

--- a/projects/storefrontlib/cms-components/content/paragraph/paragraph.module.ts
+++ b/projects/storefrontlib/cms-components/content/paragraph/paragraph.module.ts
@@ -8,11 +8,17 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CmsConfig, provideDefaultConfig } from '@spartacus/core';
+import { BypassSecurityTrustHtmlModule } from '../../../shared/pipes/bypass-security-trust-html/bypass-security-trust-html.module';
 import { SupplementHashAnchorsModule } from '../../../shared/pipes/suplement-hash-anchors/supplement-hash-anchors.module';
 import { ParagraphComponent } from './paragraph.component';
 
 @NgModule({
-  imports: [CommonModule, RouterModule, SupplementHashAnchorsModule],
+  imports: [
+    CommonModule,
+    RouterModule,
+    SupplementHashAnchorsModule,
+    BypassSecurityTrustHtmlModule,
+  ],
   providers: [
     provideDefaultConfig(<CmsConfig>{
       cmsComponents: {

--- a/projects/storefrontlib/shared/pipes/bypass-security-trust-html/bypass-security-trust-html.module.ts
+++ b/projects/storefrontlib/shared/pipes/bypass-security-trust-html/bypass-security-trust-html.module.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NgModule } from '@angular/core';
+import { BypassSecurityTrustHtmlPipe } from './bypass-security-trust-html.pipe';
+
+@NgModule({
+  declarations: [BypassSecurityTrustHtmlPipe],
+  exports: [BypassSecurityTrustHtmlPipe],
+})
+export class BypassSecurityTrustHtmlModule {}

--- a/projects/storefrontlib/shared/pipes/bypass-security-trust-html/bypass-security-trust-html.pipe.spec.ts
+++ b/projects/storefrontlib/shared/pipes/bypass-security-trust-html/bypass-security-trust-html.pipe.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
+import { BypassSecurityTrustHtmlPipe } from './bypass-security-trust-html.pipe';
+
+describe('BypassSecurityTrustHtmlPipe', () => {
+  let pipe: BypassSecurityTrustHtmlPipe;
+  let sanitizer: DomSanitizer;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [BypassSecurityTrustHtmlPipe],
+    });
+
+    pipe = TestBed.inject(BypassSecurityTrustHtmlPipe);
+    sanitizer = TestBed.inject(DomSanitizer);
+  });
+
+  it('should create the pipe', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return SafeHtml using DomSanitizer', () => {
+    const html = `<div><a href="#test">link</a></div>`;
+    const result = pipe.transform(html);
+
+    // The return should be a SafeHtml wrapper
+    expect(result).toBeTruthy();
+    expect(result).toEqual(sanitizer.bypassSecurityTrustHtml(html));
+  });
+
+  it('should return SafeHtml even for empty string', () => {
+    const result = pipe.transform('');
+    expect(result).toEqual(sanitizer.bypassSecurityTrustHtml(''));
+  });
+
+  it('should return SafeHtml for undefined input as empty string', () => {
+    const result = pipe.transform(undefined);
+    expect(result).toEqual(sanitizer.bypassSecurityTrustHtml(''));
+  });
+});

--- a/projects/storefrontlib/shared/pipes/bypass-security-trust-html/bypass-security-trust-html.pipe.ts
+++ b/projects/storefrontlib/shared/pipes/bypass-security-trust-html/bypass-security-trust-html.pipe.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { inject, Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+/*
+ * Converts the provided HTML string into SafeHtml using Angular’s DomSanitizer,
+ * allowing HTML content — normally blocked for security reasons — to be safely
+ * rendered in the template (e.g., CMS-provided content used with [innerHTML]).
+ *
+ * Note: this pipe only bypasses Angular’s built-in security checks;
+ * it does **not** sanitize or modify the HTML. Use it only when the input
+ * content is trusted.
+ */
+@Pipe({
+  name: 'cxBypassSecurityTrustHtml',
+  standalone: false,
+})
+export class BypassSecurityTrustHtmlPipe implements PipeTransform {
+  protected sanitizer = inject(DomSanitizer);
+
+  public transform(html: string = ''): SafeHtml {
+    return this.sanitizer.bypassSecurityTrustHtml(html);
+  }
+}


### PR DESCRIPTION
When clicking on a CMS Paragraph, the component was being recreated in the DOM — visible as a flicker in the DevTools.
The issue occurred because the bypassSecurityTrustHtml method was being called directly from the template. Since this method runs on every change detection cycle, it continuously produced new SafeHtml instances. As a result, Angular interpreted the content as changed even when it wasn’t.

This disrupted the component’s lifecycle and caused it to be constantly re-rendered, leading to the flickering effect.

To fix the issue, I replaced the direct method call with a new pipe (cxBypassSecurityTrustHtml). The pipe ensures stable references according to Angular’s change detection strategy, preventing unnecessary reprocessing and stopping the component from being recreated.

With this change, the component remains stable during change detection, and the flickering no longer occurs.

https://github.com/user-attachments/assets/5db44017-5ffe-4c97-9990-6327eb72a95d


