### PR TITLE
fix: isCartUserGuest - Incorrect user email information definition in multi-site

### DIFF
--- a/feature-libs/cart/base/core/facade/active-cart.service.ts
+++ b/feature-libs/cart/base/core/facade/active-cart.service.ts
@@ -541,7 +541,7 @@ export class ActiveCartService implements ActiveCartFacade, OnDestroy {
     return Boolean(
       cartUser &&
         (cartUser.name === OCC_USER_ID_GUEST ||
-          isEmail(cartUser.uid?.split('|').slice(1).join('|')))
+          isEmail(cartUser.uid?.split('|').slice(1)[0]))
     );
   }
 


### PR DESCRIPTION
In multi-site projects, the uid information in cart.user includes the user's email along with the baseSite information.

For example: 7c867be3-d7c6-442b-aff9-7f1c315ee838|[site@example.com](mailto:site@example.com)|apparel-uk

In the isCartUserGuest function in activeCartService, the user's email is checked as "[site@example.com](mailto:site@example.com)|apparel-uk" for the isEmail check. Since the email address contains the "|" character, the isEmail function returns false. After the credit card is saved in the Guest checkout steps, the "cart.user.name" value changes. Since the isEmail function also returns false, checkout.guard cannot be passed and the user needs to set the email again. However, since the email is already set, the user receives an error while setting the email again and cannot continue with the process.

It was recreated through a different branch: https://github.com/SAP/spartacus/pull/20200