### PR TITLE
feat: The site-context getLabel has been made multilingual

### DIFF
--- a/projects/assets/src/translations/cs/common.json
+++ b/projects/assets/src/translations/cs/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Zmenšit",
     "selected": "Vybráno",
     "expand": "Rozbalit",
-    "collapse": "Sbalit"
+    "collapse": "Sbalit",
+    "language": "Jazyk",
+    "currency": "Měna"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/de/common.json
+++ b/projects/assets/src/translations/de/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Verkleinern",
     "selected": "Ausgewählt",
     "expand": "Expandieren",
-    "collapse": "Komprimieren"
+    "collapse": "Komprimieren",
+    "language": "Sprache",
+    "currency": "Währung"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/en/common.json
+++ b/projects/assets/src/translations/en/common.json
@@ -34,6 +34,8 @@
     "selected": "Selected",
     "expand": "Expand",
     "collapse": "Collapse",
+    "language": "Language",
+    "currency": "Currency",
     "readMore": "Read More",
     "readLess": "Read Less"
   },

--- a/projects/assets/src/translations/es/common.json
+++ b/projects/assets/src/translations/es/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Alejar",
     "selected": "Seleccionado",
     "expand": "Ampliar",
-    "collapse": "Contraer"
+    "collapse": "Contraer",
+    "language": "Idioma",
+    "currency": "Moneda"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/es_CO/common.json
+++ b/projects/assets/src/translations/es_CO/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Alejar",
     "selected": "Seleccionado",
     "expand": "Ampliar",
-    "collapse": "Contraer"
+    "collapse": "Contraer",
+    "language": "Idioma",
+    "currency": "Moneda"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/fr/common.json
+++ b/projects/assets/src/translations/fr/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Zoom arrière",
     "selected": "Sélectionné",
     "expand": "Développer",
-    "collapse": "Réduire"
+    "collapse": "Réduire",
+    "language": "Langue",
+    "currency": "Devise"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/hi/common.json
+++ b/projects/assets/src/translations/hi/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "ज़ूम आउट",
     "selected": "चयनित",
     "expand": "विस्तृत करें",
-    "collapse": "संकुचित करें"
+    "collapse": "संकुचित करें",
+    "language": "भाषा",
+    "currency": "मुद्रा"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/hu/common.json
+++ b/projects/assets/src/translations/hu/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Kicsinyítés",
     "selected": "Kiválasztva",
     "expand": "Kibontás",
-    "collapse": "Összecsukás"
+    "collapse": "Összecsukás",
+    "language": "Nyelv",
+    "currency": "Pénznem"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/id/common.json
+++ b/projects/assets/src/translations/id/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Perkecil",
     "selected": "Dipilih",
     "expand": "Perluas",
-    "collapse": "Ciutkan"
+    "collapse": "Ciutkan",
+    "language": "Bahasa",
+    "currency": "Mata Uang"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/it/common.json
+++ b/projects/assets/src/translations/it/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Riduci",
     "selected": "Selezionato",
     "expand": "Espandi",
-    "collapse": "Comprimi"
+    "collapse": "Comprimi",
+    "language": "Lingua",
+    "currency": "Valuta"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/ja/common.json
+++ b/projects/assets/src/translations/ja/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "縮小",
     "selected": "選択済み",
     "expand": "展開",
-    "collapse": "折りたたむ"
+    "collapse": "折りたたむ",
+    "language": "言語",
+    "currency": "通貨"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/ko/common.json
+++ b/projects/assets/src/translations/ko/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "축소",
     "selected": "선택됨",
     "expand": "펼치기",
-    "collapse": "접기"
+    "collapse": "접기",
+    "language": "언어",
+    "currency": "통화"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/pl/common.json
+++ b/projects/assets/src/translations/pl/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Pomniejsz",
     "selected": "Wybrane",
     "expand": "Rozwiń",
-    "collapse": "Zwiń"
+    "collapse": "Zwiń",
+    "language": "Język",
+    "currency": "Waluta"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/pt/common.json
+++ b/projects/assets/src/translations/pt/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Reduzir",
     "selected": "Selecionado",
     "expand": "Expandir",
-    "collapse": "Comprimir"
+    "collapse": "Comprimir",
+    "language": "Idioma",
+    "currency": "Moeda"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/ru/common.json
+++ b/projects/assets/src/translations/ru/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "Уменьшить",
     "selected": "Выбрано",
     "expand": "Развернуть",
-    "collapse": "Свернуть"
+    "collapse": "Свернуть",
+    "language": "Язык",
+    "currency": "Валюта"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/zh/common.json
+++ b/projects/assets/src/translations/zh/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "缩小",
     "selected": "已选择",
     "expand": "展开",
-    "collapse": "折叠"
+    "collapse": "折叠",
+    "language": "语言",
+    "currency": "货币"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/assets/src/translations/zh_TW/common.json
+++ b/projects/assets/src/translations/zh_TW/common.json
@@ -33,7 +33,9 @@
     "zoomOut": "縮小",
     "selected": "已選擇",
     "expand": "展開",
-    "collapse": "收縮"
+    "collapse": "收縮",
+    "language": "語言",
+    "currency": "貨幣"
   },
   "pageMetaResolver": {
     "category": {

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-component.service.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-component.service.ts
@@ -12,16 +12,12 @@ import {
   isNotUndefined,
   LANGUAGE_CONTEXT_ID,
   SiteContext,
+  TranslationService,
 } from '@spartacus/core';
 import { Observable, of } from 'rxjs';
 import { filter, map, switchMap, take } from 'rxjs/operators';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 import { SiteContextType } from './site-context.model';
-
-const LABELS: { [key: string]: string } = {
-  [LANGUAGE_CONTEXT_ID]: 'Language',
-  [CURRENCY_CONTEXT_ID]: 'Currency',
-};
 
 @Injectable()
 export class SiteContextComponentService {
@@ -29,7 +25,8 @@ export class SiteContextComponentService {
     @Optional()
     protected componentData: CmsComponentData<CmsSiteContextSelectorComponent>,
     private contextServiceMap: ContextServiceMap,
-    protected injector: Injector
+    protected injector: Injector,
+    protected translationService: TranslationService,
   ) {}
 
   getItems(context?: SiteContextType): Observable<any> {
@@ -58,12 +55,13 @@ export class SiteContextComponentService {
     );
   }
 
-  getLabel(context?: SiteContextType): Observable<any> {
+  getLabel(context?: SiteContextType): Observable<string> {
     return this.getContext(context).pipe(
-      map((ctx) => {
+      switchMap((ctx) => {
         if (ctx) {
-          return LABELS[ctx];
+          return this.translationService.translate(`common.${ctx}`);
         }
+        return of('');
       })
     );
   }

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.component.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.component.ts
@@ -50,7 +50,7 @@ export class SiteContextSelectorComponent {
     this.componentService.setActive(value, this.context);
   }
 
-  get label$(): Observable<any> {
+  get label$(): Observable<string> {
     return this.componentService.getLabel(this.context);
   }
 

--- a/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.module.ts
+++ b/projects/storefrontlib/cms-components/misc/site-context-selector/site-context-selector.module.ts
@@ -12,6 +12,7 @@ import {
   ContextServiceMap,
   provideDefaultConfig,
   SiteContextModule,
+  TranslationService,
 } from '@spartacus/core';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 import { IconModule } from '../icon/index';
@@ -30,7 +31,7 @@ import { SiteContextSelectorComponent } from './site-context-selector.component'
             {
               provide: SiteContextComponentService,
               useClass: SiteContextComponentService,
-              deps: [CmsComponentData, ContextServiceMap, Injector],
+              deps: [CmsComponentData, ContextServiceMap, Injector, TranslationService],
             },
           ],
         },


### PR DESCRIPTION
The Language and Currency label values ​​used in `site-context-selector.component` are fixed values ​​within `site-context-component.service`. I've changed this to be compatible with multi-language structures.

The Language and Currency label values ​​used in `site-context-selector.component` are constant values ​​within `site-context-component.service`. I've changed this to be compatible with multi-language structures.

Now, instead of reading the label value from a constant variable, it reads it from the `language` and `currency` parameters in `common.json`. Also, the `getLabel` function used to return `Observable<any>`; I've changed this to `Observable<string>` for type safety.