### PR TITLE
fix: CXSPA-11582 - Fix Sonar Typescript warings

### DIFF
--- a/.github/workflows/ci-continuous-integration.yml
+++ b/.github/workflows/ci-continuous-integration.yml
@@ -62,6 +62,7 @@ jobs:
           args: >
             -Dsonar.qualitygate.wait=true
             -Dsonar.projectKey=composable-storefront
+            -Dsonar.typescript.exclusions=**/.github/**
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonar.tools.sap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           args: >
             -Dsonar.qualitygate.wait=true
             -Dsonar.projectKey=composable-storefront
+            -Dsonar.typescript.exclusions=**/.github/**
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonar.tools.sap


### PR DESCRIPTION
Closes: [CXSPA-11582](https://jira.tools.sap/browse/CXSPA-11582)

The warnings happen because SonarQube is attempting to analyse `tsconfig` files that belong to Github Actions. They use an incompatible TS version so we need to exclude them from Sonar's TypeScript analysis. Unfortunately, this kind of exclusion can not be set in the web UI.