### PR TITLE
fix: Deprecate a11y toggles for Feb 2026 release

### DIFF
--- a/feature-libs/cart/base/components/mini-cart/mini-cart.component.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.component.ts
@@ -22,6 +22,5 @@ export class MiniCartComponent {
 
   total$: Observable<string> = this.miniCartComponentService.getTotalPrice();
 
-  constructor(protected miniCartComponentService: MiniCartComponentService) {
-  }
+  constructor(protected miniCartComponentService: MiniCartComponentService) {}
 }

--- a/feature-libs/cart/base/components/mini-cart/mini-cart.component.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.component.ts
@@ -6,7 +6,6 @@
 
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ICON_TYPE } from '@spartacus/storefront';
-import { useFeatureStyles } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { MiniCartComponentService } from './mini-cart-component.service';
 
@@ -24,6 +23,5 @@ export class MiniCartComponent {
   total$: Observable<string> = this.miniCartComponentService.getTotalPrice();
 
   constructor(protected miniCartComponentService: MiniCartComponentService) {
-    useFeatureStyles('a11yMiniCartFocusOnMobile');
   }
 }

--- a/feature-libs/cart/base/styles/components/_mini-cart.scss
+++ b/feature-libs/cart/base/styles/components/_mini-cart.scss
@@ -49,14 +49,12 @@
     }
   }
 
-  @include forFeature('a11yMiniCartFocusOnMobile') {
-    @include media-breakpoint-down(md) {
-      a {
-        &:focus {
-          outline-offset: -4px;
-          outline-color: var(--cx-color-inverse);
-          box-shadow: 0 0 0 2px var(--cx-color-visual-focus) inset;
-        }
+  @include media-breakpoint-down(md) {
+    a {
+      &:focus {
+        outline-offset: -4px;
+        outline-color: var(--cx-color-inverse);
+        box-shadow: 0 0 0 2px var(--cx-color-visual-focus) inset;
       }
     }
   }

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.html
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.html
@@ -67,41 +67,6 @@
         class="quick-order-results-product-container"
       >
         <button
-          *cxFeature="'!a11yQuickOrderSearchListKeyboardNavigation'"
-          (blur)="onBlur($event)"
-          (mousedown)="add(product, $event)"
-          (keydown.arrowdown)="focusNextChild($event)"
-          (keydown.arrowup)="focusPreviousChild($event)"
-          (keydown.enter)="add(product, $event)"
-          (keydown.escape)="clear($event)"
-          [class.has-media]="
-            config?.quickOrder?.searchForm?.displayProductImages
-          "
-          class="quick-order-results-product"
-          role="option"
-        >
-          <cx-media
-            *ngIf="config?.quickOrder?.searchForm?.displayProductImages"
-            [alt]="product.name"
-            [container]="product.images?.PRIMARY"
-            class="media"
-            format="thumbnail"
-            role="presentation"
-          ></cx-media>
-          <div class="name" [innerHTML]="product.name"></div>
-          <span class="id">
-            {{
-              'quickOrderForm.id'
-                | cxTranslate
-                  : {
-                      id: product.code,
-                    }
-            }}
-          </span>
-          <span class="price">{{ product.price?.formattedValue }}</span>
-        </button>
-        <button
-          *cxFeature="'a11yQuickOrderSearchListKeyboardNavigation'"
           (blur)="onBlur($event)"
           (mousedown)="add(product, $event)"
           (keydown.arrowdown)="focusNextChild($event)"

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
@@ -149,15 +149,9 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
 
     // Focus on first index moving to last
     if (results.length) {
-      if (
-        this.featureConfigService.isEnabled(
-          'a11ySearchableDropdownFirstElementFocus'
-        )
-      ) {
-        this.winRef.document
-          .querySelector('main')
-          ?.classList.remove('mouse-focus');
-      }
+      this.winRef.document
+        .querySelector('main')
+        ?.classList.remove('mouse-focus');
       if (focusedIndex >= results.length - 1) {
         results[0].focus();
       } else {

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
@@ -9,7 +9,6 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  inject,
   Input,
   OnDestroy,
   OnInit,
@@ -19,7 +18,6 @@ import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { QuickOrderFacade } from '@spartacus/cart/quick-order/root';
 import {
   Config,
-  FeatureConfigService,
   Product,
   WindowRef,
 } from '@spartacus/core';
@@ -52,7 +50,6 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
 
   @ViewChild('quickOrderInput') quickOrderInput: ElementRef;
 
-  private featureConfigService = inject(FeatureConfigService);
   protected subscription = new Subscription();
   protected searchSubscription = new Subscription();
 
@@ -83,7 +80,7 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
 
     if (this.isResultsBoxOpen()) {
       this.toggleBodyClass(SEARCH_BOX_ACTIVE_CLASS, false);
-      
+
       requestAnimationFrame(() => {
         this.quickOrderInput.nativeElement.focus();
       });

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
@@ -83,15 +83,10 @@ export class QuickOrderFormComponent implements OnInit, OnDestroy {
 
     if (this.isResultsBoxOpen()) {
       this.toggleBodyClass(SEARCH_BOX_ACTIVE_CLASS, false);
-      if (
-        this.featureConfigService.isEnabled(
-          'a11yQuickOrderSearchBoxRefocusOnClose'
-        )
-      ) {
-        requestAnimationFrame(() => {
-          this.quickOrderInput.nativeElement.focus();
-        });
-      }
+      
+      requestAnimationFrame(() => {
+        this.quickOrderInput.nativeElement.focus();
+      });
     }
 
     const product = this.form.get('product')?.value;

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.ts
@@ -16,11 +16,7 @@ import {
 } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { QuickOrderFacade } from '@spartacus/cart/quick-order/root';
-import {
-  Config,
-  Product,
-  WindowRef,
-} from '@spartacus/core';
+import { Config, Product, WindowRef } from '@spartacus/core';
 import { ICON_TYPE } from '@spartacus/storefront';
 import { Observable, Subscription } from 'rxjs';
 import {

--- a/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.ts
+++ b/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.ts
@@ -19,7 +19,7 @@ import {
   SavedCartFacade,
   SavedCartFormType,
 } from '@spartacus/cart/saved-cart/root';
-import { RoutingService, useFeatureStyles } from '@spartacus/core';
+import { RoutingService } from '@spartacus/core';
 import {
   LAUNCH_CALLER,
   LaunchDialogService,
@@ -63,9 +63,7 @@ export class SavedCartListComponent implements OnInit, OnDestroy {
     protected savedCartService: SavedCartFacade,
     protected vcr: ViewContainerRef,
     protected launchDialogService: LaunchDialogService
-  ) {
-    useFeatureStyles('a11yHighContrastBorders');
-  }
+  ) {}
 
   ngOnInit(): void {
     this.isLoading$ = this.savedCartService.getSavedCartListProcessLoading();

--- a/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.ts
@@ -160,9 +160,7 @@ export class CheckoutDeliveryAddressComponent implements OnInit {
     );
 
     this.setAddress(address);
-    if (this.featureConfigService?.isEnabled('a11yFocusOnCardAfterSelecting')) {
-      this.focusCardAfterSelecting();
-    }
+    this.focusCardAfterSelecting();
   }
 
   /**

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.ts
@@ -218,9 +218,7 @@ export class CheckoutPaymentMethodComponent implements OnInit, OnDestroy {
     );
 
     this.savePaymentMethod(paymentDetails);
-    if (this.featureConfigService?.isEnabled('a11yFocusOnCardAfterSelecting')) {
-      this.focusCardAfterSelecting();
-    }
+    this.focusCardAfterSelecting();
   }
 
   /**

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.ts
@@ -11,8 +11,7 @@ import {
 } from '@spartacus/checkout/base/root';
 import {
   PaymentDetails,
-  TranslationService,
-  useFeatureStyles,
+  TranslationService
 } from '@spartacus/core';
 import { billingAddressCard, paymentMethodCard } from '@spartacus/order/root';
 import { Card, ICON_TYPE } from '@spartacus/storefront';
@@ -37,9 +36,7 @@ export class CheckoutReviewPaymentComponent {
     protected checkoutStepService: CheckoutStepService,
     protected checkoutPaymentFacade: CheckoutPaymentFacade,
     protected translationService: TranslationService
-  ) {
-    useFeatureStyles('a11yHighContrastBorders');
-  }
+  ) {}
 
   paymentDetails$: Observable<PaymentDetails | undefined> =
     this.checkoutPaymentFacade.getPaymentDetailsState().pipe(

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.ts
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-payment/checkout-review-payment.component.ts
@@ -9,10 +9,7 @@ import {
   CheckoutPaymentFacade,
   CheckoutStepType,
 } from '@spartacus/checkout/base/root';
-import {
-  PaymentDetails,
-  TranslationService
-} from '@spartacus/core';
+import { PaymentDetails, TranslationService } from '@spartacus/core';
 import { billingAddressCard, paymentMethodCard } from '@spartacus/order/root';
 import { Card, ICON_TYPE } from '@spartacus/storefront';
 import { Observable, combineLatest } from 'rxjs';

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.ts
@@ -8,7 +8,6 @@ import { Component } from '@angular/core';
 import {
   RoutingService,
   TranslationService,
-  useFeatureStyles,
 } from '@spartacus/core';
 import {
   CustomerTicketingConfig,
@@ -32,9 +31,7 @@ export class CustomerTicketingListComponent {
     protected routingService: RoutingService,
     protected translationService: TranslationService,
     protected customerTicketingConfig: CustomerTicketingConfig
-  ) {
-    useFeatureStyles('a11yHighContrastBorders');
-  }
+  ) {}
   PAGE_SIZE =
     this.customerTicketingConfig.customerTicketing?.listViewPageSize || 5;
   sortType: string;

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.ts
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.ts
@@ -5,10 +5,7 @@
  */
 
 import { Component } from '@angular/core';
-import {
-  RoutingService,
-  TranslationService,
-} from '@spartacus/core';
+import { RoutingService, TranslationService } from '@spartacus/core';
 import {
   CustomerTicketingConfig,
   CustomerTicketingFacade,

--- a/feature-libs/organization/administration/components/shared/card/card.component.html
+++ b/feature-libs/organization/administration/components/shared/card/card.component.html
@@ -9,14 +9,10 @@
       <div class="title">
         <h3>
           <span
-            *cxFeature="'a11yRegionAssociatedHeaders'"
             id="{{ i18nRoot + '_title' }}"
           >
             {{ i18nRoot + '.title' | cxTranslate: { item: item$ | async } }}
           </span>
-          <ng-container *cxFeature="'!a11yRegionAssociatedHeaders'">
-            {{ i18nRoot + '.title' | cxTranslate: { item: item$ | async } }}
-          </ng-container>
           <button
             *ngIf="showHint"
             [cxPopover]="detailHint"

--- a/feature-libs/organization/administration/components/shared/card/card.component.html
+++ b/feature-libs/organization/administration/components/shared/card/card.component.html
@@ -8,9 +8,7 @@
     <div class="title-bar">
       <div class="title">
         <h3>
-          <span
-            id="{{ i18nRoot + '_title' }}"
-          >
+          <span id="{{ i18nRoot + '_title' }}">
             {{ i18nRoot + '.title' | cxTranslate: { item: item$ | async } }}
           </span>
           <button

--- a/feature-libs/organization/administration/components/shared/card/card.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/card/card.component.spec.ts
@@ -149,7 +149,7 @@ describe('CardComponent', () => {
         By.css('cx-popover > .popover-body > p')
       );
       expect(el).toBeTruthy();
-      expect(el.nativeElement.innerText).toBe('organization.budget.hint');
+      expect(el.nativeElement.innerText.trim()).toBe('organization.budget.hint');
     });
   });
 });

--- a/feature-libs/organization/administration/components/shared/card/card.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/card/card.component.spec.ts
@@ -149,7 +149,9 @@ describe('CardComponent', () => {
         By.css('cx-popover > .popover-body > p')
       );
       expect(el).toBeTruthy();
-      expect(el.nativeElement.innerText.trim()).toBe('organization.budget.hint');
+      expect(el.nativeElement.innerText.trim()).toBe(
+        'organization.budget.hint'
+      );
     });
   });
 });

--- a/feature-libs/organization/administration/components/shared/list/list.component.html
+++ b/feature-libs/organization/administration/components/shared/list/list.component.html
@@ -11,7 +11,6 @@
           <!-- TODO: (CXSPA-6624) - Remove feature flag next major release -->
           <h2>
             <span
-              *cxFeature="'a11yRegionAssociatedHeaders'"
               id="{{ viewType + '_title' }}"
             >
               {{
@@ -19,12 +18,6 @@
                   | cxTranslate: { count: getListCount(data) }
               }}
             </span>
-            <ng-container *cxFeature="'!a11yRegionAssociatedHeaders'">
-              {{
-                viewType + '.header'
-                  | cxTranslate: { count: getListCount(data) }
-              }}
-            </ng-container>
             <button
               [cxPopover]="listHint"
               [cxPopoverOptions]="{

--- a/feature-libs/organization/administration/components/shared/list/list.component.html
+++ b/feature-libs/organization/administration/components/shared/list/list.component.html
@@ -10,9 +10,7 @@
         <div aria-live="polite" class="title">
           <!-- TODO: (CXSPA-6624) - Remove feature flag next major release -->
           <h2>
-            <span
-              id="{{ viewType + '_title' }}"
-            >
+            <span id="{{ viewType + '_title' }}">
               {{
                 viewType + '.header'
                   | cxTranslate: { count: getListCount(data) }

--- a/feature-libs/organization/administration/components/shared/list/list.component.spec.ts
+++ b/feature-libs/organization/administration/components/shared/list/list.component.spec.ts
@@ -268,7 +268,7 @@ describe('ListComponent', () => {
         By.css('cx-popover > .popover-body > p')
       );
       expect(el).toBeTruthy();
-      expect(el.nativeElement.innerText).toBe('orgBudget.hint');
+      expect(el.nativeElement.innerText.trim()).toBe('orgBudget.hint');
     });
   });
 

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.html
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.html
@@ -143,18 +143,7 @@
                     class="cx-unit-level-order-history-value"
                   >
                     {{ order?.orgCustomer?.name }}
-                    <ng-container
-                      *cxFeature="'a11yTruncatedTextUnitLevelOrderHistory'"
-                    >
-                      <span>{{ order?.orgCustomer?.email }}</span>
-                    </ng-container>
-                    <ng-container
-                      *cxFeature="'!a11yTruncatedTextUnitLevelOrderHistory'"
-                    >
-                      <span class="text-ellipsis">{{
-                        order?.orgCustomer?.email
-                      }}</span>
-                    </ng-container>
+                    <span>{{ order?.orgCustomer?.email }}</span>
                   </a>
                 </td>
                 <td class="cx-unit-level-order-history-unit">

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.ts
@@ -8,7 +8,6 @@ import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
 import {
   RoutingService,
   TranslationService,
-  useFeatureStyles,
 } from '@spartacus/core';
 import { Order, OrderHistoryList } from '@spartacus/order/root';
 import { OrderHistoryQueryParams } from '@spartacus/organization/unit-order/core';
@@ -37,9 +36,7 @@ export class UnitLevelOrderHistoryComponent implements OnDestroy {
     protected routing: RoutingService,
     protected unitOrdersFacade: UnitOrderFacade,
     protected translation: TranslationService
-  ) {
-    useFeatureStyles('a11yTruncatedTextUnitLevelOrderHistory');
-  }
+  ) {}
 
   orders$: Observable<OrderHistoryList | undefined> = this.unitOrdersFacade
     .getOrderHistoryList(this.PAGE_SIZE)

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.ts
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.ts
@@ -5,10 +5,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
-import {
-  RoutingService,
-  TranslationService,
-} from '@spartacus/core';
+import { RoutingService, TranslationService } from '@spartacus/core';
 import { Order, OrderHistoryList } from '@spartacus/order/root';
 import { OrderHistoryQueryParams } from '@spartacus/organization/unit-order/core';
 import { UnitOrderFacade } from '@spartacus/organization/unit-order/root';

--- a/feature-libs/organization/unit-order/styles/components/unit-level-order-history/_unit-level-order-history.scss
+++ b/feature-libs/organization/unit-order/styles/components/unit-level-order-history/_unit-level-order-history.scss
@@ -22,10 +22,7 @@
   }
 
   .cx-unit-level-order-history-filter-label-wrapper {
-    width: 200px;
-    @include forFeature('a11yTruncatedTextUnitLevelOrderHistory') {
-      width: unset;
-    }
+    width: unset;
     border: 1px solid var(--cx-color-secondary);
     border-radius: 3px;
   }
@@ -107,14 +104,6 @@
 
         &:last-child {
           padding-bottom: 1.25rem;
-        }
-      }
-      // TODO: Remove following .text-ellipsis block once 'a11yTruncatedTextUnitLevelOrderHistory' feature flag is removed
-      .text-ellipsis {
-        @include media-breakpoint-up(md) {
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
         }
       }
 

--- a/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.html
+++ b/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.html
@@ -21,15 +21,12 @@
       [attr.data-preferred-store]="pointOfServiceName.name"
       class="set-preferred-heading"
       [attr.aria-label]="
-        (getSetStoreButtonLabel(data.storeSelected?.name || '')
-          | cxTranslate) +
+        (getSetStoreButtonLabel(data.storeSelected?.name || '') | cxTranslate) +
         ', ' +
         pointOfServiceName.displayName
       "
     >
-      {{
-        getSetStoreButtonLabel(data.storeSelected?.name || '') | cxTranslate
-      }}
+      {{ getSetStoreButtonLabel(data.storeSelected?.name || '') | cxTranslate }}
     </button>
   </div>
 </ng-container>

--- a/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.html
+++ b/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.html
@@ -1,56 +1,18 @@
-<ng-container *cxFeature="'a11yRepeatingButtonsUniqueLabels'">
-  <ng-container *ngIf="{ storeSelected: storeSelected$ | async } as data">
-    <div
-      [attr.data-preferred-store]="pointOfServiceName.name"
-      [attr.data-store-is-selected]="
-        pointOfServiceName.name === data.storeSelected?.name
-      "
-      class="setpreferredstore-container"
-      (click)="setAsPreferred()"
-    >
-      <div
-        [ngClass]="
-          pointOfServiceName.name === data.storeSelected?.name
-            ? 'icon-selected'
-            : 'icon-not-selected'
-        "
-      >
-        <cx-icon aria-hidden="true" [type]="ICON_TYPE.HEART"></cx-icon>
-      </div>
-      <button
-        data-text="setPreferredStore.myStore"
-        [attr.data-preferred-store]="pointOfServiceName.name"
-        class="set-preferred-heading"
-        [attr.aria-label]="
-          (getSetStoreButtonLabel(data.storeSelected?.name || '')
-            | cxTranslate) +
-          ', ' +
-          pointOfServiceName.displayName
-        "
-      >
-        {{
-          getSetStoreButtonLabel(data.storeSelected?.name || '') | cxTranslate
-        }}
-      </button>
-    </div>
-  </ng-container>
-</ng-container>
-<ng-container *cxFeature="'!a11yRepeatingButtonsUniqueLabels'">
+<ng-container *ngIf="{ storeSelected: storeSelected$ | async } as data">
   <div
     [attr.data-preferred-store]="pointOfServiceName.name"
     [attr.data-store-is-selected]="
-      pointOfServiceName.name === (storeSelected$ | async)?.name
+      pointOfServiceName.name === data.storeSelected?.name
     "
     class="setpreferredstore-container"
     (click)="setAsPreferred()"
   >
     <div
-      [ngClass]="{
-        'icon-selected':
-          pointOfServiceName.name === (storeSelected$ | async)?.name,
-        'icon-not-selected':
-          pointOfServiceName.name !== (storeSelected$ | async)?.name,
-      }"
+      [ngClass]="
+        pointOfServiceName.name === data.storeSelected?.name
+          ? 'icon-selected'
+          : 'icon-not-selected'
+      "
     >
       <cx-icon aria-hidden="true" [type]="ICON_TYPE.HEART"></cx-icon>
     </div>
@@ -58,11 +20,15 @@
       data-text="setPreferredStore.myStore"
       [attr.data-preferred-store]="pointOfServiceName.name"
       class="set-preferred-heading"
+      [attr.aria-label]="
+        (getSetStoreButtonLabel(data.storeSelected?.name || '')
+          | cxTranslate) +
+        ', ' +
+        pointOfServiceName.displayName
+      "
     >
       {{
-        pointOfServiceName.name === (storeSelected$ | async)?.name
-          ? ('setPreferredStore.myStore' | cxTranslate)
-          : ('setPreferredStore.makeThisMyStore' | cxTranslate)
+        getSetStoreButtonLabel(data.storeSelected?.name || '') | cxTranslate
       }}
     </button>
   </div>

--- a/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.component.ts
+++ b/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.component.ts
@@ -18,8 +18,7 @@ export class FutureStockAccordionComponent {
   expanded: boolean = false;
   iconType = ICON_TYPE;
 
-  constructor(protected futureStockService: FutureStockFacade) {
-  }
+  constructor(protected futureStockService: FutureStockFacade) {}
 
   toggle(): void {
     this.expanded = !this.expanded;

--- a/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.component.ts
+++ b/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.component.ts
@@ -5,7 +5,6 @@
  */
 
 import { Component } from '@angular/core';
-import { useFeatureStyles } from '@spartacus/core';
 import { FutureStockFacade } from '@spartacus/product/future-stock/root';
 import { ICON_TYPE } from '@spartacus/storefront';
 
@@ -20,7 +19,6 @@ export class FutureStockAccordionComponent {
   iconType = ICON_TYPE;
 
   constructor(protected futureStockService: FutureStockFacade) {
-    useFeatureStyles('a11yUseProperTextColorForFutureStockAccordion');
   }
 
   toggle(): void {

--- a/feature-libs/product/future-stock/styles/_future-stock-accordion.scss
+++ b/feature-libs/product/future-stock/styles/_future-stock-accordion.scss
@@ -11,14 +11,11 @@ cx-future-stock-accordion {
     padding: 0;
     margin: 0.5rem auto;
     cursor: pointer;
+    color: var(--cx-color-text);
 
     @include media-breakpoint-down(md) {
       margin-inline-start: 0;
       padding: 0;
-    }
-
-    @include forFeature('a11yUseProperTextColorForFutureStockAccordion') {
-      color: var(--cx-color-text);
     }
 
     &:hover {

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -10,11 +10,6 @@
 // Thanks to that, customers using a property that was recently removed, will know they have to adapt their code.
 export interface FeatureTogglesInterface {
   /**
-   * In `AnonymousConsentDialogComponent` display notifications inside the modal without closing it
-   */
-  a11yAnonymousConsentMessageInDialog?: boolean;
-
-  /**
    * `QuickOrderFormComponent` - disable navigation with Tab/Shift+Tab for search results list
    */
   a11yQuickOrderSearchListKeyboardNavigation?: boolean;
@@ -496,7 +491,6 @@ export interface FeatureTogglesInterface {
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
-  a11yAnonymousConsentMessageInDialog: true,
   a11yQuickOrderSearchListKeyboardNavigation: true,
   a11yKeyboardAccessibleZoom: false,
   a11yTruncatedTextUnitLevelOrderHistory: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -61,12 +61,6 @@ export interface FeatureTogglesInterface {
   a11yAddPaddingToCarouselPanel?: boolean;
 
   /**
-   * Restores the focus to the card once a option has been selected and the checkout has updated.
-   * Affects: CheckoutPaymentMethodComponent, CheckoutDeliveryAddressComponent
-   */
-  a11yFocusOnCardAfterSelecting?: boolean;
-
-  /**
    * Search dropdowns will display the focus ring correctly when navigating to the options using the down arrow key.
    * Affects: SearchBoxComponent, QuickOrderFormComponent
    */
@@ -455,7 +449,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
   a11yAddPaddingToCarouselPanel: false,
-  a11yFocusOnCardAfterSelecting: true,
   a11ySearchableDropdownFirstElementFocus: true,
   a11yHideConsentButtonWhenBannerVisible: true,
   a11yRepeatingButtonsUniqueLabels: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -61,12 +61,6 @@ export interface FeatureTogglesInterface {
   a11yAddPaddingToCarouselPanel?: boolean;
 
   /**
-   * Adds a unique `aria-label` to repeating buttons that contain the same text.
-   * Affects: SetPreferredStoreComponent
-   */
-  a11yRepeatingButtonsUniqueLabels?: boolean;
-
-  /**
    * Ensures that borders across all UI elements are visible and meet accessibility standards in high-contrast dark and light themes.
    * This change is applied globally to enhance usability for users relying on high-contrast modes.
    * Affects: CustomerTickingListComponent, CheckoutReviewPaymentComponent, SavedCartListComponent
@@ -434,7 +428,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
   a11yAddPaddingToCarouselPanel: false,
-  a11yRepeatingButtonsUniqueLabels: true,
   a11yHighContrastBorders: true,
   a11yRegionAssociatedHeaders: true,
   a11yHamburgerMenuTrapFocus: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -69,12 +69,6 @@ export interface FeatureTogglesInterface {
   enableClaimCustomerCouponWithCodeInRequestBody?: boolean;
 
   /**
-   * When enabled, the scroll-to-top button adjusts its position when other UI elements
-   * (like cookie consent banner) appear at the bottom of the page to prevent overlapping
-   */
-  a11yScrollToTopPositioning?: boolean;
-
-  /**
    * Improves wide viewport layout issues.
    * Affects the styles of: Order confirmation page, product configurator.
    */
@@ -408,7 +402,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
   a11yAddPaddingToCarouselPanel: false,
-  a11yScrollToTopPositioning: true,
   a11yWideScreenImprovements: true,
   a11yOptimizedMenuSpacing: true,
   a11yNgSelectLayering: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -69,13 +69,6 @@ export interface FeatureTogglesInterface {
   enableClaimCustomerCouponWithCodeInRequestBody?: boolean;
 
   /**
-   * Header. Fixes trapping focus on menu items on mobile when the menu is expanded.
-   * Sets `tabindex` attribute  to `-1` for all visible focusable elements in the header section to exclude them from
-   * keyboard navigation
-   */
-  a11yHamburgerMenuTrapFocus?: boolean;
-
-  /**
    * When enabled, the scroll-to-top button adjusts its position when other UI elements
    * (like cookie consent banner) appear at the bottom of the page to prevent overlapping
    */
@@ -415,7 +408,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
   a11yAddPaddingToCarouselPanel: false,
-  a11yHamburgerMenuTrapFocus: true,
   a11yScrollToTopPositioning: true,
   a11yWideScreenImprovements: true,
   a11yOptimizedMenuSpacing: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -10,11 +10,6 @@
 // Thanks to that, customers using a property that was recently removed, will know they have to adapt their code.
 export interface FeatureTogglesInterface {
   /**
-   * 'TabComponent' disallow automatic tab activation.
-   */
-  a11yTabsManualActivation?: boolean;
-
-  /**
    * In `AnonymousConsentDialogComponent` display notifications inside the modal without closing it
    */
   a11yAnonymousConsentMessageInDialog?: boolean;
@@ -501,7 +496,6 @@ export interface FeatureTogglesInterface {
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
-  a11yTabsManualActivation: true,
   a11yAnonymousConsentMessageInDialog: true,
   a11yQuickOrderSearchListKeyboardNavigation: true,
   a11yKeyboardAccessibleZoom: false,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -15,12 +15,6 @@ export interface FeatureTogglesInterface {
   a11yKeyboardAccessibleZoom?: boolean;
 
   /**
-   * `UnitLevelOrderHistoryComponent` filter input label and table email address
-   * are not truncated
-   */
-  a11yTruncatedTextUnitLevelOrderHistory?: boolean;
-
-  /**
    * When using CartItemListComponent as an outlet ([cxOutlet]="CartOutlets.CART_ITEM_LIST"):
    * prevents the form from being recreated when neither the items nor other dependent properties (e.g., readonly) have changed.
    */
@@ -487,7 +481,6 @@ export interface FeatureTogglesInterface {
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yKeyboardAccessibleZoom: false,
-  a11yTruncatedTextUnitLevelOrderHistory: true,
   a11yPreventCartItemsFormRedundantRecreation: false,
   a11yResetFocusAfterNavigating: true,
   a11yStoreFinderLabel: false,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -21,11 +21,6 @@ export interface FeatureTogglesInterface {
   a11yPreventCartItemsFormRedundantRecreation?: boolean;
 
   /**
-   * Resets the focus after navigating to a new page.
-   */
-  a11yResetFocusAfterNavigating?: boolean;
-
-  /**
    * Adds label to 'StoreFinderSearchComponent' store search input field.
    */
   a11yStoreFinderLabel?: boolean;
@@ -482,7 +477,6 @@ export interface FeatureTogglesInterface {
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yKeyboardAccessibleZoom: false,
   a11yPreventCartItemsFormRedundantRecreation: false,
-  a11yResetFocusAfterNavigating: true,
   a11yStoreFinderLabel: false,
   a11yImprovedErrorMessage: true,
   a11yLinkBtnsToTertiaryBtns: false,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -61,12 +61,6 @@ export interface FeatureTogglesInterface {
   a11yAddPaddingToCarouselPanel?: boolean;
 
   /**
-   * Search dropdowns will display the focus ring correctly when navigating to the options using the down arrow key.
-   * Affects: SearchBoxComponent, QuickOrderFormComponent
-   */
-  a11ySearchableDropdownFirstElementFocus?: boolean;
-
-  /**
    * Hides the 'Consent Management' button from the tab order when the cookies banner is visible.
    * Ensures the button is re-enabled and part of the tab order once consent is given and the banner disappears.
    * Renames the button from "View Details" to "Consent Management" after consent is given.
@@ -449,7 +443,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
   a11yAddPaddingToCarouselPanel: false,
-  a11ySearchableDropdownFirstElementFocus: true,
   a11yHideConsentButtonWhenBannerVisible: true,
   a11yRepeatingButtonsUniqueLabels: true,
   a11yHighContrastBorders: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -61,13 +61,6 @@ export interface FeatureTogglesInterface {
   a11yAddPaddingToCarouselPanel?: boolean;
 
   /**
-   * Ensures that borders across all UI elements are visible and meet accessibility standards in high-contrast dark and light themes.
-   * This change is applied globally to enhance usability for users relying on high-contrast modes.
-   * Affects: CustomerTickingListComponent, CheckoutReviewPaymentComponent, SavedCartListComponent
-   */
-  a11yHighContrastBorders?: boolean;
-
-  /**
    * In CustomerCouponConnector, Enables claiming customer coupon with coupon code in httpRequest body with POST method.
    *
    * When set to `false`, claiming customer coupon works with coupon code as parameter in URL, which exposes sensitive data and has security risk.
@@ -428,7 +421,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
   a11yAddPaddingToCarouselPanel: false,
-  a11yHighContrastBorders: true,
   a11yRegionAssociatedHeaders: true,
   a11yHamburgerMenuTrapFocus: true,
   a11yScrollToTopPositioning: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -76,12 +76,6 @@ export interface FeatureTogglesInterface {
   a11yHamburgerMenuTrapFocus?: boolean;
 
   /**
-   * Associates content regions with their headers improving readout while navigating between sections.
-   * Affects: CardComponent, AccountSummaryDocumentComponent, ListComponent
-   */
-  a11yRegionAssociatedHeaders?: boolean;
-
-  /**
    * When enabled, the scroll-to-top button adjusts its position when other UI elements
    * (like cookie consent banner) appear at the bottom of the page to prevent overlapping
    */
@@ -421,7 +415,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
   a11yAddPaddingToCarouselPanel: false,
-  a11yRegionAssociatedHeaders: true,
   a11yHamburgerMenuTrapFocus: true,
   a11yScrollToTopPositioning: true,
   a11yWideScreenImprovements: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -38,12 +38,6 @@ export interface FeatureTogglesInterface {
   a11yLinkBtnsToTertiaryBtns?: boolean;
 
   /**
-   * 'NgSelectA11yDirective' will customize a ng-select dropdowns by setting custom
-   * ariaLabelDropdown ng-select attribute value to provided common.ngSelectDropdownOptionsList translation
-   */
-  a11yNgSelectAriaLabelDropdownCustomized?: boolean;
-
-  /**
    * 'NgSelectA11yDirective' will close a dropdown with options on Escape key press
    * when a screen reader is used.
    * Replaces select with ng-select component in the following component:
@@ -481,7 +475,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yImprovedErrorMessage: true,
   a11yLinkBtnsToTertiaryBtns: false,
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
-  a11yNgSelectAriaLabelDropdownCustomized: true,
   a11yMiniCartFocusOnMobile: true,
   updateConsentGivenInOnChanges: true,
   a11yQuickOrderSearchBoxRefocusOnClose: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -10,11 +10,6 @@
 // Thanks to that, customers using a property that was recently removed, will know they have to adapt their code.
 export interface FeatureTogglesInterface {
   /**
-   * `QuickOrderFormComponent` - disable navigation with Tab/Shift+Tab for search results list
-   */
-  a11yQuickOrderSearchListKeyboardNavigation?: boolean;
-
-  /**
    * Adds a keyboard accessible zoom button to the `ProductImageZoomViewComponent`.
    */
   a11yKeyboardAccessibleZoom?: boolean;
@@ -491,7 +486,6 @@ export interface FeatureTogglesInterface {
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
-  a11yQuickOrderSearchListKeyboardNavigation: true,
   a11yKeyboardAccessibleZoom: false,
   a11yTruncatedTextUnitLevelOrderHistory: true,
   a11yPreventCartItemsFormRedundantRecreation: false,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -10,11 +10,6 @@
 // Thanks to that, customers using a property that was recently removed, will know they have to adapt their code.
 export interface FeatureTogglesInterface {
   /**
-   * In `FutureStockAccordionComponent` use `cx-color-text` for button color
-   */
-  a11yUseProperTextColorForFutureStockAccordion?: boolean;
-
-  /**
    * Fix popover appearance when a High Contrast Theme is applied.
    */
   a11yPopoverHighContrast?: boolean;
@@ -511,7 +506,6 @@ export interface FeatureTogglesInterface {
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
-  a11yUseProperTextColorForFutureStockAccordion: true,
   a11yPopoverHighContrast: true,
   a11yTabsManualActivation: true,
   a11yAnonymousConsentMessageInDialog: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -10,11 +10,6 @@
 // Thanks to that, customers using a property that was recently removed, will know they have to adapt their code.
 export interface FeatureTogglesInterface {
   /**
-   * Fix popover appearance when a High Contrast Theme is applied.
-   */
-  a11yPopoverHighContrast?: boolean;
-
-  /**
    * 'TabComponent' disallow automatic tab activation.
    */
   a11yTabsManualActivation?: boolean;
@@ -506,7 +501,6 @@ export interface FeatureTogglesInterface {
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
-  a11yPopoverHighContrast: true,
   a11yTabsManualActivation: true,
   a11yAnonymousConsentMessageInDialog: true,
   a11yQuickOrderSearchListKeyboardNavigation: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -55,11 +55,6 @@ export interface FeatureTogglesInterface {
   updateConsentGivenInOnChanges?: boolean;
 
   /**
-   * When enabled the input element in `QuickOrderFormComponent' will regain its focus after the dropdown is closed.
-   */
-  a11yQuickOrderSearchBoxRefocusOnClose?: boolean;
-
-  /**
    * Adds a visible focus indicator for keyboard navigation in the `SearchBoxComponent` without affecting the visual state for mouse interactions.
    * Affects: SearchBoxComponent
    */
@@ -471,7 +466,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yLinkBtnsToTertiaryBtns: false,
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
-  a11yQuickOrderSearchBoxRefocusOnClose: true,
   a11yKeyboardFocusInSearchBox: true,
   a11yAddPaddingToCarouselPanel: false,
   a11yNavigationButtonsAriaFixes: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -61,12 +61,6 @@ export interface FeatureTogglesInterface {
   a11yAddPaddingToCarouselPanel?: boolean;
 
   /**
-   * Removes invalid aria-level usage on button elements and ensures buttons have a proper accessible name via aria-label or aria-labelledby.
-   * Affects: NavigationUIComponent
-   */
-  a11yNavigationButtonsAriaFixes?: boolean;
-
-  /**
    * Restores the focus to the card once a option has been selected and the checkout has updated.
    * Affects: CheckoutPaymentMethodComponent, CheckoutDeliveryAddressComponent
    */
@@ -461,7 +455,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
   a11yAddPaddingToCarouselPanel: false,
-  a11yNavigationButtonsAriaFixes: true,
   a11yFocusOnCardAfterSelecting: true,
   a11ySearchableDropdownFirstElementFocus: true,
   a11yHideConsentButtonWhenBannerVisible: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -46,11 +46,6 @@ export interface FeatureTogglesInterface {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox?: boolean;
 
   /**
-   * In `MiniCart component`, improve visible focus contrast on mobile.
-   */
-  a11yMiniCartFocusOnMobile?: boolean;
-
-  /**
    * Updates the derivative `consentGiven` state when `consent` is updated.
    *
    * Components affected:
@@ -475,7 +470,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yImprovedErrorMessage: true,
   a11yLinkBtnsToTertiaryBtns: false,
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
-  a11yMiniCartFocusOnMobile: true,
   updateConsentGivenInOnChanges: true,
   a11yQuickOrderSearchBoxRefocusOnClose: true,
   a11yKeyboardFocusInSearchBox: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -61,15 +61,6 @@ export interface FeatureTogglesInterface {
   a11yAddPaddingToCarouselPanel?: boolean;
 
   /**
-   * Hides the 'Consent Management' button from the tab order when the cookies banner is visible.
-   * Ensures the button is re-enabled and part of the tab order once consent is given and the banner disappears.
-   * Renames the button from "View Details" to "Consent Management" after consent is given.
-   * Ensures the button is centered in the `AnonymousConsentOpenDialogComponent` and has clear, four-sided visible focus when navigated via keyboard.
-   * Affects: AnonymousConsentOpenDialogComponent, AnonymousConsentManagementBannerComponent
-   */
-  a11yHideConsentButtonWhenBannerVisible?: boolean;
-
-  /**
    * Adds a unique `aria-label` to repeating buttons that contain the same text.
    * Affects: SetPreferredStoreComponent
    */
@@ -443,7 +434,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
   a11yAddPaddingToCarouselPanel: false,
-  a11yHideConsentButtonWhenBannerVisible: true,
   a11yRepeatingButtonsUniqueLabels: true,
   a11yHighContrastBorders: true,
   a11yRegionAssociatedHeaders: true,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -55,12 +55,6 @@ export interface FeatureTogglesInterface {
   updateConsentGivenInOnChanges?: boolean;
 
   /**
-   * Adds a visible focus indicator for keyboard navigation in the `SearchBoxComponent` without affecting the visual state for mouse interactions.
-   * Affects: SearchBoxComponent
-   */
-  a11yKeyboardFocusInSearchBox?: boolean;
-
-  /**
    * Adds horizontal padding to the 'carousel-panel' to fix the issue where the focus only covers three sides of the 'Previous slide' and 'Next slide' buttons within the carousel section.
    * Affects: CarouselComponent
    */
@@ -466,7 +460,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yLinkBtnsToTertiaryBtns: false,
   a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
   updateConsentGivenInOnChanges: true,
-  a11yKeyboardFocusInSearchBox: true,
   a11yAddPaddingToCarouselPanel: false,
   a11yNavigationButtonsAriaFixes: true,
   a11yFocusOnCardAfterSelecting: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -304,7 +304,6 @@ if (environment.cpq) {
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         updateConsentGivenInOnChanges: true,
         a11yAddPaddingToCarouselPanel: true,
-        a11yFocusOnCardAfterSelecting: true,
         a11ySearchableDropdownFirstElementFocus: true,
         a11yHideConsentButtonWhenBannerVisible: true,
         a11yRepeatingButtonsUniqueLabels: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -303,7 +303,6 @@ if (environment.cpq) {
         a11yLinkBtnsToTertiaryBtns: true,
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         updateConsentGivenInOnChanges: true,
-        a11yQuickOrderSearchBoxRefocusOnClose: true,
         a11yKeyboardFocusInSearchBox: true,
         a11yAddPaddingToCarouselPanel: true,
         a11yNavigationButtonsAriaFixes: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -304,7 +304,6 @@ if (environment.cpq) {
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         updateConsentGivenInOnChanges: true,
         a11yAddPaddingToCarouselPanel: true,
-        a11yRepeatingButtonsUniqueLabels: true,
         a11yHighContrastBorders: true,
         a11yRegionAssociatedHeaders: true,
         dispatchLoginActionOnlyWhenTokenReceived: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -304,7 +304,6 @@ if (environment.cpq) {
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         updateConsentGivenInOnChanges: true,
         a11yAddPaddingToCarouselPanel: true,
-        a11yRegionAssociatedHeaders: true,
         dispatchLoginActionOnlyWhenTokenReceived: true,
         a11yHamburgerMenuTrapFocus: true,
         a11yScrollToTopPositioning: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -305,7 +305,6 @@ if (environment.cpq) {
         updateConsentGivenInOnChanges: true,
         a11yAddPaddingToCarouselPanel: true,
         dispatchLoginActionOnlyWhenTokenReceived: true,
-        a11yScrollToTopPositioning: true,
         a11yWideScreenImprovements: true,
         a11yOptimizedMenuSpacing: true,
         a11yNgSelectLayering: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -304,7 +304,6 @@ if (environment.cpq) {
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         updateConsentGivenInOnChanges: true,
         a11yAddPaddingToCarouselPanel: true,
-        a11yHighContrastBorders: true,
         a11yRegionAssociatedHeaders: true,
         dispatchLoginActionOnlyWhenTokenReceived: true,
         a11yHamburgerMenuTrapFocus: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -304,7 +304,6 @@ if (environment.cpq) {
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         updateConsentGivenInOnChanges: true,
         a11yAddPaddingToCarouselPanel: true,
-        a11yHideConsentButtonWhenBannerVisible: true,
         a11yRepeatingButtonsUniqueLabels: true,
         a11yHighContrastBorders: true,
         a11yRegionAssociatedHeaders: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -304,7 +304,6 @@ if (environment.cpq) {
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         updateConsentGivenInOnChanges: true,
         a11yAddPaddingToCarouselPanel: true,
-        a11ySearchableDropdownFirstElementFocus: true,
         a11yHideConsentButtonWhenBannerVisible: true,
         a11yRepeatingButtonsUniqueLabels: true,
         a11yHighContrastBorders: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -296,7 +296,6 @@ if (environment.cpq) {
     },
     provideFeatureTogglesFactory(() => {
       const appFeatureToggles: Required<FeatureToggles> = {
-        a11yTabsManualActivation: true,
         a11yAnonymousConsentMessageInDialog: true,
         a11yQuickOrderSearchListKeyboardNavigation: false,
         a11yKeyboardAccessibleZoom: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -297,7 +297,6 @@ if (environment.cpq) {
     provideFeatureTogglesFactory(() => {
       const appFeatureToggles: Required<FeatureToggles> = {
         a11yKeyboardAccessibleZoom: true,
-        a11yTruncatedTextUnitLevelOrderHistory: true,
         a11yPreventCartItemsFormRedundantRecreation: true,
         a11yResetFocusAfterNavigating: true,
         a11yImprovedErrorMessage: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -296,7 +296,6 @@ if (environment.cpq) {
     },
     provideFeatureTogglesFactory(() => {
       const appFeatureToggles: Required<FeatureToggles> = {
-        a11yPopoverHighContrast: true,
         a11yTabsManualActivation: true,
         a11yAnonymousConsentMessageInDialog: true,
         a11yQuickOrderSearchListKeyboardNavigation: false,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -304,7 +304,6 @@ if (environment.cpq) {
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         updateConsentGivenInOnChanges: true,
         a11yAddPaddingToCarouselPanel: true,
-        a11yNavigationButtonsAriaFixes: true,
         a11yFocusOnCardAfterSelecting: true,
         a11ySearchableDropdownFirstElementFocus: true,
         a11yHideConsentButtonWhenBannerVisible: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -296,7 +296,6 @@ if (environment.cpq) {
     },
     provideFeatureTogglesFactory(() => {
       const appFeatureToggles: Required<FeatureToggles> = {
-        a11yUseProperTextColorForFutureStockAccordion: true,
         a11yPopoverHighContrast: true,
         a11yTabsManualActivation: true,
         a11yAnonymousConsentMessageInDialog: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -296,7 +296,6 @@ if (environment.cpq) {
     },
     provideFeatureTogglesFactory(() => {
       const appFeatureToggles: Required<FeatureToggles> = {
-        a11yQuickOrderSearchListKeyboardNavigation: false,
         a11yKeyboardAccessibleZoom: true,
         a11yTruncatedTextUnitLevelOrderHistory: true,
         a11yPreventCartItemsFormRedundantRecreation: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -303,7 +303,6 @@ if (environment.cpq) {
         a11yLinkBtnsToTertiaryBtns: true,
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
         updateConsentGivenInOnChanges: true,
-        a11yKeyboardFocusInSearchBox: true,
         a11yAddPaddingToCarouselPanel: true,
         a11yNavigationButtonsAriaFixes: true,
         a11yFocusOnCardAfterSelecting: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -302,7 +302,6 @@ if (environment.cpq) {
         a11yStoreFinderLabel: true,
         a11yLinkBtnsToTertiaryBtns: true,
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
-        a11yNgSelectAriaLabelDropdownCustomized: true,
         a11yMiniCartFocusOnMobile: true,
         updateConsentGivenInOnChanges: true,
         a11yQuickOrderSearchBoxRefocusOnClose: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -305,7 +305,6 @@ if (environment.cpq) {
         updateConsentGivenInOnChanges: true,
         a11yAddPaddingToCarouselPanel: true,
         dispatchLoginActionOnlyWhenTokenReceived: true,
-        a11yHamburgerMenuTrapFocus: true,
         a11yScrollToTopPositioning: true,
         a11yWideScreenImprovements: true,
         a11yOptimizedMenuSpacing: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -302,7 +302,6 @@ if (environment.cpq) {
         a11yStoreFinderLabel: true,
         a11yLinkBtnsToTertiaryBtns: true,
         a11ySelectImprovementsCustomerTicketingCreateSelectbox: true,
-        a11yMiniCartFocusOnMobile: true,
         updateConsentGivenInOnChanges: true,
         a11yQuickOrderSearchBoxRefocusOnClose: true,
         a11yKeyboardFocusInSearchBox: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -298,7 +298,6 @@ if (environment.cpq) {
       const appFeatureToggles: Required<FeatureToggles> = {
         a11yKeyboardAccessibleZoom: true,
         a11yPreventCartItemsFormRedundantRecreation: true,
-        a11yResetFocusAfterNavigating: true,
         a11yImprovedErrorMessage: true,
         a11yStoreFinderLabel: true,
         a11yLinkBtnsToTertiaryBtns: true,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -296,7 +296,6 @@ if (environment.cpq) {
     },
     provideFeatureTogglesFactory(() => {
       const appFeatureToggles: Required<FeatureToggles> = {
-        a11yAnonymousConsentMessageInDialog: true,
         a11yQuickOrderSearchListKeyboardNavigation: false,
         a11yKeyboardAccessibleZoom: true,
         a11yTruncatedTextUnitLevelOrderHistory: true,

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.html
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.html
@@ -4,26 +4,7 @@
     class="anonymous-consent-banner"
   >
     <div class="container">
-      <div class="row" *cxFeature="'!a11yHideConsentButtonWhenBannerVisible'">
-        <div class="col-lg-7 col-xs-12">
-          <div class="cx-banner-title">
-            {{ 'anonymousConsents.banner.title' | cxTranslate }}
-          </div>
-          <div class="cx-banner-description">
-            {{ 'anonymousConsents.banner.description' | cxTranslate }}
-          </div>
-        </div>
-
-        <div class="col-lg-5 col-xs-12 cx-banner-buttons">
-          <button class="btn btn-secondary" (click)="viewDetails()">
-            {{ 'anonymousConsents.banner.viewDetails' | cxTranslate }}
-          </button>
-          <button class="btn btn-primary" (click)="allowAll()">
-            {{ 'anonymousConsents.banner.allowAll' | cxTranslate }}
-          </button>
-        </div>
-      </div>
-      <div class="row" *cxFeature="'a11yHideConsentButtonWhenBannerVisible'">
+      <div class="row">
         <div class="col-xl-7 col-lg-6 col-xs-12">
           <div class="cx-banner-title">
             {{ 'anonymousConsents.banner.title' | cxTranslate }}

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/banner/anonymous-consent-management-banner.component.ts
@@ -5,7 +5,7 @@
  */
 
 import { Component, OnDestroy, ViewContainerRef } from '@angular/core';
-import { AnonymousConsentsService, useFeatureStyles } from '@spartacus/core';
+import { AnonymousConsentsService } from '@spartacus/core';
 import { Observable, Subscription } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { LAUNCH_CALLER } from '../../../layout/launch-dialog/config/launch-config';
@@ -26,9 +26,7 @@ export class AnonymousConsentManagementBannerComponent implements OnDestroy {
     protected anonymousConsentsService: AnonymousConsentsService,
     protected vcr: ViewContainerRef,
     protected launchDialogService: LaunchDialogService
-  ) {
-    useFeatureStyles('a11yScrollToTopPositioning');
-  }
+  ) {}
 
   viewDetails(): void {
     this.hideBanner();

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.html
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.html
@@ -1,16 +1,8 @@
-<ng-container *cxFeature="'!a11yHideConsentButtonWhenBannerVisible'">
-  <button #open class="btn btn-link" (click)="openDialog()">
-    {{ 'anonymousConsents.dialog.title' | cxTranslate }}
-  </button>
-</ng-container>
-
-<ng-container *cxFeature="'a11yHideConsentButtonWhenBannerVisible'">
-  <button
-    *ngIf="!(bannerVisible$ | async)"
-    #open
-    class="btn btn-link"
-    (click)="openDialog()"
-  >
-    {{ 'anonymousConsents.dialog.title' | cxTranslate }}
-  </button>
-</ng-container>
+<button
+  *ngIf="!(bannerVisible$ | async)"
+  #open
+  class="btn btn-link"
+  (click)="openDialog()"
+>
+  {{ 'anonymousConsents.dialog.title' | cxTranslate }}
+</button>

--- a/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.ts
+++ b/projects/storefrontlib/cms-components/anonymous-consent-management/open-dialog/anonymous-consent-open-dialog.component.ts
@@ -10,7 +10,7 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
-import { AnonymousConsentsService, useFeatureStyles } from '@spartacus/core';
+import { AnonymousConsentsService } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { LAUNCH_CALLER } from '../../../layout/launch-dialog/config/launch-config';
@@ -30,9 +30,7 @@ export class AnonymousConsentOpenDialogComponent {
     protected vcr: ViewContainerRef,
     protected anonymousConsentsService: AnonymousConsentsService,
     protected launchDialogService: LaunchDialogService
-  ) {
-    useFeatureStyles('a11yHideConsentButtonWhenBannerVisible');
-  }
+  ) {}
 
   openDialog(): void {
     const dialog = this.launchDialogService.openDialog(

--- a/projects/storefrontlib/cms-components/content/tab/tab.component.spec.ts
+++ b/projects/storefrontlib/cms-components/content/tab/tab.component.spec.ts
@@ -105,9 +105,7 @@ describe('TabComponent', () => {
     });
 
     it('should navigate menu buttons with arrow keys', () => {
-      expect(component.isOpen(0)).toEqual(true);
-      expect(component.isOpen(1)).toEqual(false);
-      expect(component.isOpen(2)).toEqual(false);
+      const focusSpy = spyOn(component, 'focus');
 
       component.handleKeydownEvent(
         0,
@@ -115,10 +113,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowRight' })
       );
-
-      expect(component.isOpen(0)).toEqual(false);
-      expect(component.isOpen(1)).toEqual(true);
-      expect(component.isOpen(2)).toEqual(false);
+      expect(focusSpy).toHaveBeenCalledWith(1);
 
       component.handleKeydownEvent(
         1,
@@ -126,10 +121,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowDown' })
       );
-
-      expect(component.isOpen(0)).toEqual(false);
-      expect(component.isOpen(1)).toEqual(false);
-      expect(component.isOpen(2)).toEqual(true);
+      expect(focusSpy).toHaveBeenCalledWith(2);
 
       component.handleKeydownEvent(
         2,
@@ -137,10 +129,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowLeft' })
       );
-
-      expect(component.isOpen(0)).toEqual(false);
-      expect(component.isOpen(1)).toEqual(true);
-      expect(component.isOpen(2)).toEqual(false);
+      expect(focusSpy).toHaveBeenCalledWith(1);
 
       component.handleKeydownEvent(
         1,
@@ -148,15 +137,11 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowUp' })
       );
-
-      expect(component.isOpen(0)).toEqual(true);
-      expect(component.isOpen(1)).toEqual(false);
-      expect(component.isOpen(2)).toEqual(false);
+      expect(focusSpy).toHaveBeenCalledWith(0);
     });
 
     it('should wrap navigation on menu buttons with arrow keys', () => {
-      expect(component.isOpen(0)).toEqual(true);
-      expect(component.isOpen(3)).toEqual(false);
+      const focusSpy = spyOn(component, 'focus');
 
       component.handleKeydownEvent(
         0,
@@ -164,9 +149,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowUp' })
       );
-
-      expect(component.isOpen(0)).toEqual(false);
-      expect(component.isOpen(3)).toEqual(true);
+      expect(focusSpy).toHaveBeenCalledWith(3);
 
       component.handleKeydownEvent(
         3,
@@ -174,9 +157,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowDown' })
       );
-
-      expect(component.isOpen(0)).toEqual(true);
-      expect(component.isOpen(3)).toEqual(false);
+      expect(focusSpy).toHaveBeenCalledWith(0);
 
       component.handleKeydownEvent(
         0,
@@ -184,9 +165,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowLeft' })
       );
-
-      expect(component.isOpen(0)).toEqual(false);
-      expect(component.isOpen(3)).toEqual(true);
+      expect(focusSpy).toHaveBeenCalledWith(3);
 
       component.handleKeydownEvent(
         3,
@@ -194,9 +173,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowRight' })
       );
-
-      expect(component.isOpen(0)).toEqual(true);
-      expect(component.isOpen(3)).toEqual(false);
+      expect(focusSpy).toHaveBeenCalledWith(0);
     });
 
     it('should NOT navigate menu buttons with restricted arrow keys', () => {
@@ -208,9 +185,7 @@ describe('TabComponent', () => {
       };
       fixture.detectChanges();
 
-      expect(component.isOpen(0)).toEqual(true);
-      expect(component.isOpen(1)).toEqual(false);
-      expect(component.isOpen(2)).toEqual(false);
+      const focusSpy = spyOn(component, 'focus');
 
       component.handleKeydownEvent(
         0,
@@ -218,10 +193,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowRight' })
       );
-
-      expect(component.isOpen(0)).toEqual(false);
-      expect(component.isOpen(1)).toEqual(true);
-      expect(component.isOpen(2)).toEqual(false);
+      expect(focusSpy).toHaveBeenCalledWith(1);
 
       component.handleKeydownEvent(
         1,
@@ -229,10 +201,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowDown' })
       );
-
-      expect(component.isOpen(0)).toEqual(false);
-      expect(component.isOpen(1)).toEqual(true);
-      expect(component.isOpen(2)).toEqual(false);
+      expect(focusSpy).toHaveBeenCalledTimes(1);
 
       component.handleKeydownEvent(
         1,
@@ -240,10 +209,7 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowLeft' })
       );
-
-      expect(component.isOpen(0)).toEqual(true);
-      expect(component.isOpen(1)).toEqual(false);
-      expect(component.isOpen(2)).toEqual(false);
+      expect(focusSpy).toHaveBeenCalledWith(0);
 
       component.handleKeydownEvent(
         0,
@@ -251,27 +217,11 @@ describe('TabComponent', () => {
         component.config.mode,
         new KeyboardEvent('keydown', { key: 'ArrowUp' })
       );
-
-      expect(component.isOpen(0)).toEqual(true);
-      expect(component.isOpen(1)).toEqual(false);
-      expect(component.isOpen(2)).toEqual(false);
+      expect(focusSpy).toHaveBeenCalledTimes(2);
     });
 
     it('should navigate to last tab with END key', () => {
-      expect(component.isOpen(0)).toEqual(true);
-      expect(component.isOpen(1)).toEqual(false);
-      expect(component.isOpen(3)).toEqual(false);
-
-      component.handleKeydownEvent(
-        0,
-        component.tabs,
-        component.config.mode,
-        new KeyboardEvent('keydown', { key: 'ArrowDown' })
-      );
-
-      expect(component.isOpen(0)).toEqual(false);
-      expect(component.isOpen(1)).toEqual(true);
-      expect(component.isOpen(3)).toEqual(false);
+      const focusSpy = spyOn(component, 'focus');
 
       component.handleKeydownEvent(
         1,
@@ -280,33 +230,11 @@ describe('TabComponent', () => {
         new KeyboardEvent('keydown', { key: 'End' })
       );
 
-      expect(component.isOpen(0)).toEqual(false);
-      expect(component.isOpen(1)).toEqual(false);
-      expect(component.isOpen(3)).toEqual(true);
+      expect(focusSpy).toHaveBeenCalledWith(3);
     });
 
     it('should navigate to first tab with HOME key', () => {
-      component.handleKeydownEvent(
-        0,
-        component.tabs,
-        component.config.mode,
-        new KeyboardEvent('keydown', { key: 'ArrowUp' })
-      );
-
-      expect(component.isOpen(3)).toEqual(true);
-      expect(component.isOpen(2)).toEqual(false);
-      expect(component.isOpen(0)).toEqual(false);
-
-      component.handleKeydownEvent(
-        3,
-        component.tabs,
-        component.config.mode,
-        new KeyboardEvent('keydown', { key: 'ArrowUp' })
-      );
-
-      expect(component.isOpen(3)).toEqual(false);
-      expect(component.isOpen(2)).toEqual(true);
-      expect(component.isOpen(0)).toEqual(false);
+      const focusSpy = spyOn(component, 'focus');
 
       component.handleKeydownEvent(
         2,
@@ -315,9 +243,7 @@ describe('TabComponent', () => {
         new KeyboardEvent('keydown', { key: 'Home' })
       );
 
-      expect(component.isOpen(3)).toEqual(false);
-      expect(component.isOpen(2)).toEqual(false);
-      expect(component.isOpen(0)).toEqual(true);
+      expect(focusSpy).toHaveBeenCalledWith(0);
     });
 
     it('should not set aria-controls when the tab is closed', () => {

--- a/projects/storefrontlib/cms-components/content/tab/tab.component.ts
+++ b/projects/storefrontlib/cms-components/content/tab/tab.component.ts
@@ -21,7 +21,7 @@ import { BehaviorSubject, Observable, of, Subscription } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { Tab, TabConfig, TAB_MODE } from './tab.model';
 import { wrapIntoBounds } from './tab.utils';
-import { TranslationService, FeatureConfigService } from '@spartacus/core';
+import { TranslationService } from '@spartacus/core';
 
 @Component({
   selector: 'cx-tab',
@@ -47,9 +47,6 @@ export class TabComponent implements OnInit, AfterViewInit, OnDestroy {
   protected breakpointService = inject(BreakpointService);
   protected translationService = inject(TranslationService);
   protected cd = inject(ChangeDetectorRef);
-  private featureConfigService = inject(FeatureConfigService, {
-    optional: true,
-  });
 
   @ViewChildren('tabHeader') tabHeaders: QueryList<any>;
 
@@ -113,19 +110,10 @@ export class TabComponent implements OnInit, AfterViewInit, OnDestroy {
   selectOrFocus(tabNum: number, mode: TAB_MODE, event: KeyboardEvent): void {
     event.preventDefault();
 
-    if (this.featureConfigService?.isEnabled('a11yTabsManualActivation')) {
-      switch (mode) {
-        case TAB_MODE.TAB:
-        case TAB_MODE.ACCORDIAN:
-          return this.focus(tabNum);
-      }
-    } else {
-      switch (mode) {
-        case TAB_MODE.TAB:
-          return this.select(tabNum, mode);
-        case TAB_MODE.ACCORDIAN:
-          return this.focus(tabNum);
-      }
+    switch (mode) {
+      case TAB_MODE.TAB:
+      case TAB_MODE.ACCORDIAN:
+        return this.focus(tabNum);
     }
   }
 

--- a/projects/storefrontlib/cms-components/navigation/navigation/navigation-ui.component.html
+++ b/projects/storefrontlib/cms-components/navigation/navigation/navigation-ui.component.html
@@ -67,14 +67,23 @@
         >
           {{ node.title }}
         </cx-generic-link>
-        <ng-container *cxFeature="'!a11yNavigationButtonsAriaFixes'">
+        <h4
+          *ngIf="(isDesktop$ | async) && depth; else dropdownHeader"
+          (keydown.arrowDown)="focusOnNode($any($event))"
+          (keydown.space)="onSpace($any($event))"
+          tabindex="0"
+        >
+          {{ node.title }}
+        </h4>
+        <ng-template #dropdownHeader>
           <button
-            aria-level="4"
-            [attr.role]="(isDesktop$ | async) && depth ? 'heading' : 'button'"
             [attr.aria-haspopup]="true"
             [attr.aria-expanded]="false"
-            [attr.aria-controls]="node.title"
-            [attr.aria-describedby]="'greeting'"
+            [attr.aria-label]="node.url ? node.title : null"
+            [attr.aria-controls]="transformIntoValidID(node.title)"
+            [attr.title]="
+              'navigation.menuButonTitle' | cxTranslate: { title: node.title }
+            "
             (click)="toggleOpen($any($event))"
             (mouseenter)="onMouseEnter($event)"
             (keydown.space)="onSpace($any($event))"
@@ -88,40 +97,7 @@
             </ng-container>
             <cx-icon [type]="iconType.CARET_DOWN"></cx-icon>
           </button>
-        </ng-container>
-        <ng-container *cxFeature="'a11yNavigationButtonsAriaFixes'">
-          <h4
-            *ngIf="(isDesktop$ | async) && depth; else dropdownHeader"
-            (keydown.arrowDown)="focusOnNode($any($event))"
-            (keydown.space)="onSpace($any($event))"
-            tabindex="0"
-          >
-            {{ node.title }}
-          </h4>
-          <ng-template #dropdownHeader>
-            <button
-              [attr.aria-haspopup]="true"
-              [attr.aria-expanded]="false"
-              [attr.aria-label]="node.url ? node.title : null"
-              [attr.aria-controls]="transformIntoValidID(node.title)"
-              [attr.title]="
-                'navigation.menuButonTitle' | cxTranslate: { title: node.title }
-              "
-              (click)="toggleOpen($any($event))"
-              (mouseenter)="onMouseEnter($event)"
-              (keydown.space)="onSpace($any($event))"
-              (keydown.enter)="onSpace($any($event))"
-              (keydown.esc)="back()"
-              (keydown.arrowDown)="focusOnNode($any($event))"
-              (focus)="depth || reinitializeMenu()"
-            >
-              <ng-container *ngIf="!node.url">
-                {{ node.title }}
-              </ng-container>
-              <cx-icon [type]="iconType.CARET_DOWN"></cx-icon>
-            </button>
-          </ng-template>
-        </ng-container>
+        </ng-template>
       </ng-container>
       <ng-template #title>
         <span

--- a/projects/storefrontlib/cms-components/navigation/navigation/navigation-ui.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/navigation/navigation-ui.component.ts
@@ -119,7 +119,6 @@ export class NavigationUIComponent implements OnInit, OnDestroy {
       })
     );
     useFeatureStyles('a11yOptimizedMenuSpacing');
-    useFeatureStyles('a11yNavigationButtonsAriaFixes');
   }
 
   /**
@@ -264,20 +263,10 @@ export class NavigationUIComponent implements OnInit, OnDestroy {
    * Focuses on the first focusable element in the dropdown
    */
   focusOnNode(event: UIEvent): void {
-    if (
-      this.featureConfigService?.isEnabled('a11yNavigationButtonsAriaFixes')
-    ) {
-      const firstFocusableNode = (<HTMLElement>(
-        event.target
-      ))?.nextElementSibling?.querySelector('button, h4, a') as HTMLElement;
-      firstFocusableNode?.focus();
-    } else {
-      const firstFocusableElement =
-        (<HTMLElement>event.target).nextElementSibling?.querySelector(
-          'button'
-        ) || (<HTMLElement>event.target).nextElementSibling?.querySelector('a');
-      firstFocusableElement?.focus();
-    }
+    const firstFocusableNode = (<HTMLElement>(
+      event.target
+    ))?.nextElementSibling?.querySelector('button, h4, a') as HTMLElement;
+    firstFocusableNode?.focus();
   }
 
   back(): void {
@@ -396,22 +385,6 @@ export class NavigationUIComponent implements OnInit, OnDestroy {
       return 0;
     }
     return depth > 0 && !node?.children ? -1 : 0;
-  }
-
-  // TODO: Delete deprecated methods once `a11yNavigationButtonsAriaFixes` feature flag is removed.
-  /**
-   * Replace spaces with hyphens and convert to lowercase
-   * @deprecated
-   */
-  getSanitizedTitle(title: string | undefined): string | null {
-    return title ? title.replace(/\s+/g, '-').toLowerCase() : null;
-  }
-  /**
-   * Returns the value for the `aria-control` and the `aria-label` attribute of a button.
-   * @deprecated
-   */
-  getAriaLabelAndControl(node: NavigationNode): string | null {
-    return this.getSanitizedTitle(node.title) || null;
   }
 
   transformIntoValidID(string: string): string | null {

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.ts
@@ -456,15 +456,9 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
     ];
     // Focus on first index moving to last
     if (results.length) {
-      if (
-        this.featureConfigService?.isEnabled(
-          'a11ySearchableDropdownFirstElementFocus'
-        )
-      ) {
-        this.winRef.document
-          .querySelector('header')
-          ?.classList.remove('mouse-focus');
-      }
+      this.winRef.document
+        .querySelector('header')
+        ?.classList.remove('mouse-focus');
       if (focusedIndex >= results.length - 1) {
         results[0].focus();
       } else {

--- a/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.ts
+++ b/projects/storefrontlib/cms-components/navigation/search-box/search-box.component.ts
@@ -24,7 +24,6 @@ import {
   FeatureConfigService,
   PageType,
   RoutingService,
-  useFeatureStyles,
   WindowRef,
 } from '@spartacus/core';
 import { Observable, of, Subscription } from 'rxjs';
@@ -149,9 +148,7 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
     protected componentData: CmsComponentData<CmsSearchBoxComponent>,
     protected winRef: WindowRef,
     protected routingService: RoutingService
-  ) {
-    useFeatureStyles('a11yKeyboardFocusInSearchBox');
-  }
+  ) {}
 
   /**
    * Returns the SearchBox configuration. The configuration is driven by multiple

--- a/projects/storefrontlib/layout/main/storefront.component.spec.ts
+++ b/projects/storefrontlib/layout/main/storefront.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component, DebugElement, Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { FeatureConfigService, RoutingService } from '@spartacus/core';
+import { RoutingService } from '@spartacus/core';
 import { EMPTY, Observable, of } from 'rxjs';
 import { OutletDirective } from '../../cms-structure';
 import { MockFeatureDirective } from '../../shared/test/mock-feature-directive';
@@ -115,12 +115,6 @@ describe('StorefrontComponent', () => {
           provide: SkipLinkService,
           useClass: MockSkipLinkService,
         },
-        {
-          provide: FeatureConfigService,
-          useValue: {
-            isEnabled: () => true,
-          },
-        },
       ],
     }).compileComponents();
   }));
@@ -195,9 +189,6 @@ describe('StorefrontComponent', () => {
 
     it('should call skipLinkService.scrollToTarget when navigation ends and document has active element', () => {
       spyOn(skipLinkService, 'scrollToTarget');
-      spyOn(component['featureConfigService'], 'isEnabled').and.returnValue(
-        true
-      );
 
       const mockDocument = {
         activeElement: document.createElement('button'),
@@ -212,26 +203,12 @@ describe('StorefrontComponent', () => {
 
     it('should not call skipLinkService.scrollToTarget when navigation ends and focus is on body', () => {
       spyOn(skipLinkService, 'scrollToTarget');
-      spyOn(component['featureConfigService'], 'isEnabled').and.returnValue(
-        true
-      );
       const body = document.createElement('body');
       const mockDocument = {
         activeElement: body,
         body,
       };
       component['document'] = mockDocument as any;
-
-      component['onNavigation'](false);
-
-      expect(skipLinkService.scrollToTarget).not.toHaveBeenCalled();
-    });
-
-    it('should not call skipLinkService.scrollToTarget when feature is disabled', () => {
-      spyOn(skipLinkService, 'scrollToTarget');
-      spyOn(component['featureConfigService'], 'isEnabled').and.returnValue(
-        false
-      );
 
       component['onNavigation'](false);
 

--- a/projects/storefrontlib/layout/main/storefront.component.ts
+++ b/projects/storefrontlib/layout/main/storefront.component.ts
@@ -87,7 +87,6 @@ export class StorefrontComponent implements OnInit, OnDestroy {
     protected elementRef: ElementRef<HTMLElement>,
     protected keyboardFocusService: KeyboardFocusService
   ) {
-    useFeatureStyles('a11yKeyboardFocusInSearchBox');
     useFeatureStyles('a11yNgSelectLayering');
     useFeatureStyles('topProgressBarUseTransformAnimation');
     useFeatureStyles('unifiedDefaultHeaderSlotsAcrossBreakpoints');

--- a/projects/storefrontlib/layout/main/storefront.component.ts
+++ b/projects/storefrontlib/layout/main/storefront.component.ts
@@ -18,10 +18,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-  RoutingService,
-  useFeatureStyles,
-} from '@spartacus/core';
+import { RoutingService, useFeatureStyles } from '@spartacus/core';
 import { Observable, Subscription, tap } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 import {
@@ -155,7 +152,8 @@ export class StorefrontComponent implements OnInit, OnDestroy {
     this.stopNavigating = isNavigating === false;
 
     // After clicking a link the focus should move to the first available item in the main content area.
-    if (this.stopNavigating &&
+    if (
+      this.stopNavigating &&
       this.document?.activeElement !== this.document?.body
     ) {
       this.skipLinkService?.scrollToTarget('cx-main');

--- a/projects/storefrontlib/layout/main/storefront.component.ts
+++ b/projects/storefrontlib/layout/main/storefront.component.ts
@@ -160,9 +160,7 @@ export class StorefrontComponent implements OnInit, OnDestroy {
     this.stopNavigating = isNavigating === false;
 
     // After clicking a link the focus should move to the first available item in the main content area.
-    if (
-      this.featureConfigService.isEnabled('a11yResetFocusAfterNavigating') &&
-      this.stopNavigating &&
+    if (this.stopNavigating &&
       this.document?.activeElement !== this.document?.body
     ) {
       this.skipLinkService?.scrollToTarget('cx-main');

--- a/projects/storefrontlib/layout/main/storefront.component.ts
+++ b/projects/storefrontlib/layout/main/storefront.component.ts
@@ -19,7 +19,6 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
-  FeatureConfigService,
   RoutingService,
   useFeatureStyles,
 } from '@spartacus/core';
@@ -50,7 +49,6 @@ export class StorefrontComponent implements OnInit, OnDestroy {
 
   readonly StorefrontOutlets = StorefrontOutlets;
 
-  private featureConfigService = inject(FeatureConfigService);
   protected destroyRef = inject(DestroyRef);
   @Optional() protected document = inject(DOCUMENT, {
     optional: true,
@@ -105,9 +103,7 @@ export class StorefrontComponent implements OnInit, OnDestroy {
       })
     );
 
-    if (this.featureConfigService.isEnabled('a11yHamburgerMenuTrapFocus')) {
-      this.trapFocusOnMenuIfExpanded();
-    }
+    this.trapFocusOnMenuIfExpanded();
   }
 
   collapseMenuIfClickOutside(event: any): void {

--- a/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.html
+++ b/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.html
@@ -34,18 +34,16 @@
         ></div>
       </div>
 
-      <ng-container *cxFeature="'a11yAnonymousConsentMessageInDialog'">
-        <div class="cx-dialog-message" aria-live="assertive" aria-atomic="true">
-          <cx-message
-            *ngIf="message$ | async as message"
-            [text]="message.key | cxTranslate"
-            [type]="message.type"
-            [isVisibleCloseButton]="true"
-            (closeMessage)="closeMessage()"
-            [cxFocus]="{ autofocus: '.cx-message' }"
-          ></cx-message>
-        </div>
-      </ng-container>
+      <div class="cx-dialog-message" aria-live="assertive" aria-atomic="true">
+        <cx-message
+          *ngIf="message$ | async as message"
+          [text]="message.key | cxTranslate"
+          [type]="message.type"
+          [isVisibleCloseButton]="true"
+          (closeMessage)="closeMessage()"
+          [cxFocus]="{ autofocus: '.cx-message' }"
+        ></cx-message>
+      </div>
       <!-- Actions -->
       <div class="cx-dialog-buttons">
         <button class="btn btn-link cx-action-link" (click)="rejectAll()">

--- a/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.spec.ts
+++ b/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.spec.ts
@@ -174,6 +174,15 @@ describe('AnonymousConsentsDialogComponent', () => {
         anonymousConsentsConfig.anonymousConsents.requiredConsents = [
           mockTemplates[0].id,
         ];
+
+        const closeDialogSpy = spyOn(
+          launchDialogService,
+          'closeDialog'
+        ).and.stub();
+        const messageNextSpy = spyOn(
+          component.message$,
+          'next'
+        ).and.callThrough();
         spyOn(component, 'close').and.stub();
         spyOn(anonymousConsentsService, 'isConsentGiven').and.returnValues(
           true,
@@ -193,12 +202,24 @@ describe('AnonymousConsentsDialogComponent', () => {
         expect(anonymousConsentsService.withdrawConsent).toHaveBeenCalledTimes(
           1
         );
-        expect(component.close).toHaveBeenCalledWith('rejectAll');
+        expect(closeDialogSpy).not.toHaveBeenCalled();
+        expect(messageNextSpy).toHaveBeenCalledWith({
+          type: GlobalMessageType.MSG_TYPE_CONFIRMATION,
+          key: 'consentManagementForm.message.success.withdrawn',
+        });
       });
     });
     describe('when no required consent is present', () => {
       it('should call withdrawAllConsents and close the modal dialog', () => {
-        spyOn(component, 'close').and.stub();
+        const closeDialogSpy = spyOn(
+          launchDialogService,
+          'closeDialog'
+        ).and.stub();
+        const messageNextSpy = spyOn(
+          component.message$,
+          'next'
+        ).and.callThrough();
+
         spyOn(anonymousConsentsService, 'isConsentGiven').and.returnValues(
           true,
           true
@@ -217,7 +238,11 @@ describe('AnonymousConsentsDialogComponent', () => {
         expect(anonymousConsentsService.withdrawConsent).toHaveBeenCalledTimes(
           mockTemplates.length
         );
-        expect(component.close).toHaveBeenCalledWith('rejectAll');
+        expect(closeDialogSpy).not.toHaveBeenCalled();
+        expect(messageNextSpy).toHaveBeenCalledWith({
+          type: GlobalMessageType.MSG_TYPE_CONFIRMATION,
+          key: 'consentManagementForm.message.success.withdrawn',
+        });
       });
     });
   });
@@ -238,7 +263,16 @@ describe('AnonymousConsentsDialogComponent', () => {
         anonymousConsentsConfig.anonymousConsents.requiredConsents = [
           mockTemplates[0].id,
         ];
-        spyOn(component, 'close').and.stub();
+
+        const closeDialogSpy = spyOn(
+          launchDialogService,
+          'closeDialog'
+        ).and.stub();
+        const messageNextSpy = spyOn(
+          component.message$,
+          'next'
+        ).and.callThrough();
+
         spyOn(anonymousConsentsService, 'isConsentWithdrawn').and.returnValues(
           true,
           true
@@ -255,12 +289,24 @@ describe('AnonymousConsentsDialogComponent', () => {
         component.allowAll();
 
         expect(anonymousConsentsService.giveConsent).toHaveBeenCalledTimes(1);
-        expect(component.close).toHaveBeenCalledWith('allowAll');
+        expect(closeDialogSpy).not.toHaveBeenCalled();
+        expect(messageNextSpy).toHaveBeenCalledWith({
+          type: GlobalMessageType.MSG_TYPE_CONFIRMATION,
+          key: 'consentManagementForm.message.success.given',
+        });
       });
     });
     describe('when no required consent is present', () => {
       it('should call giveConsent for each consent and close the modal dialog', () => {
-        spyOn(component, 'close').and.stub();
+        const closeDialogSpy = spyOn(
+          launchDialogService,
+          'closeDialog'
+        ).and.stub();
+        const messageNextSpy = spyOn(
+          component.message$,
+          'next'
+        ).and.callThrough();
+
         spyOn(anonymousConsentsService, 'isConsentWithdrawn').and.returnValues(
           true,
           true
@@ -279,7 +325,11 @@ describe('AnonymousConsentsDialogComponent', () => {
         expect(anonymousConsentsService.giveConsent).toHaveBeenCalledTimes(
           mockTemplates.length
         );
-        expect(component.close).toHaveBeenCalledWith('allowAll');
+        expect(closeDialogSpy).not.toHaveBeenCalled();
+        expect(messageNextSpy).toHaveBeenCalledWith({
+          type: GlobalMessageType.MSG_TYPE_CONFIRMATION,
+          key: 'consentManagementForm.message.success.given',
+        });
       });
     });
     describe('when the consents have null state', () => {
@@ -295,7 +345,14 @@ describe('AnonymousConsentsDialogComponent', () => {
           },
         ];
 
-        spyOn(component, 'close').and.stub();
+        const closeDialogSpy = spyOn(
+          launchDialogService,
+          'closeDialog'
+        ).and.stub();
+        const messageNextSpy = spyOn(
+          component.message$,
+          'next'
+        ).and.callThrough();
         spyOn(anonymousConsentsService, 'isConsentWithdrawn').and.returnValues(
           true,
           true
@@ -314,7 +371,11 @@ describe('AnonymousConsentsDialogComponent', () => {
         expect(anonymousConsentsService.giveConsent).toHaveBeenCalledTimes(
           mockTemplates.length
         );
-        expect(component.close).toHaveBeenCalledWith('allowAll');
+        expect(closeDialogSpy).not.toHaveBeenCalled();
+        expect(messageNextSpy).toHaveBeenCalledWith({
+          type: GlobalMessageType.MSG_TYPE_CONFIRMATION,
+          key: 'consentManagementForm.message.success.given',
+        });
       });
     });
   });

--- a/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.ts
+++ b/projects/storefrontlib/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.ts
@@ -18,10 +18,8 @@ import {
   AnonymousConsentsConfig,
   AnonymousConsentsService,
   ConsentTemplate,
-  FeatureConfigService,
   GlobalMessageService,
   GlobalMessageType,
-  useFeatureStyles,
   WindowRef,
 } from '@spartacus/core';
 import { combineLatest, Observable, Subject, Subscription } from 'rxjs';
@@ -39,7 +37,6 @@ export class AnonymousConsentDialogComponent implements OnInit, OnDestroy {
   protected winRef = inject(WindowRef);
 
   private subscriptions = new Subscription();
-  private featureConfigService = inject(FeatureConfigService);
 
   showLegalDescription: boolean | undefined = true;
   iconTypes = ICON_TYPE;
@@ -88,7 +85,6 @@ export class AnonymousConsentDialogComponent implements OnInit, OnDestroy {
         this.requiredConsents = this.config.anonymousConsents.requiredConsents;
       }
     }
-    useFeatureStyles('a11yAnonymousConsentMessageInDialog');
   }
 
   ngOnInit(): void {
@@ -127,13 +123,6 @@ export class AnonymousConsentDialogComponent implements OnInit, OnDestroy {
         )
         .subscribe(() => this.onConsentWithdrawnSuccess())
     );
-    if (
-      !this.featureConfigService.isEnabled(
-        'a11yAnonymousConsentMessageInDialog'
-      )
-    ) {
-      this.close('rejectAll');
-    }
   }
 
   allowAll(): void {
@@ -163,13 +152,6 @@ export class AnonymousConsentDialogComponent implements OnInit, OnDestroy {
         )
         .subscribe(() => this.onConsentGivenSuccess())
     );
-    if (
-      !this.featureConfigService.isEnabled(
-        'a11yAnonymousConsentMessageInDialog'
-      )
-    ) {
-      this.close('allowAll');
-    }
   }
 
   private isRequiredConsent(template: ConsentTemplate): boolean {
@@ -211,37 +193,19 @@ export class AnonymousConsentDialogComponent implements OnInit, OnDestroy {
   }
 
   protected onConsentGivenSuccess(): void {
-    if (
-      this.featureConfigService.isEnabled('a11yAnonymousConsentMessageInDialog')
-    ) {
-      this.selectedInput = <HTMLElement>this.winRef.document.activeElement;
-      this.message$.next({
-        type: GlobalMessageType.MSG_TYPE_CONFIRMATION,
-        key: 'consentManagementForm.message.success.given',
-      });
-    } else {
-      this.globalMessageService?.add(
-        { key: 'consentManagementForm.message.success.given' },
-        GlobalMessageType.MSG_TYPE_CONFIRMATION
-      );
-    }
+    this.selectedInput = <HTMLElement>this.winRef.document.activeElement;
+    this.message$.next({
+      type: GlobalMessageType.MSG_TYPE_CONFIRMATION,
+      key: 'consentManagementForm.message.success.given',
+    });
   }
 
   protected onConsentWithdrawnSuccess(): void {
-    if (
-      this.featureConfigService.isEnabled('a11yAnonymousConsentMessageInDialog')
-    ) {
-      this.selectedInput = <HTMLElement>this.winRef.document.activeElement;
-      this.message$.next({
-        type: GlobalMessageType.MSG_TYPE_CONFIRMATION,
-        key: 'consentManagementForm.message.success.withdrawn',
-      });
-    } else {
-      this.globalMessageService?.add(
-        { key: 'consentManagementForm.message.success.withdrawn' },
-        GlobalMessageType.MSG_TYPE_CONFIRMATION
-      );
-    }
+    this.selectedInput = <HTMLElement>this.winRef.document.activeElement;
+    this.message$.next({
+      type: GlobalMessageType.MSG_TYPE_CONFIRMATION,
+      key: 'consentManagementForm.message.success.withdrawn',
+    });
   }
 
   closeMessage(): void {

--- a/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
+++ b/projects/storefrontlib/shared/components/ng-select-a11y/ng-select-a11y.directive.ts
@@ -99,13 +99,7 @@ export class NgSelectA11yDirective implements AfterViewInit {
 
     this.renderer.setAttribute(inputCombobox, 'role', 'combobox');
     this.renderer.setAttribute(inputCombobox, 'aria-expanded', 'false');
-    if (
-      this.featureConfigService?.isEnabled(
-        'a11yNgSelectAriaLabelDropdownCustomized'
-      )
-    ) {
-      this.customizeNgSelectAriaLabelDropdown();
-    }
+    this.customizeNgSelectAriaLabelDropdown();
 
     const isOpened$ = this.selectComponent.openEvent.pipe(map(() => 'true'));
     const isClosed$ = this.selectComponent.closeEvent.pipe(map(() => 'false'));

--- a/projects/storefrontlib/shared/components/popover/popover.directive.spec.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.directive.spec.ts
@@ -129,7 +129,13 @@ describe('PopoverDirective', () => {
     fixture.detectChanges();
 
     getPopoverOpener().nativeElement.click();
-    expect(document.body.lastChild).toBe(getPopoverComponent().nativeElement);
+
+    const popoverEl = getPopoverComponent().nativeElement as HTMLElement;
+    const body = document.body;
+    const host = (body.firstElementChild ?? body) as HTMLElement;
+
+    expect(host.contains(popoverEl)).toBeTruthy();
+    expect(popoverEl.parentElement).toBe(host);
   });
 
   it('should call passed method on popover `open` event', () => {

--- a/projects/storefrontlib/shared/components/popover/popover.directive.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.directive.ts
@@ -212,7 +212,7 @@ export class PopoverDirective implements OnInit {
 
       if (this.cxPopoverOptions?.appendToBody) {
         const body = this.winRef.document.body;
-        const element = (body.firstElementChild ?? body);
+        const element = body.firstElementChild ?? body;
         this.renderer.appendChild(
           element,
           this.popoverContainer.location.nativeElement

--- a/projects/storefrontlib/shared/components/popover/popover.directive.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.directive.ts
@@ -14,14 +14,12 @@ import {
   HostListener,
   Input,
   OnInit,
-  Optional,
   Output,
   Renderer2,
   TemplateRef,
   ViewContainerRef,
-  inject,
 } from '@angular/core';
-import { FeatureConfigService, WindowRef } from '@spartacus/core';
+import { WindowRef } from '@spartacus/core';
 import { Subject } from 'rxjs';
 import { FocusConfig } from '../../../layout/a11y/keyboard-focus/keyboard-focus.model';
 import { PopoverComponent } from './popover.component';
@@ -119,10 +117,6 @@ export class PopoverDirective implements OnInit {
     }
   }
 
-  @Optional() featureConfigService? = inject(FeatureConfigService, {
-    optional: true,
-  });
-
   protected openTriggerEvents: PopoverEvent[] = [
     PopoverEvent.OPEN,
     PopoverEvent.OPEN_BY_KEYBOARD,
@@ -218,13 +212,7 @@ export class PopoverDirective implements OnInit {
 
       if (this.cxPopoverOptions?.appendToBody) {
         const body = this.winRef.document.body;
-        const element = this.featureConfigService?.isEnabled(
-          'a11yPopoverHighContrast'
-        )
-          ? // we need to select first child element if exists,
-            // otherwise HCT theming in popover will not be picked up.
-            (body.firstElementChild ?? body)
-          : body;
+        const element = (body.firstElementChild ?? body)
         this.renderer.appendChild(
           element,
           this.popoverContainer.location.nativeElement

--- a/projects/storefrontlib/shared/components/popover/popover.directive.ts
+++ b/projects/storefrontlib/shared/components/popover/popover.directive.ts
@@ -212,7 +212,7 @@ export class PopoverDirective implements OnInit {
 
       if (this.cxPopoverOptions?.appendToBody) {
         const body = this.winRef.document.body;
-        const element = (body.firstElementChild ?? body)
+        const element = (body.firstElementChild ?? body);
         this.renderer.appendChild(
           element,
           this.popoverContainer.location.nativeElement

--- a/projects/storefrontstyles/scss/components/content/navigation/_category-navigation.scss
+++ b/projects/storefrontstyles/scss/components/content/navigation/_category-navigation.scss
@@ -9,12 +9,10 @@
     width: 100%;
   }
 
-  @include forFeature('a11yNavigationButtonsAriaFixes') {
-    h4 {
-      text-transform: uppercase;
-      font-weight: 600;
-      width: 100%;
-    }
+  h4 {
+    text-transform: uppercase;
+    font-weight: 600;
+    width: 100%;
   }
 
   li {

--- a/projects/storefrontstyles/scss/components/layout/_storefront.scss
+++ b/projects/storefrontstyles/scss/components/layout/_storefront.scss
@@ -54,10 +54,8 @@
       box-shadow: 0 0 0 0;
     }
 
-    @include forFeature('a11yKeyboardFocusInSearchBox') {
-      :focus-within {
-        --cx-visual-focus-width: 0;
-      }
+    :focus-within {
+      --cx-visual-focus-width: 0;
     }
   }
 

--- a/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-dialog.scss
+++ b/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-dialog.scss
@@ -32,13 +32,11 @@
         }
       }
 
-      @include forFeature('a11yAnonymousConsentMessageInDialog') {
-        .cx-dialog-message {
-          padding: 1.5rem 1.75rem 0;
+      .cx-dialog-message {
+        padding: 1.5rem 1.75rem 0;
 
-          .cx-message {
-            margin: 0;
-          }
+        .cx-message {
+          margin: 0;
         }
       }
 

--- a/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-management-banner.scss
+++ b/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-management-banner.scss
@@ -51,9 +51,7 @@
     }
   }
 
-  @include forFeature('a11yScrollToTopPositioning') {
-    &:has(.anonymous-consent-banner) ~ cx-scroll-to-top {
-      bottom: 180px;
-    }
+  &:has(.anonymous-consent-banner) ~ cx-scroll-to-top {
+    bottom: 180px;
   }
 }

--- a/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-open-dialog.scss
+++ b/projects/storefrontstyles/scss/components/myaccount/anonymous-consent/_anonymous-consent-open-dialog.scss
@@ -1,19 +1,13 @@
 %cx-anonymous-consent-open-dialog {
   display: flex;
   justify-content: center;
-  margin: 0 3vw 3vw 3vw;
-
-  @include forFeature('a11yHideConsentButtonWhenBannerVisible') {
-    margin: 0;
-  }
+  margin: 0;
 
   @include media-breakpoint-down(sm) {
     justify-content: flex-start;
   }
   .btn-link {
-    @include forFeature('a11yHideConsentButtonWhenBannerVisible') {
-      margin: 1.5vw 3vw;
-    }
+    margin: 1.5vw 3vw;
     padding: 0;
     color: var(--cx-color-inverse);
     font-size: 0.875rem;

--- a/projects/storefrontstyles/scss/components/product/search/_searchbox.scss
+++ b/projects/storefrontstyles/scss/components/product/search/_searchbox.scss
@@ -165,10 +165,8 @@
       padding-bottom: 6px;
       padding-inline-start: 10px;
 
-      @include forFeature('a11yKeyboardFocusInSearchBox') {
-        &:focus-within {
-          @include visible-focus();
-        }
+      &:focus-within {
+        @include visible-focus();
       }
 
       @include media-breakpoint-up(md) {
@@ -188,11 +186,9 @@
         z-index: 20;
         padding-top: 25px;
 
-        @include forFeature('a11yKeyboardFocusInSearchBox') {
-          &:focus-within {
-            padding: 27px 10px 8px;
-            outline: 0;
-          }
+        &:focus-within {
+          padding: 27px 10px 8px;
+          outline: 0;
         }
       }
     }
@@ -210,10 +206,8 @@
         border: 1px solid var(--cx-color-medium);
         border-radius: 4px;
 
-        @include forFeature('a11yKeyboardFocusInSearchBox') {
-          &:focus {
-            @include visible-focus();
-          }
+        &:focus {
+          @include visible-focus();
         }
       }
 


### PR DESCRIPTION
Ticket: [CXSPA-11707](https://jira.tools.sap/browse/CXSPA-11707)


Deprecate the following accessibility toggles, as part of the deprecation plan for the Feb 2026:
- a11yUseProperTextColorForFutureStockAccordion
- a11yPopoverHighContrast
- a11yTabsManualActivation
- a11yAnonymousConsentMessageInDialog
- a11yQuickOrderSearchListKeyboardNavigation
- a11yTruncatedTextUnitLevelOrderHistory
- a11yResetFocusAfterNavigating
- a11yNgSelectAriaLabelDropdownCustomized
- a11yMiniCartFocusOnMobile
- a11yQuickOrderSearchBoxRefocusOnClose
- a11yKeyboardFocusInSearchBox
- a11yNavigationButtonsAriaFixes
- a11yFocusOnCardAfterSelecting
- a11ySearchableDropdownFirstElementFocus
- a11yHideConsentButtonWhenBannerVisible
- a11yRepeatingButtonsUniqueLabels
- a11yHighContrastBorders
- a11yRegionAssociatedHeaders
- a11yHamburgerMenuTrapFocus
- a11yScrollToTopPositioning