### PR TITLE
fix: Add missing thead in SavedCartListComponent

### DIFF
--- a/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.html
+++ b/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.html
@@ -10,6 +10,31 @@
 
     <ng-container *ngIf="savedCarts?.length > 0; else noSavedCarts">
       <table role="table" class="table cx-saved-cart-list-table">
+        <thead
+          role="row"
+          class="cx-saved-cart-list-thead-mobile"
+        >
+          <tr>
+            <th scope="col">
+              {{ 'savedCartList.cartName' | cxTranslate }}
+            </th>
+            <th scope="col">
+              {{ 'savedCartList.cartId' | cxTranslate }}
+            </th>
+            <th scope="col">
+              {{ 'savedCartList.dateSaved' | cxTranslate }}
+            </th>
+            <th scope="col" class="cx-saved-cart-list-th-qty">
+              {{ 'savedCartList.quantityFull' | cxTranslate }}
+            </th>
+            <th scope="col" class="cx-saved-cart-list-th-total">
+              {{ 'savedCartList.total' | cxTranslate }}
+            </th>
+            <th scope="col">
+              {{ 'savedCartList.actions' | cxTranslate }}
+            </th>
+          </tr>
+        </thead>
         <tbody>
           <tr
             role="row"

--- a/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.html
+++ b/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.html
@@ -10,10 +10,7 @@
 
     <ng-container *ngIf="savedCarts?.length > 0; else noSavedCarts">
       <table role="table" class="table cx-saved-cart-list-table">
-        <thead
-          role="row"
-          class="cx-saved-cart-list-thead-mobile"
-        >
+        <thead role="row" class="cx-saved-cart-list-thead-mobile">
           <tr>
             <th scope="col">
               {{ 'savedCartList.cartName' | cxTranslate }}


### PR DESCRIPTION
Restore missing `<thead>` on `SavedCartList` after a11y flag cleanup for Dec Release.

Saved Cart had a special nested setup with two `<thead>` blocks behind opposite *`cxFeature` (`!a11yTableHeaderReadout` and `a11yTableHeaderReadout`).
Once the deprecated flag wrapper was removed, there was effectively no `<thead>` rendered in the affected path.


This PR adds back the missing `<thead>` (without reintroducing the deprecated flag structure) so the table header renders consistently.