### PR TITLE
feat: CXSPA-11727 Installation and migration docs adjustments

### DIFF
--- a/docs/migration/221121_8/installation.md
+++ b/docs/migration/221121_8/installation.md
@@ -1,6 +1,6 @@
-# Installing Spartacus 2211.21 with Angular 20
+# Installing Spartacus 221121.8 with Angular 21
 
-This guide provides step-by-step instructions for creating a fresh Angular 20 application and installing Spartacus 2211.21.
+This guide provides step-by-step instructions for creating a fresh Angular 20 application and installing Spartacus 221121.8
 
 ## Prerequisites
 
@@ -8,20 +8,20 @@ Before starting, ensure you have the following installed:
 
 - **Node.js**: Version 22 or higher
 - **npm**: Version 10 or higher
-- **Angular CLI**: Version 20
+- **Angular CLI**: Version 21
 
 Install or update Angular CLI globally:
 
 ```bash
-npm install -g @angular/cli@20
+npm install -g @angular/cli@21
 ```
 
-## Step 1: Create a New Angular 20 Application
+## Step 1: Create a New Angular 21 Application
 
-Create a new Angular 20 application:
+Create a new Angular 21 application:
 
 ```bash
-ng new my-spartacus-app --style=scss --ssr=false --zoneless=false --standalone=false
+ng new my-spartacus-app --style=scss --ssr=false --zoneless=false --standalone=false --file-name-style-guide=2016
 cd my-spartacus-app
 ```
 
@@ -37,6 +37,21 @@ The schematics will:
 - rename files in the project to use classic file name style guide (e.g., `app.component.ts` instead of `app.ts`)
 - Install required Spartacus libraries
 - Configure your application for Spartacus
+
+## Manual Changes
+
+//TODO: if Angular installation schematics are updated to include these changes, we can remove this section.
+In `main.ts`, update the replace deprecated BootstrapOptions object property `ngZoneEventCoalescing` with the new `provideZoneChangeDetection` function:
+
+```diff
++ import { provideZoneChangeDetection } from '@angular/core';
+
+ platformBrowser().bootstrapModule(AppModule, {
+-  ngZoneEventCoalescing: true,
++  provideZoneChangeDetection({ eventCoalescing: true }),
+})
+  .catch(err => console.error(err));
+```
 
 ## Step 3: SSR-Specific Configuration (If Using SSR)
 

--- a/docs/migration/221121_8/installation.md
+++ b/docs/migration/221121_8/installation.md
@@ -8,12 +8,12 @@ Before starting, ensure you have the following installed:
 
 - **Node.js**: Version 22 or higher
 - **npm**: Version 10 or higher
-- **Angular CLI**: Version 21
+- **Angular CLI**: Version 21.0.5
 
 Install or update Angular CLI globally:
 
 ```bash
-npm install -g @angular/cli@21
+npm install -g @angular/cli@21.0.5
 ```
 
 ## Step 1: Create a New Angular 21 Application
@@ -38,21 +38,6 @@ The schematics will:
 - Install required Spartacus libraries
 - Configure your application for Spartacus
 
-## Manual Changes
-
-//TODO: if Angular installation schematics are updated to include these changes, we can remove this section.
-In `main.ts`, update the replace deprecated BootstrapOptions object property `ngZoneEventCoalescing` with the new `provideZoneChangeDetection` function:
-
-```diff
-+ import { provideZoneChangeDetection } from '@angular/core';
-
- platformBrowser().bootstrapModule(AppModule, {
--  ngZoneEventCoalescing: true,
-+  provideZoneChangeDetection({ eventCoalescing: true }),
-})
-  .catch(err => console.error(err));
-```
-
 ## Step 3: SSR-Specific Configuration (If Using SSR)
 
 For Spartacus with Server-Side Rendering (SSR), run the following command:
@@ -62,30 +47,3 @@ ng add @spartacus/schematics@221121.<latest> --ssr
 ```
 This will set up SSR-specific configurations.
 
-### Manual Changes for SSR with `application` builder
-
-If you enabled SSR during project creation, you need to make an additional manual changes in the project files:
-
-1. remove `app.routes.server.ts` file as it is not supported by Spartacus SSR.
-2. remove `provideServerRendering` from `app.server.module.ts` file:
-
-```diff
-import { NgModule } from '@angular/core';
-import { provideServerRendering, withRoutes } from '@angular/ssr';
-import { provideServer } from '@spartacus/setup/ssr';
-import { App } from './app.component';
-import { AppModule } from './app.module';
-import { serverRoutes } from './app.routes.server';
-
-@NgModule({
-  imports: [AppModule],
-  providers: [
--   provideServerRendering(withRoutes(serverRoutes)),
-    ...provideServer({
-      serverRequestOrigin: process.env['SERVER_REQUEST_ORIGIN'],
-    }),
-  ],
-  bootstrap: [App],
-})
-export class AppServerModule {}
-```

--- a/docs/migration/221121_8/installation.md
+++ b/docs/migration/221121_8/installation.md
@@ -30,11 +30,10 @@ cd my-spartacus-app
 Run the Spartacus schematics to add Spartacus to your project:
 
 ```bash
-ng add @spartacus/schematics@221121.<latest>
+ng add @spartacus/schematics@221121.8
 ```
 
 The schematics will:
-- rename files in the project to use classic file name style guide (e.g., `app.component.ts` instead of `app.ts`)
 - Install required Spartacus libraries
 - Configure your application for Spartacus
 
@@ -43,7 +42,7 @@ The schematics will:
 For Spartacus with Server-Side Rendering (SSR), run the following command:
 
 ```bash
-ng add @spartacus/schematics@221121.<latest> --ssr
+ng add @spartacus/schematics@221121.8 --ssr
 ```
 This will set up SSR-specific configurations.
 

--- a/docs/migration/221121_8/migration.md
+++ b/docs/migration/221121_8/migration.md
@@ -139,7 +139,31 @@ Let's make following manual changes to modernize so it's similar to a new Angula
     }
 ```
 
-Starting from Angular 20, the `outputPath` option defaults to `dist/<project-name>`, what removest the need to explicitly setting it within a freshly generated app. If your migrated app has `outputPath` set to `dist/<project-name>`, we recommend removing it to keep it consistent with a new app structure.
+Starting from Angular 20, the `outputPath` option defaults to `dist/<your-project-name>`, what removes the need to explicitly setting it within a freshly generated app. If your migrated app has `outputPath` set to `dist/<your-project-name>`, we recommend removing it from the `angular.json` to keep it consistent with a new app structure.
+
+```diff
+ "projects": {
+    <your-project-name>: {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "options": {
+-            "outputPath": "dist/<your-project-name>",
+            "browser": "src/main.ts",
+            "polyfills": [
+              "zone.js"
+            ],
+            ...
+        }
+      }
+    }
+```
+
+For more, see: https://github.com/angular/angular-cli/pull/29905
+
 
 1. In `tsconfig.json`, update the config in the following way:
 

--- a/docs/migration/221121_8/migration.md
+++ b/docs/migration/221121_8/migration.md
@@ -1,17 +1,14 @@
-# Migrating a custom app to use Spartacus with Angular 20
+# Migrating a custom app to use Spartacus 221121.8 with Angular 21
 
-Before upgrading Spartacus to the new version with Angular 20, you need to first:
+Before upgrading Spartacus to the new version with Angular 21, you need to first:
 
 - upgrade Spartacus to version 221121.5.0 (with Angular 19)
-- install Node 22 version
-- if your project uses SSR (Server-Side Rendering), please upgrade `@types/node` to version 22
+- ensure you have Node 22 version installed
+- upgrade Angular to version v20 and then to v21
 
-  ```bash
-  npm i @types/node@22 -D
-  ```
-- upgrade Angular to version v20
+## Update Angular to 20 and 21
 
-## Update Angular to 20 and 3rd party deps to be compatible with Angular 20
+### Update Angular to 20 and 3rd party deps to be compatible with Angular 20
 
 Follow the [Angular guidelines for upgrading from v19 to v20](https://angular.dev/update-guide?v=19.0-20.0&l=3) and bump the Angular version locally, and update other 3rd party dependencies from Angular ecosystem to versions compatible with Angular 20 (e.g. `@ng-select/ng-select@latest`, `@ngrx/store@20`, `angular-oauth2-oidc@20`, `ngx-infinite-scroll@latest`):
 
@@ -86,12 +83,27 @@ The result of migration should be following:
 
 Angular migration also takes care of adding `"typeSeparator": "."` to and proper type (suffix) to relevant schematics.
 
+### Update Angular to 21 and 3rd party deps to be compatible with Angular 21
+
+Follow the [Angular guidelines for upgrading from v20 to v21](https://angular.dev/update-guide?v=20.0-21.0&l=3) and bump the Angular version locally, and update other 3rd party dependencies from Angular ecosystem to versions compatible with Angular 21 (e.g. `@ng-select/ng-select@latest`, `@ngrx/store@21`, `angular-oauth2-oidc@21`, `ngx-infinite-scroll@latest`):
+
+```bash
+ng update @angular/core@21 @angular/cli@21 @ngrx/store@21 angular-oauth2-oidc@21 @ng-select/ng-select@21 ngx-infinite-scroll@21 --force
+git add .
+git commit -m "update angular 21 and 3rd party deps angular 21 compatible"
+```
+While migrating to Angular 20, you'll be asked whether to run the `use-application-builder` migration:
+
+`❯◯ [use-application-builder] Migrate application projects to the new build system.`
+
+If you didn't run it during Angular 20 migration, let's select this migration to replace old builders located under `@angular-devkit/build-angular` with new ones under `@angular/build`. The result of migration should be similar to the one shown in the previous step. If you already ran it during Angular 20 migration, the migration won't make any changes.
+
 ## Run Spartacus update
 
 After successfully updating the application to Angular 20 and Express 5, execute this command to initiate the Spartacus update process.
 
 ```bash
-ng update @spartacus/schematics@2211.21
+ng update @spartacus/schematics@221121.8
 ```
 
 ### Manual changes
@@ -150,7 +162,6 @@ Let's make following manual changes to modernize so it's similar to a new Angula
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-+    "typeCheckHostBindings": true,
     "strictTemplates": true
   },
 +  "files": [],
@@ -199,16 +210,36 @@ import { SpartacusModule } from './spartacus/spartacus.module';
 export class AppModule { }
 ```
 
-## If using Server Side Rendering (SSR)
+Note: The following migration should also take care of adding `provideZoneChangeDetection` to `main.ts` together with migrating deprecated bootstrap options:
+
+```
+❯ Migrates deprecated bootstrap options to providers.
+UPDATE src/main.ts (334 bytes)
+(1 file modified)
+```
+
+If not, please add it manually as shown below:
+
+```diff
++ import { provideZoneChangeDetection } from '@angular/core';
+
+ platformBrowser().bootstrapModule(AppModule, {
+-  ngZoneEventCoalescing: true,
++  provideZoneChangeDetection({ eventCoalescing: true }),
+})
+  .catch(err => console.error(err));
+```
+
+## Additional migration steps if using Server Side Rendering (SSR)
 
 ### Upgrade Express to Version 5
 
 Spartacus 221121.<latest> requires Express 5.x. Upgrade Express:
 
 ```bash
-npm install express@^5.1.0
+ng update express@5.1.0
 git add .
-git commit -m "chore: upgrade Express to v5"
+git commit -m "chore: upgrade Express to v5.1.0"
 ```
 
 ### Manual changes

--- a/docs/migration/221121_8/migration.md
+++ b/docs/migration/221121_8/migration.md
@@ -30,8 +30,6 @@ The result of migration should be following:
  "projects": {
     <your-project-name>: {
       "projectType": "application",
-+      "root": "",
-+      "sourceRoot": "src",
       "prefix": "app",
       "architect": {
         "build": {
@@ -81,18 +79,25 @@ The result of migration should be following:
 +  }
 ```
 
-Angular migration also takes care of adding `"typeSeparator": "."` to and proper type (suffix) to relevant schematics.
+
+You might also face the following migrations when updating to Angular 20:
+```bash
+Select the migrations that you'd like to run  
+❯◯ [control-flow-migration] Converts the entire application to block control flow syntax.  
+ ◯ [router-current-navigation] Replaces usages of the deprecated Router getCurrentNavigation method with the Router.currentNavigation signal.
+```
+From Spartacus perspective these migrations are not required, however you may decide to opt-in to them.
 
 ### Update Angular to 21 and 3rd party deps to be compatible with Angular 21
 
 Follow the [Angular guidelines for upgrading from v20 to v21](https://angular.dev/update-guide?v=20.0-21.0&l=3) and bump the Angular version locally, and update other 3rd party dependencies from Angular ecosystem to versions compatible with Angular 21 (e.g. `@ng-select/ng-select@latest`, `@ngrx/store@21`, `angular-oauth2-oidc@21`, `ngx-infinite-scroll@latest`):
 
 ```bash
-ng update @angular/core@21 @angular/cli@21 @ngrx/store@21 angular-oauth2-oidc@21 @ng-select/ng-select@21 ngx-infinite-scroll@21 --force
+ng update @angular/core@21 @angular/cli@21 @ngrx/store@21 angular-oauth2-oidc@20 @ng-select/ng-select@21 ngx-infinite-scroll@21 --force
 git add .
 git commit -m "update angular 21 and 3rd party deps angular 21 compatible"
 ```
-While migrating to Angular 20, you'll be asked whether to run the `use-application-builder` migration:
+While migrating to Angular 21, you'll be asked whether to run the `use-application-builder` migration:
 
 `❯◯ [use-application-builder] Migrate application projects to the new build system.`
 
@@ -134,7 +139,7 @@ Let's make following manual changes to modernize so it's similar to a new Angula
     }
 ```
 
-2. In `tsconfig.json`, update the `types` array to include `"node20"` instead of `"node"`:
+1. In `tsconfig.json`, update the config in the following way:
 
 ```diff
 /* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
@@ -176,11 +181,30 @@ Let's make following manual changes to modernize so it's similar to a new Angula
 +}
 ```
 
-1. In `app.module.ts`, add the `provideBrowserGlobalErrorListeners` to the `providers` array. For more, see: https://angular.dev/best-practices/error-handling#client-side-rendering
+It's worth noting that starting from Angular 21, flag `typeCheckHostBindings` is enabled by default. Due to its srtict type checking, it cause a [known issue](https://github.com/angular/angular/issues/63170) if specific `keydown` bindings are used in `@HostListener` decorators. To solve the problem in Spartacus repo, we introduced [type augmentation](https://github.com/SAP/spartacus/blob/ac651f413f44345bf8519391789c4f47c8ed02b0/types.d.ts#L1) for `global` interface. If you encounter similar issues in your application, it is recommended to apply the same type augmentation approach in your project.
+
+While it's not recommended, you can still disable the flag by adding the following configuration to your `tsconfig.json`:
+
+```diff
+{
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true,
++    "typeCheckHostBindings": false
+  },
+}
+```
+
+
+3. In `app.module.ts`, add the `provideBrowserGlobalErrorListeners` and `provideZoneChangeDetection({ eventCoalescing: true }),` to the `providers` array. 
+For more about `provideBrowserGlobalErrorListeners`, see: https://angular.dev/best-practices/error-handling#client-side-rendering
+For more about `provideZoneChangeDetection`, see: https://angular.dev/api/core/provideZoneChangeDetection
 
 ```diff
 -import { NgModule } from '@angular/core';
-+import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
++import { NgModule, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { provideHttpClient, withFetch, withInterceptorsFromDi } from "@angular/common/http";
@@ -203,6 +227,7 @@ import { SpartacusModule } from './spartacus/spartacus.module';
   ],
   providers: [
 +    provideBrowserGlobalErrorListeners(),
++    provideZoneChangeDetection({ eventCoalescing: true }),
     provideHttpClient(withFetch(), withInterceptorsFromDi())
   ],
   bootstrap: [App]
@@ -210,22 +235,16 @@ import { SpartacusModule } from './spartacus/spartacus.module';
 export class AppModule { }
 ```
 
-Note: The following migration should also take care of adding `provideZoneChangeDetection` to `main.ts` together with migrating deprecated bootstrap options:
+4. In `main.ts`, remove the `applicationProviders` with`provideZoneChangeDetection({ eventCoalescing: true })` from the `platformBrowser().bootstrapModule` call.
 
-```
-❯ Migrates deprecated bootstrap options to providers.
-UPDATE src/main.ts (334 bytes)
-(1 file modified)
-```
-
-If not, please add it manually as shown below:
 
 ```diff
-+ import { provideZoneChangeDetection } from '@angular/core';
+- import { provideZoneChangeDetection } from '@angular/core';
 
- platformBrowser().bootstrapModule(AppModule, {
--  ngZoneEventCoalescing: true,
-+  provideZoneChangeDetection({ eventCoalescing: true }),
+platformBrowser().bootstrapModule(AppModule, {
+-  applicationProviders: [
+-    provideZoneChangeDetection({ eventCoalescing: true }),
+-  ],
 })
   .catch(err => console.error(err));
 ```
@@ -234,7 +253,7 @@ If not, please add it manually as shown below:
 
 ### Upgrade Express to Version 5
 
-Spartacus 221121.<latest> requires Express 5.x. Upgrade Express:
+Spartacus 221121.8 requires Express 5.x. Upgrade Express:
 
 ```bash
 ng update express@5.1.0

--- a/docs/migration/221121_8/migration.md
+++ b/docs/migration/221121_8/migration.md
@@ -139,6 +139,8 @@ Let's make following manual changes to modernize so it's similar to a new Angula
     }
 ```
 
+Starting from Angular 20, the `outputPath` option defaults to `dist/<project-name>`, what removest the need to explicitly setting it within a freshly generated app. If your migrated app has `outputPath` set to `dist/<project-name>`, we recommend removing it to keep it consistent with a new app structure.
+
 1. In `tsconfig.json`, update the config in the following way:
 
 ```diff
@@ -181,17 +183,13 @@ Let's make following manual changes to modernize so it's similar to a new Angula
 +}
 ```
 
-It's worth noting that starting from Angular 21, flag `typeCheckHostBindings` is enabled by default. Due to its srtict type checking, it cause a [known issue](https://github.com/angular/angular/issues/63170) if specific `keydown` bindings are used in `@HostListener` decorators. To solve the problem in Spartacus repo, we introduced [type augmentation](https://github.com/SAP/spartacus/blob/ac651f413f44345bf8519391789c4f47c8ed02b0/types.d.ts#L1) for `global` interface. If you encounter similar issues in your application, it is recommended to apply the same type augmentation approach in your project.
+Note: In fresh apps generated with Angular 21 CLI, the flag `typeCheckHostBindings` is enabled by default, so we suggest adding it also in migrated apps from Angular 19 to 21. However in apps migrated from Angular 19 to 21 beware it might cause issues. Due to its strict type checking, it causes a [known Angular issue](https://github.com/angular/angular/issues/63170) if specific `keydown` bindings are used in `@HostListener` decorators. To solve the problem in Spartacus repo, we introduced [type augmentation](https://github.com/SAP/spartacus/blob/ac651f413f44345bf8519391789c4f47c8ed02b0/types.d.ts#L1) for `global` interface. If you encounter similar issues in your application, we recommend you to apply analogical type augmentation solution in your project like we did in Spartacus repo.
 
 While it's not recommended, you can still disable the flag by adding the following configuration to your `tsconfig.json`:
 
 ```diff
 {
   "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true,
 +    "typeCheckHostBindings": false
   },
 }

--- a/docs/migration/221121_8/migration.md
+++ b/docs/migration/221121_8/migration.md
@@ -139,7 +139,7 @@ Let's make following manual changes to modernize so it's similar to a new Angula
     }
 ```
 
-Starting from Angular 20, the `outputPath` option defaults to `dist/<your-project-name>`, what removes the need to explicitly setting it within a freshly generated app. If your migrated app has `outputPath` set to `dist/<your-project-name>`, we recommend removing it from the `angular.json` to keep it consistent with a new app structure.
+Note: In fresh apps generated with Angular 21, the `outputPath` option is skipped and implicitly defaults to `dist/<your-project-name>`. If your migrated app has `outputPath` set to `dist/<your-project-name>`, we recommend removing it from the `angular.json` as not necessary.
 
 ```diff
  "projects": {

--- a/docs/migration/221121_8/migration.md
+++ b/docs/migration/221121_8/migration.md
@@ -165,7 +165,7 @@ Note: In fresh apps generated with Angular 21, the `outputPath` option is skippe
 For more, see: https://github.com/angular/angular-cli/pull/29905
 
 
-1. In `tsconfig.json`, update the config in the following way:
+2. In `tsconfig.json`, update the config in the following way:
 
 ```diff
 /* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */


### PR DESCRIPTION
- adjusted installation and migration docs with Angular 21 requirements
- adjusted version references to 221121.8 - the one we will use for major release

QA steps:

1. installation
   - follow instructions from installation.md file
   - test if installed app works
2. migration
    - build libs:
      ```bash
      npm run build:libs
      ```
    - publish libraries on Verdaccio:
      ```bash
      ts-node ./tools/schematics/testing
      ```
   - generate fresh Angular 19 app
     ```bash
     npx @angular/cli@19 new my-app --style=scss --ssr=false --zoneless=false --standalone=false
     ```
   - go to app's location and add `.npmrc` file (`touch .npmrc`) with the following snippet (to install packages from RBSC):
      ```bash
      always-auth=true
      @spartacus:registry=https://73554900100900004337.dev.npmsrv.base.repositories.cloud.sap/
      //73554900100900004337.dev.npmsrv.base.repositories.cloud.sap/:_auth=<PUT_HERE_YOUR_TOKEN>
      ```
   - commit changes
   - install from RBSC the Spartacus in version 221121.4
      ```bash
      npx ng add @spartacus/schematics@221121.4 --baseUrl=https://40.76.109.9:9002
      ```
    - comment/remove `.npmrc` file after installing Spartacus
    - follow migration.md steps
    - verify if app works
    - repeat above steps for SSR app (install Saprtacus with `--ssr` flag in app that supposed to be migrated) and include steps required for SSR