### PR TITLE
chore: add `.gitignore` to Punchout schematics

### DIFF
--- a/integration-libs/punchout/schematics/.gitignore
+++ b/integration-libs/punchout/schematics/.gitignore
@@ -1,0 +1,18 @@
+# Outputs
+**/*.js
+**/*.js.map
+**/*.d.ts
+
+# IDEs
+.idea/
+jsconfig.json
+.vscode/
+
+# Misc
+node_modules/
+npm-debug.log*
+yarn-error.log*
+
+# Mac OSX Finder files.
+**/.DS_Store
+.DS_Store

--- a/tools/build-lib/declaration-merging/index.ts
+++ b/tools/build-lib/declaration-merging/index.ts
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2025 SAP Spartacus team <spartacus-team@sap.com>
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
This PR adds missing `.gitignore` file preventing from merging unwanted files generated during building schematics.

The content was copy-pasted from other libs.