### PR TITLE
feat: CXSPA-11729 Remove redundant 'applyClassicNamingConvention' from schematics

### DIFF
--- a/feature-libs/asm/schematics/add-asm/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/asm/schematics/add-asm/__snapshots__/index_spec.ts.snap
@@ -72,13 +72,34 @@ exports[`Spartacus Asm schematics: ng-add Asm feature general setup styling shou
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/cart/schematics/add-cart/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/cart/schematics/add-cart/__snapshots__/index_spec.ts.snap
@@ -95,13 +95,34 @@ exports[`Spartacus Cart schematics: ng-add Cart Base feature general setup styli
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -265,13 +286,34 @@ exports[`Spartacus Cart schematics: ng-add Cart Import Export feature general se
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -435,13 +477,34 @@ exports[`Spartacus Cart schematics: ng-add Quick Order feature general setup sty
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -605,13 +668,34 @@ exports[`Spartacus Cart schematics: ng-add Saved Cart feature general setup styl
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -785,13 +869,34 @@ exports[`Spartacus Cart schematics: ng-add Wish List feature general setup styli
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/checkout/schematics/add-checkout/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/checkout/schematics/add-checkout/__snapshots__/index_spec.ts.snap
@@ -147,13 +147,34 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature b2b general setu
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -317,13 +338,34 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature base general set
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -581,13 +623,34 @@ exports[`Spartacus Checkout schematics: ng-add Checkout feature scheduled replen
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/customer-ticketing/schematics/add-customer-ticketing/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/customer-ticketing/schematics/add-customer-ticketing/__snapshots__/index_spec.ts.snap
@@ -72,13 +72,34 @@ exports[`Spartacus Customer Ticketing schematics: ng-add Customer Ticketing feat
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/estimated-delivery-date/schematics/add-estimated-delivery-date/__snapshots__/index_spec.ts.snap
@@ -56,13 +56,34 @@ exports[`Spartacus Estimated-Delivery-Date schematics: ng-add Estimated-Delivery
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/order/schematics/add-order/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/order/schematics/add-order/__snapshots__/index_spec.ts.snap
@@ -72,13 +72,34 @@ exports[`Spartacus Order schematics: ng-add Order feature general setup styling 
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/organization/schematics/add-organization/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/organization/schematics/add-organization/__snapshots__/index_spec.ts.snap
@@ -110,13 +110,34 @@ exports[`Spartacus Organization schematics: ng-add Account summary feature gener
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -315,13 +336,34 @@ exports[`Spartacus Organization schematics: ng-add Administration feature genera
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -520,13 +562,34 @@ exports[`Spartacus Organization schematics: ng-add Order approval feature genera
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -725,13 +788,34 @@ exports[`Spartacus Organization schematics: ng-add Unit order feature general se
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -930,13 +1014,34 @@ exports[`Spartacus Organization schematics: ng-add User registration feature gen
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/pdf-invoices/schematics/add-pdf-invoices/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/pdf-invoices/schematics/add-pdf-invoices/__snapshots__/index_spec.ts.snap
@@ -21,13 +21,34 @@ exports[`Spartacus PDF Invoices schematics: ng-add PDF Invoices feature general 
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/pickup-in-store/schematics/add-pickup-in-store/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/pickup-in-store/schematics/add-pickup-in-store/__snapshots__/index_spec.ts.snap
@@ -75,13 +75,34 @@ exports[`Spartacus Pickup in Store schematics: ng-add Pick Up In Store feature g
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/product-configurator/schematics/add-product-configurator/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product-configurator/schematics/add-product-configurator/__snapshots__/index_spec.ts.snap
@@ -141,13 +141,34 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -363,13 +384,34 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -564,13 +606,34 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -731,13 +794,34 @@ exports[`Spartacus product configurator schematics: ng-add Product config featur
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product-multi-dimensional/schematics/add-product-multi-dimensional/__snapshots__/index_spec.ts.snap
@@ -25,13 +25,34 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add list feature gen
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -191,13 +212,34 @@ exports[`Spartacus Product Multi-Dimensional schematics: ng-add selector feature
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/product/schematics/add-product/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/product/schematics/add-product/__snapshots__/index_spec.ts.snap
@@ -110,13 +110,34 @@ exports[`Spartacus Product schematics: ng-add BulkPricing feature general setup 
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -315,13 +336,34 @@ exports[`Spartacus Product schematics: ng-add FutureStock feature general setup 
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -485,13 +527,34 @@ exports[`Spartacus Product schematics: ng-add ImageZoom feature general setup st
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -655,13 +718,34 @@ exports[`Spartacus Product schematics: ng-add Variants feature general setup sty
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/qualtrics/schematics/add-qualtrics/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/qualtrics/schematics/add-qualtrics/__snapshots__/index_spec.ts.snap
@@ -59,13 +59,34 @@ exports[`Spartacus Qualtrics schematics: ng-add Qualtrics feature general setup 
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/quote/schematics/add-quote/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/quote/schematics/add-quote/__snapshots__/index_spec.ts.snap
@@ -130,13 +130,34 @@ exports[`Spartacus Quote schematics: ng-add Quote feature general setup styling 
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/requested-delivery-date/schematics/add-requested-delivery-date/__snapshots__/index_spec.ts.snap
@@ -21,13 +21,34 @@ exports[`Spartacus Requested Delivery Date schematics: ng-add Requested Delivery
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/smartedit/schematics/add-smartedit/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/smartedit/schematics/add-smartedit/__snapshots__/index_spec.ts.snap
@@ -34,13 +34,34 @@ exports[`Spartacus SmartEdit schematics: ng-add SmartEdit feature general setup 
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/storefinder/schematics/add-storefinder/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/storefinder/schematics/add-storefinder/__snapshots__/index_spec.ts.snap
@@ -75,13 +75,34 @@ exports[`Spartacus Storefinder schematics: ng-add Storefinder feature general se
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/feature-libs/subscription-billing/schematics/add-subscription-billing/index_spec.ts
+++ b/feature-libs/subscription-billing/schematics/add-subscription-billing/index_spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -40,6 +41,7 @@ describe('Spartacus Subscription Billing Schematics: ng-add', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
   const spartacusDefaultOptions: SpartacusOptions = {
     project: 'schematics-test',

--- a/feature-libs/user/schematics/add-user/__snapshots__/index_spec.ts.snap
+++ b/feature-libs/user/schematics/add-user/__snapshots__/index_spec.ts.snap
@@ -103,13 +103,34 @@ exports[`Spartacus User schematics: ng-add User Profile feature general setup st
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -270,13 +291,34 @@ exports[`Spartacus User schematics: ng-add User-Account feature general setup st
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/epd-visualization/schematics/add-epd-visualization/__snapshots__/index_spec.ts.snap
@@ -134,13 +134,34 @@ exports[`Spartacus SAP EPD Visualization integration schematics: ng-add SAP EPD 
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/integration-libs/opf/schematics/add-opf/__snapshots__/index_spec.ts.snap
+++ b/integration-libs/opf/schematics/add-opf/__snapshots__/index_spec.ts.snap
@@ -68,13 +68,34 @@ exports[`Spartacus SAP OPF integration schematics: ng-add SAP OPF feature genera
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/integration-libs/opf/schematics/add-opf/index_spec.ts
+++ b/integration-libs/opf/schematics/add-opf/index_spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -52,6 +53,7 @@ describe('Spartacus SAP OPF integration schematics: ng-add', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const spartacusDefaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/add-cms-component/index_spec.ts
+++ b/projects/schematics/src/add-cms-component/index_spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { addSymbolToNgModuleMetadata } from '@schematics/angular/utility/ast-utils';
@@ -99,6 +100,7 @@ describe('add-cms-component', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const defaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/add-spartacus/index.ts
+++ b/projects/schematics/src/add-spartacus/index.ts
@@ -630,115 +630,6 @@ function replaceCaretWithTildeForSpartacusDependencies(
   };
 }
 
-/**
- * Applies the classic naming convention to the project.
- *
- * NOTE: This is a temporary solution for the apps created with Angular v20.
- *       Since v20, Angular CLI by default creates a file `app.ts` in the project.
- *       For v21, there is a dedicated flag `--file-name-style-guide` for the `ng new` command.
- */
-function applyClassicNamingConvention(options: SpartacusOptions): Rule {
-  return (tree: Tree, context: SchematicContext): Tree => {
-    if (options.debug) {
-      context.logger.info(`⌛️ Applying classic naming convention...`);
-    }
-
-    const project = getProjectFromWorkspace(tree, options);
-    const appDir = project.sourceRoot ? `${project.sourceRoot}/app` : 'src/app';
-
-    const renames = [
-      { old: 'app.ts', new: 'app.component.ts' },
-      { old: 'app.html', new: 'app.component.html' },
-      { old: 'app.scss', new: 'app.component.scss' },
-      { old: 'app-module.ts', new: 'app.module.ts' },
-      { old: 'app-routing-module.ts', new: 'app-routing.module.ts' },
-    ];
-
-    let performedRenames = false;
-
-    renames.forEach((rename) => {
-      const oldPath = `${appDir}/${rename.old}`;
-      const newPath = `${appDir}/${rename.new}`;
-      if (tree.exists(newPath) && tree.exists(oldPath)) {
-        // if the new file already exists and the old file exists, delete the old file to avoid conflicts
-        tree.delete(oldPath);
-        context.logger.info(
-          `✅ File ${newPath} already exists, skipping rename`
-        );
-        return;
-      }
-      if (tree.exists(oldPath)) {
-        tree.rename(oldPath, newPath);
-        performedRenames = true;
-        if (options.debug) {
-          context.logger.info(`Renamed ${oldPath} to ${newPath}`);
-        }
-      }
-    });
-
-    if (performedRenames) {
-      tree.visit((filePath) => {
-        if (!filePath.endsWith('.ts')) {
-          return;
-        }
-
-        const buffer = tree.read(filePath);
-        if (!buffer) {
-          return;
-        }
-
-        let content = buffer.toString();
-        let updated = false;
-
-        // app.ts -> app.component.ts
-        // Only match relative imports
-        if (content.match(/(['"])(\.\.?\/[^'"]*)app(['"])/)) {
-          content = content.replace(
-            /(['"])(\.\.?\/[^'"]*)app(['"])/g,
-            '$1$2app.component$3'
-          );
-          updated = true;
-        }
-
-        // app-module.ts -> app.module.ts
-        if (content.match(/(['"])(\.\.?\/[^'"]*)app-module(['"])/)) {
-          content = content.replace(
-            /(['"])(\.\.?\/[^'"]*)app-module(['"])/g,
-            '$1$2app.module$3'
-          );
-          updated = true;
-        }
-
-        // app-routing-module.ts -> app-routing.module.ts
-        if (content.match(/(['"])(\.\.?\/[^'"]*)app-routing-module(['"])/)) {
-          content = content.replace(
-            /(['"])(\.\.?\/[^'"]*)app-routing-module(['"])/g,
-            '$1$2app-routing.module$3'
-          );
-          updated = true;
-        }
-
-        if (filePath.endsWith('app.component.ts')) {
-          if (content.includes('app.html')) {
-            content = content.replace(/app\.html/g, 'app.component.html');
-            updated = true;
-          }
-          if (content.includes('app.scss')) {
-            content = content.replace(/app\.scss/g, 'app.component.scss');
-            updated = true;
-          }
-        }
-
-        if (updated) {
-          tree.overwrite(filePath, content);
-        }
-      });
-    }
-
-    return tree;
-  };
-}
-
 export function addSpartacus(options: SpartacusOptions): Rule {
   return (tree: Tree, context: SchematicContext) => {
     const features = analyzeCrossFeatureDependencies(options.features ?? []);
@@ -748,7 +639,6 @@ export function addSpartacus(options: SpartacusOptions): Rule {
     ];
     const packageJsonFile = readPackageJson(tree);
     return chain([
-      applyClassicNamingConvention(options),
       verifyAppModuleExists(options),
 
       analyzeApplication(options, features),

--- a/projects/schematics/src/add-spartacus/index_spec.ts
+++ b/projects/schematics/src/add-spartacus/index_spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -42,6 +43,7 @@ const appOptions: ApplicationOptions = {
   style: Style.Scss,
   skipTests: false,
   standalone: false,
+  fileNameStyleGuide: FileNameStyleGuide.The2016,
 };
 
 const defaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -94,14 +94,35 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
       "root": "",
       "schematics": {
         "@schematics/angular:component": {
+          "addTypeToClassName": false,
           "standalone": false,
           "style": "scss",
+          "type": "component",
         },
         "@schematics/angular:directive": {
+          "addTypeToClassName": false,
           "standalone": false,
+          "type": "directive",
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": ".",
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": ".",
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": ".",
         },
         "@schematics/angular:pipe": {
           "standalone": false,
+          "typeSeparator": ".",
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": ".",
+        },
+        "@schematics/angular:service": {
+          "addTypeToClassName": false,
+          "type": "service",
         },
       },
       "sourceRoot": "src",

--- a/projects/schematics/src/add-ssr/index_spec.ts
+++ b/projects/schematics/src/add-ssr/index_spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -36,6 +37,7 @@ describe('add-ssr', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const defaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/migrations/mechanism/scaffold-app-structure/scaffold-app-structure_spec.ts
+++ b/projects/schematics/src/migrations/mechanism/scaffold-app-structure/scaffold-app-structure_spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -73,6 +74,7 @@ describe('scaffold app structure', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   beforeEach(async () => {

--- a/projects/schematics/src/ng-add/index_spec.ts
+++ b/projects/schematics/src/ng-add/index_spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -36,6 +37,7 @@ describe('Spartacus Schematics: ng-add', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const defaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/shared/utils/__snapshots__/lib-utils_spec.ts.snap
+++ b/projects/schematics/src/shared/utils/__snapshots__/lib-utils_spec.ts.snap
@@ -139,13 +139,34 @@ exports[`Lib utils assets options should update angular.json file with assets 1`
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",
@@ -241,13 +262,34 @@ exports[`Lib utils assets options should update angular.json file with assets 2`
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss",
-          "standalone": false
+          "standalone": false,
+          "type": "component",
+          "addTypeToClassName": false
         },
         "@schematics/angular:directive": {
-          "standalone": false
+          "standalone": false,
+          "type": "directive",
+          "addTypeToClassName": false
         },
         "@schematics/angular:pipe": {
-          "standalone": false
+          "standalone": false,
+          "typeSeparator": "."
+        },
+        "@schematics/angular:service": {
+          "type": "service",
+          "addTypeToClassName": false
+        },
+        "@schematics/angular:guard": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:interceptor": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:module": {
+          "typeSeparator": "."
+        },
+        "@schematics/angular:resolver": {
+          "typeSeparator": "."
         }
       },
       "root": "",

--- a/projects/schematics/src/shared/utils/__snapshots__/workspace-utils_spec.ts.snap
+++ b/projects/schematics/src/shared/utils/__snapshots__/workspace-utils_spec.ts.snap
@@ -81,14 +81,35 @@ exports[`Workspace utils getProject should return project 1`] = `
   "root": "",
   "schematics": {
     "@schematics/angular:component": {
+      "addTypeToClassName": false,
       "standalone": false,
       "style": "scss",
+      "type": "component",
     },
     "@schematics/angular:directive": {
+      "addTypeToClassName": false,
       "standalone": false,
+      "type": "directive",
+    },
+    "@schematics/angular:guard": {
+      "typeSeparator": ".",
+    },
+    "@schematics/angular:interceptor": {
+      "typeSeparator": ".",
+    },
+    "@schematics/angular:module": {
+      "typeSeparator": ".",
     },
     "@schematics/angular:pipe": {
       "standalone": false,
+      "typeSeparator": ".",
+    },
+    "@schematics/angular:resolver": {
+      "typeSeparator": ".",
+    },
+    "@schematics/angular:service": {
+      "addTypeToClassName": false,
+      "type": "service",
     },
   },
   "sourceRoot": "src",

--- a/projects/schematics/src/shared/utils/feature-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/feature-utils_spec.ts
@@ -2,6 +2,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -55,6 +56,7 @@ describe('Feature utils', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const spartacusDefaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/shared/utils/file-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/file-utils_spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { getSourceNodes } from '@schematics/angular/utility/ast-utils';
@@ -313,6 +314,7 @@ describe('File utils', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
   const defaultOptions = {
     project: 'schematics-test',

--- a/projects/schematics/src/shared/utils/generate-default-workspace.ts
+++ b/projects/schematics/src/shared/utils/generate-default-workspace.ts
@@ -4,17 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schema as SpartacusOptions } from '../../add-spartacus/schema';
-import { SPARTACUS_SCHEMATICS } from '../libs-constants';
 import {
   SchematicTestRunner,
   UnitTestTree,
 } from '@angular-devkit/schematics/testing';
-import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
+import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
+import { Schema as SpartacusOptions } from '../../add-spartacus/schema';
+import { SPARTACUS_SCHEMATICS } from '../libs-constants';
 
 const workspaceOptions: WorkspaceOptions = {
   name: 'workspace',
@@ -30,6 +31,7 @@ const appOptions: ApplicationOptions = {
   skipTests: false,
   projectRoot: '',
   standalone: false,
+  fileNameStyleGuide: FileNameStyleGuide.The2016,
 };
 
 const spartacusDefaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/shared/utils/import-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/import-utils_spec.ts
@@ -4,6 +4,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -65,6 +66,7 @@ describe('Import utils', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const spartacusDefaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/shared/utils/lib-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/lib-utils_spec.ts
@@ -2,6 +2,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -46,6 +47,7 @@ describe('Lib utils', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const spartacusDefaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/shared/utils/logger-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/logger-utils_spec.ts
@@ -2,6 +2,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -38,6 +39,7 @@ describe('Logger utils', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const spartacusDefaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/shared/utils/module-file-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/module-file-utils_spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -60,6 +61,7 @@ describe('Module file utils', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
   const defaultOptions = {
     project: 'schematics-test',

--- a/projects/schematics/src/shared/utils/new-module-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/new-module-utils_spec.ts
@@ -4,6 +4,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -46,6 +47,7 @@ describe('New Module utils', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const spartacusDefaultOptions: SpartacusOptions = {

--- a/projects/schematics/src/shared/utils/package-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/package-utils_spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -40,6 +41,7 @@ describe('Package utils', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
   const defaultOptions = {
     project: 'schematics-test',

--- a/projects/schematics/src/shared/utils/workspace-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/workspace-utils_spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import {
@@ -49,6 +50,7 @@ describe('Workspace utils', () => {
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
   const defaultOptions: SpartacusOptions = {
     project: 'schematics-test',

--- a/projects/schematics/src/wrapper-module/index_spec.ts
+++ b/projects/schematics/src/wrapper-module/index_spec.ts
@@ -2,6 +2,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import {
   Schema as ApplicationOptions,
+  FileNameStyleGuide,
   Style,
 } from '@schematics/angular/application/schema';
 import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
@@ -59,6 +60,7 @@ describe('Spartacus Wrapper Module Schematics: ng g @spartacus/schematics:wrappe
     skipTests: false,
     projectRoot: '',
     standalone: false,
+    fileNameStyleGuide: FileNameStyleGuide.The2016,
   };
 
   const defaultOptions: SpartacusOptions = {


### PR DESCRIPTION
This PR removes function required during Angular 20 upgrade, renaming files to names required by Spartacus schematics (`app.ts` -> `app.component.ts` and so on). Starting From Angular 21, there is a dedicated `ng new` flag `--file-name-style-guide=2016` to use the classic naming convention
The PR also updates tests and snapshots to work with new flag.

QA steps:
  1. build libs:
     ```bash
     npm run build:libs
     ```
  2. publish libraries on Verdaccio:
     ```bash
     ts-node ./tools/schematics/testing
     ```
  3. generate fresh Angular 21 app
      ```bash
      npx @angular/cli@21 new my-app --style=scss --ssr=false --zoneless=false --standalone=false --file-name-style-guide=2016
      ```
  4. go to app's folder and install Spartacus
     ```
     cd my-app && ng add @spartacus/schematics
     ```
  5. verify if app works
  6. for SSR, generate fresh Angular 21 app
      ```bash
      npx @angular/cli@21 new my-app --style=scss --ssr=false --zoneless=false --standalone=false --file-name-style-guide=2016
      ```
  7. add Spartacus with SSR
       ```
       cd my-app && ng add @spartacus/schematics --ssr
       ```
  8. verify if app works

closes [CXSPA-11729](https://jira.tools.sap/browse/CXSPA-11729)