### PR TITLE
feat: CXSPA-11728 Installation script update

### DIFF
--- a/scripts/install/config.default.sh
+++ b/scripts/install/config.default.sh
@@ -64,7 +64,7 @@ CLONE_DIR="clone"
 INSTALLATION_DIR="apps"
 E2E_TEST_DIR=${CLONE_DIR}/projects/storefrontapp-e2e-cypress
 
-ANGULAR_CLI_VERSION='^20.3.0'
+ANGULAR_CLI_VERSION='^21.0.5'
 SPARTACUS_VERSION='latest'
 
 CSR_PORT="4200"

--- a/scripts/install/functions.sh
+++ b/scripts/install/functions.sh
@@ -93,12 +93,15 @@ function create_shell_app {
     local EXTRA_ANGULAR_CLI_FLAGS=""
     if [ "$(compareSemver "$ANGULAR_CLI_VERSION" "17.0.0")" -ge 0 ]; then
         EXTRA_ANGULAR_CLI_FLAGS="--standalone=false --ssr=false" # SSR can be added later by running other schematics (e.g. Spartacus installation schematics with its flag --ssr).
-        echo "Angular CLI version >= 17.0.0, so applying extra flags to the command 'ng new': ${EXTRA_ANGULAR_CLI_FLAGS}"
     fi
     if [ "$(compareSemver "$ANGULAR_CLI_VERSION" "20.0.0")" -ge 0 ]; then
-        EXTRA_ANGULAR_CLI_FLAGS="${EXTRA_ANGULAR_CLI_FLAGS} --zoneless=false --ai-config=none"
-        echo "Angular CLI version >= 20.0.0, so applying extra flag --zoneless=false"
+        EXTRA_ANGULAR_CLI_FLAGS="${EXTRA_ANGULAR_CLI_FLAGS} --zoneless=false --ai-config=none --file-name-style-guide=2016"
     fi
+
+    if [ -n "${EXTRA_ANGULAR_CLI_FLAGS}" ]; then
+        echo "Angular CLI version ${ANGULAR_CLI_VERSION} so applying extra flags to command 'ng new': ${EXTRA_ANGULAR_CLI_FLAGS}"
+    fi
+    
 
     ( cd ${INSTALLATION_DIR} && \
         ng new ${1} \


### PR DESCRIPTION
 This PR adjusts installation script to work with Angular 21:
 
 - sets `ANGULAR_CLI_VERSION` to 21 in `config.default.sh`
 - modifies `functions.sh` so new required flags are added when scaffolding fresh application
 
 QA:
- cp config.default.sh config.sh
- in `config.sh`, change the following variables:
  ```bash
  BACKEND_URL="https://40.76.109.9:9002"
  BRANCH='epic/angular-21-upgrade'
  ```
- `cd scripts/install`
- run `bash run.sh install`
- run `bash run.sh start` to run Spartacus in CSR and SSR
- verify that started apps work as expected
 
 closes [CXSPA-11728](https://jira.tools.sap/browse/CXSPA-11728)