### PR TITLE
fix: Failing unit tests for checkout components

### DIFF
--- a/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
+++ b/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
@@ -338,7 +338,7 @@ describe('B2BCheckoutDeliveryAddressComponent', () => {
     fixture.detectChanges();
 
     component.selectAddress(mockAddress1);
- 
+
     expect(
       checkoutDeliveryAddressFacade.setDeliveryAddress
     ).toHaveBeenCalledWith(mockAddress1);

--- a/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
+++ b/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
@@ -335,8 +335,10 @@ describe('B2BCheckoutDeliveryAddressComponent', () => {
   });
 
   it('should be able to select address', () => {
-    component.selectAddress(mockAddress1);
+    fixture.detectChanges();
 
+    component.selectAddress(mockAddress1);
+ 
     expect(
       checkoutDeliveryAddressFacade.setDeliveryAddress
     ).toHaveBeenCalledWith(mockAddress1);
@@ -349,6 +351,8 @@ describe('B2BCheckoutDeliveryAddressComponent', () => {
       createSpy().and.returnValue(
         of({ loading: false, error: false, data: mockAddress2 })
       );
+
+    fixture.detectChanges();
 
     component.selectAddress(mockAddress2);
 

--- a/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.spec.ts
@@ -275,6 +275,8 @@ describe('CheckoutDeliveryAddressComponent', () => {
   });
 
   it('should be able to select address', () => {
+    fixture.detectChanges();
+
     component.selectAddress(mockAddress1);
 
     expect(
@@ -289,6 +291,8 @@ describe('CheckoutDeliveryAddressComponent', () => {
       createSpy().and.returnValue(
         of({ loading: false, error: false, data: mockAddress2 })
       );
+
+    fixture.detectChanges();
 
     component.selectAddress(mockAddress2);
 

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.spec.ts
@@ -559,6 +559,8 @@ describe('CheckoutPaymentMethodComponent', () => {
     });
 
     it('should be able to select payment method', () => {
+      fixture.detectChanges();
+
       component.selectPaymentMethod(mockPaymentDetails);
 
       expect(mockCheckoutPaymentService.setPaymentDetails).toHaveBeenCalledWith(
@@ -575,6 +577,7 @@ describe('CheckoutPaymentMethodComponent', () => {
         createSpy().and.returnValue(
           of({ loading: false, error: false, data: mockPayments[0] })
         );
+      fixture.detectChanges();
 
       component.selectPaymentMethod(mockPayments[0]);
 


### PR DESCRIPTION
The `should be able to select address`  test case from `checkout-delivery-address.component.spec.ts` was occasionally failing (usually on the first run). This PR provides explicit `fixture.detectChanges()` call to ensure that data, depending on the `OnInit` lifecycle hook, required for the further steps is defined. In addition, it provides fixes to similar places where the issue may appear.

Issue occurred after making the `focusCartAfterSelecting` call required due to https://github.com/SAP/spartacus/pull/20964