### PR TITLE
fix: (CXSPA-11706) Deprecate enableCarouselCategoryProducts feature toggle

### DIFF
--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -102,16 +102,6 @@ export interface FeatureTogglesInterface {
   a11yNgSelectUnicodeCarets?: boolean;
 
   /**
-   * Enables the product carousel to include products based on specified category codes.
-   *
-   * - When this feature is enabled, the carousel will fetch and display products
-   *   associated with the `categoryCodes` provided.
-   * - The `categoryCodes` are configured and managed through SmartEdit
-   *
-   */
-  enableCarouselCategoryProducts?: boolean;
-
-  /**
    * When enabled, the `ConfiguratorAttributeHeaderComponent` component displays
    * a `ConfiguratorShowOptionsComponent` component underneath the attribute name.
    * The `ConfiguratorShowOptionsComponent` component allows to load the domain values
@@ -392,7 +382,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   productReviewCharactersLeft: false,
   a11yNgSelectAriaControls: true,
   a11yConfiguratorOverviewHeaderVPC: false,
-  enableCarouselCategoryProducts: true,
   enableReadDomainValuesOnDemand: true,
   opfEnablePreventingFromCheckoutWithoutEmail: true,
   storeFinderFacadeCleanup: false,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -312,7 +312,6 @@ if (environment.cpq) {
         productReviewCharactersLeft: true,
         a11yNgSelectAriaControls: true,
         a11yConfiguratorOverviewHeaderVPC: true,
-        enableCarouselCategoryProducts: true,
         enableReadDomainValuesOnDemand: true,
         opfEnablePreventingFromCheckoutWithoutEmail: true,
         storeFinderFacadeCleanup: true,

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
@@ -168,7 +168,6 @@ const mockComponentData: CmsProductCarouselComponent = {
   title: 'Mock Title',
   name: 'Mock Product Carousel',
   container: 'false',
-  categoryCodes: 'electronics',
 };
 const mockComponentWithAddCartData: CmsProductCarouselComponent = {
   ...mockComponentData,
@@ -180,6 +179,10 @@ const MockCmsProductCarouselComponent = <CmsComponentData<any>>{
 };
 const MockCmsProductCarouselComponentAddToCart = <CmsComponentData<any>>{
   data$: of(mockComponentWithAddCartData),
+};
+
+const MockCmsProductCarouselComponentCategoryCodes = <CmsComponentData<any>>{
+  data$: of({ ...mockComponentData, categoryCodes: 'electronics' }),
 };
 
 class MockProductService implements Partial<ProductService> {
@@ -270,7 +273,6 @@ describe('ProductCarouselComponent', () => {
 
   beforeEach(() => {
     mockFeatureToggles = {
-      enableCarouselCategoryProducts: false,
       productCarouselScrolling: true,
     };
     fixture = TestBed.createComponent(ProductCarouselComponent);
@@ -319,7 +321,6 @@ describe('ProductCarouselComponent', () => {
   });
 
   it('should have product code 111 in first product', waitForAsync(() => {
-    mockFeatureToggles.enableCarouselCategoryProducts = false;
     spyOn(featureConfigService, 'isEnabled').and.callThrough();
     fixture.detectChanges();
 
@@ -332,7 +333,6 @@ describe('ProductCarouselComponent', () => {
   }));
 
   it('Should use batch API with carouselMinimal scope when componentMappingExist is false', (done) => {
-    mockFeatureToggles.enableCarouselCategoryProducts = false;
     spyOn(featureConfigService, 'isEnabled').and.callThrough();
     fixture.detectChanges();
 
@@ -392,7 +392,6 @@ describe('ProductCarouselComponent', () => {
     });
 
     it('Should use batch API with carousel scope when componentMappingExist is true', (done) => {
-      mockFeatureToggles.enableCarouselCategoryProducts = false;
       spyOn(featureConfigService, 'isEnabled').and.callThrough();
       spyOn(productSearchByCodeService, 'get').and.callThrough();
       fixture.detectChanges();
@@ -417,7 +416,7 @@ describe('ProductCarouselComponent', () => {
       TestBed.configureTestingModule(testBedDefaults);
 
       TestBed.overrideProvider(CmsComponentData, {
-        useValue: MockCmsProductCarouselComponentAddToCart,
+        useValue: MockCmsProductCarouselComponentCategoryCodes,
       });
       TestBed.compileComponents();
       fixture = TestBed.createComponent(ProductCarouselComponent);
@@ -455,7 +454,6 @@ describe('ProductCarouselComponent', () => {
     });
 
     it('should retrieve products by category', (done) => {
-      mockFeatureToggles.enableCarouselCategoryProducts = true;
       spyOn(featureConfigService, 'isEnabled').and.callThrough();
 
       spyOn(productSearchByCategoryService, 'get').and.callThrough();

--- a/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.ts
+++ b/projects/storefrontlib/cms-components/product/carousel/product-carousel/product-carousel.component.ts
@@ -11,7 +11,6 @@ import {
   TrackByFunction,
 } from '@angular/core';
 import {
-  FeatureConfigService,
   CmsProductCarouselComponent as model,
   Product,
   ProductScope,
@@ -31,8 +30,6 @@ import { CmsComponentData } from '../../../../cms-structure/page/model/cms-compo
   standalone: false,
 })
 export class ProductCarouselComponent {
-  private featureConfigService: FeatureConfigService =
-    inject(FeatureConfigService);
   protected productSearchByCodeService: ProductSearchByCodeService = inject(
     ProductSearchByCodeService
   );
@@ -88,12 +85,8 @@ export class ProductCarouselComponent {
 
   handleCategoryCodes(data: model): Observable<model> {
     const categoryCodes = data?.categoryCodes?.split(' ');
-
     // Try to add category codes to the carousel product codes
-    if (
-      categoryCodes &&
-      this.featureConfigService.isEnabled('enableCarouselCategoryProducts')
-    ) {
+    if (categoryCodes) {
       return zip(
         categoryCodes.map((categoryCode) =>
           this.productSearchByCategoryService.get({


### PR DESCRIPTION
closes: https://jira.tools.sap/browse/CXSPA-11706