### PR TITLE
fix: CXSPA-11733 Issues with SSR Cypress E2Es

### DIFF
--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -13,7 +13,11 @@ import {
 import localeDe from '@angular/common/locales/de';
 import localeJa from '@angular/common/locales/ja';
 import localeZh from '@angular/common/locales/zh';
-import { NgModule } from '@angular/core';
+import {
+  NgModule,
+  provideBrowserGlobalErrorListeners,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import {
   BrowserModule,
   provideClientHydration,
@@ -68,6 +72,8 @@ if (!environment.production) {
   providers: [
     provideHttpClient(withFetch(), withInterceptorsFromDi()),
     provideClientHydration(withEventReplay(), withNoHttpTransferCache()),
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideBrowserGlobalErrorListeners(),
     provideConfig(<OccConfig>{
       backend: {
         occ: {

--- a/projects/storefrontapp/src/main.ts
+++ b/projects/storefrontapp/src/main.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { enableProdMode, provideZoneChangeDetection } from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { enableProdMode } from '@angular/core';
+import { platformBrowser } from '@angular/platform-browser';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
@@ -14,10 +14,8 @@ if (environment.production) {
 }
 
 function bootstrap() {
-  platformBrowserDynamic()
-    .bootstrapModule(AppModule, {
-      applicationProviders: [provideZoneChangeDetection()],
-    })
+  platformBrowser()
+    .bootstrapModule(AppModule)
     /* eslint-disable-next-line no-console
     --
     It's just an example application file. This message is not crucial


### PR DESCRIPTION
Cypress tets for SSR were failing due to unexpected `NG0205: Injector has already been destroyed`
<img width="878" height="305" alt="image" src="https://github.com/user-attachments/assets/3613fb4c-147a-4313-962e-438dbaf77c55" />
Link to example failing check: https://github.com/SAP/spartacus/actions/runs/20916679856/job/60093114689?pr=20946

Issue was resolved by moving `provideZoneChangeDetection` from deprecated `platformBrowserDynamic` in `main.ts` to the `app.module.ts`, where this config should land, based on [the Angular Team recommendation](https://github.com/angular/angular-cli/pull/32208#discussion_r2651948165).

Apart from that change, the following was changed (not related to the SSR issue)
- deprecated `platformBrowserDynamic` replaced with recommended `platformBrowser`
- new [provideBrowserGlobalErrorListeners](https://angular.dev/best-practices/error-handling#client-side-rendering) added to the storefrontapp

QA steps:
1. how to reproduce failing tests
  - go to `epic/angular-21-upgrade`
  - build libs, storefrontapp with SSR mode and serve SSR app with CI config
  ```bash
  npm run build:libs
  npm run build:ssr
  npm run serve:ssr:ci
  ```
  - in `cypress.config.ts`, change e2e.baseUrl to `http://localhost:4000`
  ```diff
  e2e: {
    // We've imported your old cypress plugins here.
    // You may want to clean this up later by importing these.
    setupNodeEvents(on, config) {
      return require('./cypress/plugins/index.js')(on, config);
    },
  -  baseUrl: 'http://localhost:4200',
  +  baseUrl: 'http://localhost:4000',
  },
  ```
  - in second terminal, run Cypress
  ```bash
  npm run e2e:open
  ```
  - run failing `ssr/product-listing-page.e2e.cy.ts`
  - in the terminal where app with SSR was served, verify if error `NG0205` occured
 2. test the fix
  - go to `fix/CXSPA-11823`
  - repeat all above stepst for building and running app and Cypress
  - run previously failing `ssr/product-listing-page.e2e.cy.ts` and verify if all tests passed

  

