### PR TITLE
test: Adjust failing E2E to work with event coalescing

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
@@ -452,9 +452,7 @@ export function completeReplenishmentForm(replenishmentPeriod: string) {
     cy.get('cx-schedule-replenishment-order .cx-days select')
       .select(replenishmentDay)
       .should('have.value', replenishmentDay);
-  }
 
-  if (replenishmentPeriod === recurrencePeriod.WEEKLY) {
     cy.get(
       'cx-schedule-replenishment-order .cx-repeat-days-container [type="checkbox"]'
     ).check();

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/b2b/b2b-checkout.ts
@@ -438,10 +438,17 @@ export function completeReplenishmentForm(replenishmentPeriod: string) {
     .select(replenishmentPeriod)
     .should('have.value', replenishmentPeriod);
 
-  if (
-    replenishmentPeriod === recurrencePeriod.DAILY ||
-    replenishmentPeriod === recurrencePeriod.WEEKLY
-  ) {
+  if (replenishmentPeriod === recurrencePeriod.DAILY) {
+    cy.get('cx-schedule-replenishment-order .cx-days select')
+      .select(replenishmentDay)
+      .should('have.value', replenishmentDay);
+  }
+
+  if (replenishmentPeriod === recurrencePeriod.WEEKLY) {
+    // ensure the WEEKLY period was selected by verifying the days container is visible
+    cy.get('cx-schedule-replenishment-order .cx-repeat-days-container').should(
+      'be.visible'
+    );
     cy.get('cx-schedule-replenishment-order .cx-days select')
       .select(replenishmentDay)
       .should('have.value', replenishmentDay);

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/order-history.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/order-history.ts
@@ -206,10 +206,14 @@ export const orderHistoryTest = {
         .its('response.statusCode')
         .should('eq', 200);
 
+      cy.intercept('GET', /users\/current\/orders/).as('ordersAfterLangSwitch');
+
       cy.onMobile(() => {
         clickHamburger();
       });
       switchLanguage('en');
+
+      cy.wait('@ordersAfterLangSwitch');
 
       cy.get('.cx-order-history-placed > .cx-order-history-value')
         .first()
@@ -217,10 +221,16 @@ export const orderHistoryTest = {
           dayNumberEN = getDayNumber(element)[1];
         });
 
+      cy.intercept('GET', /users\/current\/orders/).as(
+        'ordersAfterLangSwitchDE'
+      );
+
       cy.onMobile(() => {
         clickHamburger();
       });
       switchLanguage('de');
+
+      cy.wait('@ordersAfterLangSwitchDE');
 
       cy.get('.cx-order-history-placed > .cx-order-history-value')
         .first()
@@ -228,10 +238,16 @@ export const orderHistoryTest = {
           expect(getDayNumber(element)[0]).to.eq(dayNumberEN);
         });
 
+      cy.intercept('GET', /users\/current\/orders/).as(
+        'ordersAfterLangSwitchEN'
+      );
+
       cy.onMobile(() => {
         clickHamburger();
       });
       switchLanguage('en'); // switch language back
+
+      cy.wait('@ordersAfterLangSwitchEN');
     });
   },
   checkOrderDetailsUnconsignedEntries() {

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/order-history.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/order-history.ts
@@ -206,14 +206,13 @@ export const orderHistoryTest = {
         .its('response.statusCode')
         .should('eq', 200);
 
-      cy.intercept('GET', /users\/current\/orders/).as('ordersAfterLangSwitch');
-
       cy.onMobile(() => {
         clickHamburger();
       });
       switchLanguage('en');
 
-      cy.wait('@ordersAfterLangSwitch');
+      // wait for switch to EN language
+      cy.wait('@getOrderHistoryPage');
 
       cy.get('.cx-order-history-placed > .cx-order-history-value')
         .first()
@@ -221,16 +220,13 @@ export const orderHistoryTest = {
           dayNumberEN = getDayNumber(element)[1];
         });
 
-      cy.intercept('GET', /users\/current\/orders/).as(
-        'ordersAfterLangSwitchDE'
-      );
-
       cy.onMobile(() => {
         clickHamburger();
       });
       switchLanguage('de');
 
-      cy.wait('@ordersAfterLangSwitchDE');
+      // wait for switch to DE language
+      cy.wait('@getOrderHistoryPage');
 
       cy.get('.cx-order-history-placed > .cx-order-history-value')
         .first()
@@ -238,16 +234,13 @@ export const orderHistoryTest = {
           expect(getDayNumber(element)[0]).to.eq(dayNumberEN);
         });
 
-      cy.intercept('GET', /users\/current\/orders/).as(
-        'ordersAfterLangSwitchEN'
-      );
-
       cy.onMobile(() => {
         clickHamburger();
       });
       switchLanguage('en'); // switch language back
 
-      cy.wait('@ordersAfterLangSwitchEN');
+      // wait for switch to EN language
+      cy.wait('@getOrderHistoryPage');
     });
   },
   checkOrderDetailsUnconsignedEntries() {


### PR DESCRIPTION
This PR contains adjustments in failing E2Es, ensuring assertions and Cypress logis is invoked in a proper order. 
<img width="682" height="387" alt="image" src="https://github.com/user-attachments/assets/e8d7a1ea-7e1e-40ba-9cd0-5048e320dfdc" />

Required due to enabling event coalescing.

QA steps:
1. For `b2b/regression/replenishment/b2b-weekly-replenishment-checkout-flow.e2e.cy.ts`
  - in first terminal run `npm run start:b2b`
  - in second terminal run `npm run e2e:open:b2b`
  - find and run failing test
2. For `regression/my-account/order-history-orders-flow.e2e.cy.ts`
  - in first terminal run `npm run start`
  - in second terminal run `npm run e2e:open`
  - find and run failing test
