### PR TITLE
fix: SSR returns page with status 500 when CmsPageNotFoundOutboundHttpError occurs

### DIFF
--- a/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.spec.ts
+++ b/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.spec.ts
@@ -6,7 +6,8 @@ import {
 } from '@angular/common/http';
 import { ErrorHandler, Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Observable, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
+import { UserIdService } from '../../auth';
 import { OccEndpointsService } from '../../occ';
 import { WindowRef } from '../../window';
 import { HttpErrorHandlerInterceptor } from './http-error-handler.interceptor';
@@ -22,7 +23,17 @@ class MockErrorHandler {
 
 @Injectable()
 class MockOccEndpointsService {
-  buildUrl = (val: string) => val;
+  buildUrl = (val: string, options?: { userId?: string }) => {
+    if (options?.userId) {
+      return `users/${options.userId}/cms/${val}`;
+    }
+    return val;
+  };
+}
+
+@Injectable()
+class MockUserIdService {
+  getUserId = () => of('anonymous');
 }
 
 describe('HttpErrorHandlerInterceptor', () => {
@@ -37,6 +48,7 @@ describe('HttpErrorHandlerInterceptor', () => {
       providers: [
         HttpErrorHandlerInterceptor,
         { provide: OccEndpointsService, useClass: MockOccEndpointsService },
+        { provide: UserIdService, useClass: MockUserIdService },
         { provide: WindowRef, useValue: { isBrowser: () => false } },
         { provide: ErrorHandler, useClass: MockErrorHandler },
       ],

--- a/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.ts
+++ b/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.ts
@@ -12,8 +12,10 @@ import {
   HttpRequest,
 } from '@angular/common/http';
 import { ErrorHandler, Injectable, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { UserIdService } from '../../auth';
 import { HttpResponseStatus } from '../../global-message';
 import { OccEndpointsService } from '../../occ';
 import { WindowRef } from '../../window';
@@ -40,6 +42,9 @@ export class HttpErrorHandlerInterceptor implements HttpInterceptor {
   protected errorHandler = inject(ErrorHandler);
   protected occEndpointsService = inject(OccEndpointsService);
   protected windowRef = inject(WindowRef);
+
+  // userId to build correct pages endpoint URL
+  private userId = toSignal(inject(UserIdService).getUserId());
 
   intercept(
     request: HttpRequest<unknown>,
@@ -83,7 +88,9 @@ export class HttpErrorHandlerInterceptor implements HttpInterceptor {
    * @returns `true` if the error corresponds to a CMS page not found HTTP error, `false` otherwise.
    */
   protected isCmsPageNotFoundHttpError(error: unknown): boolean {
-    const expectedUrl = this.occEndpointsService.buildUrl('pages');
+    const expectedUrl = this.occEndpointsService.buildUrl('pages', {
+      urlParams: { userId: this.userId() },
+    });
     return (
       error instanceof HttpErrorResponse &&
       error.status === HttpResponseStatus.NOT_FOUND &&

--- a/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.ts
+++ b/projects/core/src/error-handling/http-error-handler/http-error-handler.interceptor.ts
@@ -43,8 +43,7 @@ export class HttpErrorHandlerInterceptor implements HttpInterceptor {
   protected occEndpointsService = inject(OccEndpointsService);
   protected windowRef = inject(WindowRef);
 
-  // userId to build correct pages endpoint URL
-  private userId = toSignal(inject(UserIdService).getUserId());
+  protected userId = toSignal(inject(UserIdService).getUserId());
 
   intercept(
     request: HttpRequest<unknown>,


### PR DESCRIPTION
1. This PR provides fix for [http-error-handler.interceptor.ts](https://github.com/SAP/spartacus/compare/develop-next-major...fix/ssr-error-handling?expand=1#diff-e4fce2eb8e674f1d42977abe3b17965e4a4e8c37891ad1a4265516f38ef57ac6)  caused by changes in `default-cms-config.ts` provided with https://github.com/SAP/spartacus/pull/21005.

QA steps:
- go to [default-cms-config.ts](https://github.com/SAP/spartacus/blob/7022e49af0d619cb00e3d633958751192f7d1aa7/projects/core/src/cms/config/default-cms-config.ts#L15) and change config for `pages` to the following to make this API call failing:
   ```diff
   backend: {
      occ: {
        endpoints: {
          component: 'users/${userId}/cms/components/${id}',
          components: 'users/${userId}/cms/components',
  -        pages: 'users/${userId}/cms/pages',
  +        pages: 'users/${userId}/cms/pages2',
          page: 'users/${userId}/cms/pages/${id}',
        },
      },
    },
   ```
- run `npm run dev:ssr` and in the browser's devtools, verify if the page was returned with 404 status  
  <img width="990" height="187" alt="image" src="https://github.com/user-attachments/assets/57ff33d6-f894-42b7-a1a4-c5a1f9537c59" />

- revert changes from the default-cms-config.ts
- run the following commands (one by one) to see if SSR e2es are passing:
  ```bash
  npm run build:libs
  npm run build:ssr:local-http-backend
  npm run test:ssr
  ```
