### PR TITLE
feat: CXSPA-11736 Migration - upgrade Express to v5.1.0 and update server.ts

### DIFF
--- a/projects/schematics/src/migrations/221121_8/express-v5/index.ts
+++ b/projects/schematics/src/migrations/221121_8/express-v5/index.ts
@@ -1,0 +1,270 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { normalize } from '@angular-devkit/core';
+import {
+  chain,
+  noop,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  NodeDependency,
+  NodeDependencyType,
+} from '@schematics/angular/utility/dependencies';
+import * as ts from 'typescript';
+import { getServerTsPath } from '../../../shared/utils/file-utils';
+import {
+  getServerTsPathForApplicationBuilder,
+  isSsrUsed,
+  isUsingLegacyServerBuilder,
+  readPackageJson,
+  updatePackageJsonDependencies,
+} from '../../../shared/utils/package-utils';
+
+/**
+ * Finds the server.ts file in the project.
+ * Uses the appropriate method based on SSR configuration.
+ */
+function findServerFile(tree: Tree): string | null {
+  if (isSsrUsed(tree)) {
+    const serverPath = getServerTsPathForApplicationBuilder(tree);
+    if (serverPath) {
+      return serverPath;
+    }
+  }
+
+  if (isUsingLegacyServerBuilder(tree)) {
+    const serverPath = getServerTsPath(tree);
+    if (serverPath) {
+      return serverPath;
+    }
+  }
+
+  const possiblePaths = ['./server.ts', './src/server.ts'];
+  for (const path of possiblePaths) {
+    if (tree.exists(normalize(path))) {
+      return path;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Updates server.ts file to replace wildcard strings with regex patterns for Express 5 compatibility.
+ */
+function updateServerTsFile(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    context.logger.info(
+      '\n⌛️ Updating server.ts for Express 5 compatibility...'
+    );
+
+    const serverFilePath = findServerFile(tree);
+    if (!serverFilePath) {
+      context.logger.info(
+        '  ↳ No server.ts file found - skipping server.ts updates'
+      );
+      return tree;
+    }
+
+    const fileContentBuffer = tree.read(serverFilePath);
+    if (!fileContentBuffer) {
+      context.logger.warn(
+        `  ↳ Could not read ${serverFilePath} - skipping update`
+      );
+      return tree;
+    }
+
+    const content = fileContentBuffer.toString('utf-8');
+    const originalContent = content;
+
+    try {
+      const sourceFile = ts.createSourceFile(
+        serverFilePath,
+        content,
+        ts.ScriptTarget.Latest,
+        true
+      );
+
+      const replacements: Replacement[] = [];
+      collectServerGetReplacements(sourceFile, sourceFile, replacements);
+
+      const updatedContent =
+        replacements.length > 0
+          ? applyReplacements(content, replacements)
+          : content;
+
+      if (updatedContent !== originalContent) {
+        tree.overwrite(serverFilePath, updatedContent);
+        context.logger.info(
+          `✅ Updated ${serverFilePath} for Express 5 compatibility`
+        );
+      } else {
+        context.logger.info(
+          `  ↳ ${serverFilePath} already uses Express 5 compatible patterns or no changes needed`
+        );
+      }
+    } catch (error) {
+      context.logger.warn(
+        `  ↳ Failed to parse ${serverFilePath} - skipping update: ${error}`
+      );
+    }
+
+    return tree;
+  };
+}
+
+/**
+ * Visits AST nodes to find server.get() calls and replace wildcard strings with regex patterns.
+ */
+interface Replacement {
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+function collectServerGetReplacements(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+  replacements: Replacement[]
+): void {
+  if (ts.isCallExpression(node)) {
+    const expression = node.expression;
+    if (
+      ts.isPropertyAccessExpression(expression) &&
+      ts.isIdentifier(expression.expression) &&
+      expression.expression.text === 'server' &&
+      ts.isIdentifier(expression.name) &&
+      expression.name.text === 'get'
+    ) {
+      if (node.arguments.length > 0) {
+        const firstArg = node.arguments[0];
+
+        if (ts.isStringLiteral(firstArg)) {
+          const argText = firstArg.text;
+
+          if (argText === '*.*') {
+            replacements.push({
+              start: firstArg.getStart(sourceFile),
+              end: firstArg.getEnd(),
+              replacement: '/.*\\..*/',
+            });
+          } else if (argText === '*') {
+            replacements.push({
+              start: firstArg.getStart(sourceFile),
+              end: firstArg.getEnd(),
+              replacement: '/.*/',
+            });
+          }
+        }
+      }
+    }
+  }
+
+  ts.forEachChild(node, (childNode) => {
+    collectServerGetReplacements(childNode, sourceFile, replacements);
+  });
+}
+
+function applyReplacements(
+  content: string,
+  replacements: Replacement[]
+): string {
+  const sortedReplacements = [...replacements].sort(
+    (a, b) => b.start - a.start
+  );
+
+  let updatedContent = content;
+  for (const replacement of sortedReplacements) {
+    const before = updatedContent.substring(0, replacement.start);
+    const after = updatedContent.substring(replacement.end);
+    updatedContent = before + replacement.replacement + after;
+  }
+
+  return updatedContent;
+}
+
+/**
+ * Updates Express dependency to version 5.1.0 in package.json.
+ */
+function updateExpressDependency(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const packageJson = readPackageJson(tree);
+    const dependencies: NodeDependency[] = [];
+
+    if (packageJson.dependencies?.express) {
+      dependencies.push({
+        name: 'express',
+        version: '^5.1.0',
+        type: NodeDependencyType.Default,
+        overwrite: true,
+      });
+    }
+
+    if (packageJson.devDependencies?.express) {
+      dependencies.push({
+        name: 'express',
+        version: '^5.1.0',
+        type: NodeDependencyType.Dev,
+        overwrite: true,
+      });
+    }
+
+    if (dependencies.length === 0) {
+      context.logger.info(
+        '  ↳ Express is not installed - skipping Express dependency update'
+      );
+      return noop();
+    }
+
+    return updatePackageJsonDependencies(dependencies, packageJson)(
+      tree,
+      context
+    );
+  };
+}
+
+/**
+ * Migration to upgrade Express to v5.1.0 and update server.ts for Express 5 compatibility.
+ *
+ * This migration:
+ * 1. Updates Express dependency to ^5.1.0 in package.json
+ * 2. Updates server.ts to replace wildcard strings with regex patterns:
+ *    - '*.*' becomes regex pattern matching files with extensions
+ *    - '*' becomes regex pattern matching all routes
+ *
+ * This migration only runs for apps that use SSR (Server-Side Rendering).
+ */
+export function migrate(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const hasSSR = isSsrUsed(tree) || isUsingLegacyServerBuilder(tree);
+
+    if (!hasSSR) {
+      context.logger.info(
+        '\n⏭️  Skipping Express v5 migration - SSR is not configured in this app'
+      );
+      return noop();
+    }
+
+    const packageJson = readPackageJson(tree);
+    const hasExpress =
+      packageJson.dependencies?.express || packageJson.devDependencies?.express;
+
+    if (!hasExpress) {
+      context.logger.info(
+        '\n⏭️  Skipping Express v5 migration - Express is not installed in this app'
+      );
+      return noop();
+    }
+
+    return chain([updateExpressDependency(), updateServerTsFile()])(
+      tree,
+      context
+    );
+  };
+}

--- a/projects/schematics/src/migrations/221121_8/express-v5/index.ts
+++ b/projects/schematics/src/migrations/221121_8/express-v5/index.ts
@@ -128,42 +128,61 @@ interface Replacement {
   replacement: string;
 }
 
+function isServerGetCall(node: ts.Node): node is ts.CallExpression {
+  if (!ts.isCallExpression(node)) {
+    return false;
+  }
+  const expression = node.expression;
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === 'server' &&
+    ts.isIdentifier(expression.name) &&
+    expression.name.text === 'get'
+  );
+}
+
+function getWildcardReplacement(argText: string): string | null {
+  if (argText === '*.*') {
+    return '/.*\\..*/';
+  }
+  if (argText === '*') {
+    return '/.*/';
+  }
+  return null;
+}
+
+function processServerGetCall(
+  node: ts.CallExpression,
+  sourceFile: ts.SourceFile,
+  replacements: Replacement[]
+): void {
+  if (node.arguments.length === 0) {
+    return;
+  }
+
+  const firstArg = node.arguments[0];
+  if (!ts.isStringLiteral(firstArg)) {
+    return;
+  }
+
+  const replacement = getWildcardReplacement(firstArg.text);
+  if (replacement) {
+    replacements.push({
+      start: firstArg.getStart(sourceFile),
+      end: firstArg.getEnd(),
+      replacement,
+    });
+  }
+}
+
 function collectServerGetReplacements(
   node: ts.Node,
   sourceFile: ts.SourceFile,
   replacements: Replacement[]
 ): void {
-  if (ts.isCallExpression(node)) {
-    const expression = node.expression;
-    if (
-      ts.isPropertyAccessExpression(expression) &&
-      ts.isIdentifier(expression.expression) &&
-      expression.expression.text === 'server' &&
-      ts.isIdentifier(expression.name) &&
-      expression.name.text === 'get'
-    ) {
-      if (node.arguments.length > 0) {
-        const firstArg = node.arguments[0];
-
-        if (ts.isStringLiteral(firstArg)) {
-          const argText = firstArg.text;
-
-          if (argText === '*.*') {
-            replacements.push({
-              start: firstArg.getStart(sourceFile),
-              end: firstArg.getEnd(),
-              replacement: '/.*\\..*/',
-            });
-          } else if (argText === '*') {
-            replacements.push({
-              start: firstArg.getStart(sourceFile),
-              end: firstArg.getEnd(),
-              replacement: '/.*/',
-            });
-          }
-        }
-      }
-    }
+  if (isServerGetCall(node)) {
+    processServerGetCall(node, sourceFile, replacements);
   }
 
   ts.forEachChild(node, (childNode) => {
@@ -253,7 +272,7 @@ export function migrate(): Rule {
 
     const packageJson = readPackageJson(tree);
     const hasExpress =
-      packageJson.dependencies?.express || packageJson.devDependencies?.express;
+      packageJson.dependencies?.express ?? packageJson.devDependencies?.express;
 
     if (!hasExpress) {
       context.logger.info(

--- a/projects/schematics/src/migrations/221121_8/express-v5/index_spec.ts
+++ b/projects/schematics/src/migrations/221121_8/express-v5/index_spec.ts
@@ -1,0 +1,498 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { join } from 'path';
+
+const collectionPath = join(__dirname, '../../migrations.json');
+const MIGRATION_SCRIPT_NAME = '02-migration-v221121_8-express-v5';
+
+fdescribe('Express v5 Migration', () => {
+  let tree: Tree;
+  let runner: SchematicTestRunner;
+
+  const workspaceContent = {
+    version: 1,
+    projects: {
+      'test-app': {
+        root: '',
+        architect: {
+          build: {
+            builder: '@angular-devkit/build-angular:application',
+            options: {
+              browser: 'src/main.ts',
+              server: 'src/main.server.ts',
+              ssr: {
+                entry: 'server.ts',
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const serverTsWithWildcards = `
+import express from 'express';
+
+export function app(): express.Express {
+  const server = express();
+
+  server.get('*.*', express.static('./browser', { maxAge: '1y' }));
+
+  server.get('*', (req, res) => {
+    res.render('index', { req });
+  });
+
+  return server;
+}
+`;
+
+  const serverTsWithDoubleQuotes = `
+import express from 'express';
+
+export function app(): express.Express {
+  const server = express();
+
+  server.get("*.*", express.static('./browser', { maxAge: '1y' }));
+
+  server.get("*", (req, res) => {
+    res.render('index', { req });
+  });
+
+  return server;
+}
+`;
+
+  const serverTsAlreadyUpdated = `
+import express from 'express';
+
+export function app(): express.Express {
+  const server = express();
+
+  server.get(/.*\\..*/, express.static('./browser', { maxAge: '1y' }));
+
+  server.get(/.*/, (req, res) => {
+    res.render('index', { req });
+  });
+
+  return server;
+}
+`;
+
+  const serverTsMultiline = `
+import express from 'express';
+
+export function app(): express.Express {
+  const server = express();
+
+  server.get(
+    '*.*',
+    express.static('./browser', { maxAge: '1y' })
+  );
+
+  server.get(
+    '*',
+    (req, res) => {
+      res.render('index', { req });
+    }
+  );
+
+  return server;
+}
+`;
+
+  const serverTsMultilineDoubleQuotes = `
+import express from 'express';
+
+export function app(): express.Express {
+  const server = express();
+
+  server.get(
+    "*.*",
+    express.static('./browser', { maxAge: '1y' })
+  );
+
+  server.get(
+    "*",
+    (req, res) => {
+      res.render('index', { req });
+    }
+  );
+
+  return server;
+}
+`;
+
+  beforeEach(() => {
+    tree = Tree.empty();
+    runner = new SchematicTestRunner('migrations', collectionPath);
+    tree.create('/angular.json', JSON.stringify(workspaceContent));
+    tree.create('/server.ts', 'export const server = {};');
+  });
+
+  describe('Express dependency update', () => {
+    it('should update Express to ^5.1.0 in package.json', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedPackageJson = JSON.parse(newTree.readText('/package.json'));
+      expect(updatedPackageJson.dependencies.express).toBe('^5.1.0');
+    });
+
+    it('should skip migration if Express is not present in package.json', async () => {
+      const packageJson = {
+        dependencies: {},
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedPackageJson = JSON.parse(newTree.readText('/package.json'));
+      expect(updatedPackageJson.dependencies.express).toBeUndefined();
+    });
+
+    it('should update Express in devDependencies if present', async () => {
+      const packageJson = {
+        devDependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedPackageJson = JSON.parse(newTree.readText('/package.json'));
+      expect(updatedPackageJson.devDependencies.express).toBe('^5.1.0');
+    });
+  });
+
+  describe('server.ts file updates', () => {
+    it('should replace wildcard strings with regex patterns in root server.ts', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      if (tree.exists('/server.ts')) {
+        tree.delete('/server.ts');
+      }
+      tree.create('/server.ts', serverTsWithWildcards);
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedContent = newTree.readText('/server.ts');
+      expect(updatedContent).toContain('server.get(/.*\\..*/,');
+      expect(updatedContent).toContain('server.get(/.*/,');
+      expect(updatedContent).not.toContain("server.get('*.*',");
+      expect(updatedContent).not.toContain("server.get('*',");
+    });
+
+    it('should replace wildcard strings with regex patterns in src/server.ts', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      // Update workspace to point to src/server.ts
+      const workspaceWithSrcServer = {
+        ...workspaceContent,
+        projects: {
+          'test-app': {
+            ...workspaceContent.projects['test-app'],
+            architect: {
+              build: {
+                ...workspaceContent.projects['test-app'].architect.build,
+                options: {
+                  ...workspaceContent.projects['test-app'].architect.build
+                    .options,
+                  ssr: {
+                    entry: 'src/server.ts',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      tree.overwrite('/angular.json', JSON.stringify(workspaceWithSrcServer));
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      tree.create('/src/server.ts', serverTsWithWildcards);
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedContent = newTree.readText('/src/server.ts');
+      // Check for regex pattern (may be on multiple lines)
+      expect(updatedContent).toMatch(/server\.get\s*\(\s*\/\.\*\\\.\.\*\/\s*,/);
+      expect(updatedContent).toMatch(/server\.get\s*\(\s*\/\.\*\/\s*,/);
+      expect(updatedContent).not.toContain("server.get('*.*',");
+      expect(updatedContent).not.toContain("server.get('*',");
+    });
+
+    it('should handle double quotes in wildcard strings', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      if (tree.exists('/server.ts')) {
+        tree.delete('/server.ts');
+      }
+      tree.create('/server.ts', serverTsWithDoubleQuotes);
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedContent = newTree.readText('/server.ts');
+      expect(updatedContent).toContain('server.get(/.*\\..*/,');
+      expect(updatedContent).toContain('server.get(/.*/,');
+      expect(updatedContent).not.toContain('server.get("*.*",');
+      expect(updatedContent).not.toContain('server.get("*",');
+    });
+
+    it('should not modify server.ts if already updated', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      if (tree.exists('/server.ts')) {
+        tree.delete('/server.ts');
+      }
+      tree.create('/server.ts', serverTsAlreadyUpdated);
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedContent = newTree.readText('/server.ts');
+      expect(updatedContent).toBe(serverTsAlreadyUpdated);
+    });
+
+    it('should skip migration if server.ts file does not exist', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      // Remove server.ts files created in beforeEach to test this scenario
+      tree.delete('/server.ts');
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      expect(newTree.exists('/server.ts')).toBe(false);
+      expect(newTree.exists('/src/server.ts')).toBe(false);
+      const updatedPackageJson = JSON.parse(newTree.readText('/package.json'));
+      expect(updatedPackageJson.dependencies.express).toBe('^4.18.0');
+    });
+
+    it('should handle server.ts with only one wildcard pattern', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      const serverTsWithOnlyWildcard = `
+import express from 'express';
+
+export function app(): express.Express {
+  const server = express();
+
+  server.get('*', (req, res) => {
+    res.render('index', { req });
+  });
+
+  return server;
+}
+`;
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      if (tree.exists('/server.ts')) {
+        tree.delete('/server.ts');
+      }
+      tree.create('/server.ts', serverTsWithOnlyWildcard);
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedContent = newTree.readText('/server.ts');
+      expect(updatedContent).toContain('server.get(/.*/,');
+      expect(updatedContent).not.toContain("server.get('*',");
+    });
+
+    it('should handle server.ts with only wildcard dot pattern', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      const serverTsWithOnlyWildcardDot = `
+import express from 'express';
+
+export function app(): express.Express {
+  const server = express();
+
+  server.get('*.*', express.static('./browser', { maxAge: '1y' }));
+
+  return server;
+}
+`;
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      if (tree.exists('/server.ts')) {
+        tree.delete('/server.ts');
+      }
+      tree.create('/server.ts', serverTsWithOnlyWildcardDot);
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedContent = newTree.readText('/server.ts');
+      expect(updatedContent).toContain('server.get(/.*\\..*/,');
+      expect(updatedContent).not.toContain("server.get('*.*',");
+    });
+
+    it('should handle multiline server.get calls with wildcard patterns', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      if (tree.exists('/server.ts')) {
+        tree.delete('/server.ts');
+      }
+      tree.create('/server.ts', serverTsMultiline);
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedContent = newTree.readText('/server.ts');
+      // Check for regex pattern (may be on multiple lines)
+      expect(updatedContent).toMatch(/server\.get\s*\(\s*\/\.\*\\\.\.\*\/\s*,/);
+      expect(updatedContent).toMatch(/server\.get\s*\(\s*\/\.\*\/\s*,/);
+      expect(updatedContent).not.toContain("server.get('*.*',");
+      expect(updatedContent).not.toContain("server.get('*',");
+    });
+
+    it('should handle multiline server.get calls with double quotes', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      if (tree.exists('/server.ts')) {
+        tree.delete('/server.ts');
+      }
+      tree.create('/server.ts', serverTsMultilineDoubleQuotes);
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedContent = newTree.readText('/server.ts');
+      // Check for regex pattern (may be on multiple lines)
+      expect(updatedContent).toMatch(/server\.get\s*\(\s*\/\.\*\\\.\.\*\/\s*,/);
+      expect(updatedContent).toMatch(/server\.get\s*\(\s*\/\.\*\/\s*,/);
+      expect(updatedContent).not.toContain('server.get("*.*",');
+      expect(updatedContent).not.toContain('server.get("*",');
+    });
+  });
+
+  describe('combined migration', () => {
+    it('should update both package.json and server.ts', async () => {
+      const packageJson = {
+        dependencies: {
+          express: '^4.18.0',
+        },
+      };
+
+      tree.create('/package.json', JSON.stringify(packageJson));
+      if (tree.exists('/server.ts')) {
+        tree.delete('/server.ts');
+      }
+      tree.create('/server.ts', serverTsWithWildcards);
+
+      const newTree = await runner.runSchematic(
+        MIGRATION_SCRIPT_NAME,
+        {},
+        tree
+      );
+
+      const updatedPackageJson = JSON.parse(newTree.readText('/package.json'));
+      expect(updatedPackageJson.dependencies.express).toBe('^5.1.0');
+
+      const updatedContent = newTree.readText('/server.ts');
+      expect(updatedContent).toContain('server.get(/.*\\..*/,');
+      expect(updatedContent).toContain('server.get(/.*/,');
+    });
+  });
+});

--- a/projects/schematics/src/migrations/221121_8/express-v5/index_spec.ts
+++ b/projects/schematics/src/migrations/221121_8/express-v5/index_spec.ts
@@ -11,7 +11,7 @@ import { join } from 'path';
 const collectionPath = join(__dirname, '../../migrations.json');
 const MIGRATION_SCRIPT_NAME = '02-migration-v221121_8-express-v5';
 
-fdescribe('Express v5 Migration', () => {
+describe('Express v5 Migration', () => {
   let tree: Tree;
   let runner: SchematicTestRunner;
 

--- a/projects/schematics/src/migrations/migrations.json
+++ b/projects/schematics/src/migrations/migrations.json
@@ -79,6 +79,11 @@
       "version": "221121.8.0",
       "factory": "./221121_8/angular-providers/index#migrate",
       "description": "Add provideBrowserGlobalErrorListeners to app.module.ts"
+    },
+    "02-migration-v221121_8-express-v5": {
+      "version": "221121.8.0",
+      "factory": "./221121_8/express-v5/index#migrate",
+      "description": "Upgrade Express to v5.1.0 and update server.ts for Express 5 compatibility"
     }
   }
 }

--- a/projects/schematics/src/shared/utils/package-utils.ts
+++ b/projects/schematics/src/shared/utils/package-utils.ts
@@ -200,7 +200,10 @@ export function isSsrUsed(tree: Tree): boolean {
 
   if (
     typeof builderType !== 'string' ||
-    builderType !== '@angular-devkit/build-angular:application'
+    ![
+      '@angular-devkit/build-angular:application',
+      '@angular/build:application',
+    ].includes(builderType)
   ) {
     return false;
   }

--- a/projects/schematics/src/shared/utils/package-utils_spec.ts
+++ b/projects/schematics/src/shared/utils/package-utils_spec.ts
@@ -172,6 +172,16 @@ describe('Package utils', () => {
         ssrTree.create('server.ts', 'export const server = {};');
         expect(isSsrUsed(ssrTree)).toBeTruthy();
       });
+
+      it('should return true when using @angular/build:application builder with SSR', () => {
+        createWorkspace(
+          '@angular/build:application',
+          'src/main.server.ts',
+          'server.ts'
+        );
+        ssrTree.create('server.ts', 'export const server = {};');
+        expect(isSsrUsed(ssrTree)).toBeTruthy();
+      });
     });
 
     describe('getServerTsPathForApplicationBuilder', () => {


### PR DESCRIPTION
This PR contains schematics for upgrading Express to v5.1.0 and updating `server.ts` file for Express 5 compatibility in migrated apps with SSR. Fresh Angular apps with SSR are using Express v^5.1.0, and this migration ensures migrated apps are updated accordingly.

The migration:
- Updates Express dependency to `^5.1.0` in `package.json`
- Replaces wildcard strings in `server.ts` with regex patterns (`'*.*'` → `/.*\..*/`, `'*'` → `/.*/`)

**QA steps:**

**Prerequisites:**
- checkout the PR's branch
- build libs:
  ```bash
  npm run build:libs
  ```
- publish libraries on Verdaccio:
  ```bash
  ts-node ./tools/schematics/testing
  ```

**SSR:**
1. generate fresh Angular 20 app
   ```bash
   npx @angular/cli@19 new my-app --style=scss --standalone=false --ssr=true
   ```
2. go to app's location and add `.npmrc` file (`touch .npmrc`) with the following snippet (to install packages from RBSC):
    ```bash
    always-auth=true
    @spartacus:registry=https://73554900100900004337.dev.npmsrv.base.repositories.cloud.sap/
    //73554900100900004337.dev.npmsrv.base.repositories.cloud.sap/:_auth=<PUT_HERE_YOUR_TOKEN>
    ```
3. commit changes
4. install from RBSC the Spartacus in version 221121.5
    ```bash
    npx ng add @spartacus/schematics@221121.5 --baseUrl=https://40.76.109.9:9002 --ssr
    ```
5.
    - bump Angular libs to v20 and related libs to version that supports new Angular:
     ```bash
      npx ng update @angular/core@20 @angular/cli@20 @ngrx/store@20 angular-oauth2-oidc@20 @ng-select/ng-select@20 ngx-infinite-scroll@20 --force
      git add .
      git commit -m "update angular 20 and 3rd party deps angular 20 compatible"     
      ```
    - bump Angular libs to v21 and related libs to version that supports new Angular:
     ```bash
     npx ng update @angular/core@21 @angular/cli@21 @ngrx/store@21 @ng-select/ng-select@21 ngx-infinite-scroll@21 --force
     git add .
     git commit -m "update angular 21 and 3rd party deps angular 21 compatible"
     ```
6. comment or remove the `.npmrc` from the project (to get packages from Verdaccio) and commit changes
7. verify that Express is at version 4.x in `package.json` and `server.ts` contains wildcard strings

8. update Spartacus packages:
   ```bash
   npx ng update @spartacus/schematics@latest
   ```
9. verify if the following logs are present in the terminal:
```bash
❯ Upgrade Express to v5.1.0 and update server.ts for Express 5 compatibility.
    🩹 Upgrading 'express' to ^5.1.0 (was 4.18.2)
    
    ⌛️ Updating server.ts for Express 5 compatibility...
    ✅ Updated src/server.ts for Express 5 compatibility
UPDATE package.json (2540 bytes)
UPDATE src/server.ts (1814 bytes)
```
10. verify that Express was updated to `^5.1.0` in `package.json`
11. verify that `server.ts` was updated with regex patterns

**CSR:**
1. Repeat steps 1-6 from instructions for SSR, but omit `--ssr` flag when generating Angular app and installing Spartacus
2. update Spartacus packages:
   ```bash
   npx ng update @spartacus/schematics@latest
   ```
3. verify that migration logs indicate no changes were made:
```bash
❯ Upgrade Express to v5.1.0 and update server.ts for Express 5 compatibility.
    
    ⏭️  Skipping Express v5 migration - SSR is not configured in this app
  Migration completed (No changes made).
```
