### PR TITLE
feat: add CX_MEDIA_BASE_URL env var and mediaBaseUrl for controling media server url

### DIFF
--- a/projects/storefrontapp/src/app/app.module.ts
+++ b/projects/storefrontapp/src/app/app.module.ts
@@ -81,6 +81,9 @@ if (!environment.production) {
           baseUrl: environment.occBaseUrl,
           prefix: environment.occApiPrefix,
         },
+        media: {
+          baseUrl: environment.mediaBaseUrl,
+        },
       },
     }),
     provideConfig(<RoutingConfig>{

--- a/projects/storefrontapp/src/environments/environment.prod.ts
+++ b/projects/storefrontapp/src/environments/environment.prod.ts
@@ -9,6 +9,8 @@ import { Environment } from './models/environment.model';
 export const environment: Environment = {
   production: true,
   occBaseUrl: buildProcess.env.CX_BASE_URL,
+  mediaBaseUrl:
+    buildProcess.env.CX_MEDIA_BASE_URL ?? buildProcess.env.CX_BASE_URL,
   occApiPrefix: '/occ/v2/',
   cds: buildProcess.env.CX_CDS,
   b2b: buildProcess.env.CX_B2B,

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -22,6 +22,8 @@ import { Environment } from './models/environment.model';
 export const environment: Environment = {
   production: false,
   occBaseUrl: buildProcess.env.CX_BASE_URL,
+  mediaBaseUrl:
+    buildProcess.env.CX_MEDIA_BASE_URL ?? buildProcess.env.CX_BASE_URL,
   occApiPrefix: '/occ/v2/',
   cds: buildProcess.env.CX_CDS ?? false,
   b2b: buildProcess.env.CX_B2B ?? false,

--- a/projects/storefrontapp/src/environments/models/build.process.env.d.ts
+++ b/projects/storefrontapp/src/environments/models/build.process.env.d.ts
@@ -12,6 +12,7 @@ interface BuildProcess {
 
 interface Env {
   CX_BASE_URL: string;
+  CX_MEDIA_BASE_URL?: string;
   CX_CDS: boolean;
   CX_CDC: boolean;
   CX_CDP: boolean;

--- a/projects/storefrontapp/src/environments/models/environment.model.ts
+++ b/projects/storefrontapp/src/environments/models/environment.model.ts
@@ -7,6 +7,7 @@
 export interface Environment {
   production: boolean;
   occBaseUrl: string;
+  mediaBaseUrl?: string;
   occApiPrefix: string;
   b2b: boolean;
   cds: boolean;


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-11937.

* Adding new `mediaBaseUrl` and `CX_MEDIA_BASE_URL` env var for setting/configuring Spartacus media resolution endpoint. From this point on media urls can be configured via `mediaBaseUrl` (or `CX_MEDIA_BASE_URL`) W/o modifying the source-code. This is needed for easier support of custom media servers/urls - like the new media api url update change (from `/medias/` to /`api/storefront/medias/` -> from https://jira.tools.sap/browse/CXSPA-11937).