### PR TITLE
fix: Missing 'provideServerRendering' in fresh apps

### DIFF
--- a/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -137,7 +137,7 @@ exports[`add-ssr angular.json should be configured properly 1`] = `
 
 exports[`add-ssr app.module.server.ts should be updated 1`] = `
 "import { NgModule } from '@angular/core';
-
+import { provideServerRendering,  } from '@angular/ssr';
 import { App } from './app.component';
 import { AppModule } from './app.module';
 import { provideServer } from '@spartacus/setup/ssr';
@@ -145,12 +145,10 @@ import { provideServer } from '@spartacus/setup/ssr';
 
 @NgModule({
   imports: [AppModule],
-  providers: [
-    
+  providers: [provideServerRendering(), 
      ...provideServer({
         serverRequestOrigin: process.env['SERVER_REQUEST_ORIGIN'],
-      }),
-  ],
+      }),],
   bootstrap: [App],
 })
 export class AppServerModule {}

--- a/projects/schematics/src/add-ssr/index.ts
+++ b/projects/schematics/src/add-ssr/index.ts
@@ -479,7 +479,9 @@ function removeServerRoutesImport(spartacusOptions: SpartacusOptions): Rule {
 /**
  * Removes the withRoutes import from @angular/ssr in app.module.server.ts.
  */
-function removeWithRoutesFromAngularSsrImport(spartacusOptions: SpartacusOptions): Rule {
+function removeWithRoutesFromAngularSsrImport(
+  spartacusOptions: SpartacusOptions
+): Rule {
   return (tree: Tree, context: SchematicContext): Tree => {
     const appServerModulePath = getPathResultsForFile(
       tree,

--- a/projects/schematics/src/add-ssr/index.ts
+++ b/projects/schematics/src/add-ssr/index.ts
@@ -517,6 +517,61 @@ function removeWithRoutesFromAngularSsrImport(spartacusOptions: SpartacusOptions
   };
 }
 
+function findProvideServerRenderingElement(
+  providersArray: ts.ArrayLiteralExpression
+): ts.CallExpression | undefined {
+  const providerElement = providersArray.elements.find((element) => {
+    if (!ts.isCallExpression(element)) {
+      return false;
+    }
+    const expression = element.expression;
+    return (
+      ts.isIdentifier(expression) &&
+      expression.text === 'provideServerRendering'
+    );
+  });
+
+  return providerElement as ts.CallExpression | undefined;
+}
+
+function isWithRoutesCallExpression(node: ts.Node): boolean {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === 'withRoutes'
+  );
+}
+
+function removeWithRoutesArgument(
+  tree: Tree,
+  appServerModulePath: string,
+  providerElement: ts.CallExpression,
+  spartacusOptions: SpartacusOptions,
+  context: SchematicContext
+): void {
+  if (providerElement.arguments.length === 0) {
+    return;
+  }
+
+  const firstArg = providerElement.arguments[0];
+  if (!isWithRoutesCallExpression(firstArg)) {
+    return;
+  }
+
+  const removeArgChange = new RemoveChange(
+    appServerModulePath,
+    firstArg.getStart(),
+    firstArg.getFullText()
+  );
+  commitChanges(tree, appServerModulePath, [removeArgChange]);
+
+  if (spartacusOptions.debug) {
+    context.logger.info(
+      `✅ Removed withRoutes(serverRoutes) from provideServerRendering in ${appServerModulePath}`
+    );
+  }
+}
+
 /**
  * Removes the withRoutes(serverRoutes) parameter from provideServerRendering in app.module.server.ts.
  */
@@ -542,54 +597,34 @@ function removeWithRoutesFromProvideServerRendering(
       ANGULAR_CORE
     )[0];
 
-    if (ngModuleDecorator) {
-      const providersAssignment = getMetadataField(
-        ngModuleDecorator as ts.ObjectLiteralExpression,
-        'providers'
-      )[0] as ts.PropertyAssignment;
-
-      if (providersAssignment) {
-        const providersArray =
-          providersAssignment.initializer as ts.ArrayLiteralExpression;
-
-        const providerElement = providersArray.elements.find((element) => {
-          if (ts.isCallExpression(element)) {
-            const expression = element.expression;
-            return (
-              ts.isIdentifier(expression) &&
-              expression.text === 'provideServerRendering'
-            );
-          }
-          return false;
-        });
-
-        if (
-          providerElement &&
-          ts.isCallExpression(providerElement) &&
-          providerElement.arguments.length > 0
-        ) {
-          const firstArg = providerElement.arguments[0];
-          if (
-            ts.isCallExpression(firstArg) &&
-            ts.isIdentifier(firstArg.expression) &&
-            firstArg.expression.text === 'withRoutes'
-          ) {
-            const removeArgChange = new RemoveChange(
-              appServerModulePath,
-              firstArg.getStart(),
-              firstArg.getFullText()
-            );
-            commitChanges(tree, appServerModulePath, [removeArgChange]);
-
-            if (spartacusOptions.debug) {
-              context.logger.info(
-                `✅ Removed withRoutes(serverRoutes) from provideServerRendering in ${appServerModulePath}`
-              );
-            }
-          }
-        }
-      }
+    if (!ngModuleDecorator) {
+      return tree;
     }
+
+    const providersAssignment = getMetadataField(
+      ngModuleDecorator as ts.ObjectLiteralExpression,
+      'providers'
+    )[0] as ts.PropertyAssignment;
+
+    if (!providersAssignment) {
+      return tree;
+    }
+
+    const providersArray =
+      providersAssignment.initializer as ts.ArrayLiteralExpression;
+    const providerElement = findProvideServerRenderingElement(providersArray);
+
+    if (!providerElement) {
+      return tree;
+    }
+
+    removeWithRoutesArgument(
+      tree,
+      appServerModulePath,
+      providerElement,
+      spartacusOptions,
+      context
+    );
 
     return tree;
   };

--- a/projects/schematics/src/add-ssr/index.ts
+++ b/projects/schematics/src/add-ssr/index.ts
@@ -477,9 +477,9 @@ function removeServerRoutesImport(spartacusOptions: SpartacusOptions): Rule {
 }
 
 /**
- * Removes the @angular/ssr import from app.module.server.ts.
+ * Removes the withRoutes import from @angular/ssr in app.module.server.ts.
  */
-function removeAngularSsrImport(spartacusOptions: SpartacusOptions): Rule {
+function removeWithRoutesFromAngularSsrImport(spartacusOptions: SpartacusOptions): Rule {
   return (tree: Tree, context: SchematicContext): Tree => {
     const appServerModulePath = getPathResultsForFile(
       tree,
@@ -493,26 +493,22 @@ function removeAngularSsrImport(spartacusOptions: SpartacusOptions): Rule {
 
     const appServerModuleSource = getTsSourceFile(tree, appServerModulePath);
 
-    const hasProvideServerRendering = isImported(
-      appServerModuleSource,
-      'provideServerRendering',
-      ANGULAR_SSR
-    );
     const hasWithRoutes = isImported(
       appServerModuleSource,
       'withRoutes',
       ANGULAR_SSR
     );
 
-    if (hasProvideServerRendering && hasWithRoutes) {
-      const angularSsrImportRemoval = removeImport(appServerModuleSource, {
+    if (hasWithRoutes) {
+      const withRoutesImportRemoval = removeImport(appServerModuleSource, {
+        className: 'withRoutes',
         importPath: ANGULAR_SSR,
       });
-      commitChanges(tree, appServerModulePath, [angularSsrImportRemoval]);
+      commitChanges(tree, appServerModulePath, [withRoutesImportRemoval]);
 
       if (spartacusOptions.debug) {
         context.logger.info(
-          `✅ Removed @angular/ssr import from ${appServerModulePath}`
+          `✅ Removed withRoutes from @angular/ssr import in ${appServerModulePath}`
         );
       }
     }
@@ -522,9 +518,9 @@ function removeAngularSsrImport(spartacusOptions: SpartacusOptions): Rule {
 }
 
 /**
- * Removes the provideServerRendering provider from app.module.server.ts.
+ * Removes the withRoutes(serverRoutes) parameter from provideServerRendering in app.module.server.ts.
  */
-function removeProvideServerRenderingFromProviders(
+function removeWithRoutesFromProvideServerRendering(
   spartacusOptions: SpartacusOptions
 ): Rule {
   return (tree: Tree, context: SchematicContext): Tree => {
@@ -556,22 +552,40 @@ function removeProvideServerRenderingFromProviders(
         const providersArray =
           providersAssignment.initializer as ts.ArrayLiteralExpression;
 
-        const providerToRemove = providersArray.elements.find((element) =>
-          element.getText().includes('provideServerRendering')
-        );
-
-        if (providerToRemove) {
-          const removeProviderChange = new RemoveChange(
-            appServerModulePath,
-            providerToRemove.getStart(),
-            providerToRemove.getFullText()
-          );
-          commitChanges(tree, appServerModulePath, [removeProviderChange]);
-
-          if (spartacusOptions.debug) {
-            context.logger.info(
-              `✅ Removed provideServerRendering(withRoutes(serverRoutes)) from ${appServerModulePath}`
+        const providerElement = providersArray.elements.find((element) => {
+          if (ts.isCallExpression(element)) {
+            const expression = element.expression;
+            return (
+              ts.isIdentifier(expression) &&
+              expression.text === 'provideServerRendering'
             );
+          }
+          return false;
+        });
+
+        if (
+          providerElement &&
+          ts.isCallExpression(providerElement) &&
+          providerElement.arguments.length > 0
+        ) {
+          const firstArg = providerElement.arguments[0];
+          if (
+            ts.isCallExpression(firstArg) &&
+            ts.isIdentifier(firstArg.expression) &&
+            firstArg.expression.text === 'withRoutes'
+          ) {
+            const removeArgChange = new RemoveChange(
+              appServerModulePath,
+              firstArg.getStart(),
+              firstArg.getFullText()
+            );
+            commitChanges(tree, appServerModulePath, [removeArgChange]);
+
+            if (spartacusOptions.debug) {
+              context.logger.info(
+                `✅ Removed withRoutes(serverRoutes) from provideServerRendering in ${appServerModulePath}`
+              );
+            }
           }
         }
       }
@@ -589,8 +603,8 @@ function removeServerRoutesFile(spartacusOptions: SpartacusOptions): Rule {
   return chain([
     removeServerRoutesFileFromSrc(spartacusOptions),
     removeServerRoutesImport(spartacusOptions),
-    removeAngularSsrImport(spartacusOptions),
-    removeProvideServerRenderingFromProviders(spartacusOptions),
+    removeWithRoutesFromAngularSsrImport(spartacusOptions),
+    removeWithRoutesFromProvideServerRendering(spartacusOptions),
   ]);
 }
 

--- a/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/projects/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -112,7 +112,7 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
 
 exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 3`] = `
 "import { NgModule } from '@angular/core';
-
+import { provideServerRendering,  } from '@angular/ssr';
 import { App } from './app.component';
 import { AppModule } from './app.module';
 import { provideServer } from '@spartacus/setup/ssr';
@@ -120,12 +120,10 @@ import { provideServer } from '@spartacus/setup/ssr';
 
 @NgModule({
   imports: [AppModule],
-  providers: [
-    
+  providers: [provideServerRendering(), 
      ...provideServer({
         serverRequestOrigin: process.env['SERVER_REQUEST_ORIGIN'],
-      }),
-  ],
+      }),],
   bootstrap: [App],
 })
 export class AppServerModule {}


### PR DESCRIPTION
This PR provides a fix for installation schematics, that scaffolded fresh apps without 'provideServerRendering', required for SSR apps to work properly.

QA steps:
- build and deploy Spartacus packages locally:
  `npx ts-node ./tools/schematics/testing.ts` in the SPA root folder
- create new app `npx @angular/cli@21 new my-app --standalone=false --style=scss --routing=false --sile-name-style-guide=2016`
- go to the project's directory and install Spartacus from local packages:
  `npx ng add @spartacus/schematics@latest --baseUrl="https://40.76.109.9:9002" --ssr`
- verify if `app.module.server.ts` contains `provideServerRendering`
- run `npm run build` and ` NODE_TLS_REJECT_UNAUTHORIZED=0 npm run serve:ssr:my-app` to verify if app works
- in browser's devtools, open `Elements` tab and scroll to bottom to verify if transfer state is present (ng-state was missing without the fix:
  <img width="1116" height="709" alt="image" src="https://github.com/user-attachments/assets/d6f235bb-4a57-4937-9e05-08ebfc3088cb" />
