### PR TITLE
chore: Bump tar to v7.5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32230,9 +32230,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "devOptional": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
This PR updates tar library to 7.5.7, required to fix CVE-2026-24842
