### PR TITLE
chore: removed the deprecated 'OptimizedSsrEngine.log' method in favor of 'this.logger'

### DIFF
--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -867,7 +867,7 @@ describe('OptimizedSsrEngine', () => {
       expect(engineRunner.renderCount).toEqual(1);
       expect(engineRunner.optimizedSsrEngine['log']).not.toHaveBeenCalledWith(
         `Rendering of ${requestUrl} was not able to complete. This might cause memory leaks!`,
-        false
+        { request: expect.objectContaining({ originalUrl: requestUrl }) }
       );
     }));
 
@@ -883,7 +883,6 @@ describe('OptimizedSsrEngine', () => {
       expect(engineRunner.renderCount).toEqual(0);
       expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
         `Rendering of ${requestUrl} was not able to complete. This might cause memory leaks!`,
-        false,
         { request: expect.objectContaining({ originalUrl: requestUrl }) }
       );
 
@@ -908,7 +907,6 @@ describe('OptimizedSsrEngine', () => {
       expect(engineRunner.renderCount).toEqual(0);
       expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
         `Rendering of ${requestUrl} was not able to complete. This might cause memory leaks!`,
-        false,
         { request: expect.objectContaining({ originalUrl: requestUrl }) }
       );
 
@@ -939,7 +937,6 @@ describe('OptimizedSsrEngine', () => {
       // while the concurrency slot is busy rendering the first hanging request, the second request gets the CSR version
       expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
         `CSR fallback: Concurrency limit exceeded (1)`,
-        true,
         { request: expect.objectContaining({ originalUrl: csrRequest }) }
       );
       expect(engineRunner.renderCount).toEqual(0);
@@ -950,7 +947,6 @@ describe('OptimizedSsrEngine', () => {
       tick(maxRenderTime);
       expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
         `Rendering of ${hangingRequest} was not able to complete. This might cause memory leaks!`,
-        false,
         { request: expect.objectContaining({ originalUrl: hangingRequest }) }
       );
       expect(engineRunner.renderCount).toEqual(0);
@@ -960,7 +956,6 @@ describe('OptimizedSsrEngine', () => {
       tick(1);
       expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
         `Rendering started (${ssrRequest})`,
-        true,
         { request: expect.objectContaining({ originalUrl: ssrRequest }) }
       );
       expect(getCurrentConcurrency(engineRunner)).toEqual({
@@ -986,7 +981,6 @@ describe('OptimizedSsrEngine', () => {
       tick(fiveMinutes + 101);
       expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
         `Rendering of ${requestUrl} completed after the specified maxRenderTime, therefore it was ignored.`,
-        false,
         { request: expect.objectContaining({ originalUrl: requestUrl }) }
       );
       expect(engineRunner.responses).toEqual(['']);
@@ -1039,12 +1033,10 @@ describe('OptimizedSsrEngine', () => {
 
         expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
           `CSR fallback: rendering in progress (${requestUrl})`,
-          true,
           { request: expect.objectContaining({ originalUrl: requestUrl }) }
         );
         expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
           `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
-          false,
           { request: expect.objectContaining({ originalUrl: requestUrl }) }
         );
         expect(engineRunner.responses).toEqual(['', '']);
@@ -1071,7 +1063,6 @@ describe('OptimizedSsrEngine', () => {
           tick(100);
           expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
             `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
-            false,
             { request: expect.objectContaining({ originalUrl: requestUrl }) }
           );
 
@@ -1198,7 +1189,6 @@ describe('OptimizedSsrEngine', () => {
           tick(100);
           expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
             `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
-            false,
             { request: expect.objectContaining({ originalUrl: requestUrl }) }
           );
           expect(engineRunner.responses).toEqual(['']); // the first request fallback to CSR due to timeout
@@ -1329,7 +1319,6 @@ describe('OptimizedSsrEngine', () => {
           tick(maxRenderTime);
           expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
             `Rendering of ${hangingRequest} was not able to complete. This might cause memory leaks!`,
-            false,
             { request: expect.objectContaining({ originalUrl: requestUrl }) }
           );
           expect(getCurrentConcurrency(engineRunner)).toEqual({
@@ -1346,7 +1335,6 @@ describe('OptimizedSsrEngine', () => {
           tick(1);
           expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
             `Rendering started (${ssrRequest})`,
-            true,
             { request: expect.objectContaining({ originalUrl: ssrRequest }) }
           );
           expect(getCurrentConcurrency(engineRunner)).toEqual({
@@ -1383,12 +1371,10 @@ describe('OptimizedSsrEngine', () => {
 
         expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
           `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
-          false,
           { request: expect.objectContaining({ originalUrl: requestUrl }) }
         );
         expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
           `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${differentUrl}`,
-          false,
           { request: expect.objectContaining({ originalUrl: differentUrl }) }
         );
 

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -861,11 +861,13 @@ describe('OptimizedSsrEngine', () => {
       const engineRunner = new TestEngineRunner({}, renderTime).request(
         requestUrl
       );
-      jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+      jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
       tick(renderTime + 1);
       expect(engineRunner.renderCount).toEqual(1);
-      expect(engineRunner.optimizedSsrEngine['log']).not.toHaveBeenCalledWith(
+      expect(
+        engineRunner.optimizedSsrEngine['logger'].log
+      ).not.toHaveBeenCalledWith(
         `Rendering of ${requestUrl} was not able to complete. This might cause memory leaks!`,
         { request: expect.objectContaining({ originalUrl: requestUrl }) }
       );
@@ -877,11 +879,13 @@ describe('OptimizedSsrEngine', () => {
       const engineRunner = new TestEngineRunner({}, renderTime).request(
         requestUrl
       );
-      jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+      jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
       tick(fiveMinutes);
       expect(engineRunner.renderCount).toEqual(0);
-      expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+      expect(
+        engineRunner.optimizedSsrEngine['logger'].log
+      ).toHaveBeenCalledWith(
         `Rendering of ${requestUrl} was not able to complete. This might cause memory leaks!`,
         { request: expect.objectContaining({ originalUrl: requestUrl }) }
       );
@@ -901,11 +905,13 @@ describe('OptimizedSsrEngine', () => {
         },
         renderTime
       ).request(requestUrl);
-      jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+      jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
       tick(maxRenderTime);
       expect(engineRunner.renderCount).toEqual(0);
-      expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+      expect(
+        engineRunner.optimizedSsrEngine['logger'].log
+      ).toHaveBeenCalledWith(
         `Rendering of ${requestUrl} was not able to complete. This might cause memory leaks!`,
         { request: expect.objectContaining({ originalUrl: requestUrl }) }
       );
@@ -924,7 +930,7 @@ describe('OptimizedSsrEngine', () => {
         { concurrency: 1, maxRenderTime },
         renderTime
       );
-      jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+      jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
       // issue two requests
       engineRunner.request(hangingRequest);
@@ -935,17 +941,20 @@ describe('OptimizedSsrEngine', () => {
 
       tick(1);
       // while the concurrency slot is busy rendering the first hanging request, the second request gets the CSR version
-      expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
-        `CSR fallback: Concurrency limit exceeded (1)`,
-        { request: expect.objectContaining({ originalUrl: csrRequest }) }
-      );
+      expect(
+        engineRunner.optimizedSsrEngine['logger'].log
+      ).toHaveBeenCalledWith(`CSR fallback: Concurrency limit exceeded (1)`, {
+        request: expect.objectContaining({ originalUrl: csrRequest }),
+      });
       expect(engineRunner.renderCount).toEqual(0);
       expect(getCurrentConcurrency(engineRunner)).toEqual({
         currentConcurrency: 1,
       });
 
       tick(maxRenderTime);
-      expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+      expect(
+        engineRunner.optimizedSsrEngine['logger'].log
+      ).toHaveBeenCalledWith(
         `Rendering of ${hangingRequest} was not able to complete. This might cause memory leaks!`,
         { request: expect.objectContaining({ originalUrl: hangingRequest }) }
       );
@@ -954,10 +963,11 @@ describe('OptimizedSsrEngine', () => {
       // even though the hanging request is still rendering, we've freed up a slot for a new request
       engineRunner.request(ssrRequest);
       tick(1);
-      expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
-        `Rendering started (${ssrRequest})`,
-        { request: expect.objectContaining({ originalUrl: ssrRequest }) }
-      );
+      expect(
+        engineRunner.optimizedSsrEngine['logger'].log
+      ).toHaveBeenCalledWith(`Rendering started (${ssrRequest})`, {
+        request: expect.objectContaining({ originalUrl: ssrRequest }),
+      });
       expect(getCurrentConcurrency(engineRunner)).toEqual({
         currentConcurrency: 1,
       });
@@ -975,11 +985,13 @@ describe('OptimizedSsrEngine', () => {
         },
         renderTime
       ).request(requestUrl);
-      jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+      jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
       expect(engineRunner.responses).toEqual([]);
 
       tick(fiveMinutes + 101);
-      expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+      expect(
+        engineRunner.optimizedSsrEngine['logger'].log
+      ).toHaveBeenCalledWith(
         `Rendering of ${requestUrl} completed after the specified maxRenderTime, therefore it was ignored.`,
         { request: expect.objectContaining({ originalUrl: requestUrl }) }
       );
@@ -1016,7 +1028,7 @@ describe('OptimizedSsrEngine', () => {
           { timeout, reuseCurrentRendering: false },
           400
         );
-        jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+        jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
         engineRunner.request(requestUrl);
         expect(getRenderCallbacksCount(engineRunner, requestUrl)).toEqual({
@@ -1031,11 +1043,15 @@ describe('OptimizedSsrEngine', () => {
 
         tick(100);
 
-        expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+        expect(
+          engineRunner.optimizedSsrEngine['logger'].log
+        ).toHaveBeenCalledWith(
           `CSR fallback: rendering in progress (${requestUrl})`,
           { request: expect.objectContaining({ originalUrl: requestUrl }) }
         );
-        expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+        expect(
+          engineRunner.optimizedSsrEngine['logger'].log
+        ).toHaveBeenCalledWith(
           `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
           { request: expect.objectContaining({ originalUrl: requestUrl }) }
         );
@@ -1053,7 +1069,7 @@ describe('OptimizedSsrEngine', () => {
             { timeout, reuseCurrentRendering: true },
             400
           );
-          jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+          jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
           engineRunner.request(requestUrl);
           tick(200);
@@ -1061,7 +1077,9 @@ describe('OptimizedSsrEngine', () => {
           engineRunner.request(requestUrl);
 
           tick(100);
-          expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+          expect(
+            engineRunner.optimizedSsrEngine['logger'].log
+          ).toHaveBeenCalledWith(
             `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
             { request: expect.objectContaining({ originalUrl: requestUrl }) }
           );
@@ -1079,7 +1097,7 @@ describe('OptimizedSsrEngine', () => {
             { timeout, reuseCurrentRendering: true },
             1000
           );
-          engineRunner.optimizedSsrEngine['log'] = logSpy;
+          engineRunner.optimizedSsrEngine['logger'].log = logSpy;
 
           engineRunner.request(requestUrl);
 
@@ -1155,7 +1173,7 @@ describe('OptimizedSsrEngine', () => {
             { timeout, reuseCurrentRendering: true, concurrency: 2 },
             400
           );
-          jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+          jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
           // start 1st request
           engineRunner.request(requestUrl);
@@ -1187,7 +1205,9 @@ describe('OptimizedSsrEngine', () => {
 
           // 1st request timeout
           tick(100);
-          expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+          expect(
+            engineRunner.optimizedSsrEngine['logger'].log
+          ).toHaveBeenCalledWith(
             `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
             { request: expect.objectContaining({ originalUrl: requestUrl }) }
           );
@@ -1220,14 +1240,14 @@ describe('OptimizedSsrEngine', () => {
             timeout: 200,
             concurrency: 1,
           });
-          jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+          jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
           engineRunner.request('a');
           engineRunner.request('a');
 
           tick(200);
           expect(
-            engineRunner.optimizedSsrEngine['log']
+            engineRunner.optimizedSsrEngine['logger'].log
           ).not.toHaveBeenCalledWith(
             `CSR fallback: Concurrency limit exceeded (1)`
           );
@@ -1299,7 +1319,7 @@ describe('OptimizedSsrEngine', () => {
             { concurrency: 2, maxRenderTime, reuseCurrentRendering: true },
             renderTime
           );
-          jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+          jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
           engineRunner.request(hangingRequest);
           engineRunner.request(hangingRequest);
@@ -1317,7 +1337,9 @@ describe('OptimizedSsrEngine', () => {
           );
 
           tick(maxRenderTime);
-          expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+          expect(
+            engineRunner.optimizedSsrEngine['logger'].log
+          ).toHaveBeenCalledWith(
             `Rendering of ${hangingRequest} was not able to complete. This might cause memory leaks!`,
             { request: expect.objectContaining({ originalUrl: requestUrl }) }
           );
@@ -1333,10 +1355,11 @@ describe('OptimizedSsrEngine', () => {
           // even though the hanging request is still rendering, we've freed up a slot for a new request
           engineRunner.request(ssrRequest);
           tick(1);
-          expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
-            `Rendering started (${ssrRequest})`,
-            { request: expect.objectContaining({ originalUrl: ssrRequest }) }
-          );
+          expect(
+            engineRunner.optimizedSsrEngine['logger'].log
+          ).toHaveBeenCalledWith(`Rendering started (${ssrRequest})`, {
+            request: expect.objectContaining({ originalUrl: ssrRequest }),
+          });
           expect(getCurrentConcurrency(engineRunner)).toEqual({
             currentConcurrency: 1,
           });
@@ -1361,7 +1384,7 @@ describe('OptimizedSsrEngine', () => {
           { timeout, reuseCurrentRendering: true },
           400
         );
-        jest.spyOn(engineRunner.optimizedSsrEngine as any, 'log');
+        jest.spyOn(engineRunner.optimizedSsrEngine['logger'], 'log');
 
         engineRunner.request(requestUrl);
         tick(200);
@@ -1369,11 +1392,15 @@ describe('OptimizedSsrEngine', () => {
         engineRunner.request(differentUrl);
         tick(300);
 
-        expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+        expect(
+          engineRunner.optimizedSsrEngine['logger'].log
+        ).toHaveBeenCalledWith(
           `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${requestUrl}`,
           { request: expect.objectContaining({ originalUrl: requestUrl }) }
         );
-        expect(engineRunner.optimizedSsrEngine['log']).toHaveBeenCalledWith(
+        expect(
+          engineRunner.optimizedSsrEngine['logger'].log
+        ).toHaveBeenCalledWith(
           `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${differentUrl}`,
           { request: expect.objectContaining({ originalUrl: differentUrl }) }
         );

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -8,11 +8,7 @@
 import { Request, Response } from 'express';
 import * as fs from 'fs';
 import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
-import {
-  EXPRESS_SERVER_LOGGER,
-  ExpressServerLogger,
-  ExpressServerLoggerContext,
-} from '../logger';
+import { EXPRESS_SERVER_LOGGER, ExpressServerLogger } from '../logger';
 import { getLoggableSsrOptimizationOptions } from './get-loggable-ssr-optimization-options';
 import { RenderingCache } from './rendering-cache/rendering-cache';
 import { preprocessRequestForLogger } from './request-context';
@@ -94,7 +90,7 @@ export class OptimizedSsrEngine {
       this.ssrOptions
     );
 
-    this.log(`[spartacus] SSR optimization engine initialized`, {
+    this.logger.log(`[spartacus] SSR optimization engine initialized`, {
       options: loggableSsrOptions,
     });
   }
@@ -143,12 +139,12 @@ export class OptimizedSsrEngine {
       !this.ssrOptions?.reuseCurrentRendering;
 
     if (fallBack) {
-      this.log(
+      this.logger.log(
         `CSR fallback: rendering in progress (${request?.originalUrl})`,
         { request }
       );
     } else if (concurrencyLimitExceeded) {
-      this.log(
+      this.logger.log(
         `CSR fallback: Concurrency limit exceeded (${this.ssrOptions?.concurrency})`,
         { request }
       );
@@ -252,7 +248,7 @@ export class OptimizedSsrEngine {
     const response: Response = options.req.res;
 
     if (this.returnCachedRender(request, callback)) {
-      this.log(`Render from cache (${request?.originalUrl})`, {
+      this.logger.log(`Render from cache (${request?.originalUrl})`, {
         request,
       });
       return;
@@ -269,7 +265,7 @@ export class OptimizedSsrEngine {
       requestTimeout = setTimeout(() => {
         requestTimeout = undefined;
         this.fallbackToCsr(response, filePath, callback);
-        this.log(
+        this.logger.log(
           `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${request?.originalUrl}`,
           { request }
         );
@@ -309,10 +305,6 @@ export class OptimizedSsrEngine {
       renderCallback,
       request,
     });
-  }
-
-  private log(message: string, context: ExpressServerLoggerContext): void {
-    this.logger.log(message, context || {});
   }
 
   /** Retrieve the document from the cache or the filesystem */
@@ -379,7 +371,7 @@ export class OptimizedSsrEngine {
       });
     }
 
-    this.log(
+    this.logger.log(
       `Request is waiting for the SSR rendering to complete (${request?.originalUrl})`,
       { request }
     );
@@ -418,13 +410,13 @@ export class OptimizedSsrEngine {
         if (this.ssrOptions?.reuseCurrentRendering) {
           this.renderCallbacks.delete(renderingKey);
         }
-        this.log(
+        this.logger.log(
           `Rendering of ${request?.originalUrl} was not able to complete. This might cause memory leaks!`,
           { request }
         );
       }, this.ssrOptions?.maxRenderTime ?? 300000); // 300000ms == 5 minutes
 
-    this.log(`Rendering started (${request?.originalUrl})`, { request });
+    this.logger.log(`Rendering started (${request?.originalUrl})`, { request });
     this.renderingCache.setAsRendering(renderingKey);
     this.currentConcurrency++;
 
@@ -442,7 +434,7 @@ export class OptimizedSsrEngine {
     this.expressEngine(filePath, options, (err, html) => {
       if (!maxRenderTimeout) {
         // ignore this render's result because it exceeded maxRenderTimeout
-        this.log(
+        this.logger.log(
           `Rendering of ${request.originalUrl} completed after the specified maxRenderTime, therefore it was ignored.`,
           { request }
         );
@@ -450,7 +442,7 @@ export class OptimizedSsrEngine {
       }
       clearTimeout(maxRenderTimeout);
 
-      this.log(`Rendering completed (${request?.originalUrl})`, {
+      this.logger.log(`Rendering completed (${request?.originalUrl})`, {
         request,
       });
       this.currentConcurrency--;
@@ -468,7 +460,7 @@ export class OptimizedSsrEngine {
     request: Request
   ): void {
     if (html) {
-      this.log(
+      this.logger.log(
         `Request is resolved with the SSR rendering result (${request?.originalUrl})`,
         { request }
       );

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -37,7 +37,7 @@ export type SsrCallbackFn = (
 export class OptimizedSsrEngine {
   protected currentConcurrency = 0;
   protected renderingCache: RenderingCache;
-  private logger: ExpressServerLogger;
+  protected logger: ExpressServerLogger;
   private templateCache = new Map<string, string>();
 
   /**

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -94,7 +94,7 @@ export class OptimizedSsrEngine {
       this.ssrOptions
     );
 
-    this.log(`[spartacus] SSR optimization engine initialized`, true, {
+    this.log(`[spartacus] SSR optimization engine initialized`, {
       options: loggableSsrOptions,
     });
   }
@@ -145,13 +145,11 @@ export class OptimizedSsrEngine {
     if (fallBack) {
       this.log(
         `CSR fallback: rendering in progress (${request?.originalUrl})`,
-        true,
         { request }
       );
     } else if (concurrencyLimitExceeded) {
       this.log(
         `CSR fallback: Concurrency limit exceeded (${this.ssrOptions?.concurrency})`,
-        true,
         { request }
       );
     }
@@ -254,7 +252,7 @@ export class OptimizedSsrEngine {
     const response: Response = options.req.res;
 
     if (this.returnCachedRender(request, callback)) {
-      this.log(`Render from cache (${request?.originalUrl})`, true, {
+      this.log(`Render from cache (${request?.originalUrl})`, {
         request,
       });
       return;
@@ -273,7 +271,6 @@ export class OptimizedSsrEngine {
         this.fallbackToCsr(response, filePath, callback);
         this.log(
           `SSR rendering exceeded timeout ${timeout}, fallbacking to CSR for ${request?.originalUrl}`,
-          false,
           { request }
         );
       }, timeout);
@@ -314,14 +311,7 @@ export class OptimizedSsrEngine {
     });
   }
 
-  /**
-   * @deprecated since v2211.27 - This method will be private in the future.
-   */
-  protected log(
-    message: string,
-    _ignoredLegacyDebugParameter = true,
-    context: ExpressServerLoggerContext
-  ): void {
+  private log(message: string, context: ExpressServerLoggerContext): void {
     this.logger.log(message, context || {});
   }
 
@@ -391,7 +381,6 @@ export class OptimizedSsrEngine {
 
     this.log(
       `Request is waiting for the SSR rendering to complete (${request?.originalUrl})`,
-      true,
       { request }
     );
   }
@@ -431,12 +420,11 @@ export class OptimizedSsrEngine {
         }
         this.log(
           `Rendering of ${request?.originalUrl} was not able to complete. This might cause memory leaks!`,
-          false,
           { request }
         );
       }, this.ssrOptions?.maxRenderTime ?? 300000); // 300000ms == 5 minutes
 
-    this.log(`Rendering started (${request?.originalUrl})`, true, { request });
+    this.log(`Rendering started (${request?.originalUrl})`, { request });
     this.renderingCache.setAsRendering(renderingKey);
     this.currentConcurrency++;
 
@@ -456,14 +444,13 @@ export class OptimizedSsrEngine {
         // ignore this render's result because it exceeded maxRenderTimeout
         this.log(
           `Rendering of ${request.originalUrl} completed after the specified maxRenderTime, therefore it was ignored.`,
-          false,
           { request }
         );
         return;
       }
       clearTimeout(maxRenderTimeout);
 
-      this.log(`Rendering completed (${request?.originalUrl})`, true, {
+      this.log(`Rendering completed (${request?.originalUrl})`, {
         request,
       });
       this.currentConcurrency--;
@@ -483,7 +470,6 @@ export class OptimizedSsrEngine {
     if (html) {
       this.log(
         `Request is resolved with the SSR rendering result (${request?.originalUrl})`,
-        true,
         { request }
       );
     }

--- a/docs/migration/221121_7/221121_7-typescript-manual.doc.md
+++ b/docs/migration/221121_7/221121_7-typescript-manual.doc.md
@@ -106,10 +106,10 @@
 - **Reason:** Deprecated in favor of `CdcPreferenceSerializer` service class.
 - **Action Required:** Use the `CdcPreferenceSerializer` class methods.
 
-### `OptimizedSsrEngine` Logger Method
+### `OptimizedSsrEngine`
 - **Removed Method:** `log(message: string, _ignoredLegacyDebugParameter: boolean, context: ExpressServerLoggerContext)`
 - **Reason:** Deprecated since **2211.27**
-- **Action Required:** If you extended the `OptimizedSsrEngine` and used called yourself the removed method `log()`, please update your code to use the property `this.logger` instead, e.g. `this.logger.log(message, context);`
+- **Action Required:** Use `this.logger` instead, e.g. `this.logger.log(message, context);`
 
 ## Removed Tokens
 

--- a/docs/migration/221121_7/221121_7-typescript-manual.doc.md
+++ b/docs/migration/221121_7/221121_7-typescript-manual.doc.md
@@ -106,6 +106,11 @@
 - **Reason:** Deprecated in favor of `CdcPreferenceSerializer` service class.
 - **Action Required:** Use the `CdcPreferenceSerializer` class methods.
 
+### `OptimizedSsrEngine` Logger Method
+- **Removed Method:** `log(message: string, _ignoredLegacyDebugParameter: boolean, context: ExpressServerLoggerContext)`
+- **Reason:** Deprecated since **2211.27**
+- **Action Required:** If you extended the `OptimizedSsrEngine` and used called yourself the removed method `log()`, please update your code to use the property `this.logger` instead, e.g. `this.logger.log(message, context);`
+
 ## Removed Tokens
 
 ### `USE_LEGACY_MEDIA_COMPONENT`


### PR DESCRIPTION
Before:
- method `OptimizedSsrEngine.log` was deprecated since more than year ago
- the deprecated method contained a legacy 2nd argument (which was useless and ignored, which disturbed readability, but we couldn't remove it until the method was `protected`, i.e. in public APi)

After:
- now removed the deprecated method and replaced its usages `this.log()` with `this.logger.log()`
- changed `this.logger` from `private` to `protected`
- updated unit tests which expected `this.log` to be called. Now they expect `this.logger.log` to be called instead
- updated migration doc on manual Typescript breaking changes with advice to use `this.logger` object instead

fixes https://jira.tools.sap/browse/CXSPA-12038