### PR TITLE
WIP: spike - vite dev server for SSR

### DIFF
--- a/core-libs/setup/ssr/engine/ng-express-engine.ts
+++ b/core-libs/setup/ssr/engine/ng-express-engine.ts
@@ -4,14 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { StaticProvider } from '@angular/core';
 import {
+  AngularNodeAppEngine,
   CommonEngineOptions,
   CommonEngineRenderOptions,
+  writeResponseToNodeResponse,
 } from '@angular/ssr/node';
 import { Request, Response } from 'express';
-import { REQUEST, RESPONSE } from '../tokens/express.tokens';
-import { CxCommonEngine } from './cx-common-engine';
 
 /**
  * @license
@@ -27,30 +26,36 @@ export type NgSetupOptions = Pick<
 > &
   CommonEngineOptions;
 
-/**
- * @license
- * The MIT License
- * Copyright (c) 2010-2023 Google LLC. http://angular.io/license
- *
- * See:
- * - https://github.com/angular/universal/blob/e798d256de5e4377b704e63d993dc56ea35df97d/modules/express-engine/src/main.ts
- */
-function getReqResProviders(req: Request, res?: Response): StaticProvider[] {
-  const providers: StaticProvider[] = [
-    {
-      provide: REQUEST,
-      useValue: req,
-    },
-  ];
-  if (res) {
-    providers.push({
-      provide: RESPONSE,
-      useValue: res,
-    });
-  }
+// SPIKE - CAUTION 1 - removed providers of REQUEST and RESPONSE as there is no way to provide them via AngularNodeAppEngine.handle()
+//                       As a result, we'll need to use Angular's new DI tokens REQUEST and RESPONSE_INIT from @angular/core
+//         CAUTION 2 - now I expect some Spartacus features to be not working properly (those based in REQUEST/RESPONSE)
+//                       but please mind I've run dev server with env variable SERVER_REQUEST_ORIGIN, so perhaps it satisfies Spartacus needs
+//
+//
+//   /**
+//  * @license
+//  * The MIT License
+//  * Copyright (c) 2010-2023 Google LLC. http://angular.io/license
+//  *
+//  * See:
+//  * - https://github.com/angular/universal/blob/e798d256de5e4377b704e63d993dc56ea35df97d/modules/express-engine/src/main.ts
+//  */
+// function getReqResProviders(req: Request, res?: Response): StaticProvider[] {
+//   const providers: StaticProvider[] = [
+//     {
+//       provide: REQUEST,
+//       useValue: req,
+//     },
+//   ];
+//   if (res) {
+//     providers.push({
+//       provide: RESPONSE,
+//       useValue: res,
+//     });
+//   }
 
-  return providers;
-}
+//   return providers;
+// }
 
 /**
  * @license
@@ -79,47 +84,38 @@ export interface RenderOptions extends CommonEngineRenderOptions {
  * See:
  * - https://github.com/angular/universal/blob/e798d256de5e4377b704e63d993dc56ea35df97d/modules/express-engine/src/main.ts
  */
-export function ngExpressEngine(setupOptions: NgSetupOptions) {
-  const engine = new CxCommonEngine({
-    bootstrap: setupOptions.bootstrap,
-    providers: setupOptions.providers,
-    enablePerformanceProfiler: setupOptions.enablePerformanceProfiler,
-  });
+export function ngExpressEngine(
+  // SPIKE - PERHAPS we need a way to pass options like `inlineCriticalCss`, etc. in case of AngularNodeAppEngine
+  _setupOptions: NgSetupOptions
+) {
+  const angularApp = new AngularNodeAppEngine();
 
   return function (
-    filePath: string,
-    options: object,
+    _filePath: string,
+    options: object, // SPIKE - necessary properties: req, res
+    // SPIKE - I guess this callback is not needed (in server.ts it's nearly empty besides calling next(err)). but lets leave it for now
     callback: (err?: Error | null, html?: string) => void
   ) {
     try {
       const renderOptions = { ...options } as RenderOptions;
-      if (!setupOptions.bootstrap && !renderOptions.bootstrap) {
-        throw new Error('You must pass in a NgModule to be bootstrapped');
-      }
 
       const { req } = renderOptions;
       const res = renderOptions.res ?? req.res;
 
-      renderOptions.url =
-        renderOptions.url ??
-        `${req.protocol}://${req.get('host') || ''}${req.baseUrl}${req.url}`;
-      renderOptions.documentFilePath =
-        renderOptions.documentFilePath ?? filePath;
-      renderOptions.providers = [
-        ...(renderOptions.providers ?? []),
-        getReqResProviders(req, res),
-      ];
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      renderOptions.publicPath =
-        renderOptions.publicPath ??
-        setupOptions.publicPath ??
-        (options as any).settings?.views;
-      renderOptions.inlineCriticalCss =
-        renderOptions.inlineCriticalCss ?? setupOptions.inlineCriticalCss;
+      if (!res) {
+        throw new Error('Response object is required');
+      }
 
-      engine
-        .render(renderOptions)
-        .then((html) => callback(null, html))
+      angularApp
+        .handle(req)
+        .then((response) => {
+          if (response) {
+            writeResponseToNodeResponse(response, res);
+            callback(null, '');
+          } else {
+            callback(new Error('No response from AngularNodeAppEngine')); // it will be passed in server.ts to next()
+          }
+        })
         .catch(callback);
     } catch (err) {
       err instanceof Error && callback(err);

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.ts
@@ -6,13 +6,8 @@
 
 /* webpackIgnore: true */
 import { Request, Response } from 'express';
-import * as fs from 'fs';
 import { NgExpressEngineInstance } from '../engine-decorator/ng-express-engine-decorator';
-import {
-  EXPRESS_SERVER_LOGGER,
-  ExpressServerLogger,
-  ExpressServerLoggerContext,
-} from '../logger';
+import { ExpressServerLogger, ExpressServerLoggerContext } from '../logger';
 import { getLoggableSsrOptimizationOptions } from './get-loggable-ssr-optimization-options';
 import { RenderingCache } from './rendering-cache/rendering-cache';
 import { preprocessRequestForLogger } from './request-context';
@@ -42,7 +37,8 @@ export class OptimizedSsrEngine {
   protected currentConcurrency = 0;
   protected renderingCache: RenderingCache;
   private logger: ExpressServerLogger;
-  private templateCache = new Map<string, string>();
+
+  // private templateCache = new Map<string, string>(); // SPIKE - commented our as temporarily unused
 
   /**
    * When the config `reuseCurrentRendering` is enabled, we want perform
@@ -326,15 +322,20 @@ export class OptimizedSsrEngine {
   }
 
   /** Retrieve the document from the cache or the filesystem */
-  protected getDocument(filePath: string): string {
-    let doc = this.templateCache.get(filePath);
+  protected getDocument(_filePath: string): string {
+    // SPIKE OLD
+    // let doc = this.templateCache.get(filePath);
 
-    if (!doc) {
-      doc = fs.readFileSync(filePath, 'utf-8');
-      this.templateCache.set(filePath, doc);
-    }
+    // if (!doc) {
+    //   doc = fs.readFileSync(filePath, 'utf-8');
+    //   this.templateCache.set(filePath, doc);
+    // }
 
-    return doc;
+    // return doc;
+
+    // SPIKE NEW CAUTION - we don't have access to filesystem in vite dev server
+    //                      so CSR fallback doesn't work properly, we just returning DUMMY content for now!
+    return '<html><body><h1>This should be CSR fallback, but we I dont know how to get contents of index.server.html</h1></body></html>';
   }
 
   /**
@@ -442,13 +443,17 @@ export class OptimizedSsrEngine {
 
     options = {
       ...options,
-      providers: [
-        {
-          provide: EXPRESS_SERVER_LOGGER,
-          useValue: this.logger,
-        },
-        ...(options?.providers ?? []),
-      ],
+
+      // SPIKE CAUTION - passing providers doesn't work with AngularNodeAppEngine, so commenting out for now
+      //                  but we'll nee to figure out a different way to setup JSON logger in SSR, with Request context
+      //                  NOW STANDARDIZED SSR LOGGER DOESN'T WORK!
+      // providers: [
+      //   {
+      //     provide: EXPRESS_SERVER_LOGGER,
+      //     useValue: this.logger,
+      //   },
+      //   ...(options?.providers ?? []),
+      // ],
     };
 
     this.expressEngine(filePath, options, (err, html) => {

--- a/projects/storefrontapp/project.json
+++ b/projects/storefrontapp/project.json
@@ -135,6 +135,7 @@
           }
         },
         "server": "projects/storefrontapp/src/main.server.ts",
+        "outputMode": "server",
         "prerender": false,
         "ssr": {
           "entry": "projects/storefrontapp/src/server.ts"
@@ -214,10 +215,10 @@
       "executor": "@angular-builders/custom-esbuild:dev-server",
       "configurations": {
         "production": {
-          "buildTarget": "storefrontapp:build:production,noSsr"
+          "buildTarget": "storefrontapp:build:production"
         },
         "development": {
-          "buildTarget": "storefrontapp:build:development,noSsr"
+          "buildTarget": "storefrontapp:build:development"
         }
       },
       "defaultConfiguration": "development"

--- a/projects/storefrontapp/src/environments/environment.ts
+++ b/projects/storefrontapp/src/environments/environment.ts
@@ -9,14 +9,6 @@
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `angular.json`.
 
-/*
- * For easier debugging in development mode, you can import the following file
- * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
- *
- * This import should be commented out in production mode because it will have a negative impact
- * on performance if an error is thrown.
- */
-import 'zone.js/plugins/zone-error'; // Included with Angular CLI.
 import { Environment } from './models/environment.model';
 
 export const environment: Environment = {

--- a/projects/storefrontapp/src/server.ts
+++ b/projects/storefrontapp/src/server.ts
@@ -4,18 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { APP_BASE_HREF } from '@angular/common';
+import { createNodeRequestHandler, isMainModule } from '@angular/ssr/node';
 import {
   NgExpressEngineDecorator,
   SsrOptimizationOptions,
-  defaultExpressErrorHandlers,
   defaultSsrOptimizationOptions,
   ngExpressEngine as engine,
 } from '@spartacus/setup/ssr';
 import express from 'express';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join, resolve } from 'path';
 import bootstrap from './main.server';
 
 const ssrOptions: SsrOptimizationOptions = {
@@ -30,61 +26,77 @@ const ssrOptions: SsrOptimizationOptions = {
 
 const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions);
 
+// Create the engine instance once, to be used directly (bypassing Express view system)
+// Otherwise we get this error from Express: https://github.com/expressjs/express/blob/91891e3aee6f2a0b1c4db1e0b499338d05bda91b/lib/application.js#L516
+// because in Vite Dev Server there are no physical files on the disk (only virtual),
+// so we cannot plug those files into Express view system.
+const ssrEngine = ngExpressEngine({ bootstrap });
+
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
-  const serverDistFolder = dirname(fileURLToPath(import.meta.url));
-  const browserDistFolder = resolve(serverDistFolder, '../browser');
-  const indexHtml = join(serverDistFolder, 'index.server.html');
-  const indexHtmlContent = readFileSync(indexHtml, 'utf-8');
 
   server.set('trust proxy', 'loopback');
 
-  // Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
-  server.engine(
-    'html',
-    ngExpressEngine({
-      bootstrap,
-    })
-  );
+  // All regular routes use the Angular SSR engine directly (bypassing Express view system)
+  server.get(/.*/, (req, res, next) => {
+    ssrEngine(
+      '', // SPIKE - filePath is not used by ngExpressEngine, so just passing empty value
+      {
+        req,
 
-  server.set('view engine', 'html');
-  server.set('views', browserDistFolder);
+        // SPIKE - VERY IMPORTANT to pass `res` here, so ngExpressEngine send write response
+        // directly to it, by calling to `writeResponseToNodeResponse(response, res)` - to forward
+        // `response` from AngularNodeAppEngine to the `res` of Express
+        res,
 
-  // Serve static files from /browser
-  server.get(
-    /.*\..*/,
-    express.static(browserDistFolder, {
-      maxAge: '1y',
-    })
-  );
-
-  // All regular routes use the Universal engine
-  server.get(/.*/, (req, res) => {
-    res.render(indexHtml, {
-      req,
-      providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],
-    });
+        // SPIKE - providers are no longer passed to the app, because AngularNodeAppEngine doesn't accept extra providers
+        // providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],
+      },
+      (err) => {
+        // if AngularNodeAppEngine.handle fails, it calls this `callback(err)`. thanks to it, here in server.ts
+        // we can forward the error to `next()` error handler
+        if (err) {
+          next(err);
+        }
+        // Note: successful response is written directly by ngExpressEngine via writeResponseToNodeResponse
+      }
+    );
   });
 
-  server.use(defaultExpressErrorHandlers(indexHtmlContent));
+  // SPIKE CAUTION - disabling our custom error handlers for now, because I don't know how to obtain
+  //                 indexHtmlContent here in vite dev server, because files seem to be virtual only there
+  // server.use(defaultExpressErrorHandlers(indexHtmlContent));
 
   return server;
 }
 
-function run() {
-  const port = process.env['PORT'] || 4000;
+// SPIKE - conflict of names (comparing to fresh angular app): app vs appInstance, so renaming to appInstance for now
+const appInstance = app();
 
-  // Start up the Node server
-  const server = app();
-  server.listen(port, () => {
-    /* eslint-disable-next-line no-console
-    --
-    It's just an example application file. This message is not crucial
-    to be logged using any special logger. Moreover, we don't have
-    any special logger available in this context. */
-    console.log(`Node Express server listening on http://localhost:${port}`);
-  });
+/**
+ * Start the server if this module is the main entry point, or it is ran via PM2.
+ * The server listens on the port defined by the `PORT` environment variable, or defaults to 4000.
+ */
+if (isMainModule(import.meta.url) || process.env['pm_id']) {
+  const port = process.env['PORT'] || 4000;
+  appInstance.listen(
+    port,
+    // SPIKE - somehow it doesn't accept `(error)` argument. maybe I'm using wrong `express@4` version still locally?
+    // (error) => {
+    // if (error) {
+    //   throw error;
+    // }
+    () => {
+      /* eslint-disable-next-line no-console
+      --
+      It's just an example application file. This message is not crucial
+      to be logged using any special logger. Moreover, we don't have
+      any special logger available in this context. */
+      console.log(`Node Express server listening on http://localhost:${port}`);
+    }
+  );
 }
 
-run();
+// SPIKE - this named export is expected by Angular's builder with "outputMode": "server"
+export const reqHandler = createNodeRequestHandler(appInstance);


### PR DESCRIPTION
**Working PoC of vite dev server with SSR:**
- removed `noSsr` from target `"serve"` in `storefrontapp/project.json`
- to make it work I neeed to make following changes:
   - ngExpressEngine now uses AngularNodeAppEngine instead of CommonEngine
   - server.ts now calls ngExpressEngine directly as a function instead of via Express' `res.render()` method
   - removed `import 'zone.js/plugins/zone-error'` from `environment.ts` (as it caused errors; and this code seems not needed anyway)


**How to run**
`SERVER_REQUEST_ORIGIN=http://localhost:4200 NODE_TLS_REJECT_UNAUTHORIZED=0  npm run start`

**Caveats:**
- standardized SSR logging is disabled (i.e. we use default LoggerService with console.log) because I could not pass extra providers (with EXPRESS_SERVER_LOGGER) from Express to AngularNodeAppEngine
- REQUEST and RESPONSE injection tokens are not provided, because I could not pass extra providers from Express to Angular AngularNodeAppEngine
- CSR fallback is mocked - returning dummy html instead of real CSR shell app html, because I couldn't read physical file from virtual vite's files folder
- prod build compiles (`SERVER_REQUEST_ORIGIN=http://localhost:4200 NODE_TLS_REJECT_UNAUTHORIZED=0  npm run start`)
  - but then serving this app fails with angular error in console [NG05104](https://angular.dev/errors/NG05104)

**Next steps:**
- try adding `outputMode: server` in `storefrontapp/project.json` for the target `build` and then fixing build issues
- addressing caveats