### PR TITLE
fix: missing peerDependency '@angular/forms' in 'subscription-billing' lib

### DIFF
--- a/feature-libs/subscription-billing/package.json
+++ b/feature-libs/subscription-billing/package.json
@@ -29,6 +29,7 @@
     "@angular-devkit/schematics": "^21.1.0",
     "@angular/common": "^21.1.0",
     "@angular/core": "^21.1.0",
+    "@angular/forms": "^21.1.0",
     "@angular/router": "^21.1.0",
     "@ng-select/ng-select": "^21.1.4",
     "@spartacus/cart": "221121.7.0",

--- a/projects/schematics/src/dependencies.json
+++ b/projects/schematics/src/dependencies.json
@@ -305,6 +305,7 @@
     "@angular-devkit/schematics": "^21.1.0",
     "@angular/common": "^21.1.0",
     "@angular/core": "^21.1.0",
+    "@angular/forms": "^21.1.0",
     "@angular/router": "^21.1.0",
     "@ng-select/ng-select": "^21.1.4",
     "@spartacus/cart": "221121.7.0",


### PR DESCRIPTION
Checking for missing peerDependencies

--- feature-libs/subscription-billing/package.json -----------------------------
 ✖  Missing `@angular/forms` dependency that is directly referenced in library.

 i  All dependencies that are directly referenced should be specified as `dependencies` or `peerDependencies`.
    Adding new `peerDependency` might be a breaking change!
    This can be automatically fixed by running `npm run config:update`.