### PR TITLE
feat: (CXSPA-7459) - Organization table notification readout fix

### DIFF
--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
@@ -1,6 +1,10 @@
 <div
   class="inner"
-  [cxFocus]="featureConfigService.isEnabled('a11yCardNotificationMessage') ? {} : { autofocus: true, focusOnEscape: true }"
+  [cxFocus]="
+    isA11yCardNotificationMessageEnabled
+      ? {}
+      : { autofocus: true, focusOnEscape: true }
+  "
   (esc)="close()"
 >
   <cx-icon *ngIf="messageIcon" [type]="messageIcon"></cx-icon>

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
@@ -1,6 +1,6 @@
 <div
   class="inner"
-  [cxFocus]="{ autofocus: true, focusOnEscape: true }"
+  [cxFocus]="featureConfigService.isEnabled('a11yCardNotificationMessage') ? {} : { autofocus: true, focusOnEscape: true }"
   (esc)="close()"
 >
   <cx-icon *ngIf="messageIcon" [type]="messageIcon"></cx-icon>

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
@@ -1,7 +1,7 @@
 <div
   class="inner"
   [cxFocus]="
-    isA11yCardNotificationMessageEnabled
+    isA11yCardNotificationMessageFeatureEnabled
       ? {}
       : { autofocus: true, focusOnEscape: true }
   "

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
@@ -25,7 +25,7 @@ export class NotificationMessageComponent extends BaseMessageComponent {
 
   private featureConfigService = inject(FeatureConfigService);
 
-  get isA11yCardNotificationMessageEnabled(): boolean {
+  get isA11yCardNotificationMessageFeatureEnabled(): boolean {
     return this.featureConfigService.isEnabled('a11yCardNotificationMessage');
   }
 }

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
@@ -23,5 +23,9 @@ import { BaseMessageComponent } from '../base-message.component';
 export class NotificationMessageComponent extends BaseMessageComponent {
   closeIcon = ICON_TYPE.CLOSE;
 
-  featureConfigService = inject(FeatureConfigService);
+  private featureConfigService = inject(FeatureConfigService);
+
+  get isA11yCardNotificationMessageEnabled(): boolean {
+    return this.featureConfigService.isEnabled('a11yCardNotificationMessage');
+  }
 }

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
@@ -5,8 +5,8 @@
  */
 
 import { NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { TranslatePipe } from '@spartacus/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { FeatureConfigService, TranslatePipe } from '@spartacus/core';
 import {
   FocusDirective,
   ICON_TYPE,
@@ -22,4 +22,6 @@ import { BaseMessageComponent } from '../base-message.component';
 })
 export class NotificationMessageComponent extends BaseMessageComponent {
   closeIcon = ICON_TYPE.CLOSE;
+
+featureConfigService = inject(FeatureConfigService);
 }

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.ts
@@ -23,5 +23,5 @@ import { BaseMessageComponent } from '../base-message.component';
 export class NotificationMessageComponent extends BaseMessageComponent {
   closeIcon = ICON_TYPE.CLOSE;
 
-featureConfigService = inject(FeatureConfigService);
+  featureConfigService = inject(FeatureConfigService);
 }

--- a/feature-libs/organization/administration/components/shared/table/cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/cell.component.ts
@@ -33,16 +33,15 @@ export class CellComponent implements OnInit, OnDestroy {
   changeDetectorRef = inject(ChangeDetectorRef);
   private featureConfigService = inject(FeatureConfigService);
 
-  constructor(
-    protected outlet: OutletContextData<TableDataOutletContext>
-  ) {}
+  constructor(protected outlet: OutletContextData<TableDataOutletContext>) {}
 
   ngOnInit(): void {
     if (this.featureConfigService.isEnabled('a11yCardNotificationMessage')) {
       this.contextSubscription = this.outlet.context$.subscribe((context) => {
         this.outlet.context = context;
         this.changeDetectorRef.markForCheck();
-    });};
+      });
+    }
   }
 
   ngOnDestroy(): void {

--- a/feature-libs/organization/administration/components/shared/table/cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/cell.component.ts
@@ -9,10 +9,11 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   inject,
-  OnDestroy,
   OnInit,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { FeatureConfigService, UrlPipe } from '@spartacus/core';
 import {
@@ -20,7 +21,6 @@ import {
   TableDataOutletContext,
   TableFieldOptions,
 } from '@spartacus/storefront';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'cx-org-cell',
@@ -28,24 +28,22 @@ import { Subscription } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIf, RouterLink, NgTemplateOutlet, UrlPipe],
 })
-export class CellComponent implements OnInit, OnDestroy {
-  contextSubscription: Subscription;
+export class CellComponent implements OnInit {
   changeDetectorRef = inject(ChangeDetectorRef);
   private featureConfigService = inject(FeatureConfigService);
+  private destroyRef = inject(DestroyRef);
 
   constructor(protected outlet: OutletContextData<TableDataOutletContext>) {}
 
   ngOnInit(): void {
     if (this.featureConfigService.isEnabled('a11yCardNotificationMessage')) {
-      this.contextSubscription = this.outlet.context$.subscribe((context) => {
-        this.outlet.context = context;
-        this.changeDetectorRef.markForCheck();
-      });
+      this.outlet.context$
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((context) => {
+          this.outlet.context = context;
+          this.changeDetectorRef.markForCheck();
+        });
     }
-  }
-
-  ngOnDestroy(): void {
-    this.contextSubscription?.unsubscribe();
   }
 
   get tabIndex(): number {

--- a/feature-libs/organization/administration/components/shared/table/cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/cell.component.ts
@@ -5,14 +5,22 @@
  */
 
 import { NgIf, NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  inject,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { UrlPipe } from '@spartacus/core';
+import { FeatureConfigService, UrlPipe } from '@spartacus/core';
 import {
   OutletContextData,
   TableDataOutletContext,
   TableFieldOptions,
 } from '@spartacus/storefront';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'cx-org-cell',
@@ -20,8 +28,26 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIf, RouterLink, NgTemplateOutlet, UrlPipe],
 })
-export class CellComponent {
-  constructor(protected outlet: OutletContextData<TableDataOutletContext>) {}
+export class CellComponent implements OnInit, OnDestroy {
+  contextSubscription: Subscription;
+  changeDetectorRef = inject(ChangeDetectorRef);
+  private featureConfigService = inject(FeatureConfigService);
+
+  constructor(
+    protected outlet: OutletContextData<TableDataOutletContext>
+  ) {}
+
+  ngOnInit(): void {
+    if (this.featureConfigService.isEnabled('a11yCardNotificationMessage')) {
+      this.contextSubscription = this.outlet.context$.subscribe((context) => {
+        this.outlet.context = context;
+        this.changeDetectorRef.markForCheck();
+    })};
+  }
+
+  ngOnDestroy(): void {
+    this.contextSubscription?.unsubscribe();
+  }
 
   get tabIndex(): number {
     return -1;

--- a/feature-libs/organization/administration/components/shared/table/cell.component.ts
+++ b/feature-libs/organization/administration/components/shared/table/cell.component.ts
@@ -42,7 +42,7 @@ export class CellComponent implements OnInit, OnDestroy {
       this.contextSubscription = this.outlet.context$.subscribe((context) => {
         this.outlet.context = context;
         this.changeDetectorRef.markForCheck();
-    })};
+    });};
   }
 
   ngOnDestroy(): void {

--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.html
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.html
@@ -1,7 +1,9 @@
 <cx-org-card
   *ngIf="model$ | async as model"
   i18nRoot="orgUnit.details"
-  [cxFocus]="featureConfigService.isEnabled('a11yCardNotificationMessage') ? {} : { refreshFocus: model }"
+  [cxFocus]="
+    isA11yCardNotificationMessageEnabled ? {} : { refreshFocus: model }
+  "
   [showHint]="true"
 >
   <a

--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.html
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.html
@@ -1,7 +1,7 @@
 <cx-org-card
   *ngIf="model$ | async as model"
   i18nRoot="orgUnit.details"
-  [cxFocus]="{ refreshFocus: model }"
+  [cxFocus]="featureConfigService.isEnabled('a11yCardNotificationMessage') ? {} : { refreshFocus: model }"
   [showHint]="true"
 >
   <a

--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.html
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.html
@@ -2,7 +2,7 @@
   *ngIf="model$ | async as model"
   i18nRoot="orgUnit.details"
   [cxFocus]="
-    isA11yCardNotificationMessageEnabled ? {} : { refreshFocus: model }
+    isA11yCardNotificationMessageFeatureEnabled ? {} : { refreshFocus: model }
   "
   [showHint]="true"
 >

--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
@@ -7,7 +7,12 @@
 import { AsyncPipe, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { B2BUnit, FeatureConfigService, TranslatePipe, UrlPipe } from '@spartacus/core';
+import {
+  B2BUnit,
+  FeatureConfigService,
+  TranslatePipe,
+  UrlPipe,
+} from '@spartacus/core';
 import { OrgUnitService } from '@spartacus/organization/administration/core';
 import { FocusDirective } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
@@ -46,7 +51,7 @@ import { UnitItemService } from '../services/unit-item.service';
 })
 export class UnitDetailsComponent {
   featureConfigService = inject(FeatureConfigService);
-  
+
   model$: Observable<B2BUnit> = this.itemService.key$.pipe(
     switchMap((code) => this.itemService.load(code)),
     startWith({})

--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
@@ -50,7 +50,11 @@ import { UnitItemService } from '../services/unit-item.service';
   ],
 })
 export class UnitDetailsComponent {
-  featureConfigService = inject(FeatureConfigService);
+  private featureConfigService = inject(FeatureConfigService);
+
+  get isA11yCardNotificationMessageEnabled(): boolean {
+    return this.featureConfigService.isEnabled('a11yCardNotificationMessage');
+  }
 
   model$: Observable<B2BUnit> = this.itemService.key$.pipe(
     switchMap((code) => this.itemService.load(code)),

--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
@@ -5,9 +5,9 @@
  */
 
 import { AsyncPipe, NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { B2BUnit, TranslatePipe, UrlPipe } from '@spartacus/core';
+import { B2BUnit, FeatureConfigService, TranslatePipe, UrlPipe } from '@spartacus/core';
 import { OrgUnitService } from '@spartacus/organization/administration/core';
 import { FocusDirective } from '@spartacus/storefront';
 import { Observable } from 'rxjs';
@@ -45,6 +45,8 @@ import { UnitItemService } from '../services/unit-item.service';
   ],
 })
 export class UnitDetailsComponent {
+  featureConfigService = inject(FeatureConfigService);
+  
   model$: Observable<B2BUnit> = this.itemService.key$.pipe(
     switchMap((code) => this.itemService.load(code)),
     startWith({})

--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.ts
@@ -52,7 +52,7 @@ import { UnitItemService } from '../services/unit-item.service';
 export class UnitDetailsComponent {
   private featureConfigService = inject(FeatureConfigService);
 
-  get isA11yCardNotificationMessageEnabled(): boolean {
+  get isA11yCardNotificationMessageFeatureEnabled(): boolean {
     return this.featureConfigService.isEnabled('a11yCardNotificationMessage');
   }
 

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -381,7 +381,8 @@ export interface FeatureTogglesInterface {
   a11yCustomerTicketingVisualFocusFix?: boolean;
 
   /**
-   * Improves the screen reader experience of the notification message component.
+   * When enabled, the organization's table component will stop re-rendering its rows each data update.
+   * This improves the screen reader experience of the notification message component.
    * Affects: `NotificationMessageComponent`, `CellComponent`, `UnitDetailsComponent`, `TableComponent`
    */
   a11yCardNotificationMessage?: boolean;

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -379,6 +379,12 @@ export interface FeatureTogglesInterface {
    * on Customer Ticketing dialog.
    */
   a11yCustomerTicketingVisualFocusFix?: boolean;
+
+  /**
+   * Improves the screen reader experience of the notification message component.
+   * Affects: `NotificationMessageComponent`, `CellComponent`, `UnitDetailsComponent`, `TableComponent`
+   */
+  a11yCardNotificationMessage?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -421,4 +427,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   enableQuotePurchaseOrderNumber: false,
   enableReturnOrderReturnableQuantityConsigmentFallback: false,
   a11yCustomerTicketingVisualFocusFix: false,
+  a11yCardNotificationMessage: false,
 };

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -335,6 +335,7 @@ if (environment.cpq) {
         enableQuotePurchaseOrderNumber: false,
         enableReturnOrderReturnableQuantityConsigmentFallback: true,
         a11yCustomerTicketingVisualFocusFix: true,
+        a11yCardNotificationMessage: true,
       };
       return appFeatureToggles;
     }),

--- a/projects/storefrontlib/shared/components/table/table.component.spec.ts
+++ b/projects/storefrontlib/shared/components/table/table.component.spec.ts
@@ -7,6 +7,7 @@ import { TableRendererService } from './table-renderer.service';
 import { TableComponent } from './table.component';
 import { Table, TableLayout } from './table.model';
 import createSpy = jasmine.createSpy;
+import { FeatureConfigService } from '@spartacus/core';
 
 const headers: string[] = ['key1', 'key2', 'key3'];
 
@@ -35,6 +36,12 @@ class MockTableRendererService {
   add() {}
 }
 
+class MockFeatureConfigService {
+  isEnabled(): boolean {
+    return true;
+  }
+}
+
 describe('TableComponent', () => {
   let fixture: ComponentFixture<TableComponent<any>>;
   let tableComponent: TableComponent<any>;
@@ -45,6 +52,7 @@ describe('TableComponent', () => {
       imports: [OutletModule, TableComponent],
       providers: [
         { provide: TableRendererService, useClass: MockTableRendererService },
+        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
       ],
     })
       .overrideComponent(TableComponent, {
@@ -58,7 +66,7 @@ describe('TableComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should be created', () => {
+  it('should be created', () => { 
     expect(tableComponent).toBeTruthy();
   });
 

--- a/projects/storefrontlib/shared/components/table/table.component.spec.ts
+++ b/projects/storefrontlib/shared/components/table/table.component.spec.ts
@@ -66,7 +66,7 @@ describe('TableComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should be created', () => { 
+  it('should be created', () => {
     expect(tableComponent).toBeTruthy();
   });
 

--- a/projects/storefrontlib/shared/components/table/table.component.ts
+++ b/projects/storefrontlib/shared/components/table/table.component.ts
@@ -10,6 +10,7 @@ import {
   Component,
   EventEmitter,
   HostBinding,
+  inject,
   Input,
   isDevMode,
   Output,
@@ -23,6 +24,7 @@ import {
   TableOptions,
   TableStructure,
 } from './table.model';
+import { FeatureConfigService } from '@spartacus/core';
 
 /**
  * The table component provides a generic table DOM structure, with 3 layout types:
@@ -59,6 +61,8 @@ export class TableComponent<T> {
   @HostBinding('class.horizontal') horizontalLayout: boolean;
   @HostBinding('class.vertical') verticalLayout: boolean;
   @HostBinding('class.vertical-stacked') verticalStackedLayout: boolean;
+
+  private featureConfigService = inject(FeatureConfigService);
 
   private _structure: TableStructure;
   @Input() set structure(structure: TableStructure) {
@@ -155,9 +159,12 @@ export class TableComponent<T> {
     );
   }
 
-  trackData(_i: number, item: any): any {
+  trackData = (_i: number, item: any): any => {
+    if (this.featureConfigService.isEnabled('a11yCardNotificationMessage')) {
+      return item?.uid ?? JSON.stringify(item);
+    }
     return JSON.stringify(item);
-  }
+  };
 
   /**
    * Generates the table type into the UI in devMode, so that developers


### PR DESCRIPTION
Closes: [CXSPA-7459](https://jira.tools.sap/browse/CXSPA-7459)

The fix prevents the table component from re-rendering its rows each time cell data is updated. 
This wold cause the screen reader to quickly jump between elements and skip some messages.

Please see the ticket to recreate the issue for QA, the solution need to work for both Voice Over and JAWS.