### PR TITLE
chore: Restore cypress libraries from cache rather than rebuilding in ci

### DIFF
--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -35,11 +35,11 @@ runs:
         cache-key: ${{ inputs.libs-cache-key }}
         fail-on-cache-miss: true
 
-    #- name: Restore e2e libraries
-    #  uses: ./.github/actions/restore-e2e-libraries
-    #  with:
-    #    cache-key: ${{ inputs.cache-key-base }}
-    #    fail-on-cache-miss: true
+    - name: Restore e2e libraries
+      uses: ./.github/actions/restore-e2e-libraries
+      with:
+        cache-key: ${{ inputs.e2e-cache-key }}
+        fail-on-cache-miss: true
 
     - name: Restore built app
       uses: ./.github/actions/restore-built-app

--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -35,11 +35,11 @@ runs:
         cache-key: ${{ inputs.libs-cache-key }}
         fail-on-cache-miss: true
 
-    - name: Restore e2e libraries
-      uses: ./.github/actions/restore-e2e-libraries
-      with:
-        cache-key: ${{ inputs.e2e-cache-key }}
-        fail-on-cache-miss: true
+    #- name: Restore e2e libraries
+    #  uses: ./.github/actions/restore-e2e-libraries
+    #  with:
+    #    cache-key: ${{ inputs.cache-key-base }}
+    #    fail-on-cache-miss: true
 
     - name: Restore built app
       uses: ./.github/actions/restore-built-app

--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -35,14 +35,14 @@ runs:
         cache-key: ${{ inputs.libs-cache-key }}
         fail-on-cache-miss: true
 
-    - name: Restore e2e libraries
-      uses: ./.github/actions/restore-e2e-libraries
-      with:
-        cache-key: ${{ inputs.e2e-cache-key }}
-        fail-on-cache-miss: true
-
     - name: Restore built app
       uses: ./.github/actions/restore-built-app
       with:
         cache-key: ${{ inputs.app-cache-key }}
+        fail-on-cache-miss: true
+
+    - name: Restore e2e libraries
+      uses: ./.github/actions/restore-e2e-libraries
+      with:
+        cache-key: ${{ inputs.e2e-cache-key }}
         fail-on-cache-miss: true

--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -11,6 +11,9 @@ inputs:
   libs-cache-key:
     description: 'Cache key for built libraries'
     required: true
+  e2e-cache-key:
+    description: 'Cache key for e2e libraries'
+    required: true
   app-cache-key:
     description: 'Cache key for built app'
     required: true
@@ -30,6 +33,12 @@ runs:
       uses: ./.github/actions/restore-built-libraries
       with:
         cache-key: ${{ inputs.libs-cache-key }}
+        fail-on-cache-miss: true
+
+    - name: Restore e2e libraries
+      uses: ./.github/actions/restore-e2e-libraries
+      with:
+        cache-key: ${{ inputs.cache-key-base }}
         fail-on-cache-miss: true
 
     - name: Restore built app

--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -35,11 +35,11 @@ runs:
         cache-key: ${{ inputs.libs-cache-key }}
         fail-on-cache-miss: true
 
-    - name: Restore e2e libraries
-      uses: ./.github/actions/restore-e2e-libraries
-      with:
-        cache-key: ${{ inputs.cache-key-base }}
-        fail-on-cache-miss: true
+    #- name: Restore e2e libraries
+    #  uses: ./.github/actions/restore-e2e-libraries
+    #  with:
+    #    cache-key: ${{ inputs.cache-key-base }}
+    #    fail-on-cache-miss: true
 
     - name: Restore built app
       uses: ./.github/actions/restore-built-app

--- a/.github/actions/restore-built-libraries/action.yml
+++ b/.github/actions/restore-built-libraries/action.yml
@@ -16,5 +16,6 @@ runs:
       with:
         path: |
           dist
+	  storefrontapp-e2e
         key: spartacus-libs-${{ inputs.cache-key }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/restore-e2e-libraries/action.yml
+++ b/.github/actions/restore-e2e-libraries/action.yml
@@ -16,5 +16,5 @@ runs:
       with:
         path: |
           projects/storefrontapp-e2e-cypress/node_modules
-        key: nodemodules-${{ inputs.cache-key }}
+        key: nodemodules-${{ inputs.cache-key }}-
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/restore-e2e-libraries/action.yml
+++ b/.github/actions/restore-e2e-libraries/action.yml
@@ -15,6 +15,6 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          storefrontapp-e2e
-        key: spartacus-libs-${{ inputs.cache-key }}
+          projects/storefrontapp-e2e-cypress/node_modules
+        key: spartacus-e2e-${{ inputs.cache-key }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/restore-e2e-libraries/action.yml
+++ b/.github/actions/restore-e2e-libraries/action.yml
@@ -1,8 +1,8 @@
-name: 'Restore Built Libraries'
-description: 'Restore built Spartacus libraries from cache'
+name: 'Restore E2E Libraries'
+description: 'Restore built e2e libraries from cache'
 inputs:
   cache-key:
-    description: 'Cache key for built libraries'
+    description: 'Cache key for e2e libraries'
     required: true
   fail-on-cache-miss:
     description: 'Whether to fail if cache miss occurs'
@@ -11,10 +11,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Restore built libraries
+    - name: Restore e2e libraries
       uses: actions/cache@v4
       with:
         path: |
-          dist
+          storefrontapp-e2e
         key: spartacus-libs-${{ inputs.cache-key }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/restore-e2e-libraries/action.yml
+++ b/.github/actions/restore-e2e-libraries/action.yml
@@ -16,5 +16,6 @@ runs:
       with:
         path: |
           projects/storefrontapp-e2e-cypress/node_modules
-        key: nodemodules-${{ inputs.cache-key }}
+        key: nodemodules-${{ inputs.cache-key }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: nodemodules-${{ inputs.cache-key }}-
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/restore-e2e-libraries/action.yml
+++ b/.github/actions/restore-e2e-libraries/action.yml
@@ -16,5 +16,5 @@ runs:
       with:
         path: |
           projects/storefrontapp-e2e-cypress/node_modules
-        key: spartacus-e2e-${{ inputs.cache-key }}
+        key: nodemodules-${{ inputs.cache-key }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/restore-e2e-libraries/action.yml
+++ b/.github/actions/restore-e2e-libraries/action.yml
@@ -16,6 +16,5 @@ runs:
       with:
         path: |
           projects/storefrontapp-e2e-cypress/node_modules
-        key: nodemodules-${{ inputs.cache-key }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: nodemodules-${{ inputs.cache-key }}-
+        key: nodemodules-${{ inputs.cache-key }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/restore-e2e-libraries/action.yml
+++ b/.github/actions/restore-e2e-libraries/action.yml
@@ -16,5 +16,5 @@ runs:
       with:
         path: |
           projects/storefrontapp-e2e-cypress/node_modules
-        key: nodemodules-${{ inputs.cache-key }}-
+        key: nodemodules-${{ inputs.cache-key }}-${{ hashFiles('**/package-lock.json') }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/restore-e2e-libraries/action.yml
+++ b/.github/actions/restore-e2e-libraries/action.yml
@@ -16,5 +16,5 @@ runs:
       with:
         path: |
           projects/storefrontapp-e2e-cypress/node_modules
-        key: nodemodules-${{ inputs.cache-key }}-${{ hashFiles('**/package-lock.json') }}
+        key: nodemodules-${{ inputs.cache-key }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -150,7 +150,8 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
-          e2e-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}-
+          e2e-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Run e2es
         env:
           SPA_ENV: ci,b2c

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -150,7 +150,7 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
-          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
+          e2e-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
       - name: Run e2es
         env:
           SPA_ENV: ci,b2c

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -150,6 +150,7 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
+          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Run e2es
         env:
           SPA_ENV: ci
@@ -181,6 +182,7 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
+          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Run e2es
         env:
           SPA_ENV: ci,b2c
@@ -200,6 +202,7 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-ssr-${{ github.event.pull_request.head.sha || github.run_id }}
+          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Run e2es
         env:
           SPA_ENV: ci,b2c
@@ -222,6 +225,7 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2b-csr-${{ github.event.pull_request.head.sha || github.run_id }}
+          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Run e2es
         env:
           SPA_ENV: ci,b2b
@@ -250,7 +254,16 @@ jobs:
             const postScreenshotComment = require('./ci-scripts/post-screenshot-comment.js');
             await postScreenshotComment(github, context);
   merge_checks_result:
-    needs: [build_libs, build_apps, b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests, a11y_e2e_tests, notify_e2e_failures]
+    needs:
+      [
+        build_libs,
+        build_apps,
+        b2c_e2e_tests,
+        b2c_ssr_e2e_tests,
+        b2b_e2e_tests,
+        a11y_e2e_tests,
+        notify_e2e_failures,
+      ]
     name: MC - Result
     runs-on: ubuntu-latest
     if: ${{ always() }}

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -150,8 +150,7 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
-          e2e-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}-${{ hashFiles('**/package-lock.json') }}
-
+          e2e-cache-key: ${{ github.event.pull_request.base.sha || github.event.pull_request.head.sha || github.run_id }}-${{ hashFiles('**/package-lock.json') }}
       - name: Run e2es
         env:
           SPA_ENV: ci,b2c

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -150,7 +150,6 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
-          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Run e2es
         env:
           SPA_ENV: ci
@@ -182,7 +181,6 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
-          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Run e2es
         env:
           SPA_ENV: ci,b2c
@@ -202,7 +200,6 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-ssr-${{ github.event.pull_request.head.sha || github.run_id }}
-          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Run e2es
         env:
           SPA_ENV: ci,b2c
@@ -225,7 +222,6 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2b-csr-${{ github.event.pull_request.head.sha || github.run_id }}
-          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Run e2es
         env:
           SPA_ENV: ci,b2b
@@ -254,16 +250,7 @@ jobs:
             const postScreenshotComment = require('./ci-scripts/post-screenshot-comment.js');
             await postScreenshotComment(github, context);
   merge_checks_result:
-    needs:
-      [
-        build_libs,
-        build_apps,
-        b2c_e2e_tests,
-        b2c_ssr_e2e_tests,
-        b2b_e2e_tests,
-        a11y_e2e_tests,
-        notify_e2e_failures,
-      ]
+    needs: [build_libs, build_apps, b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests, a11y_e2e_tests, notify_e2e_failures]
     name: MC - Result
     runs-on: ubuntu-latest
     if: ${{ always() }}

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -133,6 +133,37 @@ jobs:
           path: |
             dist/storefrontapp
           key: spartacus-app-${{ matrix.cache_key }}-${{ matrix.build_type }}-${{ github.event.pull_request.head.sha || github.run_id }}
+  a11y_e2e_tests:
+    needs: [no_retries, validate_e2e_execution, build_apps]
+    name: MC - E2E A11Y
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        containers: [1, 2, 3]
+    if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: E2E Test Setup
+        uses: ./.github/actions/e2e-setup
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache-key-base: ${{ github.event.pull_request.base.sha }}
+          libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
+          app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
+      - name: Run e2es
+        env:
+          SPA_ENV: ci
+          BUILD_NUMBER: ci-build-number-${{ github.event.pull_request.head.sha || github.run_id }}
+          GITHUB_MATRIX_CONTAINER: ${{ matrix.containers }}
+          GITHUB_MATRIX_TOTAL: ${{ strategy.job-total }}
+          CYPRESS_ENABLE_SCREENSHOTS: true
+        run: ci-scripts/e2e-cypress.sh -s a11y --skip-build
+      - name: Collect screenshots
+        if: always()
+        uses: ./.github/actions/collect-e2e-screenshots
+        with:
+          test-suite: a11y
+          container-id: ${{ matrix.containers }}
   b2c_e2e_tests:
     needs: [no_retries, validate_e2e_execution, build_apps]
     name: MC - E2E B2C core
@@ -196,37 +227,6 @@ jobs:
           SPA_ENV: ci,b2b
           BUILD_NUMBER: ci-build-number-${{ github.event.pull_request.head.sha || github.run_id }}
         run: ci-scripts/e2e-cypress.sh -s b2b --skip-build
-  a11y_e2e_tests:
-    needs: [no_retries, validate_e2e_execution, build_apps]
-    name: MC - E2E A11Y
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        containers: [1, 2, 3]
-    if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: E2E Test Setup
-        uses: ./.github/actions/e2e-setup
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache-key-base: ${{ github.event.pull_request.base.sha }}
-          libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
-          app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
-      - name: Run e2es
-        env:
-          SPA_ENV: ci
-          BUILD_NUMBER: ci-build-number-${{ github.event.pull_request.head.sha || github.run_id }}
-          GITHUB_MATRIX_CONTAINER: ${{ matrix.containers }}
-          GITHUB_MATRIX_TOTAL: ${{ strategy.job-total }}
-          CYPRESS_ENABLE_SCREENSHOTS: true
-        run: ci-scripts/e2e-cypress.sh -s a11y --skip-build
-      - name: Collect screenshots
-        if: always()
-        uses: ./.github/actions/collect-e2e-screenshots
-        with:
-          test-suite: a11y
-          container-id: ${{ matrix.containers }}
   notify_e2e_failures:
     needs: [b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests, a11y_e2e_tests]
     name: MC - Notify E2E Failures

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -150,7 +150,7 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
-          e2e-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
+          e2e-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}-
       - name: Run e2es
         env:
           SPA_ENV: ci,b2c

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -162,11 +162,6 @@ jobs:
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - name: Restore e2e libraries
-        uses: ./.github/actions/restore-e2e-libraries
-        with:
-          cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
-          fail-on-cache-miss: true
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -189,11 +184,6 @@ jobs:
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - name: Restore e2e libraries
-        uses: ./.github/actions/restore-e2e-libraries
-        with:
-          cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
-          fail-on-cache-miss: true
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -216,11 +206,6 @@ jobs:
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - name: Restore e2e libraries
-        uses: ./.github/actions/restore-e2e-libraries
-        with:
-          cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
-          fail-on-cache-miss: true
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -133,37 +133,6 @@ jobs:
           path: |
             dist/storefrontapp
           key: spartacus-app-${{ matrix.cache_key }}-${{ matrix.build_type }}-${{ github.event.pull_request.head.sha || github.run_id }}
-  a11y_e2e_tests:
-    needs: [no_retries, validate_e2e_execution, build_apps]
-    name: MC - E2E A11Y
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        containers: [1, 2, 3]
-    if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: E2E Test Setup
-        uses: ./.github/actions/e2e-setup
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache-key-base: ${{ github.event.pull_request.base.sha }}
-          libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
-          app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
-      - name: Run e2es
-        env:
-          SPA_ENV: ci
-          BUILD_NUMBER: ci-build-number-${{ github.event.pull_request.head.sha || github.run_id }}
-          GITHUB_MATRIX_CONTAINER: ${{ matrix.containers }}
-          GITHUB_MATRIX_TOTAL: ${{ strategy.job-total }}
-          CYPRESS_ENABLE_SCREENSHOTS: true
-        run: ci-scripts/e2e-cypress.sh -s a11y --skip-build
-      - name: Collect screenshots
-        if: always()
-        uses: ./.github/actions/collect-e2e-screenshots
-        with:
-          test-suite: a11y
-          container-id: ${{ matrix.containers }}
   b2c_e2e_tests:
     needs: [no_retries, validate_e2e_execution, build_apps]
     name: MC - E2E B2C core
@@ -227,6 +196,37 @@ jobs:
           SPA_ENV: ci,b2b
           BUILD_NUMBER: ci-build-number-${{ github.event.pull_request.head.sha || github.run_id }}
         run: ci-scripts/e2e-cypress.sh -s b2b --skip-build
+  a11y_e2e_tests:
+    needs: [no_retries, validate_e2e_execution, build_apps]
+    name: MC - E2E A11Y
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        containers: [1, 2, 3]
+    if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: E2E Test Setup
+        uses: ./.github/actions/e2e-setup
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache-key-base: ${{ github.event.pull_request.base.sha }}
+          libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
+          app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
+      - name: Run e2es
+        env:
+          SPA_ENV: ci
+          BUILD_NUMBER: ci-build-number-${{ github.event.pull_request.head.sha || github.run_id }}
+          GITHUB_MATRIX_CONTAINER: ${{ matrix.containers }}
+          GITHUB_MATRIX_TOTAL: ${{ strategy.job-total }}
+          CYPRESS_ENABLE_SCREENSHOTS: true
+        run: ci-scripts/e2e-cypress.sh -s a11y --skip-build
+      - name: Collect screenshots
+        if: always()
+        uses: ./.github/actions/collect-e2e-screenshots
+        with:
+          test-suite: a11y
+          container-id: ${{ matrix.containers }}
   notify_e2e_failures:
     needs: [b2c_e2e_tests, b2c_ssr_e2e_tests, b2b_e2e_tests, a11y_e2e_tests]
     name: MC - Notify E2E Failures

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -162,6 +162,11 @@ jobs:
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v6
+      - name: Restore e2e libraries
+        uses: ./.github/actions/restore-e2e-libraries
+        with:
+          cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
+          fail-on-cache-miss: true
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -184,6 +189,11 @@ jobs:
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v6
+      - name: Restore e2e libraries
+        uses: ./.github/actions/restore-e2e-libraries
+        with:
+          cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
+          fail-on-cache-miss: true
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -206,8 +216,8 @@ jobs:
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - name: Restore built libraries
-        uses: ./.github/actions/restore-built-libraries
+      - name: Restore e2e libraries
+        uses: ./.github/actions/restore-e2e-libraries
         with:
           cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           fail-on-cache-miss: true

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -206,6 +206,11 @@ jobs:
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
       - uses: actions/checkout@v6
+      - name: Restore built libraries
+        uses: ./.github/actions/restore-built-libraries
+        with:
+          cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
+          fail-on-cache-miss: true
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -150,6 +150,7 @@ jobs:
           cache-key-base: ${{ github.event.pull_request.base.sha }}
           libs-cache-key: ${{ github.event.pull_request.head.sha || github.run_id }}
           app-cache-key: ci-b2c-csr-${{ github.event.pull_request.head.sha || github.run_id }}
+          e2e-cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Run e2es
         env:
           SPA_ENV: ci,b2c


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-12224

Notes:
- Checked job lengths.
  - A11y test suites themselves complete in under a minute.
  - Duration seems to be affected most by setup times.
  - B2C jobs seem to be the most impactful on duration. A11y jobs run in parallel to b2c so don't seem to impact total job duration.
  - A11y jobs also don't record in cypress dashboard. So job length seems to be misrepresented.
- Tested if the order matters for job sequence in the yml file (ie. B2C => b2b => a11y / a11y => b2c => b2b).
  - Looking into this to see if resource allocation gets prioritized to earlier jobs first.
  - Looks like the order does not affect resource allocation.
- Looking into setup steps.
  - It looks like npm packages still get installed on e2e jobs rather than restored from the cache.
  - Testing if packages can be restored from cache instead and checking the impact on job duration.