### PR TITLE
fix: skip first active language emission

### DIFF
--- a/projects/core/src/cms/facade/page-meta.service.spec.ts
+++ b/projects/core/src/cms/facade/page-meta.service.spec.ts
@@ -258,6 +258,7 @@ describe('PageMetaService', () => {
     it('PageMetaService should be created', () => {
       expect(service).toBeTruthy();
     });
+
     it('should skip the first getActive() emission and call refreshLatestPage on subsequent emissions', () => {
       const languageService = TestBed.inject(
         LanguageService
@@ -268,6 +269,28 @@ describe('PageMetaService', () => {
 
       // Emit second and third languages (should trigger refreshLatestPage twice)
       languageService.emitLanguage('de');
+      languageService.emitLanguage('fr');
+      expect(cmsService.refreshLatestPage).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not call refreshLatestPage for consecutive duplicate language emissions', () => {
+      const languageService = TestBed.inject(
+        LanguageService
+      ) as unknown as MockLanguageService;
+
+      // Skip the first emission
+      languageService.emitLanguage('en');
+      expect(cmsService.refreshLatestPage).not.toHaveBeenCalled();
+
+      // Emit 'de' - should trigger refresh
+      languageService.emitLanguage('de');
+      expect(cmsService.refreshLatestPage).toHaveBeenCalledTimes(1);
+
+      // Emit 'de' again (duplicate) - should NOT trigger refresh due to distinctUntilChanged
+      languageService.emitLanguage('de');
+      expect(cmsService.refreshLatestPage).toHaveBeenCalledTimes(1); // Still 1
+
+      // Emit different language - should trigger refresh
       languageService.emitLanguage('fr');
       expect(cmsService.refreshLatestPage).toHaveBeenCalledTimes(2);
     });

--- a/projects/core/src/cms/facade/page-meta.service.spec.ts
+++ b/projects/core/src/cms/facade/page-meta.service.spec.ts
@@ -3,6 +3,7 @@ import { Injectable, PLATFORM_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { firstValueFrom, Observable, of, Subject } from 'rxjs';
 import { PageType } from '../../model/cms.model';
+import { LanguageService } from '../../site-context/facade/language.service';
 import {
   BreadcrumbMeta,
   Page,
@@ -21,7 +22,6 @@ import {
 } from '../page';
 import { CmsService } from './cms.service';
 import { PageMetaService } from './page-meta.service';
-import { LanguageService } from '../../site-context/facade/language.service';
 
 const mockContentPage: Page = {
   type: PageType.CONTENT_PAGE,
@@ -257,6 +257,19 @@ describe('PageMetaService', () => {
 
     it('PageMetaService should be created', () => {
       expect(service).toBeTruthy();
+    });
+    it('should skip the first getActive() emission and call refreshLatestPage on subsequent emissions', () => {
+      const languageService = TestBed.inject(
+        LanguageService
+      ) as unknown as MockLanguageService;
+      // Emit first language (should be skipped)
+      languageService.emitLanguage('en');
+      expect(cmsService.refreshLatestPage).not.toHaveBeenCalled();
+
+      // Emit second and third languages (should trigger refreshLatestPage twice)
+      languageService.emitLanguage('de');
+      languageService.emitLanguage('fr');
+      expect(cmsService.refreshLatestPage).toHaveBeenCalledTimes(2);
     });
 
     it('should resolve page title using resolveTitle()', async () => {

--- a/projects/core/src/cms/facade/page-meta.service.ts
+++ b/projects/core/src/cms/facade/page-meta.service.ts
@@ -6,7 +6,14 @@
 
 import { inject, Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { defer, Observable, of } from 'rxjs';
-import { filter, map, shareReplay, switchMap } from 'rxjs/operators';
+import {
+  distinctUntilChanged,
+  filter,
+  map,
+  shareReplay,
+  skip,
+  switchMap,
+} from 'rxjs/operators';
 import { UnifiedInjector } from '../../lazy-loading/unified-injector';
 import { LanguageService } from '../../site-context/facade/language.service';
 import { resolveApplicable } from '../../util/applicable';
@@ -34,9 +41,13 @@ export class PageMetaService {
   ) {
     // NOTE: Solution to the issue: https://jira.tools.sap/browse/CXSPA-10923
     // Cause CMS page data refresh on language change (to update the title)
-    this.languageService.getActive().subscribe(() => {
-      this.cms.refreshLatestPage();
-    });
+    // Skip the first emission of getActive() to avoid duplicate refresh on app initialization, as the language is already set at that point.
+    this.languageService
+      .getActive()
+      .pipe(skip(1), distinctUntilChanged())
+      .subscribe(() => {
+        this.cms.refreshLatestPage();
+      });
   }
 
   protected resolvers$: Observable<PageMetaResolver[]> = this.unifiedInjector


### PR DESCRIPTION
symptoms: duplicate occ call when starting the app
solution: skip the first language getActive() emission. It is still uncleared why it this initial call occurs.
we see this pattern in other services
weg:
spartacus/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.ts
This fix has been tested on e2e and manually. No side effects to report.