### PR TITLE
fix: handle null and empty file selections in file upload component

### DIFF
--- a/projects/storefrontlib/shared/components/form/file-upload/file-upload.component.spec.ts
+++ b/projects/storefrontlib/shared/components/form/file-upload/file-upload.component.spec.ts
@@ -65,5 +65,40 @@ describe('FileUploadComponent', () => {
         mockFile,
       ] as unknown as FileList);
     });
+
+    it('should emit null when no files are selected (cancel)', () => {
+      const emptyFileListEvent = {
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        target: { files: [] as unknown as FileList },
+      };
+      spyOn(component.update, 'emit');
+      inputEl.triggerEventHandler('change', emptyFileListEvent);
+      expect(component.update.emit).toHaveBeenCalledWith(null);
+    });
+
+    it('should emit null when files is null', () => {
+      const nullFilesEvent = {
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        target: { files: null },
+      };
+      spyOn(component.update, 'emit');
+      inputEl.triggerEventHandler('change', nullFilesEvent);
+      expect(component.update.emit).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('removeFile', () => {
+    it('should clear input value and emit null', () => {
+      spyOn(component.update, 'emit');
+      const onChangeCallbackSpy = jasmine.createSpy('onChangeCallback');
+      component.registerOnChange(onChangeCallbackSpy);
+
+      component.removeFile();
+
+      expect(component.update.emit).toHaveBeenCalledWith(null);
+      expect(onChangeCallbackSpy).toHaveBeenCalledWith(null);
+    });
   });
 });

--- a/projects/storefrontlib/shared/components/form/file-upload/file-upload.component.ts
+++ b/projects/storefrontlib/shared/components/form/file-upload/file-upload.component.ts
@@ -60,12 +60,16 @@ export class FileUploadComponent implements ControlValueAccessor {
 
   selectFile($event: Event) {
     const files = ($event.target as HTMLInputElement)?.files;
-    this.onChangeCallback(files);
-    this.update.emit(files);
+    // If no files were selected (e.g., user clicked cancel), pass null instead of empty FileList
+    const value = files && files.length > 0 ? files : null;
+    this.onChangeCallback(value);
+    this.update.emit(value);
   }
 
   removeFile(): void {
     this.fileInput.nativeElement.value = '';
+    this.onChangeCallback(null);
+    this.update.emit(null);
   }
 
   get selectedFiles(): File[] | undefined {


### PR DESCRIPTION
Closes [CXSPA-10472](https://jira.tools.sap/browse/CXSPA-10472)

QA steps:
- Click "Import Products" hyperlink
- Upload an invalid .xlsx file (e.g., a blank Excel file)
- See expected error message "File is not parsable"
- Click "Select File" again without closing the Import Products dialog
- In the OS native file uploader, click the Cancel button (do not select any file)
- Error message "File is required" should appear, instead of a success message
- Console errors related to file parsing shouldn't appear

<img width="498" height="354" alt="image" src="https://github.com/user-attachments/assets/e24f6f20-f1c2-42ba-9536-d4041aba83e8" />