### PR TITLE
fix: upgrade [undici] to ^7.24.0(direct) version to address OSS Vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25748,17 +25748,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/jsdom/node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/jsdom/node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -34572,9 +34561,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -302,6 +302,7 @@
     "i18n-lint": {
       "minimatch": "3.1.5"
     },
-    "test-exclude": "^8.0.0"
+    "test-exclude": "^8.0.0",
+    "undici": "^7.24.0"
   }
 }


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-12360

Upgraded undici (resolving 6 CVEs: https://github.com/advisories/GHSA-2mjp-6q6p-2qxm, https://github.com/advisories/GHSA-vrm6-8vpv-qv8q, https://github.com/advisories/GHSA-4992-7rv2-5pvq, https://github.com/advisories/GHSA-f269-vfmq-vjvj, https://github.com/advisories/GHSA-v9p9-hfj2-hcw8, https://github.com/advisories/GHSA-phc3-fgpg-7m6h) to:

Upgraded in package.json - from 7.22.0 to "^7.24.0".