### PR TITLE
fix: suppress i18next ad in logs

### DIFF
--- a/projects/core/src/i18n/i18next/i18next-initializer.spec.ts
+++ b/projects/core/src/i18n/i18next/i18next-initializer.spec.ts
@@ -98,6 +98,17 @@ describe('I18nextInitializer', () => {
       );
     });
 
+    it('should set config `showSupportNotice` to false', () => {
+      spyOn(i18next, 'init');
+
+      initializer.initialize();
+
+      expect(i18next.init).toHaveBeenCalledWith(
+        jasmine.objectContaining({ showSupportNotice: false }),
+        jasmine.any(Function)
+      );
+    });
+
     it('should set config  `ns` to empty array', () => {
       spyOn(i18next, 'init');
 

--- a/projects/core/src/i18n/i18next/i18next-initializer.ts
+++ b/projects/core/src/i18n/i18next/i18next-initializer.ts
@@ -57,7 +57,7 @@ export class I18nextInitializer implements OnDestroy {
       },
 
       // Suppress Locize ad in i18next runtime. See: https://www.i18next.com/overview/configuration-options
-      // @ts-ignore -- our repo's i18next version doesn't have this option available, but customers' apps can have it
+      // @ts-ignore -- In CXSPA-12377 we'll remove this @ts-ignore, after we upgrade to the latest i18next version
       showSupportNotice: false,
     };
 

--- a/projects/core/src/i18n/i18next/i18next-initializer.ts
+++ b/projects/core/src/i18n/i18next/i18next-initializer.ts
@@ -55,6 +55,10 @@ export class I18nextInitializer implements OnDestroy {
         escapeValue: false,
         skipOnVariables: false,
       },
+
+      // Suppress Locize ad in i18next runtime. See: https://www.i18next.com/overview/configuration-options
+      // @ts-ignore -- our repo's i18next version doesn't have this option available, but customers' apps can have it
+      showSupportNotice: false,
     };
 
     if (this.config.i18n?.backend) {

--- a/projects/core/src/i18n/i18next/i18next-initializer.ts
+++ b/projects/core/src/i18n/i18next/i18next-initializer.ts
@@ -56,7 +56,6 @@ export class I18nextInitializer implements OnDestroy {
         skipOnVariables: false,
       },
 
-      // Suppress Locize ad in i18next runtime. See: https://www.i18next.com/overview/configuration-options
       // @ts-ignore -- In CXSPA-12377 we'll remove this @ts-ignore, after we upgrade to the latest i18next version
       showSupportNotice: false,
     };


### PR DESCRIPTION
Note: this PR fixes an issue that happens in customers' apps that use higher minor version of i18next than we in our repo. So you won't see the ad in our storeforntapp in our repo, but only in fresh apps using latest i18next minor.

fixes https://jira.tools.sap/browse/CXSPA-12274

-- 

QA steps:
- build libs and publish to verdaccio
- create fresh app with angular and spartacus (from verdaccio)
- start the app
- check the browser's console 
- verify there is no i18next ad in the console