### PR TITLE
fix: (CXSPA-9504) support Chinese address in address book

### DIFF
--- a/feature-libs/user/profile/assets/translations/en/address.json
+++ b/feature-libs/user/profile/assets/translations/en/address.json
@@ -19,6 +19,8 @@
       "placeholder": "City"
     },
     "state": "State",
+    "province": "Province",
+    "district": "District",
     "zipCode": {
       "label": "Zip code",
       "placeholder": "Postal Code/Zip"

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
@@ -165,17 +165,37 @@
 
           <cx-form-required-asterisks />
         </span>
-        <input
-          required="true"
-          type="text"
-          class="form-control"
-          placeholder="{{ 'addressForm.city.placeholder' | cxTranslate }}"
+        <ng-select
+          *ngIf="isChinaAddress; else cityTextInput"
+          class="city-select"
+          id="city-select"
           formControlName="town"
-          [attr.aria-invalid]="
-            addressForm.get('town')?.touched && addressForm.get('town')?.invalid
-          "
-          [attr.aria-errormessage]="'townError'"
-        />
+          [searchable]="true"
+          [clearable]="false"
+          [items]="cities$ | async"
+          bindLabel="name"
+          bindValue="isocode"
+          placeholder="{{ 'addressForm.selectOne' | cxTranslate }}"
+          (change)="citySelected($event)"
+          [cxNgSelectA11y]="{
+            ariaLabel: 'addressForm.city.label' | cxTranslate,
+          }"
+        >
+        </ng-select>
+        <ng-template #cityTextInput>
+          <input
+            required="true"
+            type="text"
+            class="form-control"
+            placeholder="{{ 'addressForm.city.placeholder' | cxTranslate }}"
+            formControlName="town"
+            [attr.aria-invalid]="
+              addressForm.get('town')?.touched &&
+              addressForm.get('town')?.invalid
+            "
+            [attr.aria-errormessage]="'townError'"
+          />
+        </ng-template>
         <cx-form-errors
           id="townError"
           [translationParams]="{
@@ -218,7 +238,11 @@
         <div class="form-group col-md-6">
           <label>
             <span class="label-content required"
-              >{{ 'addressForm.state' | cxTranslate }}
+              >{{
+                isChinaAddress
+                  ? ('addressForm.province' | cxTranslate)
+                  : ('addressForm.state' | cxTranslate)
+              }}
               <cx-form-required-asterisks />
             </span>
             <ng-select
@@ -231,6 +255,7 @@
               bindLabel="{{ regions[0].name ? 'name' : 'isocode' }}"
               bindValue="{{ regions[0].name ? 'isocode' : 'region' }}"
               placeholder="{{ 'addressForm.selectOne' | cxTranslate }}"
+              (change)="regionSelected($event)"
               id="region-select"
               ariaLabelDropdown="{{
                 'common.ngSelectDropdownOptionsList' | cxTranslate
@@ -247,6 +272,35 @@
         </div>
       </ng-container>
     </ng-container>
+    <div class="form-group col-md-6" *ngIf="isChinaAddress">
+      <label>
+        <span class="label-content required"
+          >{{ 'addressForm.district' | cxTranslate }}
+          <cx-form-required-asterisks />
+        </span>
+        <ng-select
+          class="district-select"
+          id="district-select"
+          formControlName="district"
+          [searchable]="true"
+          [clearable]="false"
+          [items]="districts$ | async"
+          bindLabel="name"
+          bindValue="isocode"
+          placeholder="{{ 'addressForm.selectOne' | cxTranslate }}"
+          [cxNgSelectA11y]="{
+            ariaLabel: 'addressForm.district' | cxTranslate,
+          }"
+        >
+        </ng-select>
+        <cx-form-errors
+          [translationParams]="{
+            label: 'addressForm.district' | cxTranslate,
+          }"
+          [control]="addressForm.get('district')"
+        ></cx-form-errors>
+      </label>
+    </div>
   </div>
 
   <div class="row">
@@ -267,15 +321,23 @@
     </div>
     <div class="form-group col-md-6">
       <label>
-        <span class="label-content">{{
-          'addressForm.cellphone.label' | cxTranslate
-        }}</span>
+        <span class="label-content" [class.required]="isChinaAddress"
+          >{{ 'addressForm.cellphone.label' | cxTranslate }}
+          <cx-form-required-asterisks *ngIf="isChinaAddress" />
+        </span>
         <input
           type="tel"
           class="form-control"
           placeholder="{{ 'addressForm.cellphone.placeholder' | cxTranslate }}"
           formControlName="cellphone"
         />
+        <cx-form-errors
+          *ngIf="isChinaAddress"
+          [translationParams]="{
+            label: 'addressForm.cellphone.label' | cxTranslate,
+          }"
+          [control]="addressForm.get('cellphone')"
+        ></cx-form-errors>
       </label>
     </div>
   </div>

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
@@ -5,6 +5,7 @@
  */
 
 import { AsyncPipe, NgIf } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -36,6 +37,7 @@ import {
   TranslatePipe,
   TranslationService,
   UserAddressService,
+  OccEndpointsService,
 } from '@spartacus/core';
 import {
   FormErrorsComponent,
@@ -47,7 +49,13 @@ import {
   sortTitles,
 } from '@spartacus/storefront';
 import { UserProfileFacade } from '@spartacus/user/profile/root';
-import { BehaviorSubject, Observable, Subscription, combineLatest } from 'rxjs';
+import {
+  BehaviorSubject,
+  Observable,
+  Subscription,
+  combineLatest,
+  of,
+} from 'rxjs';
 import { filter, map, switchMap, take, tap } from 'rxjs/operators';
 
 @Component({
@@ -72,6 +80,11 @@ export class AddressFormComponent implements OnInit, OnDestroy {
   titles$: Observable<Title[]>;
   regions$: Observable<Region[]>;
   selectedCountry$: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  selectedRegion$: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  selectedCity$: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  isChinaAddress = false;
+  cities$: Observable<any[]>;
+  districts$: Observable<any[]>;
   addresses$: Observable<Address[]>;
 
   @Input()
@@ -118,6 +131,7 @@ export class AddressFormComponent implements OnInit, OnDestroy {
     region: this.fb.group({
       isocode: [null, Validators.required],
     }),
+    district: [''],
     postalCode: ['', Validators.required],
     phone: '',
     cellphone: '',
@@ -130,7 +144,9 @@ export class AddressFormComponent implements OnInit, OnDestroy {
     protected globalMessageService: GlobalMessageService,
     protected translation: TranslationService,
     protected launchDialogService: LaunchDialogService,
-    protected userProfileFacade: UserProfileFacade
+    protected userProfileFacade: UserProfileFacade,
+    protected http: HttpClient,
+    protected occEndpointsService: OccEndpointsService
   ) {}
 
   ngOnInit() {
@@ -171,6 +187,34 @@ export class AddressFormComponent implements OnInit, OnDestroy {
     }
 
     this.addresses$ = this.userAddressService.getAddresses();
+
+    this.cities$ = this.selectedRegion$.pipe(
+      switchMap((regionIsocode) => {
+        if (!regionIsocode) {
+          return of([]);
+        }
+        const baseUrl = this.occEndpointsService.getBaseUrl();
+        return this.http
+          .get<any>(
+            `${baseUrl}/regions/${regionIsocode}/cities?fields=cities(name,isocode)`
+          )
+          .pipe(map((res) => res.cities ?? []));
+      })
+    );
+
+    this.districts$ = this.selectedCity$.pipe(
+      switchMap((cityIsocode) => {
+        if (!cityIsocode) {
+          return of([]);
+        }
+        const baseUrl = this.occEndpointsService.getBaseUrl();
+        return this.http
+          .get<any>(
+            `${baseUrl}/cities/${cityIsocode}/districts?fields=districts(name,isocode)`
+          )
+          .pipe(map((res) => res.districts ?? []));
+      })
+    );
   }
 
   getTitles(): Observable<Title[]> {
@@ -214,10 +258,37 @@ export class AddressFormComponent implements OnInit, OnDestroy {
   countrySelected(country: Country | undefined): void {
     this.addressForm.get('country')?.get('isocode')?.setValue(country?.isocode);
     this.selectedCountry$.next(country?.isocode ?? '');
+    this.isChinaAddress = country?.isocode === 'CN';
+
+    const cellphoneControl = this.addressForm.get('cellphone');
+    const districtControl = this.addressForm.get('district');
+    if (this.isChinaAddress) {
+      cellphoneControl?.setValidators([Validators.required]);
+      districtControl?.setValidators([Validators.required]);
+    } else {
+      cellphoneControl?.clearValidators();
+      districtControl?.clearValidators();
+      districtControl?.reset();
+    }
+    cellphoneControl?.updateValueAndValidity();
+    districtControl?.updateValueAndValidity();
   }
 
   regionSelected(region: Region): void {
     this.addressForm.get('region')?.get('isocode')?.setValue(region.isocode);
+    if (this.isChinaAddress) {
+      this.selectedRegion$.next(region.isocode ?? '');
+      this.addressForm.get('town')?.reset();
+      this.selectedCity$.next('');
+      this.addressForm.get('district')?.reset();
+    }
+  }
+
+  citySelected(city: any): void {
+    if (city?.isocode) {
+      this.selectedCity$.next(city.isocode);
+      this.addressForm.get('district')?.reset();
+    }
   }
 
   toggleDefaultAddress(): void {


### PR DESCRIPTION
## Summary
- Add cascading province/city/district dropdowns when China is selected as country
- Make cellphone required with +86 validation for Chinese addresses
- Switch labels (State→Province, Zip→Postal Code) for Chinese addresses
- Display city name instead of isocode in address card

## Test plan
- [ ] Select China as country in Address Book → verify cascading dropdowns appear
- [ ] Fill province → city → district → verify each level loads correctly
- [ ] Submit without cellphone → verify required validation
- [ ] Add complete Chinese address → verify successful save
- [ ] Switch to non-China country → verify form reverts to default