### PR TITLE
fix: remove api key from the OPF config

### DIFF
--- a/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
@@ -140,7 +140,7 @@ extensionProviders.push(provideConfig(defaultOccOpfCartConfig));
       opf: {
         opfBaseUrl:
           'https://opf-iss-d0.opf.commerce.stage.context.cloud.sap/commerce-cloud-adapter/storefront',
-        commerceCloudPublicKey: 'ab4RhYGZ+w5B0SALMPOPlepWk/kmDQjTy2FU5hrQoFg=',
+        commerceCloudPublicKey: 'ADD_COMMERCE_CLOUD_PUBLIC_KEY_HERE',
       },
     }),
     ...extensionProviders,


### PR DESCRIPTION
Closes: https://github.com/SAP/spartacus/security/secret-scanning/19