### PR TITLE
fix: upgrade [flatted] to ^3.4.2 version to address OSS Vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20820,9 +20820,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "devOptional": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -295,6 +295,7 @@
     "webpack-cli": "^6.0.0"
   },
   "overrides": {
+    "flatted": "^3.4.2",
     "koa": "^3.1.2",
     "minimatch": "^10.2.1",
     "karma": {


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-12361.

- All `flatted` dependencies now use version `3.4.2` (the patched version released March 17, 2026) which fixes `CVE-2026-32141` and `CVE-2026-33228`.