### PR TITLE
fix: handle full page redirection within smartedit (#21268)

### DIFF
--- a/feature-libs/smartedit/root/services/smart-edit-launcher.service.spec.ts
+++ b/feature-libs/smartedit/root/services/smart-edit-launcher.service.spec.ts
@@ -1,14 +1,24 @@
 import { Location } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
-import { FeatureModulesService, ScriptLoader } from '@spartacus/core';
+import {
+  FeatureModulesService,
+  ScriptLoader,
+  WindowRef,
+} from '@spartacus/core';
+import { of } from 'rxjs';
 import { defaultSmartEditConfig } from '../config/default-smart-edit-config';
 import { SmartEditConfig } from '../config/smart-edit-config';
 import { SmartEditLauncherService } from './smart-edit-launcher.service';
-import { of } from 'rxjs';
 
 class MockLocation {
   path() {
     return '';
+  }
+}
+
+class MockWindowRef {
+  isBrowser(): boolean {
+    return true;
   }
 }
 
@@ -26,14 +36,17 @@ describe('SmartEditLauncherService', () => {
   let location: Location;
   let scriptLoader: ScriptLoader;
   let featureModules: FeatureModulesService;
+  let windowRef: WindowRef;
 
   beforeEach(() => {
+    sessionStorage.clear();
     TestBed.configureTestingModule({
       providers: [
         { provide: Location, useClass: MockLocation },
         { provide: SmartEditConfig, useValue: defaultSmartEditConfig },
         { provide: ScriptLoader, useClass: MockScriptLoader },
         { provide: FeatureModulesService, useClass: MockFeatureModulesService },
+        { provide: WindowRef, useClass: MockWindowRef },
       ],
     });
 
@@ -41,6 +54,11 @@ describe('SmartEditLauncherService', () => {
     location = TestBed.inject(Location);
     scriptLoader = TestBed.inject(ScriptLoader);
     featureModules = TestBed.inject(FeatureModulesService);
+    windowRef = TestBed.inject(WindowRef);
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
   });
 
   it('should be created', () => {
@@ -69,6 +87,47 @@ describe('SmartEditLauncherService', () => {
       const launched = smartEditLauncherService.isLaunchedInSmartEdit();
       expect(launched).toBeFalsy();
     });
+
+    it('should persist cmsTicketId to sessionStorage on initial SmartEdit launch', () => {
+      spyOn(location, 'path').and.returnValue(
+        '/any/cx-preview?cmsTicketId=abc123'
+      );
+      expect(sessionStorage.getItem('smartedit.cmsTicketId')).toBeNull();
+      const launched = smartEditLauncherService.isLaunchedInSmartEdit();
+      expect(launched).toBeTruthy();
+      expect(sessionStorage.getItem('smartedit.cmsTicketId')).toBe('abc123');
+      expect(smartEditLauncherService.cmsTicketId).toBe('abc123');
+    });
+
+    it('should restore cmsTicketId from sessionStorage when full page redirect occurs after initial launch', () => {
+      spyOn(location, 'path').and.returnValues(
+        '/any/cx-preview?cmsTicketId=abc123',
+        '/any/login/callback?code=auth-code'
+      );
+      expect(sessionStorage.getItem('smartedit.cmsTicketId')).toBeNull();
+      const launched = smartEditLauncherService.isLaunchedInSmartEdit();
+      expect(launched).toBeTruthy();
+      expect(sessionStorage.getItem('smartedit.cmsTicketId')).toBe('abc123');
+      const launched2 = smartEditLauncherService.isLaunchedInSmartEdit();
+      expect(launched2).toBeTruthy();
+      expect(sessionStorage.getItem('smartedit.cmsTicketId')).toBe('abc123');
+      expect(smartEditLauncherService.cmsTicketId).toBe('abc123');
+    });
+
+    it('should prefer cmsTicketId from URL over sessionStorage', () => {
+      spyOn(location, 'path').and.returnValues(
+        '/any/cx-preview?cmsTicketId=abc123',
+        '/any/cx-preview?cmsTicketId=def456'
+      );
+      expect(sessionStorage.getItem('smartedit.cmsTicketId')).toBeNull();
+      const launched = smartEditLauncherService.isLaunchedInSmartEdit();
+      expect(launched).toBeTruthy();
+      expect(sessionStorage.getItem('smartedit.cmsTicketId')).toBe('abc123');
+      const launched2 = smartEditLauncherService.isLaunchedInSmartEdit();
+      expect(launched2).toBeTruthy();
+      expect(sessionStorage.getItem('smartedit.cmsTicketId')).toBe('def456');
+      expect(smartEditLauncherService.cmsTicketId).toBe('def456');
+    });
   });
 
   describe('should lazy load SmartEditModule', () => {
@@ -91,5 +150,32 @@ describe('SmartEditLauncherService', () => {
 
     smartEditLauncherService.load();
     expect(scriptLoader.embedScript).toHaveBeenCalled();
+  });
+
+  describe('SSR behavior', () => {
+    it('should not read cmsTicketId from sessionStorage when not in browser', () => {
+      spyOn(windowRef, 'isBrowser').and.returnValue(false);
+      sessionStorage.setItem('smartedit.cmsTicketId', 'abc123');
+      spyOn(location, 'path').and.returnValue(
+        '/any/login/callback?code=auth-code'
+      );
+
+      const launched = smartEditLauncherService.isLaunchedInSmartEdit();
+
+      expect(launched).toBeFalsy();
+      expect(smartEditLauncherService.cmsTicketId).toBeUndefined();
+    });
+
+    it('should not store cmsTicketId in sessionStorage when not in browser', () => {
+      spyOn(windowRef, 'isBrowser').and.returnValue(false);
+      spyOn(location, 'path').and.returnValue(
+        '/any/cx-preview?cmsTicketId=abc123'
+      );
+
+      smartEditLauncherService.isLaunchedInSmartEdit();
+
+      expect(sessionStorage.getItem('smartedit.cmsTicketId')).toBeNull();
+      expect(smartEditLauncherService.cmsTicketId).toBe('abc123');
+    });
   });
 });

--- a/feature-libs/smartedit/root/services/smart-edit-launcher.service.ts
+++ b/feature-libs/smartedit/root/services/smart-edit-launcher.service.ts
@@ -6,7 +6,11 @@
 
 import { Location } from '@angular/common';
 import { inject, Injectable } from '@angular/core';
-import { FeatureModulesService, ScriptLoader } from '@spartacus/core';
+import {
+  FeatureModulesService,
+  ScriptLoader,
+  WindowRef,
+} from '@spartacus/core';
 import { SmartEditConfig } from '../config/smart-edit-config';
 import { SMART_EDIT_FEATURE } from '../feature-name';
 
@@ -19,7 +23,9 @@ import { SMART_EDIT_FEATURE } from '../feature-name';
 })
 export class SmartEditLauncherService {
   protected readonly featureModulesService = inject(FeatureModulesService);
+  protected readonly windowRef = inject(WindowRef);
   private _cmsTicketId: string | undefined;
+  private static readonly STORAGE_KEY_CMS_TICKET_ID = 'smartedit.cmsTicketId';
 
   get cmsTicketId(): string | undefined {
     return this._cmsTicketId;
@@ -53,16 +59,61 @@ export class SmartEditLauncherService {
    * Indicates whether Spartacus is launched in SmartEdit
    */
   isLaunchedInSmartEdit(): boolean {
-    const path = this.location.path().split('?')[0];
-    const params = this.location.path().split('?')[1];
+    const [path, params] = this.location.path().split('?');
     const cmsToken = params
       ?.split('&')
       .find((param) => param.startsWith('cmsTicketId='));
-    this._cmsTicketId = cmsToken?.split('=')[1];
+    const cmsTicketId = cmsToken?.split('=')[1];
 
     return (
-      path.split('/').pop() === this.config.smartEdit?.storefrontPreviewRoute &&
-      !!this._cmsTicketId
+      this.isInitialSmartEditPage(path, cmsTicketId) ||
+      this.isFullPageRedirectInSmartEdit()
     );
+  }
+
+  private isInitialSmartEditPage(
+    path: string,
+    cmsTicketId: string | undefined
+  ): boolean {
+    // When both the SmartEdit cmsTicketId and the storefrontPreviewRoute values are found in the URL, store the cmsTicketId in sessionStorage.
+    // so it survives full-page navigation (e.g. CDC OIDC redirect flow).
+    if (
+      path.split('/').pop() === this.config.smartEdit?.storefrontPreviewRoute &&
+      !!cmsTicketId
+    ) {
+      this.persistCmsTicketId(cmsTicketId);
+      this._cmsTicketId = cmsTicketId;
+      return true;
+    }
+    return false;
+  }
+
+  private isFullPageRedirectInSmartEdit(): boolean {
+    // Fall back to sessionStorage for scenarios where a full-page redirect
+    // drops the cmsTicketId and other SmartEdit context from the URL.
+    this._cmsTicketId = this.restoreCmsTicketId();
+    return !!this._cmsTicketId;
+  }
+
+  private persistCmsTicketId(cmsTicketId: string): void {
+    // bypass sessionStorage when not in browser context (e.g. SSR) to avoid "SecurityError: Access to storage is denied" error
+    if (!this.windowRef.isBrowser()) {
+      return;
+    }
+    sessionStorage.setItem(
+      SmartEditLauncherService.STORAGE_KEY_CMS_TICKET_ID,
+      cmsTicketId
+    );
+  }
+
+  private restoreCmsTicketId(): string | undefined {
+    // bypass sessionStorage when not in browser context (e.g. SSR) to avoid "SecurityError: Access to storage is denied" error
+    if (!this.windowRef.isBrowser()) {
+      return undefined;
+    }
+    const stored = sessionStorage.getItem(
+      SmartEditLauncherService.STORAGE_KEY_CMS_TICKET_ID
+    );
+    return stored ?? undefined;
   }
 }


### PR DESCRIPTION
carry 'develop' fix into release branch with cherry-pick, see original PR:
https://github.com/SAP/spartacus/pull/21268

CXSPA-11484

SessionStorage key/value was added to be able to retrieve cmsTicketId after a full page redirection that requires spartacus to restart within SmartEdit.