### PR TITLE
fix: adjust currency E2E test assertion to handle formatting variations

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/site-context/currency/currency.core-e2e.cy.ts
@@ -41,7 +41,7 @@ context('Currency change', () => {
         siteContextSelector.CURRENCY_LABEL
       );
 
-      cy.get('.price').should('contain', '¥690');
+      cy.get('.price').should('contain', '¥').and('contain', '690');
       switchSiteContext(siteContextSelector.CURRENCY_USD, 'Currency');
       cy.get('.price').should('contain', '$8.20');
     });


### PR DESCRIPTION
Price formatted value for JPY changed and has space between JPY sign and the value:
<img width="664" height="192" alt="image" src="https://github.com/user-attachments/assets/078e5888-528d-4e9b-adad-78a9c7f82b87" />
See [new API ](https://20.83.184.244:9002/occ/v2/electronics-spa/products/280916?curr=JPY) vs [old API](https://composable-storefront-demo.eastus.cloudapp.azure.com:8443/occ/v2/electronics-spa/products/280916?curr=JPY)

This PR adjust currency e2e test to handle different variations.