### PR TITLE
fix: CXSPA-11478 Address security vulnerabilities in GitHub Actions pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,8 @@
 /.github/CODEOWNERS          @SAP/spartacus-admins
 /.github/workflows/          @SAP/spartacus-admins
 /.github/actions/            @SAP/spartacus-admins
+/.github/api-extractor-action/   @SAP/spartacus-admins
+/.github/cache-builded-libs/     @SAP/spartacus-admins
 /projects/storefrontstyles/vendor/bootstrap          @SAP/spartacus-admins
 
 # ================================================

--- a/.github/actions/build-integrity-check/action.yml
+++ b/.github/actions/build-integrity-check/action.yml
@@ -13,6 +13,24 @@ runs:
       if: inputs.phase == 'snapshot'
       shell: bash
       run: |
+        # SECURITY: Enable strict error handling to prevent silent failures
+        # - 'set -e' exits immediately if any command fails
+        # - 'set -u' treats unset variables as errors
+        # - 'set -o pipefail' ensures pipeline failures are detected
+        set -euo pipefail
+
+        # Use RUNNER_TEMP for better isolation and avoid predictable paths
+        SNAPSHOT_FILE="${RUNNER_TEMP}/pre-build-integrity-$(date +%s).sha256"
+
+        # Generate checksums of all source files
+        # Exclusions are necessary to ignore generated/cached files:
+        # - .git: Version control metadata
+        # - node_modules: Third-party dependencies
+        # - dist: Build output
+        # - .angular/.nx: Build cache
+        # - coverage: Test output
+        # - schematics JS files: Generated during build
+        # - feature-toggles copied files: Generated during build
         find . -type f \
           -not -path './.git/*' \
           -not -path './node_modules/*' \
@@ -26,14 +44,56 @@ runs:
           -not -path '*/schematics/*.d.ts' \
           -print0 \
           | sort -z \
-          | xargs -0 sha256sum > /tmp/pre-build-integrity.sha256
+          | xargs -0 sha256sum > "$SNAPSHOT_FILE"
 
-        echo "Snapshotted $(wc -l < /tmp/pre-build-integrity.sha256) source files for integrity check"
+        # Validate snapshot was created successfully
+        if [ ! -f "$SNAPSHOT_FILE" ]; then
+          echo "::error file=.github/actions/build-integrity-check/action.yml,title=Snapshot Creation Failed::Failed to create integrity snapshot file"
+          exit 1
+        fi
+
+        if [ ! -s "$SNAPSHOT_FILE" ]; then
+          echo "::error file=.github/actions/build-integrity-check/action.yml,title=Empty Snapshot::Integrity snapshot file is empty - cannot verify build integrity"
+          exit 1
+        fi
+
+        FILE_COUNT=$(wc -l < "$SNAPSHOT_FILE")
+        echo "✓ Snapshotted ${FILE_COUNT} source files for integrity check"
+
+        # Sanity check: Spartacus has thousands of source files
+        # If count is suspiciously low, the snapshot may be incomplete
+        if [ "$FILE_COUNT" -lt 100 ]; then
+          echo "::warning file=.github/actions/build-integrity-check/action.yml,title=Low File Count::Unexpectedly low file count in integrity snapshot (${FILE_COUNT}). Expected thousands of files. This may indicate an issue with snapshot generation."
+        fi
+
+        # Export snapshot location for verify phase
+        echo "INTEGRITY_SNAPSHOT=$SNAPSHOT_FILE" >> $GITHUB_ENV
 
     - name: Verify source file integrity after build
       if: inputs.phase == 'verify'
       shell: bash
       run: |
+        # SECURITY: Enable strict error handling to prevent silent failures
+        set -euo pipefail
+
+        SNAPSHOT_FILE="${INTEGRITY_SNAPSHOT:-/tmp/pre-build-integrity.sha256}"
+
+        # SECURITY CRITICAL: Verify pre-build snapshot exists
+        # Without this check, a missing snapshot file would cause diff to fail
+        # silently, allowing tampered builds to pass verification
+        if [ ! -f "$SNAPSHOT_FILE" ]; then
+          echo "::error file=.github/actions/build-integrity-check/action.yml,title=Snapshot Missing::Pre-build integrity snapshot is missing! This could indicate tampering or a configuration error."
+          echo "Expected snapshot at: $SNAPSHOT_FILE"
+          exit 1
+        fi
+
+        if [ ! -s "$SNAPSHOT_FILE" ]; then
+          echo "::error file=.github/actions/build-integrity-check/action.yml,title=Empty Snapshot::Pre-build integrity snapshot is empty - cannot verify build integrity"
+          exit 1
+        fi
+
+        # Generate post-build snapshot using identical file selection logic
+        POST_SNAPSHOT="${RUNNER_TEMP}/post-build-integrity-$(date +%s).sha256"
         find . -type f \
           -not -path './.git/*' \
           -not -path './node_modules/*' \
@@ -47,15 +107,59 @@ runs:
           -not -path '*/schematics/*.d.ts' \
           -print0 \
           | sort -z \
-          | xargs -0 sha256sum > /tmp/post-build-integrity.sha256
+          | xargs -0 sha256sum > "$POST_SNAPSHOT"
 
-        CHANGED=$(diff /tmp/pre-build-integrity.sha256 /tmp/post-build-integrity.sha256 || true)
-
-        if [ -n "$CHANGED" ]; then
-          echo "::error::Source files were unexpectedly modified during the build!"
-          echo "The following files were added, removed, or changed:"
-          echo "$CHANGED"
+        # Validate post-build snapshot was created
+        if [ ! -s "$POST_SNAPSHOT" ]; then
+          echo "::error file=.github/actions/build-integrity-check/action.yml,title=Post-Snapshot Failed::Failed to create post-build integrity snapshot"
           exit 1
         fi
 
-        echo "Build integrity check passed, no source files were modified"
+        # SECURITY CRITICAL: Capture both stdout and stderr from diff
+        # The previous implementation used '|| true' which suppressed all errors,
+        # allowing file-not-found errors to pass silently. Now we explicitly
+        # handle diff exit codes and capture stderr.
+        set +e  # Temporarily disable exit-on-error to handle diff exit codes
+        DIFF_OUTPUT=$(diff "$SNAPSHOT_FILE" "$POST_SNAPSHOT" 2>&1)
+        DIFF_EXIT=$?
+        set -e  # Re-enable exit-on-error
+
+        # diff exit codes:
+        # 0 = files are identical (good)
+        # 1 = files differ (integrity violation)
+        # 2 = error occurred (file missing, permission denied, etc.)
+        if [ $DIFF_EXIT -eq 2 ]; then
+          echo "::error file=.github/actions/build-integrity-check/action.yml,title=Comparison Failed::Failed to compare integrity snapshots"
+          echo "Error details: $DIFF_OUTPUT"
+          exit 1
+        fi
+
+        if [ $DIFF_EXIT -eq 1 ]; then
+          # Calculate statistics for security incident response
+          ADDED=$(echo "$DIFF_OUTPUT" | grep "^>" | wc -l || echo "0")
+          REMOVED=$(echo "$DIFF_OUTPUT" | grep "^<" | wc -l || echo "0")
+          CHANGED=$(echo "$DIFF_OUTPUT" | grep "^!" | wc -l || echo "0")
+
+          echo "::error file=.github/actions/build-integrity-check/action.yml,title=Build Integrity Violation::Source files were unexpectedly modified during the build!"
+          echo "::error::🚨 SECURITY ALERT: ${ADDED} files added, ${REMOVED} files removed, ${CHANGED} files modified during build"
+          echo ""
+          echo "This indicates potential tampering or misconfiguration. Files should NOT be modified during the build process."
+          echo ""
+          echo "::group::Changed Files (first 50 lines)"
+          echo "$DIFF_OUTPUT" | head -50
+          echo "::endgroup::"
+
+          # Save full diff for forensic analysis
+          echo "$DIFF_OUTPUT" > "${RUNNER_TEMP}/integrity-violation.log"
+          echo "::notice::Full diff saved to ${RUNNER_TEMP}/integrity-violation.log"
+
+          exit 1
+        fi
+
+        # Exit code 0: files are identical
+        PRE_COUNT=$(wc -l < "$SNAPSHOT_FILE")
+        POST_COUNT=$(wc -l < "$POST_SNAPSHOT")
+        echo "✓ Build integrity check PASSED"
+        echo "  - Pre-build files: ${PRE_COUNT}"
+        echo "  - Post-build files: ${POST_COUNT}"
+        echo "  - No source files were modified during the build process"

--- a/.github/workflows/breaking-changes-detection-bot.yml
+++ b/.github/workflows/breaking-changes-detection-bot.yml
@@ -18,7 +18,7 @@ jobs:
         uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa #0.12.1
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Breaking change detection bot
         uses: ./.github/api-extractor-action
         env:

--- a/.github/workflows/cache-builded-libs.yml
+++ b/.github/workflows/cache-builded-libs.yml
@@ -17,6 +17,6 @@ jobs:
     name: Builded libs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Cache builded libs
         uses: ./.github/cache-builded-libs

--- a/.github/workflows/cache-node-modules.yml
+++ b/.github/workflows/cache-node-modules.yml
@@ -23,7 +23,7 @@ jobs:
     name: Cache node_modules
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:

--- a/.github/workflows/ci-continuous-integration.yml
+++ b/.github/workflows/ci-continuous-integration.yml
@@ -31,7 +31,7 @@ jobs:
     name: CI - Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
       - name: Setup node
@@ -57,7 +57,7 @@ jobs:
     name: CI - SonarQube Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
       - name: SonarQube Scan
@@ -75,7 +75,7 @@ jobs:
     name: CI - Validations and static code checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
@@ -99,7 +99,7 @@ jobs:
     name: CI - Check peerDependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
       - name: Setup node

--- a/.github/workflows/ci-merge-checks.yml
+++ b/.github/workflows/ci-merge-checks.yml
@@ -36,7 +36,7 @@ jobs:
     # and the job returns a success code.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Prevent retries
         uses: ./.github/actions/prevent-retries
   validate_e2e_execution:
@@ -45,7 +45,7 @@ jobs:
     outputs:
       SHOULD_RUN_E2E: ${{ steps.save-e2e-output-result.outputs.SHOULD_RUN_E2E }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
       - name: Determine whether to run e2es
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup Node and Cache
         uses: ./.github/actions/setup-node-and-cache
         with:
@@ -67,6 +67,10 @@ jobs:
           cache-key: ${{ github.event.pull_request.base.sha }}
       - name: Install Cypress packages
         run: (cd projects/storefrontapp-e2e-cypress && npm ci)
+      - name: Snapshot source files before build
+        uses: ./.github/actions/build-integrity-check
+        with:
+          phase: snapshot
       - name: Build Spartacus libraries
         run: |
           source ci-scripts/npm-commands.sh
@@ -83,6 +87,10 @@ jobs:
             rm build.log
             exit 1
           fi
+      - name: Verify source file integrity after build
+        uses: ./.github/actions/build-integrity-check
+        with:
+          phase: verify
       - name: Cache built libraries
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4.3.0
         with:
@@ -109,7 +117,7 @@ jobs:
             cache_key: ci-b2c
             name: B2C SSR
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup Node and Cache
         uses: ./.github/actions/setup-node-and-cache
         with:
@@ -147,7 +155,7 @@ jobs:
         containers: [1, 2, 3, 4, 5]
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -166,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -188,7 +196,7 @@ jobs:
         containers: [1, 2, 3, 4]
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -210,7 +218,7 @@ jobs:
         containers: [1, 2, 3]
     if: ${{ needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -238,7 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       # Currently only A11Y screenshots are collected, but this can be extended
       # to merge screenshots from other test suites (B2C, B2B, etc.) as needed
       - name: Merge A11Y screenshots

--- a/.github/workflows/ci-pull-request-status.yml
+++ b/.github/workflows/ci-pull-request-status.yml
@@ -20,7 +20,7 @@ concurrency:
 name: Pull Request
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: Verify re-run of all jobs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Prevent retries
         uses: ./.github/actions/prevent-retries
   validate_e2e_execution:
@@ -41,7 +41,7 @@ jobs:
     outputs:
       SHOULD_RUN_E2E: ${{ steps.save-e2e-output-result.outputs.SHOULD_RUN_E2E }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
       - name: Determine whether to run e2es
@@ -54,7 +54,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Node and Cache
@@ -69,7 +69,7 @@ jobs:
     name: SonarQube Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
       - name: SonarQube Scan
@@ -88,7 +88,7 @@ jobs:
     name: Validations and static code checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup Node and Cache
         uses: ./.github/actions/setup-node-and-cache
         with:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name == 'develop' || startsWith(github.ref_name, 'release/')
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
       - name: Check for new feature toggles
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup Node and Cache
         uses: ./.github/actions/setup-node-and-cache
         with:
@@ -208,7 +208,7 @@ jobs:
             cache_key: ci-b2c
             name: B2C SSR
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup Node and Cache
         uses: ./.github/actions/setup-node-and-cache
         with:
@@ -246,7 +246,7 @@ jobs:
         containers: [1, 2, 3, 4, 5]
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -287,7 +287,7 @@ jobs:
         containers: [1, 2, 3, 4]
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -309,7 +309,7 @@ jobs:
         containers: [1, 2, 3]
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.validate_e2e_execution.outputs.SHOULD_RUN_E2E == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: E2E Test Setup
         uses: ./.github/actions/e2e-setup
         with:
@@ -330,7 +330,7 @@ jobs:
     name: SSR Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup Node and Cache
         uses: ./.github/actions/setup-node-and-cache
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/config-check.yml
+++ b/.github/workflows/config-check.yml
@@ -21,7 +21,7 @@ jobs:
         uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa #0.12.1
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version: '20'

--- a/.github/workflows/e2e-vendor.yml
+++ b/.github/workflows/e2e-vendor.yml
@@ -85,7 +85,7 @@ jobs:
             test_name: E2E tests for punchout
 
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0

--- a/.github/workflows/feature-toggle-check.yml
+++ b/.github/workflows/feature-toggle-check.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -26,7 +26,7 @@ jobs:
         uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa #0.12.1
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version: '20'

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -31,7 +31,7 @@ jobs:
     name: Lighthouse score validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:

--- a/.github/workflows/minor-release.yml
+++ b/.github/workflows/minor-release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           ref: ${{ github.event.inputs.source || 'develop' }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -37,7 +37,7 @@ jobs:
         id: current-run-major-version
         run: echo "MAJOR_VERSION=${SPARTACUS_VERSION%%.*}" >> $GITHUB_OUTPUT
       - name: Tagging the branch of release/${{ steps.current-run-major-version.outputs.MAJOR_VERSION}}.x
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           github-server-url: "https://github.tools.sap"
           repository: "cx-commerce/spartacussampledata"
@@ -51,7 +51,7 @@ jobs:
     name: Publishing Spartacus Sample Data
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
       - name: create release with sample data assets

--- a/.github/workflows/prepend-license.yml
+++ b/.github/workflows/prepend-license.yml
@@ -17,7 +17,7 @@ jobs:
     name: Add license header to files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GH_PR_TOKEN }}

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -20,7 +20,7 @@ jobs:
     name: Force sync a branch to the private repository with current git history
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           ref: ${{ github.event.inputs.branch_to_sync || env.DEFAULT_BRANCH_TO_SYNC }}
           fetch-depth: 0

--- a/.github/workflows/update-ccv2.yml
+++ b/.github/workflows/update-ccv2.yml
@@ -21,7 +21,7 @@ jobs:
     name: Updating storefront of a ccv2 environment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           ref: ${{ github.event.inputs.source_branch_to_deploy || env.DEFAULT_BRANCH_TO_DEPLOY }}
           fetch-depth: 0

--- a/.github/workflows/update-cloud-repo.yml
+++ b/.github/workflows/update-cloud-repo.yml
@@ -40,7 +40,7 @@ jobs:
           REPO_NAME=$(echo $REPO_URL | sed -E 's|.*/(.*)\.git|\1|')
           echo "REPO_NAME=$REPO_NAME" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Create storefronts
         run: |
           function setup_config_dir() {

--- a/.github/workflows/validate-translations.yml
+++ b/.github/workflows/validate-translations.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This PR addresses 5 critical security findings from the security review:

1. CRITICAL: Fix build integrity check bypass via silent failures
   - Added strict error handling with 'set -euo pipefail'
   - Validate snapshot files exist and are non-empty before comparison
   - Properly capture stderr in diff command with '2>&1'
   - Replace '|| true' pattern that suppressed all errors
   - Use RUNNER_TEMP with timestamps instead of predictable /tmp paths
   - Add comprehensive security logging with file statistics
   - Save full diff for forensic analysis on violations

   Previous implementation allowed attackers to bypass integrity check by
   deleting snapshot files or causing silent failures. This is now impossible.

2. CRITICAL: Update actions/checkout to correct v6.0.2 SHA
   - Replace incorrect SHA 8e8c483 (v6.0.1) with de0fac2 (v6.0.2) (see: https://github.com/actions/checkout/releases/tag/v6.0.2)
   - Updated across all 19 workflow files (43 occurrences)
   - Ensures all security patches from v6.0.2 are included
   - Fixes misleading audit trail

3. CRITICAL: Close CODEOWNERS protection gap for local actions
   - Add /.github/api-extractor-action/ to CODEOWNERS
   - Add /.github/cache-builded-libs/ to CODEOWNERS
   - Both now require @SAP/spartacus-admins approval
   - Prevents unauthorized modifications to trusted local actions

4. CRITICAL: Add build integrity check to ci-merge-checks.yml
   - Add snapshot phase before build_libs job
   - Add verify phase after build_libs job
   - Closes security gap where merge-check builds were unmonitored
   - Ensures 100% coverage of all build workflows

5. CRITICAL: Fix overly broad permissions in ci-pull-request-status.yml
   - Change 'contents: write' to 'contents: read'
   - Workflow only needs 'pull-requests: write' for its function
   - Implements least-privilege security principle
   - Reduces attack surface for pull_request-triggered workflows