### PR TITLE
feat: Discover Angular only custom routes (CXSPA-12852)

### DIFF
--- a/core-libs/setup/sitemaps/README.md
+++ b/core-libs/setup/sitemaps/README.md
@@ -141,7 +141,7 @@ export class MyCustomEnumerator extends RouteParamsEnumerator {
 
 ## Angular-Only Route Enumerators
 
-Use `AngularRouteEnumerator` for custom Angular routes that exist **outside Spartacus routing config** — routes with no `cxRoute` key that can have dynamic segments (`:params`).
+Use `AngularRouteEnumerator` for parameterized Angular routes that exist outside Spartacus routing config (no `cxRoute` in route `data`). Static routes are discovered automatically — only routes with `:param` segments require an enumerator. Without one, the route and all its children are skipped.
 
 ```typescript
 import { Injectable } from '@angular/core';
@@ -181,7 +181,7 @@ providers: [
 ### Key constraints
 
 - `routePath` must be the **exact `path` string** from the Angular `Route` object (e.g. `'help/:topicId'`, not `'/help/:topicId'`).
-- `paths` in the result must be **fully resolved** — any path still containing `:` is filtered out.
+- `paths` must not contain unresolved `:param` segments — the service silently drops any path matching `:\w+` before it reaches the sitemap.
 - Parameterized routes **without** a matching enumerator are skipped entirely, including all their children.
 - Parameterized routes **with** children also require an enumerator — it provides the parent path segments and children are appended to each.
 

--- a/core-libs/setup/sitemaps/README.md
+++ b/core-libs/setup/sitemaps/README.md
@@ -139,6 +139,64 @@ export class MyCustomEnumerator extends RouteParamsEnumerator {
 
 ---
 
+## Angular-Only Route Enumerators
+
+Use `AngularRouteEnumerator` for custom Angular routes that exist **outside Spartacus routing config** — routes with no `cxRoute` key that can have dynamic segments (`:params`).
+
+```typescript
+import { Injectable } from '@angular/core';
+import {
+  AngularRouteEnumerator,
+  AngularRouteEnumeratorResult,
+  AngularRouteEnumeratorContext,
+} from '@spartacus/setup/sitemaps';
+
+@Injectable()
+export class HelpTopicEnumerator extends AngularRouteEnumerator {
+  // Must exactly match the Angular route's `path` string
+  readonly routePath = 'help/:topicId';
+
+  async enumerate(
+    _context: AngularRouteEnumeratorContext
+  ): Promise<AngularRouteEnumeratorResult> {
+    const topics = await fetchTopics();
+    return {
+      // Return fully-resolved paths — no :params remaining
+      paths: topics.map((t) => `help/${t.id}`),
+    };
+  }
+}
+```
+
+Register with `ANGULAR_ROUTE_ENUMERATOR` (typically in `app.config.server.ts`):
+
+```typescript
+import { ANGULAR_ROUTE_ENUMERATOR } from '@spartacus/setup/sitemaps';
+
+providers: [
+  { provide: ANGULAR_ROUTE_ENUMERATOR, useClass: HelpTopicEnumerator, multi: true },
+]
+```
+
+### Key constraints
+
+- `routePath` must be the **exact `path` string** from the Angular `Route` object (e.g. `'help/:topicId'`, not `'/help/:topicId'`).
+- `paths` in the result must be **fully resolved** — any path still containing `:` is filtered out.
+- Parameterized routes **without** a matching enumerator are skipped entirely, including all their children.
+- Parameterized routes **with** children also require an enumerator — it provides the parent path segments and children are appended to each.
+
+### Contrast with `RouteParamsEnumerator`
+
+| | `RouteParamsEnumerator` | `AngularRouteEnumerator` |
+|---|---|---|
+| Token | `ROUTE_PARAMS_ENUMERATOR` | `ANGULAR_ROUTE_ENUMERATOR` |
+| Targets | Spartacus semantic routes (have `cxRoute`) | Pure Angular routes (no `cxRoute`) |
+| Matched by | `cxRoute` name | `routePath` string |
+| Returns | `{ params: Record<string, unknown>[] }` | `{ paths: string[] }` (concrete paths) |
+| URL building | Via `SemanticPathService` | Paths returned directly |
+
+---
+
 ## Memory Management for Large Sites
 
 ### Per-BaseSite CLI Execution
@@ -326,6 +384,7 @@ sitemaps/
 ├── model/
 │   ├── sitemap.model.ts
 │   ├── route-params-enumerator.ts
+│   ├── angular-route-enumerator.ts
 │   └── streaming.model.ts
 ├── enumerators/
 │   ├── static-route-params-enumerator.ts

--- a/core-libs/setup/sitemaps/config/sitemap-config.ts
+++ b/core-libs/setup/sitemaps/config/sitemap-config.ts
@@ -119,6 +119,6 @@ export const defaultSitemapConfig: SitemapConfig = {
     catalogs: {
       excludes: [],
       versionId: '',
-    }
+    },
   },
 };

--- a/core-libs/setup/sitemaps/model/angular-route-enumerator.ts
+++ b/core-libs/setup/sitemaps/model/angular-route-enumerator.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { InjectionToken } from '@angular/core';
 import { RouteParamsEnumeratorContext } from './route-params-enumerator';
 

--- a/core-libs/setup/sitemaps/model/angular-route-enumerator.ts
+++ b/core-libs/setup/sitemaps/model/angular-route-enumerator.ts
@@ -5,11 +5,16 @@
  */
 
 import { InjectionToken } from '@angular/core';
-import { RouteParamsEnumeratorContext } from './route-params-enumerator';
 
 export interface AngularRouteEnumeratorResult {
   /** Concrete resolved paths (no :params remaining) */
   paths: string[];
+}
+
+export interface AngularRouteEnumeratorContext {
+  baseSiteId: string;
+  language: string;
+  currency: string;
 }
 
 export abstract class AngularRouteEnumerator {
@@ -17,7 +22,7 @@ export abstract class AngularRouteEnumerator {
   abstract readonly routePath: string;
 
   abstract enumerate(
-    context: RouteParamsEnumeratorContext
+    context: AngularRouteEnumeratorContext
   ): Promise<AngularRouteEnumeratorResult>;
 }
 

--- a/core-libs/setup/sitemaps/model/angular-route-enumerator.ts
+++ b/core-libs/setup/sitemaps/model/angular-route-enumerator.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+import { RouteParamsEnumeratorContext } from './route-params-enumerator';
+
+export interface AngularRouteEnumeratorResult {
+  /** Concrete resolved paths (no :params remaining) */
+  paths: string[];
+}
+
+export abstract class AngularRouteEnumerator {
+  /** The Angular route path pattern this handles, e.g. 'help/:topicId' */
+  abstract readonly routePath: string;
+
+  abstract enumerate(
+    context: RouteParamsEnumeratorContext
+  ): Promise<AngularRouteEnumeratorResult>;
+}
+
+export const ANGULAR_ROUTE_ENUMERATOR = new InjectionToken<
+  AngularRouteEnumerator[]
+>('ANGULAR_ROUTE_ENUMERATOR');

--- a/core-libs/setup/sitemaps/services/routes-discovery.service.spec.ts
+++ b/core-libs/setup/sitemaps/services/routes-discovery.service.spec.ts
@@ -5,10 +5,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import {
-  RoutingConfig,
-  RoutingConfigService,
-} from '@spartacus/core';
+import { RoutingConfig, RoutingConfigService } from '@spartacus/core';
 import { SitemapConfig } from '../config/sitemap-config';
 import {
   ROUTE_PARAMS_ENUMERATOR,
@@ -16,6 +13,7 @@ import {
   RouteParamsEnumeratorContext,
   RouteParamsEnumeratorResult,
 } from '../model/route-params-enumerator';
+import { RoutesDiscoveryOptions } from '../model/sitemap.model';
 import { RoutesDiscoveryService } from './routes-discovery.service';
 
 class MockProductEnumerator extends RouteParamsEnumerator {
@@ -27,7 +25,11 @@ class MockProductEnumerator extends RouteParamsEnumerator {
   ): Promise<RouteParamsEnumeratorResult> {
     return {
       params: [
-        { code: '301233', name: 'VIDEOTAPE 3 N 860 P', slug: 'videotape-3-n-860-p' },
+        {
+          code: '301233',
+          name: 'VIDEOTAPE 3 N 860 P',
+          slug: 'videotape-3-n-860-p',
+        },
         { code: '456', name: 'Camera', slug: 'camera' },
       ],
     };
@@ -50,6 +52,16 @@ describe('RoutesDiscoveryService', () => {
     language: 'en',
     currency: 'USD',
     occBaseUrl: 'http://localhost:9002',
+  };
+
+  const resolvedOptions: Required<
+    Omit<RoutesDiscoveryOptions, 'include' | 'exclude'>
+  > &
+    Pick<RoutesDiscoveryOptions, 'include' | 'exclude'> = {
+    includeAuthFlowRoutes: false,
+    includeProtectedRoutes: false,
+    include: undefined,
+    exclude: undefined,
   };
 
   function configureTestBed(routingConfig: RoutingConfig) {
@@ -96,17 +108,17 @@ describe('RoutesDiscoveryService', () => {
         routing: {
           routes: {
             product: {
-              paths: [
-                'product/:productCode/:name',
-                'product/:productCode',
-              ],
+              paths: ['product/:productCode/:name', 'product/:productCode'],
               paramsMapping: { productCode: 'code', name: 'slug' },
             },
           },
         },
       });
 
-      const routes = await service.discoverRoutes(context);
+      const routes = await service.discoverSemanticRoutes(
+        context,
+        resolvedOptions
+      );
 
       // With paramsMapping { name: 'slug' }, the enumerator returns { code, name, slug }.
       // adaptParamsForMapping should ensure SemanticPathService
@@ -121,17 +133,17 @@ describe('RoutesDiscoveryService', () => {
         routing: {
           routes: {
             product: {
-              paths: [
-                'product/:productCode/:name',
-                'product/:productCode',
-              ],
+              paths: ['product/:productCode/:name', 'product/:productCode'],
               paramsMapping: { productCode: 'code' },
             },
           },
         },
       });
 
-      const routes = await service.discoverRoutes(context);
+      const routes = await service.discoverSemanticRoutes(
+        context,
+        resolvedOptions
+      );
 
       // Without name->slug mapping, SemanticPathService uses params.name directly
       expect(routes.length).toBe(2);
@@ -144,10 +156,7 @@ describe('RoutesDiscoveryService', () => {
         routing: {
           routes: {
             product: {
-              paths: [
-                'product/:productCode/:name',
-                'product/:productCode',
-              ],
+              paths: ['product/:productCode/:name', 'product/:productCode'],
               paramsMapping: { productCode: 'code', name: 'nonExistentField' },
             },
           },
@@ -158,7 +167,10 @@ describe('RoutesDiscoveryService', () => {
       // paramsMapping: { name: 'nonExistentField' } - params doesn't have 'nonExistentField'.
       // adaptParamsForMapping copies params.name -> params.nonExistentField,
       // so SemanticPathService can fill :name using params.nonExistentField.
-      const routes = await service.discoverRoutes(context);
+      const routes = await service.discoverSemanticRoutes(
+        context,
+        resolvedOptions
+      );
 
       expect(routes.length).toBe(2);
       expect(routes[0].path).toBe('product/301233/VIDEOTAPE 3 N 860 P');
@@ -166,4 +178,3 @@ describe('RoutesDiscoveryService', () => {
     });
   });
 });
-

--- a/core-libs/setup/sitemaps/services/routes-discovery.service.spec.ts
+++ b/core-libs/setup/sitemaps/services/routes-discovery.service.spec.ts
@@ -5,8 +5,15 @@
  */
 
 import { TestBed } from '@angular/core/testing';
+import { Route, Router } from '@angular/router';
 import { RoutingConfig, RoutingConfigService } from '@spartacus/core';
 import { SitemapConfig } from '../config/sitemap-config';
+import {
+  ANGULAR_ROUTE_ENUMERATOR,
+  AngularRouteEnumerator,
+  AngularRouteEnumeratorContext,
+  AngularRouteEnumeratorResult,
+} from '../model/angular-route-enumerator';
 import {
   ROUTE_PARAMS_ENUMERATOR,
   RouteParamsEnumerator,
@@ -176,5 +183,317 @@ describe('RoutesDiscoveryService', () => {
       expect(routes[0].path).toBe('product/301233/VIDEOTAPE 3 N 860 P');
       expect(routes[1].path).toBe('product/456/Camera');
     });
+  });
+});
+
+const defaultSitemapConfigValue = {
+  sitemap: {
+    maxUrlsPerSitemap: 50000,
+    routes: {
+      includeAuthFlowRoutes: false,
+      includeProtectedRoutes: false,
+      excludes: [],
+    },
+  },
+};
+
+const sharedContext: RouteParamsEnumeratorContext = {
+  baseSiteId: 'electronics-spa',
+  language: 'en',
+  currency: 'USD',
+  occBaseUrl: 'http://localhost:9002',
+};
+
+describe('discoverAllRoutes', () => {
+  let service: RoutesDiscoveryService;
+
+  function setup(
+    routerConfig: Route[],
+    sitemapConfig: any = defaultSitemapConfigValue,
+    extraProviders: any[] = []
+  ) {
+    TestBed.configureTestingModule({
+      providers: [
+        RoutesDiscoveryService,
+        RoutingConfigService,
+        { provide: Router, useValue: { config: routerConfig } },
+        { provide: RoutingConfig, useValue: { routing: { routes: {} } } },
+        { provide: SitemapConfig, useValue: sitemapConfig },
+        ...extraProviders,
+      ],
+    });
+    service = TestBed.inject(RoutesDiscoveryService);
+  }
+
+  it('should exclude routes with data.cxRoute even when not semantically discovered (e.g. login excluded by authFlow)', async () => {
+    // login is excluded from semantic discovery by includeAuthFlowRoutes:false,
+    setup([
+      { path: 'login', data: { cxRoute: 'login' } },
+      { path: 'logout', data: { cxRoute: 'logout' } },
+      { path: 'faq' },
+    ]);
+
+    const routes = await service.discoverAllRoutes(sharedContext);
+
+    expect(routes.find((r) => r.path === 'login')).toBeUndefined();
+    expect(routes.find((r) => r.path === 'logout')).toBeUndefined();
+    expect(routes.find((r) => r.path === 'faq')).toBeDefined();
+  });
+
+  it('should exclude ** wildcard routes', async () => {
+    setup([{ path: '**' }, { path: 'faq' }]);
+
+    const routes = await service.discoverAllRoutes(sharedContext);
+
+    expect(routes.map((r) => r.path)).toEqual(['faq']);
+  });
+
+  it('should exclude matcher-only routes with no path', async () => {
+    setup([{ matcher: () => null } as Route, { path: 'faq' }]);
+
+    const routes = await service.discoverAllRoutes(sharedContext);
+
+    expect(routes.map((r) => r.path)).toEqual(['faq']);
+  });
+
+  it('should respect the include option', async () => {
+    setup([{ path: 'faq' }, { path: 'about' }, { path: 'terms' }]);
+
+    const routes = await service.discoverAllRoutes(sharedContext, {
+      include: ['faq', 'about'],
+    });
+
+    expect(routes.map((r) => r.path)).toEqual(['faq', 'about']);
+  });
+
+  it('should respect the exclude option', async () => {
+    setup([{ path: 'faq' }, { path: 'about' }]);
+
+    const routes = await service.discoverAllRoutes(sharedContext, {
+      exclude: ['about'],
+    });
+
+    expect(routes.map((r) => r.path)).toEqual(['faq']);
+  });
+
+  it('should respect config excludes from SitemapConfig', async () => {
+    setup([{ path: 'faq' }, { path: 'about' }], {
+      sitemap: {
+        ...defaultSitemapConfigValue.sitemap,
+        routes: {
+          ...defaultSitemapConfigValue.sitemap.routes,
+          excludes: ['about'],
+        },
+      },
+    });
+
+    const routes = await service.discoverAllRoutes(sharedContext);
+
+    expect(routes.map((r) => r.path)).toEqual(['faq']);
+  });
+
+  it('should combine semantic and angular-only routes', async () => {
+    setup([{ path: 'faq' }]);
+
+    jest
+      .spyOn(service, 'discoverSemanticRoutes')
+      .mockResolvedValue([{ cxRoute: 'home', params: {}, path: '' }]);
+
+    const routes = await service.discoverAllRoutes(sharedContext);
+
+    expect(routes.find((r) => r.cxRoute === 'home')).toBeDefined();
+    expect(routes.find((r) => r.path === 'faq')).toBeDefined();
+  });
+});
+
+describe('discoverAngularRoutes', () => {
+  let service: RoutesDiscoveryService;
+
+  function setup(angularEnumerators: any[] = []) {
+    TestBed.configureTestingModule({
+      providers: [
+        RoutesDiscoveryService,
+        RoutingConfigService,
+        { provide: Router, useValue: { config: [] } },
+        { provide: RoutingConfig, useValue: { routing: { routes: {} } } },
+        { provide: SitemapConfig, useValue: defaultSitemapConfigValue },
+        ...angularEnumerators,
+      ],
+    });
+    service = TestBed.inject(RoutesDiscoveryService);
+  }
+
+  function discover(route: Route) {
+    return (service as any).discoverAngularRoutes(route, sharedContext);
+  }
+
+  it('should return [] for a route with no path', async () => {
+    setup();
+    expect(await discover({})).toEqual([]);
+  });
+
+  it('should return a single entry for a static leaf route', async () => {
+    setup();
+    expect(await discover({ path: 'faq' })).toEqual([
+      { cxRoute: 'faq', params: {}, path: 'faq' },
+    ]);
+  });
+
+  it('should return [] for a parameterized route with no matching enumerator', async () => {
+    setup();
+    expect(await discover({ path: 'help/:topicId' })).toEqual([]);
+  });
+
+  it('should return enumerated paths for a parameterized route with a matching enumerator', async () => {
+    class HelpEnumerator extends AngularRouteEnumerator {
+      readonly routePath = 'help/:topicId';
+      async enumerate(
+        _context: AngularRouteEnumeratorContext
+      ): Promise<AngularRouteEnumeratorResult> {
+        return { paths: ['help/angular', 'help/typescript'] };
+      }
+    }
+    setup([
+      {
+        provide: ANGULAR_ROUTE_ENUMERATOR,
+        useClass: HelpEnumerator,
+        multi: true,
+      },
+    ]);
+
+    const result = await discover({ path: 'help/:topicId' });
+
+    expect(result).toEqual([
+      { cxRoute: 'help/:topicId', params: {}, path: 'help/angular' },
+      { cxRoute: 'help/:topicId', params: {}, path: 'help/typescript' },
+    ]);
+  });
+
+  it('should filter out enumerated paths that still contain unenumerated :params', async () => {
+    class BuggyEnumerator extends AngularRouteEnumerator {
+      readonly routePath = 'help/:topicId';
+      async enumerate(
+        _context: AngularRouteEnumeratorContext
+      ): Promise<AngularRouteEnumeratorResult> {
+        return { paths: ['help/angular', 'help/:topicId'] };
+      }
+    }
+    setup([
+      {
+        provide: ANGULAR_ROUTE_ENUMERATOR,
+        useClass: BuggyEnumerator,
+        multi: true,
+      },
+    ]);
+
+    const result = await discover({ path: 'help/:topicId' });
+
+    expect(result).toEqual([
+      { cxRoute: 'help/:topicId', params: {}, path: 'help/angular' },
+    ]);
+  });
+
+  it('should prepend a static parent path to all discovered children', async () => {
+    setup();
+    const route: Route = {
+      path: 'account',
+      children: [{ path: 'orders' }, { path: 'profile' }],
+    };
+
+    const result = await discover(route);
+
+    expect(result).toEqual([
+      { cxRoute: 'orders', params: {}, path: 'account/orders' },
+      { cxRoute: 'profile', params: {}, path: 'account/profile' },
+    ]);
+  });
+
+  it('should combine enumerated parent paths with children for a parameterized parent', async () => {
+    class AccountEnumerator extends AngularRouteEnumerator {
+      readonly routePath = 'account/:userId';
+      async enumerate(
+        _context: AngularRouteEnumeratorContext
+      ): Promise<AngularRouteEnumeratorResult> {
+        return { paths: ['account/u1', 'account/u2'] };
+      }
+    }
+    setup([
+      {
+        provide: ANGULAR_ROUTE_ENUMERATOR,
+        useClass: AccountEnumerator,
+        multi: true,
+      },
+    ]);
+    const route: Route = {
+      path: 'account/:userId',
+      children: [{ path: 'orders' }, { path: 'profile' }],
+    };
+
+    const result = await discover(route);
+
+    expect(result).toEqual([
+      { cxRoute: 'orders', params: {}, path: 'account/u1/orders' },
+      { cxRoute: 'profile', params: {}, path: 'account/u1/profile' },
+      { cxRoute: 'orders', params: {}, path: 'account/u2/orders' },
+      { cxRoute: 'profile', params: {}, path: 'account/u2/profile' },
+    ]);
+  });
+
+  it('should return [] for a parameterized parent with children but no enumerator', async () => {
+    setup();
+    const route: Route = {
+      path: 'account/:userId',
+      children: [{ path: 'orders' }],
+    };
+
+    expect(await discover(route)).toEqual([]);
+  });
+
+  it('should filter out enumerated parent paths that still contain unenumerated :params', async () => {
+    class BuggyParentEnumerator extends AngularRouteEnumerator {
+      readonly routePath = 'account/:userId';
+      async enumerate(
+        _context: AngularRouteEnumeratorContext
+      ): Promise<AngularRouteEnumeratorResult> {
+        return { paths: ['account/u1', 'account/:userId'] };
+      }
+    }
+    setup([
+      {
+        provide: ANGULAR_ROUTE_ENUMERATOR,
+        useClass: BuggyParentEnumerator,
+        multi: true,
+      },
+    ]);
+    const route: Route = {
+      path: 'account/:userId',
+      children: [{ path: 'orders' }],
+    };
+
+    const result = await discover(route);
+
+    expect(result).toEqual([
+      { cxRoute: 'orders', params: {}, path: 'account/u1/orders' },
+    ]);
+  });
+
+  it('should handle nested static children recursively', async () => {
+    setup();
+    const route: Route = {
+      path: 'help',
+      children: [
+        {
+          path: 'guides',
+          children: [{ path: 'overview' }, { path: 'advanced' }],
+        },
+      ],
+    };
+
+    const result = await discover(route);
+
+    expect(result).toEqual([
+      { cxRoute: 'overview', params: {}, path: 'help/guides/overview' },
+      { cxRoute: 'advanced', params: {}, path: 'help/guides/advanced' },
+    ]);
   });
 });

--- a/core-libs/setup/sitemaps/services/routes-discovery.service.ts
+++ b/core-libs/setup/sitemaps/services/routes-discovery.service.ts
@@ -55,6 +55,9 @@ export class RoutesDiscoveryService {
 
   protected readonly PATH_PARAM_PATTERN = /:\w+/;
 
+    /**
+   * Discovers all valid semantic and Angular-only URLs with deduplication.
+   */
   async discoverAllRoutes(
     context: RouteParamsEnumeratorContext,
     options: RoutesDiscoveryOptions = {}
@@ -65,13 +68,12 @@ export class RoutesDiscoveryService {
       context,
       resolvedOptions
     );
-    const knownCxRoutes = new Set(semanticRoutes.map((r) => r.cxRoute));
     const angularOnlyRoutes = (
       await Promise.all(
         this.router.config
           .filter(
             (route: Route) =>
-              !(route.data?.cxRoute && knownCxRoutes.has(route.data.cxRoute)) &&
+              !route.data?.['cxRoute'] &&
               route.path !== '**' &&
               !(route.matcher && !route.path) &&
               (!resolvedOptions.include ||
@@ -91,10 +93,7 @@ export class RoutesDiscoveryService {
    */
   async discoverSemanticRoutes(
     context: RouteParamsEnumeratorContext,
-    resolvedOptions: Required<
-      Omit<RoutesDiscoveryOptions, 'include' | 'exclude'>
-    > &
-      Pick<RoutesDiscoveryOptions, 'include' | 'exclude'>
+    resolvedOptions: ReturnType<typeof this.resolveOptions>
   ): Promise<DiscoveredRoute[]> {
     const routes = this.routingConfig.routing?.routes || {};
     const globalProtected = this.routingConfig.routing?.protected ?? false;
@@ -141,7 +140,7 @@ export class RoutesDiscoveryService {
     }
 
     console.log(
-      `[Sitemap] RoutesDiscoveryService: Discovered ${discovered.length} URLs`
+      `[Sitemap] RoutesDiscoveryService: Discovered ${discovered.length} semantic URLs`
     );
 
     return discovered;
@@ -303,12 +302,14 @@ export class RoutesDiscoveryService {
           return [];
         }
         const { paths: parentPaths } = await enumerator.enumerate(context);
-        return parentPaths.flatMap((parentPath) =>
-          childResults.map((discovered) => ({
-            ...discovered,
-            path: `${parentPath}/${discovered.path}`,
-          }))
-        );
+        return parentPaths
+          .filter((parentPath) => !this.PATH_PARAM_PATTERN.test(parentPath))
+          .flatMap((parentPath) =>
+            childResults.map((discovered) => ({
+              ...discovered,
+              path: `${parentPath}/${discovered.path}`,
+            }))
+          );
       }
 
       return childResults.map((discovered) => ({
@@ -326,11 +327,13 @@ export class RoutesDiscoveryService {
         return []; // no enumerator, skip
       }
       const result = await enumerator.enumerate(context);
-      return result.paths.map((path) => ({
-        cxRoute: route.path!,
-        params: {},
-        path,
-      }));
+      return result.paths
+        .filter((path) => !this.PATH_PARAM_PATTERN.test(path))
+        .map((path) => ({
+          cxRoute: route.path!,
+          params: {},
+          path,
+        }));
     }
 
     return [{ cxRoute: route.path, params: {}, path: route.path }];

--- a/core-libs/setup/sitemaps/services/routes-discovery.service.ts
+++ b/core-libs/setup/sitemaps/services/routes-discovery.service.ts
@@ -55,7 +55,7 @@ export class RoutesDiscoveryService {
 
   protected readonly PATH_PARAM_PATTERN = /:\w+/;
 
-    /**
+  /**
    * Discovers all valid semantic and Angular-only URLs with deduplication.
    */
   async discoverAllRoutes(

--- a/core-libs/setup/sitemaps/services/routes-discovery.service.ts
+++ b/core-libs/setup/sitemaps/services/routes-discovery.service.ts
@@ -14,6 +14,10 @@ import {
 } from '@spartacus/core';
 import { defaultSitemapConfig, SitemapConfig } from '../config/sitemap-config';
 import {
+  ANGULAR_ROUTE_ENUMERATOR,
+  AngularRouteEnumerator,
+} from '../model/angular-route-enumerator';
+import {
   ROUTE_PARAMS_ENUMERATOR,
   RouteParamsEnumerator,
   RouteParamsEnumeratorContext,
@@ -46,7 +50,28 @@ export class RoutesDiscoveryService {
   protected enumerators: RouteParamsEnumerator[] =
     inject(ROUTE_PARAMS_ENUMERATOR, { optional: true }) ?? [];
 
+  protected angularRouteEnumerators: AngularRouteEnumerator[] =
+    inject(ANGULAR_ROUTE_ENUMERATOR, { optional: true }) ?? [];
+
   protected readonly PATH_PARAM_PATTERN = /:\w+/;
+
+  async discoverAllRoutes(
+    context: RouteParamsEnumeratorContext,
+    options: RoutesDiscoveryOptions = {}
+  ): Promise<DiscoveredRoute[]> {
+    const semanticRoutes = await this.discoverRoutes(context, options);
+    const knownCxRoutes = new Set(semanticRoutes.map((r) => r.cxRoute));
+    const angularOnlyRoutes = this.router.config
+      .filter(
+        (route: Route) =>
+          !(route.data?.cxRoute && knownCxRoutes.has(route.data.cxRoute)) &&
+          route.path !== '**' &&
+          !(route.matcher && !route.path)
+      )
+      .flatMap((route: Route) => this.extractAngularRoutes(route));
+
+    return [...semanticRoutes, ...angularOnlyRoutes];
+  }
 
   /**
    * Discovers all valid URLs for the given context and options.
@@ -56,20 +81,6 @@ export class RoutesDiscoveryService {
     options: RoutesDiscoveryOptions = {}
   ): Promise<DiscoveredRoute[]> {
     const routes = this.routingConfig.routing?.routes || {};
-    const ngRoutes = this.getAngularOnlyRoutes();
-
-    console.log('----------SEMANTIC ROUTE DISCOVERY------------');
-    for (const [routeName, routeConfig] of Object.entries(routes)) {
-      console.log('Route name: ' + routeName);
-      console.log('Route config:' + routeConfig);
-    }
-
-    console.log('----------ANGULAR ONLY------------');
-    for (const [routeName, routeConfig] of Object.entries(ngRoutes)) {
-      console.log('Route name: ' + routeName);
-      console.log('Route config:' + routeConfig);
-    }
-
     const globalProtected = this.routingConfig.routing?.protected ?? false;
     const discovered: DiscoveredRoute[] = [];
 
@@ -253,12 +264,32 @@ export class RoutesDiscoveryService {
     return adapted;
   }
 
-  protected getAngularOnlyRoutes(): Route[] {
-    return this.router.config.filter(
-      (route) =>
-        route.path && // has a path
-        !route.path.includes(':') && // no dynamic params
-        route.path !== '**' // not wildcard
-    );
+  protected extractAngularRoutes(route: Route): DiscoveredRoute[] {
+    if (!route.path) {
+      return [];
+    }
+
+    // If the route has children, recurse and prepend the parent path
+    if (route.children?.length) {
+      return route.children.flatMap((child) =>
+        this.extractAngularRoutes(child).map((discovered) => ({
+          ...discovered,
+          path: `${route.path}/${discovered.path}`,
+        }))
+      );
+    }
+
+    // Leaf route — skip if it contains unresolvable parameters like :id
+    if (route.path.includes(':')) {
+      return [];
+    }
+
+    return [
+      {
+        cxRoute: route.data?.cxRoute ?? route.path,
+        params: {},
+        path: route.path,
+      },
+    ];
   }
 }

--- a/core-libs/setup/sitemaps/services/routes-discovery.service.ts
+++ b/core-libs/setup/sitemaps/services/routes-discovery.service.ts
@@ -59,32 +59,46 @@ export class RoutesDiscoveryService {
     context: RouteParamsEnumeratorContext,
     options: RoutesDiscoveryOptions = {}
   ): Promise<DiscoveredRoute[]> {
-    const semanticRoutes = await this.discoverRoutes(context, options);
+    const resolvedOptions = this.resolveOptions(options);
+    const configExcludes = this.sitemapConfig.sitemap?.routes?.excludes ?? [];
+    const semanticRoutes = await this.discoverSemanticRoutes(
+      context,
+      resolvedOptions
+    );
     const knownCxRoutes = new Set(semanticRoutes.map((r) => r.cxRoute));
-    const angularOnlyRoutes = this.router.config
-      .filter(
-        (route: Route) =>
-          !(route.data?.cxRoute && knownCxRoutes.has(route.data.cxRoute)) &&
-          route.path !== '**' &&
-          !(route.matcher && !route.path)
+    const angularOnlyRoutes = (
+      await Promise.all(
+        this.router.config
+          .filter(
+            (route: Route) =>
+              !(route.data?.cxRoute && knownCxRoutes.has(route.data.cxRoute)) &&
+              route.path !== '**' &&
+              !(route.matcher && !route.path) &&
+              (!resolvedOptions.include ||
+                resolvedOptions.include.includes(route.path!)) &&
+              !resolvedOptions.exclude?.includes(route.path!) &&
+              !configExcludes.includes(route.path!)
+          )
+          .map((route: Route) => this.discoverAngularRoutes(route, context))
       )
-      .flatMap((route: Route) => this.extractAngularRoutes(route));
+    ).flat();
 
     return [...semanticRoutes, ...angularOnlyRoutes];
   }
 
   /**
-   * Discovers all valid URLs for the given context and options.
+   * Discovers all valid semantic URLs for the given context and options.
    */
-  async discoverRoutes(
+  async discoverSemanticRoutes(
     context: RouteParamsEnumeratorContext,
-    options: RoutesDiscoveryOptions = {}
+    resolvedOptions: Required<
+      Omit<RoutesDiscoveryOptions, 'include' | 'exclude'>
+    > &
+      Pick<RoutesDiscoveryOptions, 'include' | 'exclude'>
   ): Promise<DiscoveredRoute[]> {
     const routes = this.routingConfig.routing?.routes || {};
     const globalProtected = this.routingConfig.routing?.protected ?? false;
     const discovered: DiscoveredRoute[] = [];
-
-    const resolvedOptions = this.resolveOptions(options);
 
     for (const [routeName, routeConfig] of Object.entries(routes)) {
       if (
@@ -264,32 +278,61 @@ export class RoutesDiscoveryService {
     return adapted;
   }
 
-  protected extractAngularRoutes(route: Route): DiscoveredRoute[] {
+  protected async discoverAngularRoutes(
+    route: Route,
+    context: RouteParamsEnumeratorContext
+  ): Promise<DiscoveredRoute[]> {
     if (!route.path) {
       return [];
     }
 
-    // If the route has children, recurse and prepend the parent path
     if (route.children?.length) {
-      return route.children.flatMap((child) =>
-        this.extractAngularRoutes(child).map((discovered) => ({
-          ...discovered,
-          path: `${route.path}/${discovered.path}`,
-        }))
-      );
+      const childResults = (
+        await Promise.all(
+          route.children.map((child) =>
+            this.discoverAngularRoutes(child, context)
+          )
+        )
+      ).flat();
+
+      if (route.path.includes(':')) {
+        const enumerator = this.angularRouteEnumerators.find(
+          (e) => e.routePath === route.path
+        );
+        if (!enumerator) {
+          return [];
+        }
+        const { paths: parentPaths } = await enumerator.enumerate(context);
+        return parentPaths.flatMap((parentPath) =>
+          childResults.map((discovered) => ({
+            ...discovered,
+            path: `${parentPath}/${discovered.path}`,
+          }))
+        );
+      }
+
+      return childResults.map((discovered) => ({
+        ...discovered,
+        path: `${route.path}/${discovered.path}`,
+      }));
     }
 
-    // Leaf route — skip if it contains unresolvable parameters like :id
+    // Has :params — look for a matching enumerator
     if (route.path.includes(':')) {
-      return [];
+      const enumerator = this.angularRouteEnumerators.find(
+        (e) => e.routePath === route.path
+      );
+      if (!enumerator) {
+        return []; // no enumerator, skip
+      }
+      const result = await enumerator.enumerate(context);
+      return result.paths.map((path) => ({
+        cxRoute: route.path!,
+        params: {},
+        path,
+      }));
     }
 
-    return [
-      {
-        cxRoute: route.data?.cxRoute ?? route.path,
-        params: {},
-        path: route.path,
-      },
-    ];
+    return [{ cxRoute: route.path, params: {}, path: route.path }];
   }
 }

--- a/core-libs/setup/sitemaps/services/routes-discovery.service.ts
+++ b/core-libs/setup/sitemaps/services/routes-discovery.service.ts
@@ -5,19 +5,23 @@
  */
 
 import { inject, Injectable } from '@angular/core';
+import { Route, Router } from '@angular/router';
 import {
   ParamsMapping,
   RoutingConfig,
   RoutingConfigService,
   SemanticPathService,
 } from '@spartacus/core';
+import { defaultSitemapConfig, SitemapConfig } from '../config/sitemap-config';
 import {
   ROUTE_PARAMS_ENUMERATOR,
   RouteParamsEnumerator,
   RouteParamsEnumeratorContext,
 } from '../model/route-params-enumerator';
-import { defaultSitemapConfig, SitemapConfig } from '../config/sitemap-config';
-import { DiscoveredRoute, RoutesDiscoveryOptions } from '../model/sitemap.model';
+import {
+  DiscoveredRoute,
+  RoutesDiscoveryOptions,
+} from '../model/sitemap.model';
 
 /**
  * Service for discovering all valid URLs from Spartacus routing configuration.
@@ -33,6 +37,7 @@ import { DiscoveredRoute, RoutesDiscoveryOptions } from '../model/sitemap.model'
  */
 @Injectable()
 export class RoutesDiscoveryService {
+  protected router = inject(Router);
   protected routingConfig = inject(RoutingConfig);
   protected routingConfigService = inject(RoutingConfigService);
   protected semanticPathService = inject(SemanticPathService);
@@ -51,6 +56,20 @@ export class RoutesDiscoveryService {
     options: RoutesDiscoveryOptions = {}
   ): Promise<DiscoveredRoute[]> {
     const routes = this.routingConfig.routing?.routes || {};
+    const ngRoutes = this.getAngularOnlyRoutes();
+
+    console.log('----------SEMANTIC ROUTE DISCOVERY------------');
+    for (const [routeName, routeConfig] of Object.entries(routes)) {
+      console.log('Route name: ' + routeName);
+      console.log('Route config:' + routeConfig);
+    }
+
+    console.log('----------ANGULAR ONLY------------');
+    for (const [routeName, routeConfig] of Object.entries(ngRoutes)) {
+      console.log('Route name: ' + routeName);
+      console.log('Route config:' + routeConfig);
+    }
+
     const globalProtected = this.routingConfig.routing?.protected ?? false;
     const discovered: DiscoveredRoute[] = [];
 
@@ -105,9 +124,7 @@ export class RoutesDiscoveryService {
 
   protected resolveOptions(
     options: RoutesDiscoveryOptions
-  ): Required<
-    Omit<RoutesDiscoveryOptions, 'include' | 'exclude'>
-  > &
+  ): Required<Omit<RoutesDiscoveryOptions, 'include' | 'exclude'>> &
     Pick<RoutesDiscoveryOptions, 'include' | 'exclude'> {
     const routesCfg = this.sitemapConfig.sitemap?.routes;
     const defaultCfg = defaultSitemapConfig.sitemap!.routes!;
@@ -236,5 +253,12 @@ export class RoutesDiscoveryService {
     return adapted;
   }
 
+  protected getAngularOnlyRoutes(): Route[] {
+    return this.router.config.filter(
+      (route) =>
+        route.path && // has a path
+        !route.path.includes(':') && // no dynamic params
+        route.path !== '**' // not wildcard
+    );
+  }
 }
-

--- a/core-libs/setup/sitemaps/services/site-context-aware-routes-discovery.service.ts
+++ b/core-libs/setup/sitemaps/services/site-context-aware-routes-discovery.service.ts
@@ -67,30 +67,25 @@ export class SiteContextAwareRoutesDiscoveryService {
         occBaseUrl: context.occBaseUrl,
       };
 
-      const discoveredRoutes =
-        await this.routesDiscoveryService.discoverRoutes(
-          enumeratorContext,
-          options
-        );
+      const allRoutes = await this.routesDiscoveryService.discoverAllRoutes(
+        enumeratorContext,
+        options
+      );
 
       console.log(
-        `[Sitemap] SiteContextAwareDiscovery: Discovered ${discoveredRoutes.length} routes for language '${language}'`
+        `[Sitemap] SiteContextAwareDiscovery: Discovered ${allRoutes.length} routes for language '${language}'`
       );
 
       // Duplicate discovered paths for each currency (only prefix differs)
       for (const currency of currenciesToIterate) {
-        const key = hasCurrencyInUrl
-          ? `${language}-${currency}`
-          : language;
+        const key = hasCurrencyInUrl ? `${language}-${currency}` : language;
 
         const urlPrefix = this.buildUrlPrefix(context, language, currency);
 
-        const urls: SiteContextAwareUrl[] = discoveredRoutes.map((route) => ({
+        const urls: SiteContextAwareUrl[] = allRoutes.map((route) => ({
           cxRoute: route.cxRoute,
           params: route.params,
-          fullPath: route.path
-            ? `${urlPrefix}/${route.path}`
-            : `${urlPrefix}/`,
+          fullPath: route.path ? `${urlPrefix}/${route.path}` : `${urlPrefix}/`,
           language,
           currency,
         }));
@@ -100,9 +95,7 @@ export class SiteContextAwareRoutesDiscoveryService {
       }
     }
 
-    console.log(
-      `[Sitemap] SiteContextAwareDiscovery: Total ${totalUrls} URLs`
-    );
+    console.log(`[Sitemap] SiteContextAwareDiscovery: Total ${totalUrls} URLs`);
 
     return { urlsByLanguageCurrency, totalUrls };
   }
@@ -130,4 +123,3 @@ export class SiteContextAwareRoutesDiscoveryService {
     return prefix ? `/${prefix}` : '';
   }
 }
-


### PR DESCRIPTION
With this feature branch, sitemap generation contains these three additional URLs
<img width="746" height="411" alt="image" src="https://github.com/user-attachments/assets/70c8e913-d482-49f1-b181-64d0f5374de3" />

With no duplicates, and `login` and `logout` are found as Angular routes, but excluded as they contain data.cxRoute