### PR TITLE
fix: Add handler to prevent Punchout overwriting AuthHttpHeader

### DIFF
--- a/feature-libs/asm/root/asm-root.module.ts
+++ b/feature-libs/asm/root/asm-root.module.ts
@@ -10,6 +10,7 @@ import {
   AuthHttpHeaderService,
   AuthService,
   AuthStorageService,
+  DELEGATED_AUTH_HTTP_HEADER_SERVICE,
   ProtectedRoutesService,
   provideDefaultConfig,
 } from '@spartacus/core';
@@ -35,6 +36,13 @@ import { AsmProtectedRoutesService } from './services/asm-protected-routes.servi
     },
     {
       provide: AuthHttpHeaderService,
+      useExisting: AsmAuthHttpHeaderService,
+    },
+    // The providers below preserve backward compatibility for the CXSPA-12514 fix
+    // and should be removed once the enableExpiredRefreshTokenHandlers feature
+    // toggle is fully rolled out.
+    {
+      provide: DELEGATED_AUTH_HTTP_HEADER_SERVICE,
       useExisting: AsmAuthHttpHeaderService,
     },
     {

--- a/integration-libs/punchout/root/punchout.root.module.ts
+++ b/integration-libs/punchout/root/punchout.root.module.ts
@@ -11,17 +11,25 @@ import {
   NgModule,
   provideAppInitializer,
 } from '@angular/core';
-import { AuthHttpHeaderService, provideDefaultConfig } from '@spartacus/core';
+import {
+  AuthHttpHeaderService,
+  DEFAULT_AUTH_HTTP_HEADER_SERVICE,
+  DELEGATED_AUTH_HTTP_HEADER_SERVICE,
+  EXPIRED_REFRESH_TOKEN_HANDLERS,
+  FeatureConfigService,
+  provideDefaultConfig,
+} from '@spartacus/core';
 import {
   defaultPunchoutCmsComponentsConfig,
-  defaultPunchoutRoutingConfig,
   defaultPunchoutNavigationGuardConfig,
+  defaultPunchoutRoutingConfig,
 } from './config';
 import { PunchoutNavigationModule } from './guards/punchout-navigation.module';
 import { interceptors } from './interceptors';
 import {
-  PunchoutStatePersistenceService,
   PunchoutAuthHttpHeaderService,
+  PunchoutExpiredRefreshTokenHandler,
+  PunchoutStatePersistenceService,
   PunchoutUiRestrictionService,
 } from './services';
 
@@ -38,9 +46,28 @@ import {
       punchoutPersistenceService.initSync();
     }),
     ...interceptors,
+    // below provider should be removed after enableExpiredRefreshTokenHandlers is fully rolled out
     {
       provide: AuthHttpHeaderService,
-      useExisting: PunchoutAuthHttpHeaderService,
+      useFactory: () => {
+        const featureConfig = inject(FeatureConfigService);
+        const delegatedAuthHttpHeaderService = inject(
+          DELEGATED_AUTH_HTTP_HEADER_SERVICE,
+          {
+            optional: true,
+          }
+        );
+        // delegatedService is expected to be used by ASM to address breaking changes of CXSPA-12514
+        return featureConfig.isEnabled('enableExpiredRefreshTokenHandlers')
+          ? (delegatedAuthHttpHeaderService ??
+              inject(DEFAULT_AUTH_HTTP_HEADER_SERVICE))
+          : inject(PunchoutAuthHttpHeaderService);
+      },
+    },
+    {
+      provide: EXPIRED_REFRESH_TOKEN_HANDLERS,
+      useExisting: PunchoutExpiredRefreshTokenHandler,
+      multi: true,
     },
     PunchoutUiRestrictionService,
     {

--- a/integration-libs/punchout/root/services/index.ts
+++ b/integration-libs/punchout/root/services/index.ts
@@ -6,6 +6,7 @@
 
 export * from './punchout-auth-http-header.service';
 export * from './punchout-detection.service';
+export * from './punchout-expired-refresh-token-handler.service';
 export * from './punchout-state-persistence.service';
 export * from './punchout-store.service';
 export * from './punchout-ui-restriction.service';

--- a/integration-libs/punchout/root/services/punchout-expired-refresh-token-handler.service.spec.ts
+++ b/integration-libs/punchout/root/services/punchout-expired-refresh-token-handler.service.spec.ts
@@ -1,0 +1,120 @@
+import { TestBed } from '@angular/core/testing';
+import { AuthService } from '@spartacus/core';
+import { of } from 'rxjs';
+import { PunchoutFacade } from '../facade';
+import { PunchOutLevel, PunchOutOperation, PunchoutSession } from '../model';
+import { PunchoutExpiredRefreshTokenHandler } from './punchout-expired-refresh-token-handler.service';
+import { PunchoutDetectionService } from './punchout-detection.service';
+
+const mockSessionId = '123abc';
+const mockPunchoutSession: PunchoutSession = {
+  customerId: 'test@test.com',
+  cartId: 'mockCart',
+  punchOutLevel: PunchOutLevel.PRODUCT,
+  punchOutOperation: PunchOutOperation.EDIT,
+  selectedItem: 'mockItemId',
+  token: {
+    accessToken: 'mockToken',
+    tokenType: 'Bearer',
+  },
+};
+
+class MockPunchoutDetectionService
+  implements Partial<PunchoutDetectionService>
+{
+  isPunchoutSessionPage(): boolean {
+    return true;
+  }
+  getPunchoutSessionId(): string | undefined {
+    return mockSessionId;
+  }
+  isPunchoutSession(): boolean | undefined {
+    return false;
+  }
+}
+
+class MockAuthService implements Partial<AuthService> {
+  coreLogout(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MockPunchoutFacade implements Partial<PunchoutFacade> {
+  getPunchoutSession = () => of(mockPunchoutSession);
+  logoutPunchoutUser = () => of(true);
+  endPunchoutSession = () => of();
+}
+
+describe('PunchoutExpiredRefreshTokenHandler', () => {
+  let service: PunchoutExpiredRefreshTokenHandler;
+  let punchoutDetectionService: PunchoutDetectionService;
+  let punchoutfacade: PunchoutFacade;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: PunchoutFacade, useClass: MockPunchoutFacade },
+        {
+          provide: PunchoutDetectionService,
+          useClass: MockPunchoutDetectionService,
+        },
+        { provide: AuthService, useClass: MockAuthService },
+      ],
+    });
+    service = TestBed.inject(PunchoutExpiredRefreshTokenHandler);
+    punchoutDetectionService = TestBed.inject(PunchoutDetectionService);
+    punchoutfacade = TestBed.inject(PunchoutFacade);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return false when not in punchout page nor punchout session', (done) => {
+    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
+    spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
+      false
+    );
+    spyOn(punchoutDetectionService, 'isPunchoutSession').and.returnValue(false);
+    spyOn(punchoutfacade, 'endPunchoutSession').and.callThrough();
+
+    service.handleExpiredRefreshTokenIfApplicable().subscribe((handled) => {
+      expect(handled).toBe(false);
+      expect(punchoutfacade.logoutPunchoutUser).not.toHaveBeenCalled();
+      expect(punchoutfacade.endPunchoutSession).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should logout punchout user when on punchout session page', (done) => {
+    spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
+      true
+    );
+    spyOn(punchoutDetectionService, 'isPunchoutSession').and.returnValue(true);
+    spyOn(punchoutfacade, 'endPunchoutSession').and.callThrough();
+    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
+
+    service.handleExpiredRefreshTokenIfApplicable().subscribe((handled) => {
+      expect(handled).toBe(true);
+      expect(punchoutfacade.logoutPunchoutUser).toHaveBeenCalledWith();
+      expect(punchoutfacade.endPunchoutSession).not.toHaveBeenCalledWith();
+      done();
+    });
+  });
+
+  it('should end punchout session when punchout session already exists', (done) => {
+    spyOn(punchoutDetectionService, 'isPunchoutSessionPage').and.returnValue(
+      false
+    );
+    spyOn(punchoutDetectionService, 'isPunchoutSession').and.returnValue(true);
+    spyOn(punchoutfacade, 'endPunchoutSession').and.callThrough();
+    spyOn(punchoutfacade, 'logoutPunchoutUser').and.callThrough();
+
+    service.handleExpiredRefreshTokenIfApplicable().subscribe((handled) => {
+      expect(handled).toBe(true);
+      expect(punchoutfacade.logoutPunchoutUser).not.toHaveBeenCalledWith();
+      expect(punchoutfacade.endPunchoutSession).toHaveBeenCalledWith();
+      done();
+    });
+  });
+});

--- a/integration-libs/punchout/root/services/punchout-expired-refresh-token-handler.service.ts
+++ b/integration-libs/punchout/root/services/punchout-expired-refresh-token-handler.service.ts
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { inject, Injectable } from '@angular/core';
+import { ExpiredRefreshTokenHandler } from '@spartacus/core';
+import { Observable, of } from 'rxjs';
+import { defaultIfEmpty, map } from 'rxjs/operators';
+import { PunchoutFacade } from '../facade';
+import { PunchoutDetectionService } from './punchout-detection.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PunchoutExpiredRefreshTokenHandler
+  implements ExpiredRefreshTokenHandler
+{
+  protected punchoutDetectionService = inject(PunchoutDetectionService);
+  protected punchoutFacade = inject(PunchoutFacade);
+
+  /**
+   * Returns whether punchout-specific refresh-token expiration handling was applied.
+   * On backend errors indicating expired `refresh_token`, 2 punchout use cases:
+   * - When initializing punchout session, previous token gets silently revoked, punchoutFacade can then create punchout session.
+   * - When punchout session already exists, punchout session gets ended.
+   * It is a workaround to address CXSPA-9608 - Public pages not displayed when token is invalid.
+   * To be removed once CXSPA-9608 is closed.
+   */
+  public handleExpiredRefreshTokenIfApplicable(): Observable<boolean> {
+    if (this.punchoutDetectionService.isPunchoutSessionPage()) {
+      return this.punchoutFacade.logoutPunchoutUser().pipe(
+        map(() => true),
+        defaultIfEmpty(true)
+      );
+    }
+    if (this.punchoutDetectionService.isPunchoutSession()) {
+      return this.punchoutFacade.endPunchoutSession().pipe(
+        map(() => true),
+        defaultIfEmpty(true)
+      );
+    }
+    return of(false);
+  }
+}

--- a/projects/core/src/auth/user-auth/services/auth-http-header-handler.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header-handler.ts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
+
+/**
+ * Handler for expired refresh token scenarios.
+ * Example: when a punchout session is active, this handler can use
+ * `handleExpiredRefreshTokenIfApplicable` to take over
+ * `handleExpiredRefreshToken()` behavior, for example by ending the punchout
+ * session.
+ */
+export interface ExpiredRefreshTokenHandler {
+  handleExpiredRefreshTokenIfApplicable?(): Observable<boolean>;
+}
+
+export const EXPIRED_REFRESH_TOKEN_HANDLERS = new InjectionToken<
+  ExpiredRefreshTokenHandler[]
+>('EXPIRED_REFRESH_TOKEN_HANDLERS');

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.spec.ts
@@ -9,16 +9,25 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { BehaviorSubject, EMPTY, merge, of, queueScheduler } from 'rxjs';
 import { observeOn, take } from 'rxjs/operators';
+import { FeatureConfigService } from '../../../features-config/services/feature-config.service';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
 import { OccEndpointsService } from '../../../occ/services/occ-endpoints.service';
 import { RoutingService } from '../../../routing/facade/routing.service';
 import { AuthService } from '../facade/auth.service';
 import { AuthToken } from '../models/auth-token.model';
+import {
+  EXPIRED_REFRESH_TOKEN_HANDLERS,
+  ExpiredRefreshTokenHandler,
+} from './auth-http-header-handler';
 import { AuthHttpHeaderService } from './auth-http-header.service';
 import { AuthRedirectService } from './auth-redirect.service';
 import { AuthStorageService } from './auth-storage.service';
 import { OAuthLibWrapperService } from './oauth-lib-wrapper.service';
+
+type ExpiredRefreshTokenHandlerSpy = Required<
+  Pick<ExpiredRefreshTokenHandler, 'handleExpiredRefreshTokenIfApplicable'>
+>;
 
 const testToken: AuthToken = {
   access_token: 'acc_token',
@@ -79,6 +88,10 @@ class MockAuthRedirectService implements Partial<AuthRedirectService> {
   saveCurrentNavigationUrl = jasmine.createSpy('saveCurrentNavigationUrl');
 }
 
+class MockFeatureConfigService implements Partial<FeatureConfigService> {
+  isEnabled = jasmine.createSpy('isEnabled').and.returnValue(true);
+}
+
 describe('AuthHttpHeaderService', () => {
   let service: AuthHttpHeaderService;
   let oAuthLibWrapperService: OAuthLibWrapperService;
@@ -86,8 +99,20 @@ describe('AuthHttpHeaderService', () => {
   let routingService: RoutingService;
   let globalMessageService: GlobalMessageService;
   let authRedirectService: AuthRedirectService;
+  let featureConfigService: FeatureConfigService;
+  let firstRegisteredHandler: jasmine.SpyObj<ExpiredRefreshTokenHandlerSpy>;
 
   beforeEach(() => {
+    firstRegisteredHandler =
+      jasmine.createSpyObj<ExpiredRefreshTokenHandlerSpy>(
+        'firstRegisteredHandler',
+        ['handleExpiredRefreshTokenIfApplicable']
+      );
+
+    firstRegisteredHandler.handleExpiredRefreshTokenIfApplicable.and.returnValue(
+      of(false)
+    );
+
     TestBed.configureTestingModule({
       providers: [
         AuthHttpHeaderService,
@@ -101,6 +126,12 @@ describe('AuthHttpHeaderService', () => {
         { provide: GlobalMessageService, useClass: MockGlobalMessageService },
         { provide: AuthStorageService, useClass: MockAuthStorageService },
         { provide: AuthRedirectService, useClass: MockAuthRedirectService },
+        { provide: FeatureConfigService, useClass: MockFeatureConfigService },
+        {
+          provide: EXPIRED_REFRESH_TOKEN_HANDLERS,
+          useValue: firstRegisteredHandler,
+          multi: true,
+        },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
       ],
@@ -112,6 +143,7 @@ describe('AuthHttpHeaderService', () => {
     routingService = TestBed.inject(RoutingService);
     globalMessageService = TestBed.inject(GlobalMessageService);
     authRedirectService = TestBed.inject(AuthRedirectService);
+    featureConfigService = TestBed.inject(FeatureConfigService);
 
     getTokenFromStorage.next(testToken);
     logoutInProgressSubject.next(false);
@@ -396,6 +428,127 @@ describe('AuthHttpHeaderService', () => {
         },
         GlobalMessageType.MSG_TYPE_ERROR
       );
+    });
+
+    it('should skip default refresh token handling when a handler handles it', () => {
+      spyOn(authService, 'coreLogout').and.callThrough();
+      firstRegisteredHandler.handleExpiredRefreshTokenIfApplicable.and.returnValue(
+        of(true)
+      );
+
+      service.handleExpiredRefreshToken();
+
+      expect(authService.coreLogout).not.toHaveBeenCalled();
+      expect(
+        firstRegisteredHandler.handleExpiredRefreshTokenIfApplicable
+      ).toHaveBeenCalled();
+    });
+
+    it('should skip handlers and execute fallback when feature toggle is disabled', () => {
+      (featureConfigService.isEnabled as jasmine.Spy).and.returnValue(false);
+      spyOn(authService, 'coreLogout').and.callThrough();
+
+      service.handleExpiredRefreshToken();
+
+      expect(
+        firstRegisteredHandler.handleExpiredRefreshTokenIfApplicable
+      ).not.toHaveBeenCalled();
+      expect(authService.coreLogout).toHaveBeenCalled();
+    });
+
+    describe('with multiple handlers', () => {
+      let secondRegisteredHandler: jasmine.SpyObj<ExpiredRefreshTokenHandlerSpy>;
+
+      beforeEach(() => {
+        secondRegisteredHandler =
+          jasmine.createSpyObj<ExpiredRefreshTokenHandlerSpy>(
+            'secondRegisteredHandler',
+            ['handleExpiredRefreshTokenIfApplicable']
+          );
+        secondRegisteredHandler.handleExpiredRefreshTokenIfApplicable.and.returnValue(
+          of(false)
+        );
+
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          providers: [
+            AuthHttpHeaderService,
+            { provide: AuthService, useClass: MockAuthService },
+            {
+              provide: OAuthLibWrapperService,
+              useClass: MockOAuthLibWrapperService,
+            },
+            { provide: RoutingService, useClass: MockRoutingService },
+            { provide: OccEndpointsService, useClass: MockOccEndpointsService },
+            {
+              provide: GlobalMessageService,
+              useClass: MockGlobalMessageService,
+            },
+            { provide: AuthStorageService, useClass: MockAuthStorageService },
+            {
+              provide: AuthRedirectService,
+              useClass: MockAuthRedirectService,
+            },
+            {
+              provide: FeatureConfigService,
+              useClass: MockFeatureConfigService,
+            },
+            {
+              provide: EXPIRED_REFRESH_TOKEN_HANDLERS,
+              useValue: firstRegisteredHandler,
+              multi: true,
+            },
+            {
+              provide: EXPIRED_REFRESH_TOKEN_HANDLERS,
+              useValue: secondRegisteredHandler,
+              multi: true,
+            },
+            provideHttpClient(withInterceptorsFromDi()),
+            provideHttpClientTesting(),
+          ],
+        });
+
+        service = TestBed.inject(AuthHttpHeaderService);
+        authService = TestBed.inject(AuthService);
+        featureConfigService = TestBed.inject(FeatureConfigService);
+      });
+
+      it('should call secondRegisteredHandler when firstRegistredHandler does not handle the token expiration', () => {
+        spyOn(authService, 'coreLogout').and.callThrough();
+        firstRegisteredHandler.handleExpiredRefreshTokenIfApplicable.and.returnValue(
+          of(false)
+        );
+        secondRegisteredHandler.handleExpiredRefreshTokenIfApplicable.and.returnValue(
+          of(true)
+        );
+
+        service.handleExpiredRefreshToken();
+
+        expect(
+          firstRegisteredHandler.handleExpiredRefreshTokenIfApplicable
+        ).toHaveBeenCalled();
+        expect(
+          secondRegisteredHandler.handleExpiredRefreshTokenIfApplicable
+        ).toHaveBeenCalled();
+        expect(authService.coreLogout).not.toHaveBeenCalled();
+      });
+
+      it('should not call secondRegisteredHandler when firstRegistredHandler already handles the token expiration', () => {
+        spyOn(authService, 'coreLogout').and.callThrough();
+        firstRegisteredHandler.handleExpiredRefreshTokenIfApplicable.and.returnValue(
+          of(true)
+        );
+
+        service.handleExpiredRefreshToken();
+
+        expect(
+          firstRegisteredHandler.handleExpiredRefreshTokenIfApplicable
+        ).toHaveBeenCalled();
+        expect(
+          secondRegisteredHandler.handleExpiredRefreshTokenIfApplicable
+        ).not.toHaveBeenCalled();
+        expect(authService.coreLogout).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
+++ b/projects/core/src/auth/user-auth/services/auth-http-header.service.ts
@@ -5,18 +5,23 @@
  */
 
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
-import { Injectable, OnDestroy } from '@angular/core';
+import { inject, Injectable, InjectionToken, OnDestroy } from '@angular/core';
 import {
-  EMPTY,
-  Observable,
-  Subject,
-  Subscription,
   combineLatest,
   defer,
+  EMPTY,
+  from,
+  isObservable,
+  Observable,
+  of,
   queueScheduler,
+  Subject,
+  Subscription,
   using,
 } from 'rxjs';
 import {
+  concatMap,
+  defaultIfEmpty,
   filter,
   map,
   observeOn,
@@ -28,15 +33,53 @@ import {
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
+import { FeatureConfigService } from '../../../features-config/services/feature-config.service';
 import { GlobalMessageService } from '../../../global-message/facade/global-message.service';
 import { GlobalMessageType } from '../../../global-message/models/global-message.model';
 import { OccEndpointsService } from '../../../occ/services/occ-endpoints.service';
 import { RoutingService } from '../../../routing/facade/routing.service';
 import { AuthService } from '../facade/auth.service';
 import { AuthToken } from '../models/auth-token.model';
+import {
+  EXPIRED_REFRESH_TOKEN_HANDLERS,
+  ExpiredRefreshTokenHandler,
+} from './auth-http-header-handler';
 import { AuthRedirectService } from './auth-redirect.service';
 import { AuthStorageService } from './auth-storage.service';
 import { OAuthLibWrapperService } from './oauth-lib-wrapper.service';
+
+// Temporary compatibility tokens  to preserve legacy behavior of CXPSA-12514 fix.
+// Remove DEFAULT_AUTH_HTTP_HEADER_SERVICE and
+// DELEGATED_AUTH_HTTP_HEADER_SERVICE once
+// enableExpiredRefreshTokenHandlers feature toggle is fully rolled out.
+export const DEFAULT_AUTH_HTTP_HEADER_SERVICE =
+  new InjectionToken<AuthHttpHeaderService>(
+    'DEFAULT_AUTH_HTTP_HEADER_SERVICE',
+    {
+      providedIn: 'root',
+      factory: () =>
+        new AuthHttpHeaderService(
+          inject(AuthService),
+          inject(AuthStorageService),
+          inject(OAuthLibWrapperService),
+          inject(RoutingService),
+          inject(OccEndpointsService),
+          inject(GlobalMessageService),
+          inject(AuthRedirectService)
+        ),
+    }
+  );
+
+/**
+ * Optional delegation hook for `AuthHttpHeaderService`.
+ * Feature libraries (e.g. ASM) can provide their own `AuthHttpHeaderService`
+ * override under this token so that other libs (e.g. Punchout) can delegate
+ * to it without a hard compile-time import of the providing library.
+ */
+export const DELEGATED_AUTH_HTTP_HEADER_SERVICE =
+  new InjectionToken<AuthHttpHeaderService>(
+    'DELEGATED_AUTH_HTTP_HEADER_SERVICE'
+  );
 
 /**
  * Extendable service for `AuthInterceptor`.
@@ -45,6 +88,8 @@ import { OAuthLibWrapperService } from './oauth-lib-wrapper.service';
   providedIn: 'root',
 })
 export class AuthHttpHeaderService implements OnDestroy {
+  private featureConfig = inject(FeatureConfigService);
+
   /**
    * Starts the refresh of the access token
    */
@@ -106,6 +151,8 @@ export class AuthHttpHeaderService implements OnDestroy {
   ).pipe(shareReplay({ refCount: true, bufferSize: 1 }));
 
   protected subscriptions = new Subscription();
+  protected handlers =
+    inject(EXPIRED_REFRESH_TOKEN_HANDLERS, { optional: true }) ?? [];
 
   constructor(
     protected authService: AuthService,
@@ -216,6 +263,28 @@ export class AuthHttpHeaderService implements OnDestroy {
    * Logout user, redirected to login page and informs about expired session.
    */
   public handleExpiredRefreshToken(): void {
+    if (!this.featureConfig.isEnabled('enableExpiredRefreshTokenHandlers')) {
+      this.handleExpiredRefreshTokenFallback();
+      return;
+    }
+
+    from(this.authHttpHeaderHandlers)
+      .pipe(
+        concatMap((handler) =>
+          this.resolveHandlerRefreshTokenHandling(handler)
+        ),
+        filter((handled) => handled),
+        take(1),
+        defaultIfEmpty(false)
+      )
+      .subscribe((handled) => {
+        if (!handled) {
+          this.handleExpiredRefreshTokenFallback();
+        }
+      });
+  }
+
+  protected handleExpiredRefreshTokenFallback(): void {
     // There might be 2 cases:
     // 1. when user is already on some page (router is stable) and performs an UI action
     // that triggers http call (i.e. button click to save data in backend)
@@ -238,6 +307,28 @@ export class AuthHttpHeaderService implements OnDestroy {
         GlobalMessageType.MSG_TYPE_ERROR
       );
     });
+  }
+
+  /**
+   * Resolves handler-specific refresh token expiration handling.
+   * This approach allows features like Punchout to handle expired tokens
+   * without needing to override the entire AuthHttpHeaderService via DI,
+   * which would create a conflict with other service overrides (e.g., ASM).
+   */
+  protected resolveHandlerRefreshTokenHandling(
+    handler: ExpiredRefreshTokenHandler
+  ): Observable<boolean> {
+    const result = handler.handleExpiredRefreshTokenIfApplicable?.();
+
+    if (isObservable(result)) {
+      return result;
+    }
+
+    return of(false);
+  }
+
+  protected get authHttpHeaderHandlers(): ExpiredRefreshTokenHandler[] {
+    return this.handlers ?? [];
   }
 
   /**

--- a/projects/core/src/auth/user-auth/services/index.ts
+++ b/projects/core/src/auth/user-auth/services/index.ts
@@ -6,6 +6,7 @@
 
 export * from './auth-config.service';
 export * from './auth-flow-routes.service';
+export * from './auth-http-header-handler';
 export * from './auth-http-header.service';
 export * from './auth-multisite-isolation.service';
 export * from './auth-redirect-storage.service';

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -477,6 +477,14 @@ export interface FeatureTogglesInterface {
    * Affects: VisibleFocusDirective, ConsentManagementFormComponent, ConsentManagementComponent
    */
   a11yConsentManagementFocusPreservation?: boolean;
+
+  /**
+   * When enabled, `AuthHttpHeaderService` executes DI-provided
+   * `ExpiredRefreshTokenHandler` to take over `handleExpiredRefreshToken()` behavior in case of expired refresh token scenarios.
+   * It avoids the need to override the entire AuthHttpHeaderService just to handle expired refresh token scenarios in a custom way, for example by ending punchout session when it's active.
+   * Affects: `AuthHttpHeaderService`
+   */
+  enableExpiredRefreshTokenHandlers?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -534,4 +542,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   useEnhancedSecurePasswordValidators: false,
   enableRemoveVoucherEndpoint: false,
   showRequiredAsterisks: false,
+  enableExpiredRefreshTokenHandlers: false,
 };

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -350,6 +350,7 @@ if (environment.cpq) {
         useEnhancedSecurePasswordValidators: true,
         enableRemoveVoucherEndpoint: true,
         showRequiredAsterisks: true,
+        enableExpiredRefreshTokenHandlers: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
port this fix on release branch see PR #21363
CXSPA-12514
enableExpiredRefreshTokenHandlers toggle has been added to allow Punchout and ASM libs to be functional together.