### PR TITLE
chore: Replace deprecated ServerTestingModule with BrowserTestingModule in setup lib

### DIFF
--- a/core-libs/setup/setup-jest.ts
+++ b/core-libs/setup/setup-jest.ts
@@ -8,12 +8,12 @@ import 'zone.js';
 import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
-  platformServerTesting,
-  ServerTestingModule,
-} from '@angular/platform-server/testing';
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
 
 getTestBed().initTestEnvironment(
-  ServerTestingModule,
-  platformServerTesting(),
+  BrowserTestingModule,
+  platformBrowserTesting(),
   {}
 );


### PR DESCRIPTION
ServerTestingModule and platformServerTesting() are all deprecated since Angular v20. None of the tests in core-libs/setup/ rely on server-specific TestBed behavior (domino DOM, PLATFORM_ID='server', ServerPlatformLocation) — they only need the DI container with custom-provided tokens.

Replaced with BrowserTestingModule / platformBrowserTesting() from @angular/platform-browser/testing which is the non-deprecated alternative.

The domino jest mock (__mocks__/bundled-domino.js) remains because ng-express-engine.spec.ts and cx-common-engine.spec.ts perform actual SSR rendering via CommonEngine/renderModule, which imports @angular/platform-server and triggers domino module resolution under Jest's CJS/ESM interop.