### PR TITLE
chore: normalize federated login config interface

### DIFF
--- a/projects/core/src/federated-login/config/federated-login-config.ts
+++ b/projects/core/src/federated-login/config/federated-login-config.ts
@@ -16,7 +16,7 @@ export abstract class FederatedLoginConfig {
     enabled?: boolean;
 
     /** URL parameter name to use when passing context from an originating domain to a login domain. */
-    contextParameterName: string;
+    contextParameterName?: string;
 
     /**
      * List of hosts that serve as a federated login page.
@@ -28,7 +28,7 @@ export abstract class FederatedLoginConfig {
      *   loginDomains: ['login.shop.com', 'test.login.local:4200']
      * ```
      */
-    loginHosts: string[];
+    loginHosts?: string[];
 
     /**
      * Map of URL-safe keys to fully-qualified domains.
@@ -42,7 +42,7 @@ export abstract class FederatedLoginConfig {
      *   sf2: 'https://storefront2.com',
      * }
      */
-    originMap: Record<string, string>;
+    originMap?: Record<string, string>;
   };
 }
 

--- a/projects/core/src/federated-login/services/federated-login-context-serializer.service.ts
+++ b/projects/core/src/federated-login/services/federated-login-context-serializer.service.ts
@@ -59,7 +59,7 @@ export class FederatedLoginContextSerializerService {
   }
 
   protected getOrigin(contextKey: string) {
-    return this.config?.originMap[contextKey];
+    return this.config?.originMap?.[contextKey];
   }
 
   protected getContextKey(origin: string) {

--- a/projects/core/src/federated-login/services/federated-login.service.ts
+++ b/projects/core/src/federated-login/services/federated-login.service.ts
@@ -81,7 +81,7 @@ export class FederatedLoginService {
   protected checkLoginDomain() {
     // Using `location.origin` for SSR support
     return (
-      this.config?.loginHosts.some(
+      this.config?.loginHosts?.some(
         (host) =>
           host === new URL(this.windowRef.location.origin as string).host
       ) ?? false


### PR DESCRIPTION
All config properties are supposed to be optional so partial config updates can be made.