### PR TITLE
fix: Update e2e header validation after translation key got updated

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/payment-methods.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/payment-methods.ts
@@ -113,7 +113,7 @@ export function testRenderEmptyPaymentDetailsPage() {
   loginRegisteredUser();
   visitPaymentDetailsPage();
   cy.get('cx-payment-methods').within(() => {
-    cy.get('.cx-payment .cx-header').should('contain', 'Payment methods');
+    cy.get('.cx-payment .cx-header').should('contain', 'Payment Methods');
     cy.get('.cx-payment .cx-body').should(
       'contain',
       'New payment methods are added during checkout.'


### PR DESCRIPTION
In [commit](https://github.com/SAP/spartacus/commit/d99891883aadefd392a0f4a4dd318a10ae0466b1) the translation key, `paymentMethods`, got updated so e2e validation now fails due to case sensitivity.
<img width="610" height="391" alt="2026-05-01_10-44-26" src="https://github.com/user-attachments/assets/9851c058-e626-4cc5-b90e-214629712643" />
