### PR TITLE
fix: a11y on b2b register btn with CMS-only solution

### DIFF
--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -26,6 +26,11 @@ export interface FeatureTogglesInterface {
   a11yStoreFinderLabel?: boolean;
 
   /**
+   * Activates the B2B login/register component.
+   */
+  a11yActiveB2bLoginRegisterCpnt?: boolean;
+
+  /**
    * Replaces buttons resembling links with tetriary buttons in the following components:
    * `AddToWishListComponent`, `ProductIntroComponent`, `ProductImageZoomTriggerComponent`
    */
@@ -504,6 +509,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yKeyboardAccessibleZoom: false,
   a11yPreventCartItemsFormRedundantRecreation: false,
   a11yStoreFinderLabel: false,
+  a11yActiveB2bLoginRegisterCpnt: false,
   a11yLinkBtnsToTertiaryBtns: false,
   a11yAddPaddingToCarouselPanel: false,
   a11yNgSelectUnicodeCarets: false,

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -299,6 +299,7 @@ if (environment.cpq) {
         a11yKeyboardAccessibleZoom: true,
         a11yPreventCartItemsFormRedundantRecreation: true,
         a11yStoreFinderLabel: true,
+        a11yActiveB2bLoginRegisterCpnt: false,
         a11yLinkBtnsToTertiaryBtns: true,
         a11yAddPaddingToCarouselPanel: true,
         dispatchLoginActionOnlyWhenTokenReceived: true,

--- a/projects/storefrontlib/cms-structure/page/page-layout/page-layout.component.ts
+++ b/projects/storefrontlib/cms-structure/page/page-layout/page-layout.component.ts
@@ -54,5 +54,6 @@ export class PageLayoutComponent {
 
   constructor(protected pageLayoutService: PageLayoutService) {
     useFeatureStyles('disableCxPageSlotMarginAnimation');
+    useFeatureStyles('a11yActiveB2bLoginRegisterCpnt');
   }
 }

--- a/projects/storefrontstyles/scss/layout/page-templates/_login-page.scss
+++ b/projects/storefrontstyles/scss/layout/page-templates/_login-page.scss
@@ -35,4 +35,28 @@
       --cx-max-width: 50%;
     }
   }
+  // cx-page-slot.LeftContentSlot,
+  // cx-page-slot.RightContentSlot {
+  //   > cx-login-register {
+  //     display: none;
+  //   }
+  // }
+
+  .a11yRegisterLinkParagraph {
+    display: none;
+  }
+  // explicit default, not relying on browser
+  .a11yRegisterLink {
+    display: revert;
+  }
+
+  @include forFeature('a11yActiveB2bLoginRegisterCpnt') {
+    .a11yRegisterLinkParagraph {
+      display: inherit;
+    }
+
+    .a11yRegisterLink {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
It requires new component in sample data
addi class to be able to toggle visibility
a11yRegisterLink in OrganizationUserRegistrationLink
a11yRegisterLinkParagraph in OrganizationUserRegistrationLinkParagraph

Add this new component
OrganizationUserRegistrationLinkParagraph
Paragraph has the capability to dispaly unsanitized html content
`
<a class="a11yRegisterLinkParagraph btn btn-block btn-secondary cx-organization-user-register-button" tabindex="0" aria-describedby="register-section-label" href="/login/register">Register</a>`