### PR TITLE
fix: CXOPF-5209 : Pagination for saved card in Checkout Page and other fixes

### DIFF
--- a/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.ts
@@ -264,10 +264,15 @@ export class OpfCheckoutPaymentsComponent implements OnInit, OnDestroy {
             (state.termsAndConditionsChecked ||
               !this.explicitTermsAndConditions)
           ) {
-            isPreselected = true;
-            this.selectedPaymentId =
+            const resolvedId =
               state.selectedPaymentOptionId ??
               state.defaultSelectedPaymentOptionId;
+
+            if (resolvedId !== undefined) {
+              isPreselected = true;
+            }
+
+            this.selectedPaymentId = resolvedId;
             this.opfMetadataStoreService.updateOpfMetadata({
               selectedPaymentOptionId: this.selectedPaymentId,
             });

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-account-payment-methods/opf-tokenisation-account-payment-methods.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-account-payment-methods/opf-tokenisation-account-payment-methods.component.html
@@ -31,7 +31,7 @@
                   aria-hidden="true"
                 ></cx-icon>
                 <span class="cx-expired-error-message">
-                  {{ 'paymentCard.expiredMessageForMyAccounts' | cxTranslate }}
+                  {{ 'paymentCard.expiredMessage' | cxTranslate }}
                 </span>
               </div>
               <div class="cx-card-with-expired-pill">

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-account-payment-methods/opf-tokenisation-account-payment-methods.component.ts
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-account-payment-methods/opf-tokenisation-account-payment-methods.component.ts
@@ -67,17 +67,19 @@ export class OpfTokenisationAccountPaymentMethodsComponent implements OnInit {
           (paymentDetail) => paymentDetail.defaultPayment
         );
         const hasPaymentMethods = paymentDetails.length > 0;
-        const paymentMethodId = paymentDetails[0]?.id;
+        const firstNonExpired = paymentDetails.find(
+          (paymentDetail) => !isTokenisationCardExpired(paymentDetail)
+        );
 
-        // Set first payment method to DEFAULT if none is set
+        // Set first non-expired payment method to DEFAULT if none is set
         if (
           !this.autoDefaultRequested &&
           hasPaymentMethods &&
           !hasDefault &&
-          paymentMethodId
+          firstNonExpired
         ) {
           this.autoDefaultRequested = true;
-          this.setDefaultPaymentMethod(paymentDetails[0]);
+          this.setDefaultPaymentMethod(firstNonExpired);
         }
       })
     );
@@ -109,7 +111,7 @@ export class OpfTokenisationAccountPaymentMethodsComponent implements OnInit {
           textDefaultPaymentMethod,
         ]) => {
           const actions: { name: string; event: string }[] = [];
-          if (!defaultPayment) {
+          if (!defaultPayment && !isTokenisationCardExpired(paymentMethod)) {
             actions.push({ name: textSetAsDefault, event: 'default' });
           }
           actions.push({ name: textDelete, event: 'delete' });

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-account-payment-methods/opf-tokenisation-account-payment-methods.component.ts
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-account-payment-methods/opf-tokenisation-account-payment-methods.component.ts
@@ -114,7 +114,9 @@ export class OpfTokenisationAccountPaymentMethodsComponent implements OnInit {
           if (!defaultPayment && !isTokenisationCardExpired(paymentMethod)) {
             actions.push({ name: textSetAsDefault, event: 'default' });
           }
-          actions.push({ name: textDelete, event: 'delete' });
+          if (!defaultPayment || isTokenisationCardExpired(paymentMethod)) {
+            actions.push({ name: textDelete, event: 'delete' });
+          }
           const card: Card = {
             role: 'application',
             header: defaultPayment ? textDefaultPaymentMethod : undefined,

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
@@ -74,15 +74,15 @@
                 {{ 'paymentCard.showAll' | cxTranslate }}
               </button>
               <span class="cx-card-count"
-                >[{{ VISIBLE_CARDS_COUNT }}/{{ cards.length }}]</span
+                >[ {{ VISIBLE_CARDS_COUNT }} / {{ cards.length }} ]</span
               >
             </ng-container>
             <ng-container *ngIf="showAll">
               <span class="btn btn-link cx-show-all-expanded">
                 {{ 'paymentCard.showAll' | cxTranslate }}
               </span>
-              <span class="cx-card-count"
-                >[{{ cards.length }}/{{ cards.length }}]</span
+              <span class="cx-card-count cx-card-count--expanded"
+                >[ {{ cards.length }} / {{ cards.length }} ]</span
               >
             </ng-container>
           </div>

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
@@ -38,7 +38,10 @@
                 [content]="card.content"
                 [index]="i"
                 (setDefaultCard)="setDefaultPaymentMethod(card.paymentMethod)"
-                (sendCard)="!isCardExpired(card.paymentMethod) && selectPaymentMethod(card.paymentMethod)"
+                (sendCard)="
+                  !isCardExpired(card.paymentMethod) &&
+                    selectPaymentMethod(card.paymentMethod)
+                "
               ></cx-card>
             </div>
           </div>

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
@@ -28,7 +28,7 @@
                     aria-hidden="true"
                   ></cx-icon>
                   <span class="cx-expired-error-message">
-                    {{ 'paymentCard.expiredMessageForCheckout' | cxTranslate }}
+                    {{ 'paymentCard.expiredMessage' | cxTranslate }}
                   </span>
                 </div>
               </div>

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
@@ -10,7 +10,12 @@
         <div class="cx-checkout-body row">
           <div
             class="cx-payment-card col-md-12 col-lg-6"
-            *ngFor="let card of cards; let i = index"
+            *ngFor="
+              let card of showAll
+                ? cards
+                : (cards | slice: 0 : VISIBLE_CARDS_COUNT);
+              let i = index
+            "
           >
             <div
               class="cx-payment-card-inner"
@@ -45,6 +50,25 @@
               ></cx-card>
             </div>
           </div>
+        </div>
+
+        <div
+          *ngIf="cards.length > VISIBLE_CARDS_COUNT"
+          class="cx-show-more-cards"
+        >
+          <ng-container *ngIf="!showAll">
+            <button class="btn btn-link" (click)="showAll = true">
+              {{ 'paymentCard.showAll' | cxTranslate }}
+            </button>
+            <span class="cx-card-count"
+              >[{{ VISIBLE_CARDS_COUNT }}/{{ cards.length }}]</span
+            >
+          </ng-container>
+          <ng-container *ngIf="showAll">
+            <span class="cx-card-count"
+              >[{{ cards.length }}/{{ cards.length }}]</span
+            >
+          </ng-container>
         </div>
 
         <div class="row cx-checkout-btns">

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
@@ -38,7 +38,7 @@
                 [content]="card.content"
                 [index]="i"
                 (setDefaultCard)="setDefaultPaymentMethod(card.paymentMethod)"
-                (sendCard)="selectPaymentMethod(card.paymentMethod)"
+                (sendCard)="!isCardExpired(card.paymentMethod) && selectPaymentMethod(card.paymentMethod)"
               ></cx-card>
             </div>
           </div>

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
@@ -52,25 +52,6 @@
           </div>
         </div>
 
-        <div
-          *ngIf="cards.length > VISIBLE_CARDS_COUNT"
-          class="cx-show-more-cards"
-        >
-          <ng-container *ngIf="!showAll">
-            <button class="btn btn-link" (click)="showAll = true">
-              {{ 'paymentCard.showAll' | cxTranslate }}
-            </button>
-            <span class="cx-card-count"
-              >[{{ VISIBLE_CARDS_COUNT }}/{{ cards.length }}]</span
-            >
-          </ng-container>
-          <ng-container *ngIf="showAll">
-            <span class="cx-card-count"
-              >[{{ cards.length }}/{{ cards.length }}]</span
-            >
-          </ng-container>
-        </div>
-
         <div class="row cx-checkout-btns">
           <div class="col-md-12 col-lg-6">
             <button
@@ -84,6 +65,28 @@
             </button>
           </div>
         </div>
+
+        <ng-container *ngIf="cards.length > VISIBLE_CARDS_COUNT">
+          <hr class="cx-show-more-divider" />
+          <div class="cx-show-more-cards">
+            <ng-container *ngIf="!showAll">
+              <button class="btn btn-link" (click)="showAll = true">
+                {{ 'paymentCard.showAll' | cxTranslate }}
+              </button>
+              <span class="cx-card-count"
+                >[{{ VISIBLE_CARDS_COUNT }}/{{ cards.length }}]</span
+              >
+            </ng-container>
+            <ng-container *ngIf="showAll">
+              <span class="btn btn-link cx-show-all-expanded">
+                {{ 'paymentCard.showAll' | cxTranslate }}
+              </span>
+              <span class="cx-card-count"
+                >[{{ cards.length }}/{{ cards.length }}]</span
+              >
+            </ng-container>
+          </div>
+        </ng-container>
       </ng-template>
     </ng-container>
   </ng-container>

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.ts
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { AsyncPipe, NgFor, NgIf, SlicePipe } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -31,6 +31,7 @@ import { OpfTokenisationPaymentMethodService } from './opf-tokenisation-payment-
   imports: [
     NgIf,
     NgFor,
+    SlicePipe,
     CardComponent,
     IconComponent,
     SpinnerComponent,
@@ -51,6 +52,8 @@ export class OpfTokenisationPaymentMethodComponent
   selectedMethod$: Observable<PaymentDetails | undefined>;
   showSavedCards$: Observable<boolean>;
   iconTypes = ICON_TYPE;
+  showAll = false;
+  readonly VISIBLE_CARDS_COUNT = 2;
 
   ngOnInit(): void {
     this.OpfTokenisationPaymentMethodService.initialize();

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.ts
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.ts
@@ -69,6 +69,10 @@ export class OpfTokenisationPaymentMethodComponent
   }
 
   onCardClick(event: MouseEvent, paymentDetails: PaymentDetails): void {
+    if (this.isCardExpired(paymentDetails)) {
+      return;
+    }
+
     const target = event.target as HTMLElement | null;
 
     if (target?.closest('button, a, cx-generic-link')) {

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.service.spec.ts
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.service.spec.ts
@@ -486,6 +486,74 @@ describe('OpfTokenisationPaymentMethodService', () => {
       expect(card.text).toContain(mockPaymentDetails.cardNumber);
       expect(card.text).toContain('Expires 12/2028');
     });
+
+    it('should not include setAsDefault action for an expired card', () => {
+      const expiredPayment: PaymentDetails = {
+        ...mockPaymentDetails,
+        expiryMonth: '01',
+        expiryYear: '2020',
+        defaultPayment: false,
+      };
+      spyOn(service, 'isCardExpired').and.returnValue(true);
+
+      const card = (service as any).createCard(
+        expiredPayment,
+        {
+          textExpires: 'Expires 01/2020',
+          textUseThisPayment: 'Use this',
+          textSelected: 'Selected',
+          textSetAsDefault: 'Set as default',
+          textDefaultLabelOnCheckout: 'Default',
+        },
+        undefined
+      );
+
+      expect(card.actions?.map((a: any) => a.event)).not.toContain('default');
+    });
+
+    it('should not include useThisCard action for an expired card', () => {
+      const expiredPayment: PaymentDetails = {
+        ...mockPaymentDetails,
+        expiryMonth: '01',
+        expiryYear: '2020',
+        defaultPayment: false,
+      };
+      spyOn(service, 'isCardExpired').and.returnValue(true);
+
+      const card = (service as any).createCard(
+        expiredPayment,
+        {
+          textExpires: 'Expires 01/2020',
+          textUseThisPayment: 'Use this',
+          textSelected: 'Selected',
+          textSetAsDefault: 'Set as default',
+          textDefaultLabelOnCheckout: 'Default',
+        },
+        undefined
+      );
+
+      expect(card.actions?.map((a: any) => a.event)).not.toContain('send');
+    });
+
+    it('should include both actions for a non-expired, non-selected, non-default card', () => {
+      spyOn(service, 'isCardExpired').and.returnValue(false);
+
+      const card = (service as any).createCard(
+        { ...mockPaymentDetails, defaultPayment: false },
+        {
+          textExpires: 'Expires 12/2028',
+          textUseThisPayment: 'Use this',
+          textSelected: 'Selected',
+          textSetAsDefault: 'Set as default',
+          textDefaultLabelOnCheckout: 'Default',
+        },
+        undefined
+      );
+
+      const events = card.actions?.map((a: any) => a.event);
+      expect(events).toContain('default');
+      expect(events).toContain('send');
+    });
   });
 
   describe('selectPaymentMethod()', () => {

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.service.ts
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.service.ts
@@ -325,11 +325,12 @@ export class OpfTokenisationPaymentMethodService {
     const isSelected = selected?.id === paymentDetails.id;
     const role = !isSelected ? 'button' : 'application';
 
+    const isExpired = this.isCardExpired(paymentDetails);
     const actions: { name: string; event: string }[] = [];
-    if (!paymentDetails.defaultPayment) {
+    if (!paymentDetails.defaultPayment && !isExpired) {
       actions.push({ name: cardLabels.textSetAsDefault, event: 'default' });
     }
-    if (!isSelected) {
+    if (!isSelected && !isExpired) {
       actions.push({ name: cardLabels.textUseThisPayment, event: 'send' });
     }
 
@@ -351,6 +352,9 @@ export class OpfTokenisationPaymentMethodService {
   }
 
   selectPaymentMethod(paymentDetails: PaymentDetails): void {
+    if (this.isCardExpired(paymentDetails)) {
+      return;
+    }
     if (paymentDetails?.id === this.selectedPaymentMethod$.getValue()?.id) {
       return;
     }

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.service.ts
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.service.ts
@@ -229,10 +229,13 @@ export class OpfTokenisationPaymentMethodService {
       (!selectedMethod || Object.keys(selectedMethod).length === 0)
     ) {
       const defaultPaymentMethod = paymentMethods.find(
-        (paymentMethod) => paymentMethod.payment.defaultPayment
+        (paymentMethod) =>
+          paymentMethod.payment.defaultPayment &&
+          !this.isCardExpired(paymentMethod.payment)
       );
       if (defaultPaymentMethod) {
         selectedMethod = defaultPaymentMethod.payment;
+        this.selectedPaymentMethod$.next(selectedMethod);
         this.savePaymentMethod(selectedMethod);
       }
       this.doneAutoSelect = true;

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.service.ts
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.service.ts
@@ -23,6 +23,7 @@ import {
   switchMap,
   take,
   tap,
+  withLatestFrom,
 } from 'rxjs/operators';
 import {
   Card,
@@ -83,7 +84,6 @@ export class OpfTokenisationPaymentMethodService {
 
   paymentDetails?: PaymentDetails;
   isGuestCheckout = false;
-  doneAutoSelect = false;
 
   showSavedCards$: Observable<boolean> = this.opfMetadataStoreService
     .getOpfMetadataState()
@@ -151,6 +151,21 @@ export class OpfTokenisationPaymentMethodService {
           }
         })
     );
+
+    // Auto-select the default non-expired card once when saved cards become visible
+    this.subscriptions.add(
+      this.showSavedCards$
+        .pipe(
+          filter((show) => show),
+          switchMap(() => this.existingPaymentMethods$),
+          filter((methods) => !!methods?.length),
+          take(1),
+          withLatestFrom(this.selectedMethod$)
+        )
+        .subscribe(([methods, selectedMethod]) => {
+          this.selectDefaultPaymentMethod(methods, selectedMethod);
+        })
+    );
   }
 
   getCards$(): Observable<{ content: Card; paymentMethod: PaymentDetails }[]> {
@@ -185,9 +200,6 @@ export class OpfTokenisationPaymentMethodService {
       this.translationService.translate('paymentCard.setAsDefault'),
       this.translationService.translate('paymentCard.defaultLabelOnCheckout'),
     ]).pipe(
-      tap(([paymentMethods, selectedMethod]) =>
-        this.selectDefaultPaymentMethod(paymentMethods, selectedMethod)
-      ),
       map(
         ([
           paymentMethods,
@@ -220,25 +232,21 @@ export class OpfTokenisationPaymentMethodService {
   }
 
   selectDefaultPaymentMethod(
-    paymentMethods: { payment: PaymentDetails; expiryTranslation: string }[],
+    paymentMethods: PaymentDetails[],
     selectedMethod: PaymentDetails | undefined
-  ) {
+  ): void {
     if (
-      !this.doneAutoSelect &&
       paymentMethods?.length &&
       (!selectedMethod || Object.keys(selectedMethod).length === 0)
     ) {
       const defaultPaymentMethod = paymentMethods.find(
         (paymentMethod) =>
-          paymentMethod.payment.defaultPayment &&
-          !this.isCardExpired(paymentMethod.payment)
+          paymentMethod.defaultPayment && !this.isCardExpired(paymentMethod)
       );
       if (defaultPaymentMethod) {
-        selectedMethod = defaultPaymentMethod.payment;
-        this.selectedPaymentMethod$.next(selectedMethod);
-        this.savePaymentMethod(selectedMethod);
+        this.selectedPaymentMethod$.next(defaultPaymentMethod);
+        this.savePaymentMethod(defaultPaymentMethod);
       }
-      this.doneAutoSelect = true;
     }
   }
 

--- a/integration-libs/opf/tokenisation/styles/components/_opf-tokenisation-payment-method.scss
+++ b/integration-libs/opf/tokenisation/styles/components/_opf-tokenisation-payment-method.scss
@@ -208,6 +208,10 @@
     .cx-card-count {
       display: block;
       color: var(--cx-color-primary);
+
+      &.cx-card-count--expanded {
+        opacity: 0.4;
+      }
     }
   }
 }

--- a/integration-libs/opf/tokenisation/styles/components/_opf-tokenisation-payment-method.scss
+++ b/integration-libs/opf/tokenisation/styles/components/_opf-tokenisation-payment-method.scss
@@ -178,6 +178,23 @@
       }
     }
   }
+
+  .cx-show-more-cards {
+    text-align: center;
+    margin-top: 0.5rem;
+
+    .btn-link {
+      display: block;
+      margin: 0 auto;
+      text-decoration: none;
+      color: var(--cx-color-primary);
+    }
+
+    .cx-card-count {
+      display: block;
+      color: var(--cx-color-primary);
+    }
+  }
 }
 
 cx-global-message {

--- a/integration-libs/opf/tokenisation/styles/components/_opf-tokenisation-payment-method.scss
+++ b/integration-libs/opf/tokenisation/styles/components/_opf-tokenisation-payment-method.scss
@@ -179,6 +179,12 @@
     }
   }
 
+  .cx-show-more-divider {
+    margin-top: 1rem;
+    margin-bottom: 0;
+    border-top: 1px solid var(--cx-color-light);
+  }
+
   .cx-show-more-cards {
     text-align: center;
     margin-top: 0.5rem;
@@ -188,6 +194,15 @@
       margin: 0 auto;
       text-decoration: none;
       color: var(--cx-color-primary);
+    }
+
+    .cx-show-all-expanded {
+      display: block;
+      margin: 0 auto;
+      color: var(--cx-color-primary);
+      opacity: 0.4;
+      cursor: default;
+      pointer-events: none;
     }
 
     .cx-card-count {

--- a/projects/assets/src/translations/en/payment.json
+++ b/projects/assets/src/translations/en/payment.json
@@ -58,7 +58,8 @@
     "expired": "Expired",
     "expiredMessageForMyAccounts": "This card has expired. Please update your payment method.",
     "expiredMessageForCheckout": "This card has expired. Please update your payment method in My Account.",
-    "expiredMessage": "This card has expired."
+    "expiredMessage": "This card has expired.",
+    "showAll": "Show All"
   },
   "paymentTypes": {
     "title": "Payment method",

--- a/projects/assets/src/translations/en/payment.json
+++ b/projects/assets/src/translations/en/payment.json
@@ -57,7 +57,8 @@
     "credit": "Credit Card",
     "expired": "Expired",
     "expiredMessageForMyAccounts": "This card has expired. Please update your payment method.",
-    "expiredMessageForCheckout": "This card has expired. Please update your payment method in My Account."
+    "expiredMessageForCheckout": "This card has expired. Please update your payment method in My Account.",
+    "expiredMessage": "This card has expired."
   },
   "paymentTypes": {
     "title": "Payment method",


### PR DESCRIPTION
This PR covers the following fixes:
1. When a card is expired, the “Set as Default” option is not shown on the Payment Details page in My Account.
2. When landing on the Payment & Review page for the first time, the first payment method radio button is preselected.
3. When a card is expired, the “Set as Default” and “Use This Card” options are not shown on the Payment & Review page.
4. When landing on the Payment & Review page, the default saved card is preselected for placing an order.
5. A “Show All” option has been added as per the Figma design to load more saved cards. By default, only two cards are shown.