### PR TITLE
fix: add missing return in federated login session refresh

### DIFF
--- a/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
+++ b/projects/core/src/auth/user-auth/services/oauth-lib-wrapper.service.ts
@@ -188,6 +188,7 @@ export class OAuthLibWrapperService {
         this.federatedLoginService.origin +
         (this.semanticPathService.get('login') ?? '');
       this.winRef.location.href = originLoginUrl;
+      return;
     }
 
     return this.oAuthService.initLoginFlow();


### PR DESCRIPTION
The return statement was lost when fixing an unintended method signature change.