### PR TITLE
chore: bump axios and follow-redirects to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16676,13 +16676,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -21416,9 +21416,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "devOptional": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "webpack-cli": "^6.0.0"
   },
   "overrides": {
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "express-rate-limit": "^8.3.0",
     "flatted": "^3.4.2",
     "koa": "^3.1.2",


### PR DESCRIPTION
fixes https://dev.azure.com/hyperspace-pipelines/web/build.aspx?pcguid=61248af4-a8f0-402a-83be-cdce9680dd81&builduri=vstfs%3a%2f%2f%2fBuild%2fBuild%2f19726434&tracking_data=eyJTb3VyY2UiOiJFbWFpbCIsIlR5cGUiOiJOb3RpZmljYXRpb24iLCJTSUQiOiIxNzM0MjM0IiwiU1R5cGUiOiJHUlAiLCJSZWNpcCI6MSwiX3hjaSI6eyJOSUQiOjY1NzkxMjExMCwiTVJlY2lwIjoibTA9MSAiLCJBY3QiOiJiNDY1ZGE2YS0wM2NlLTRmZDEtOTVmZC0yMWUxOThmYzhmODIifSwiRWxlbWVudCI6Imhlcm8vY3RhIn0%3d