### PR TITLE
fix: CXSPA-13024 - cart state is now reloaded after context change, instead of emptied

### DIFF
--- a/feature-libs/cart/base/core/store/effects/cart.effect.spec.ts
+++ b/feature-libs/cart/base/core/store/effects/cart.effect.spec.ts
@@ -6,12 +6,13 @@ import {
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { StoreModule } from '@ngrx/store';
-import { Cart } from '@spartacus/cart/base/root';
+import { Store, StoreModule } from '@ngrx/store';
+import { Cart, CartType } from '@spartacus/cart/base/root';
 import {
   CLIENT_AUTH_FEATURE,
   LoggerService,
   OCC_CART_ID_CURRENT,
+  OCC_USER_ID_CURRENT,
   OccConfig,
   SiteContextActions,
   USER_FEATURE,
@@ -24,7 +25,7 @@ import { Observable, of, throwError } from 'rxjs';
 import { CartConnector } from '../../connectors/cart/cart.connector';
 import * as fromCartReducers from '../../store/reducers/index';
 import { CartActions } from '../actions/index';
-import { MULTI_CART_FEATURE } from '../multi-cart-state';
+import { MULTI_CART_FEATURE, StateWithMultiCart } from '../multi-cart-state';
 import * as fromEffects from './cart.effect';
 import createSpy = jasmine.createSpy;
 
@@ -68,7 +69,7 @@ describe('Cart effect', () => {
 
   const userId = 'testUserId';
   const cartId = 'testCartId';
-
+  let store: Store<StateWithMultiCart>;
   beforeEach(() => {
     loadMock = createSpy().and.returnValue(of(testCart));
 
@@ -107,6 +108,7 @@ describe('Cart effect', () => {
     });
 
     cartEffects = TestBed.inject(fromEffects.CartEffects);
+    store = TestBed.inject(Store);
   });
 
   describe('loadCart$', () => {
@@ -419,15 +421,18 @@ describe('Cart effect', () => {
 
     siteContextChangeActions.forEach((actionName) => {
       it(`should reset cart details on ${actionName}`, () => {
+        store.dispatch(
+          new CartActions.SetCartTypeIndex({ cartType: CartType.ACTIVE, cartId })
+        );
         const action = new SiteContextActions[actionName]();
-        const resetCartDetailsCompletion = new CartActions.ResetCartDetails();
+        const resetCartDetailsCompletion = new CartActions.LoadCart({userId: OCC_USER_ID_CURRENT, cartId});
 
         actions$ = hot('-a', { a: action });
         const expected = cold('-b', {
           b: resetCartDetailsCompletion,
         });
 
-        expect(cartEffects.resetCartDetailsOnSiteContextChange$).toBeObservable(
+        expect(cartEffects.refreshCartDetailsOnSiteContextChange$).toBeObservable(
           expected
         );
       });

--- a/feature-libs/cart/base/core/store/effects/cart.effect.ts
+++ b/feature-libs/cart/base/core/store/effects/cart.effect.ts
@@ -311,13 +311,8 @@ export class CartEffects {
           map((state) => state?.index?.[CartType.ACTIVE])
         )
       ),
-      mergeMap(([_, cartId]) => {
-        if(!cartId)
-          return [];
-        return [
-          new CartActions.LoadCart({ cartId, userId: OCC_USER_ID_CURRENT }),
-        ];
-      })
+      filter(([_, cartId]) => !!cartId),
+      map(([_, cartId]) => new CartActions.LoadCart({ cartId: cartId as string, userId: OCC_USER_ID_CURRENT }))
     )
   );
 

--- a/feature-libs/cart/base/core/store/effects/cart.effect.ts
+++ b/feature-libs/cart/base/core/store/effects/cart.effect.ts
@@ -303,7 +303,7 @@ export class CartEffects {
       )
   );
 
-  refreshCartDetailsOnSiteContextChange$: Observable<any> = createEffect(() =>
+  refreshCartDetailsOnSiteContextChange$: Observable<CartActions.LoadCart> = createEffect(() =>
     this.contextChange$.pipe(
       withLatestFrom(
         this.store.pipe(
@@ -312,6 +312,8 @@ export class CartEffects {
         )
       ),
       mergeMap(([_, cartId]) => {
+        if(!cartId)
+          return [];
         return [
           new CartActions.LoadCart({ cartId, userId: OCC_USER_ID_CURRENT }),
         ];

--- a/feature-libs/cart/base/core/store/effects/cart.effect.ts
+++ b/feature-libs/cart/base/core/store/effects/cart.effect.ts
@@ -7,10 +7,11 @@
 import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
-import { Cart } from '@spartacus/cart/base/root';
+import { Cart, CartType } from '@spartacus/cart/base/root';
 import {
   LoggerService,
   OCC_CART_ID_CURRENT,
+  OCC_USER_ID_CURRENT,
   SiteContextActions,
   isNotUndefined,
   tryNormalizeHttpError,
@@ -31,7 +32,10 @@ import { CartConnector } from '../../connectors/cart/cart.connector';
 import { getCartIdByUserId, isCartNotFoundError } from '../../utils/utils';
 import { CartActions } from '../actions/index';
 import { StateWithMultiCart } from '../multi-cart-state';
-import { getCartHasPendingProcessesSelectorFactory } from '../selectors/multi-cart.selector';
+import {
+  getCartHasPendingProcessesSelectorFactory,
+  getMultiCartState,
+} from '../selectors/multi-cart.selector';
 
 @Injectable()
 export class CartEffects {
@@ -299,18 +303,21 @@ export class CartEffects {
       )
   );
 
-  resetCartDetailsOnSiteContextChange$: Observable<CartActions.ResetCartDetails> =
-    createEffect(() =>
-      this.actions$.pipe(
-        ofType(
-          SiteContextActions.LANGUAGE_CHANGE,
-          SiteContextActions.CURRENCY_CHANGE
-        ),
-        mergeMap(() => {
-          return [new CartActions.ResetCartDetails()];
-        })
-      )
-    );
+  refreshCartDetailsOnSiteContextChange$: Observable<any> = createEffect(() =>
+    this.contextChange$.pipe(
+      withLatestFrom(
+        this.store.pipe(
+          select(getMultiCartState),
+          map((state) => state?.index?.[CartType.ACTIVE])
+        )
+      ),
+      mergeMap(([_, cartId]) => {
+        return [
+          new CartActions.LoadCart({ cartId, userId: OCC_USER_ID_CURRENT }),
+        ];
+      })
+    )
+  );
 
   addEmail$: Observable<
     | CartActions.AddEmailToCartSuccess


### PR DESCRIPTION
Fixes the following issue : 

- User logs in, adds items to the cart
- Logs out -> logs back in -> changes language (context change)
- Cart items disappear, mini-cart count disappear

(for more context, refer to Jerry Wang's comment on CXSPA-13024)

Fixed by loading the cart when the context (currency || language) changes instead of resetting it, see the ngrx effect for more details.