### PR TITLE
fix: (CXSPA-12867) Improve screenreader text for configuration groups

### DIFF
--- a/feature-libs/product-configurator/common/assets/translations/en/configurator.json
+++ b/feature-libs/product-configurator/common/assets/translations/en/configurator.json
@@ -191,7 +191,7 @@
       "conflictsInConfiguration": "There are conflicts in your configuration. Number of conflicts: {{ numberOfConflicts }}, Select for more details.",
       "listOfGroups": "List of groups",
       "inListOfGroups": "You are in the group list",
-      "groupName": "Group {{ group }}",
+      "groupName": "Group of attributes {{ group }}",
       "groupBack": "You are in a sub-group. Select to go back.",
       "conflictBack": "You are in the conflict solver. Select to go back or select next tabs to solve conflicts.",
       "iconConflict": "Group has conflicts.",


### PR DESCRIPTION
## Summary
- Update the `configurator.a11y.groupName` translation so screenreaders announce configuration groups as "Group of attributes <name>" instead of "Group <name>" for better clarity.
- Affects both the group menu (`configurator-group-menu.component.ts`, aria-label for attribute groups) and the overview menu (`configurator-overview-menu.component.html`).

## Changes
- `feature-libs/product-configurator/common/assets/translations/en/configurator.json`: `"Group {{ group }}"` → `"Group of attributes {{ group }}"`.

## Tests
- No test changes required. Existing unit tests in `configurator-group-menu.component.spec.ts` use `MockTranslatePipe` which renders the translation key + parameters (e.g. `'configurator.a11y.groupName group:Group Name'`), not the actual translated text, so they remain valid.
- No E2E tests reference the translated text.

## Locales
- Only the English translation file is updated, consistent with repo convention (non-English locales are managed by translators separately, see e.g. commit `4b1afcfd03`).