### PR TITLE
fix: Fix OPF redirect return timing to prevent false cart redirection after successful payment

### DIFF
--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.spec.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.spec.ts
@@ -86,13 +86,13 @@ describe('OpfPaymentVerificationComponent', () => {
   });
 
   describe('ngOnInit', () => {
-    it('should call checkIfProcessingCartIdExist', () => {
+    it('should not call checkIfProcessingCartIdExist on init success path', () => {
       opfPaymentVerificationServiceMock.verifyResultUrl.and.returnValue(of());
 
       component.ngOnInit();
       expect(
         opfPaymentVerificationServiceMock.checkIfProcessingCartIdExist
-      ).toHaveBeenCalled();
+      ).not.toHaveBeenCalled();
     });
 
     it('should handle success scenario', () => {
@@ -149,6 +149,9 @@ describe('OpfPaymentVerificationComponent', () => {
 
       component.ngOnInit();
 
+      expect(
+        opfPaymentVerificationServiceMock.checkIfProcessingCartIdExist
+      ).toHaveBeenCalled();
       expect(component.onError).toHaveBeenCalledWith(mockError);
     });
 

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.spec.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.spec.ts
@@ -7,6 +7,7 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import {
+  FeatureConfigService,
   HttpErrorModel,
   MockTranslatePipe,
   TranslatePipe,
@@ -30,6 +31,7 @@ describe('OpfPaymentVerificationComponent', () => {
   let routeMock: jasmine.SpyObj<ActivatedRoute>;
   let opfPaymentVerificationServiceMock: jasmine.SpyObj<OpfPaymentVerificationService>;
   let windowRefMock: jasmine.SpyObj<WindowRef>;
+  let featureConfigServiceMock: jasmine.SpyObj<FeatureConfigService>;
 
   beforeEach(() => {
     routeMock = jasmine.createSpyObj('ActivatedRoute', [], {
@@ -55,6 +57,10 @@ describe('OpfPaymentVerificationComponent', () => {
     windowRefMock = jasmine.createSpyObj('WindowRef', [], {
       nativeWindow: mockNativeWindow,
     });
+    featureConfigServiceMock = jasmine.createSpyObj('FeatureConfigService', [
+      'isEnabled',
+    ]);
+    featureConfigServiceMock.isEnabled.and.returnValue(true);
 
     TestBed.configureTestingModule({
       imports: [OpfPaymentVerificationComponent],
@@ -63,6 +69,10 @@ describe('OpfPaymentVerificationComponent', () => {
         {
           provide: OpfPaymentVerificationService,
           useValue: opfPaymentVerificationServiceMock,
+        },
+        {
+          provide: FeatureConfigService,
+          useValue: featureConfigServiceMock,
         },
         { provide: WindowRef, useValue: windowRefMock },
       ],
@@ -197,6 +207,40 @@ describe('OpfPaymentVerificationComponent', () => {
       expect(
         opfPaymentVerificationServiceMock.runHostedPagePattern
       ).not.toHaveBeenCalled();
+    });
+
+    it('should call checkIfProcessingCartIdExist on init when feature toggle is disabled', () => {
+      featureConfigServiceMock.isEnabled.and.returnValue(false);
+      opfPaymentVerificationServiceMock.verifyResultUrl.and.returnValue(of());
+
+      component.ngOnInit();
+
+      expect(
+        opfPaymentVerificationServiceMock.checkIfProcessingCartIdExist
+      ).toHaveBeenCalled();
+    });
+
+    it('should not call checkIfProcessingCartIdExist in error path when feature toggle is disabled', () => {
+      featureConfigServiceMock.isEnabled.and.returnValue(false);
+      const mockError: HttpErrorModel = { status: 500, message: 'Error' };
+      const mockVerifyResult = {
+        paymentSessionId: '1',
+        paramsMap: [],
+        afterRedirectScriptFlag: 'false',
+      };
+
+      opfPaymentVerificationServiceMock.verifyResultUrl.and.returnValue(
+        of(mockVerifyResult)
+      );
+      opfPaymentVerificationServiceMock.runHostedPagePattern.and.returnValue(
+        throwError(() => mockError)
+      );
+
+      component.ngOnInit();
+
+      expect(
+        opfPaymentVerificationServiceMock.checkIfProcessingCartIdExist
+      ).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts
@@ -12,7 +12,11 @@ import {
   inject,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { HttpErrorModel, WindowRef } from '@spartacus/core';
+import {
+  FeatureConfigService,
+  HttpErrorModel,
+  WindowRef,
+} from '@spartacus/core';
 import { OpfKeyValueMap, OpfPage } from '@spartacus/opf/base/root';
 import { Observable, Subscription } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
@@ -32,12 +36,21 @@ export class OpfPaymentVerificationComponent implements OnInit, OnDestroy {
   );
   protected vcr = inject(ViewContainerRef);
   protected winRef = inject(WindowRef);
+  private featureConfigService = inject(FeatureConfigService);
 
   protected subscription?: Subscription;
   protected isHostedFieldPattern = false;
 
   ngOnInit(): void {
     this.breakOutOfIframeIfNeeded();
+
+    const checkProcessingCartOnErrorOnly = this.featureConfigService.isEnabled(
+      'opfPaymentVerificationCheckProcessingCartOnErrorOnly'
+    );
+
+    if (!checkProcessingCartOnErrorOnly) {
+      this.opfPaymentVerificationService.checkIfProcessingCartIdExist();
+    }
 
     this.subscription = this.opfPaymentVerificationService
       .verifyResultUrl(this.route)
@@ -59,7 +72,9 @@ export class OpfPaymentVerificationComponent implements OnInit, OnDestroy {
       )
       .subscribe({
         error: (error: HttpErrorModel | undefined) => {
-          this.opfPaymentVerificationService.checkIfProcessingCartIdExist();
+          if (checkProcessingCartOnErrorOnly) {
+            this.opfPaymentVerificationService.checkIfProcessingCartIdExist();
+          }
           this.onError(error);
         },
         next: (success: boolean) => {

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.ts
@@ -39,8 +39,6 @@ export class OpfPaymentVerificationComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.breakOutOfIframeIfNeeded();
 
-    this.opfPaymentVerificationService.checkIfProcessingCartIdExist();
-
     this.subscription = this.opfPaymentVerificationService
       .verifyResultUrl(this.route)
       .pipe(
@@ -60,7 +58,10 @@ export class OpfPaymentVerificationComponent implements OnInit, OnDestroy {
         )
       )
       .subscribe({
-        error: (error: HttpErrorModel | undefined) => this.onError(error),
+        error: (error: HttpErrorModel | undefined) => {
+          this.opfPaymentVerificationService.checkIfProcessingCartIdExist();
+          this.onError(error);
+        },
         next: (success: boolean) => {
           if (!success) {
             this.onError(undefined);

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -544,7 +544,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   enablePasswordExpiredErrorTranslation: true,
   enableQuotePurchaseOrderNumber: true,
   enableReturnOrderReturnableQuantityConsigmentFallback: true,
-  opfPaymentVerificationCheckProcessingCartOnErrorOnly: false,
   enableMediaPrefix: false,
   a11yCustomerTicketingVisualFocusFix: false,
   a11yFacetFilterByLabel: false,
@@ -569,4 +568,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   showSortFieldsOnlyAtTop: false,
   showRequiredAsterisks: false,
   enableExpiredRefreshTokenHandlers: false,
+  opfPaymentVerificationCheckProcessingCartOnErrorOnly: false,
 };

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -10,6 +10,14 @@
 // Thanks to that, customers using a property that was recently removed, will know they have to adapt their code.
 export interface FeatureTogglesInterface {
   /**
+   * When enabled, `OpfPaymentVerificationComponent` calls
+   * `checkIfProcessingCartIdExist()` only on verification error.
+   *
+   * Legacy behavior called it immediately during init.
+   */
+  opfPaymentVerificationCheckProcessingCartOnErrorOnly?: boolean;
+
+  /**
    * Adds a keyboard accessible zoom button to the `ProductImageZoomViewComponent`.
    */
   a11yKeyboardAccessibleZoom?: boolean;
@@ -536,6 +544,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   enablePasswordExpiredErrorTranslation: true,
   enableQuotePurchaseOrderNumber: true,
   enableReturnOrderReturnableQuantityConsigmentFallback: true,
+  opfPaymentVerificationCheckProcessingCartOnErrorOnly: false,
   enableMediaPrefix: false,
   a11yCustomerTicketingVisualFocusFix: false,
   a11yFacetFilterByLabel: false,

--- a/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/projects/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -10,14 +10,6 @@
 // Thanks to that, customers using a property that was recently removed, will know they have to adapt their code.
 export interface FeatureTogglesInterface {
   /**
-   * When enabled, `OpfPaymentVerificationComponent` calls
-   * `checkIfProcessingCartIdExist()` only on verification error.
-   *
-   * Legacy behavior called it immediately during init.
-   */
-  opfPaymentVerificationCheckProcessingCartOnErrorOnly?: boolean;
-
-  /**
    * Adds a keyboard accessible zoom button to the `ProductImageZoomViewComponent`.
    */
   a11yKeyboardAccessibleZoom?: boolean;
@@ -507,6 +499,14 @@ export interface FeatureTogglesInterface {
    * When enabled, sytling is changed on navigation header and menu to be more cohesive.
    */
   alignNavigationMenuWithHeader?: boolean;
+
+  /**
+   * When enabled, `OpfPaymentVerificationComponent` calls
+   * `checkIfProcessingCartIdExist()` only on verification error.
+   *
+   * Legacy behavior called it immediately during init.
+   */
+  opfPaymentVerificationCheckProcessingCartOnErrorOnly?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -329,8 +329,6 @@ if (environment.cpq) {
         enablePasswordExpiredErrorTranslation: true,
         enableQuotePurchaseOrderNumber: true,
         enableReturnOrderReturnableQuantityConsigmentFallback: true,
-        // eslint-disable-next-line @nx/workspace-no-storefrontapp-false-feature-toggles -- CXSPA-13313
-        opfPaymentVerificationCheckProcessingCartOnErrorOnly: true,
         enableMediaPrefix: true,
         a11yCustomerTicketingVisualFocusFix: true,
         a11yFacetFilterByLabel: true,
@@ -356,6 +354,7 @@ if (environment.cpq) {
         showSortFieldsOnlyAtTop: true,
         showRequiredAsterisks: true,
         enableExpiredRefreshTokenHandlers: true,
+        opfPaymentVerificationCheckProcessingCartOnErrorOnly: true,
       };
       return appFeatureToggles;
     }),

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -329,6 +329,8 @@ if (environment.cpq) {
         enablePasswordExpiredErrorTranslation: true,
         enableQuotePurchaseOrderNumber: true,
         enableReturnOrderReturnableQuantityConsigmentFallback: true,
+        // eslint-disable-next-line @nx/workspace-no-storefrontapp-false-feature-toggles -- CXSPA-13313
+        opfPaymentVerificationCheckProcessingCartOnErrorOnly: true,
         enableMediaPrefix: true,
         a11yCustomerTicketingVisualFocusFix: true,
         a11yFacetFilterByLabel: true,


### PR DESCRIPTION
JIRA Ticket : [CXSPA-13313](https://jira.tools.sap/browse/CXSPA-13313) .
This PR fixes a checkout regression where redirect-based payments could place the order successfully but still send the user to cart, causing a duplicate payment-authorized flow when re-entering checkout.