### PR TITLE
fix: Remove unsecure npm token input and PAT from git api url

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -31,7 +31,9 @@ jobs:
           GHT_PRIVATE_REPO_TOKEN: ${{ secrets.GHT_PRIVATE_REPO_TOKEN }}
           GHT_SPARTACUS_REPO: ${{ secrets.GHT_SPARTACUS_REPO }}
         run: |
-          git push -u "https://${GHT_USER}:${GHT_PRIVATE_REPO_TOKEN}@github.tools.sap/cx-commerce-storefronts/${GHT_SPARTACUS_REPO}.git" "$BRANCH_TO_SYNC" -f
+          git config --global credential.helper store
+          printf 'https://%s:%s@github.tools.sap\n' "${GHT_USER}" "${GHT_PRIVATE_REPO_TOKEN}" > ~/.git-credentials
+          git push -u "https://github.tools.sap/cx-commerce-storefronts/${GHT_SPARTACUS_REPO}.git" "$BRANCH_TO_SYNC" -f
       - name: Include remaining pipeline files to the private remote's branch
         env:
           BRANCH_TO_SYNC: ${{ github.event.inputs.branch_to_sync || env.DEFAULT_BRANCH_TO_SYNC }}
@@ -49,7 +51,7 @@ jobs:
           echo "---------------------------------------------------------------------------------------------------------------------------"
           echo "Clone repo"
 
-          git clone -b "$BRANCH_TO_SYNC" "https://${GHT_USER}:${GHT_PRIVATE_REPO_TOKEN}@github.tools.sap/cx-commerce-storefronts/${GHT_SPARTACUS_REPO}.git"
+          git clone -b "$BRANCH_TO_SYNC" "https://github.tools.sap/cx-commerce-storefronts/${GHT_SPARTACUS_REPO}.git"
           cd "$GHT_SPARTACUS_REPO"
 
           git config --global user.email "$GHT_EMAIL"

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -97,9 +97,6 @@ jobs:
           echo "---------------------------------------------------------------------------------------------------------------------------"
           echo "Configure azure pipeline build packages list"
 
-          rm -f ~/.git-credentials
-          git config --global --unset credential.helper || true
-
           RELEASE_PACKAGES=$($RELEASE_PACKAGES_LIST_GENERATOR)
 
           FORMATTED_RELEASE_PACKAGES=""

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -97,6 +97,9 @@ jobs:
           echo "---------------------------------------------------------------------------------------------------------------------------"
           echo "Configure azure pipeline build packages list"
 
+          rm -f ~/.git-credentials
+          git config --global --unset credential.helper || true
+
           RELEASE_PACKAGES=$($RELEASE_PACKAGES_LIST_GENERATOR)
 
           FORMATTED_RELEASE_PACKAGES=""
@@ -155,3 +158,8 @@ jobs:
           git add .
           git commit -m "include remaining pipeline files"
           git push origin "$BRANCH_TO_SYNC"
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          rm -f ~/.git-credentials
+          git config --global --unset credential.helper || true

--- a/.github/workflows/update-cloud-repo.yml
+++ b/.github/workflows/update-cloud-repo.yml
@@ -181,3 +181,8 @@ jobs:
               "head": "'"$branch_name"'",
               "base": "main"
             }'
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          rm -f ~/.git-credentials
+          git config --global --unset credential.helper || true

--- a/.github/workflows/update-cloud-repo.yml
+++ b/.github/workflows/update-cloud-repo.yml
@@ -5,10 +5,6 @@ on:
       version:
         description: 'Enter the version to use'
         required: true
-      npm_token:
-        description: 'Enter your npm token'
-        required: true
-        secret: true
       repo_url:
         description: 'Enter the repository URL (default will be used if empty)'
         required: false
@@ -32,7 +28,9 @@ jobs:
           GH_TEMPORARY_TOKEN: ${{ secrets.GH_TEMPORARY_TOKEN }}
         run: |
           if [ -z "$INPUT_REPO_URL" ]; then
-            REPO_URL="https://${GH_TEMPORARY_TOKEN}@github.com/SAP-samples/cloud-commerce-sample-setup.git"
+            git config --global credential.helper store
+            printf 'https://oauth2:%s@github.com\n' "${GH_TEMPORARY_TOKEN}" > ~/.git-credentials
+            REPO_URL="https://github.com/SAP-samples/cloud-commerce-sample-setup.git"
           else
             REPO_URL="$INPUT_REPO_URL"
           fi
@@ -47,7 +45,7 @@ jobs:
       - name: Create storefronts
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
-          INPUT_NPM_TOKEN: ${{ github.event.inputs.npm_token }}
+          INPUT_NPM_TOKEN: ${{ secrets.SAP_COMMON_NPM_TOKEN }}
         run: |
           function setup_config_dir() {
             [ -d "${CONFIG_DIR}" ]


### PR DESCRIPTION
Partially closes: https://jira.tools.sap/browse/CXSPA-13068

1. This change moves the Git authentication token out of the git push URL and stores it in Git credentials instead.
The token is directly inside the remote URL. This works, but it is risky because the token can appear in logs, process lists, shell history, Git config, or error output.
Now Git reads the credentials from ~/.git-credentials, while the push URL itself stays clean

1. When passing npm token through the input it can also be found in debug logs output, for safety reason it was moved to repository secrets