### PR TITLE
chore: (CXSPA-13083) automate coding guidelines enforcement via ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -173,6 +173,20 @@ export default defineConfig(
           message: "Please import directly from 'rxjs' instead",
         },
       ],
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: 'MemberExpression[object.property.name="nativeElement"]',
+          message:
+            '[Spartacus] Do not access properties directly on nativeElement. Use Renderer2 instead (e.g. this.renderer.setStyle(this.el.nativeElement, ...)).',
+        },
+        {
+          selector:
+            'PropertyDefinition[accessibility="private"][value.type="CallExpression"][value.callee.name="inject"]:not([value.arguments.0.name="FeatureConfigService"])',
+          message:
+            '[Spartacus] Injected dependencies should use "protected" instead of "private" to allow customers to extend the class.',
+        },
+      ],
       'no-shadow': 'off',
       'no-throw-literal': 'error',
       'no-undef-init': 'error',
@@ -210,6 +224,7 @@ export default defineConfig(
       '@angular-eslint/template/no-negated-async': 'off',
       '@angular-eslint/template/eqeqeq': 'error',
       '@angular-eslint/template/prefer-control-flow': 'off',
+      '@angular-eslint/template/prefer-self-closing-tags': 'warn',
     },
   },
   {
@@ -237,6 +252,7 @@ export default defineConfig(
     rules: {
       '@nx/workspace-no-const-enum': 'error',
       '@nx/workspace-feature-config-service-must-be-private': 'error',
+      '@nx/workspace-no-self-public-api-import': 'warn',
     },
   },
 );

--- a/tools/eslint-rules/index.ts
+++ b/tools/eslint-rules/index.ts
@@ -48,6 +48,11 @@ import {
   rule as noStorefrontappFalseFeatureToggles,
   RULE_NAME as noStorefrontappFalseFeatureTogglesName,
 } from './rules/no-storefrontapp-false-feature-toggles';
+
+import {
+  rule as noSelfPublicApiImport,
+  RULE_NAME as noSelfPublicApiImportName,
+} from './rules/no-self-public-api-import';
 /**
  * Import your custom workspace rules at the top of this file.
  *
@@ -85,5 +90,6 @@ module.exports = {
     [noConstEnumName]: noConstEnum,
     [featureConfigServiceMustBePrivateName]: featureConfigServiceMustBePrivate,
     [noStorefrontappFalseFeatureTogglesName]: noStorefrontappFalseFeatureToggles,
+    [noSelfPublicApiImportName]: noSelfPublicApiImport,
   },
 };

--- a/tools/eslint-rules/rules/fixtures/mock-lib/package.json
+++ b/tools/eslint-rules/rules/fixtures/mock-lib/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@spartacus/mock-lib"
+}

--- a/tools/eslint-rules/rules/no-self-public-api-import.spec.ts
+++ b/tools/eslint-rules/rules/no-self-public-api-import.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path';
+import { RuleTester } from '@angular-eslint/test-utils';
+import { rule, RULE_NAME } from './no-self-public-api-import';
+
+const ruleTester = new RuleTester();
+
+// File inside the mock library — nearest package.json has name "@spartacus/mock-lib"
+const insideMockLib = path.join(
+  __dirname,
+  'fixtures',
+  'mock-lib',
+  'src',
+  'test.ts'
+);
+
+// File outside any @spartacus library (root package.json name is "storefrontapp")
+const outsideLib = path.join(__dirname, 'fixtures', 'file.ts');
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    // relative import inside the library — always valid
+    {
+      code: `import { CartService } from '../services/cart.service';`,
+      filename: insideMockLib,
+    },
+    // import from a DIFFERENT @spartacus library — valid
+    {
+      code: `import { OccConfig } from '@spartacus/core';`,
+      filename: insideMockLib,
+    },
+    // @spartacus import but the file is not inside any @spartacus library
+    {
+      code: `import { CartService } from '@spartacus/cart';`,
+      filename: outsideLib,
+    },
+  ],
+  invalid: [
+    // importing from own package's public API
+    {
+      code: `import { SomeService } from '@spartacus/mock-lib';`,
+      filename: insideMockLib,
+      errors: [{ messageId: 'noSelfPublicApiImport' }],
+    },
+    // importing from a sub-entry of own package
+    {
+      code: `import { SomeService } from '@spartacus/mock-lib/root';`,
+      filename: insideMockLib,
+      errors: [{ messageId: 'noSelfPublicApiImport' }],
+    },
+  ],
+});

--- a/tools/eslint-rules/rules/no-self-public-api-import.ts
+++ b/tools/eslint-rules/rules/no-self-public-api-import.ts
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const RULE_NAME = 'no-self-public-api-import';
+
+const dirToPackageName = new Map<string, string | null>();
+
+function getPackageNameForFile(filePath: string): string | null {
+  const dir = path.dirname(filePath);
+  if (dirToPackageName.has(dir)) {
+    return dirToPackageName.get(dir) ?? null;
+  }
+
+  let current = dir;
+  const root = path.parse(dir).root;
+  while (current !== root) {
+    const pkgPath = path.join(current, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+        const name: string | null =
+          typeof pkg.name === 'string' && pkg.name.startsWith('@spartacus/')
+            ? pkg.name
+            : null;
+        dirToPackageName.set(dir, name);
+        return name;
+      } catch {
+        break;
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  dirToPackageName.set(dir, null);
+  return null;
+}
+
+/**
+ * ESLint rule that disallows importing from a library's own public API entry point.
+ * Inside a library, use relative imports instead.
+ *
+ * Prevents circular dependencies caused by re-importing through the barrel file.
+ *
+ * @example
+ * // Inside feature-libs/cart/src/...
+ *
+ * // ✅ Valid — relative import
+ * import { CartService } from '../services/cart.service';
+ *
+ * // ✅ Valid — import from a DIFFERENT @spartacus library
+ * import { OccConfig } from '@spartacus/core';
+ *
+ * // ❌ Invalid — importing from own public API
+ * import { CartService } from '@spartacus/cart';
+ */
+export const rule = ESLintUtils.RuleCreator(() => __filename)({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Disallows importing from a library's own @spartacus public API entry point; use relative imports instead.",
+    },
+    schema: [],
+    messages: {
+      noSelfPublicApiImport:
+        '[Spartacus] Inside library "{{packageName}}", use relative imports instead of importing from its own public API entry point.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const filePath = context.filename;
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        const importSource = node.source.value as string;
+        if (!importSource.startsWith('@spartacus/')) {
+          return;
+        }
+
+        const packageName = getPackageNameForFile(filePath);
+        if (!packageName) {
+          return;
+        }
+
+        if (
+          importSource === packageName ||
+          importSource.startsWith(packageName + '/')
+        ) {
+          context.report({
+            node,
+            messageId: 'noSelfPublicApiImport',
+            data: { packageName },
+          });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
Automate checking of Coding Guidelines [CXSPA-13083](https://jira.tools.sap/login.jsp?permissionViolation=true&os_destination=https%3A%2F%2Fjira.tools.sap%2Fbrowse%2FCXSPA-13083)

- no-restricted-syntax (warn): nativeElement direct access, private inject()
- custom rule no-self-public-api-import (warn): self @spartacus/<lib> imports
- template/prefer-self-closing-tags (warn)