### PR TITLE
fix: address checkmarx issue

### DIFF
--- a/core-libs/core/src/cms/page/routing/page-link.service.ts
+++ b/core-libs/core/src/cms/page/routing/page-link.service.ts
@@ -5,7 +5,7 @@
  */
 
 import { inject, Injectable } from '@angular/core';
-import { FeatureToggles } from '@spartacus/core';
+import { FeatureToggles } from '../../../features-config/feature-toggles';
 import { WindowRef } from '../../../window/window-ref';
 import {
   CanonicalUrlOptions,

--- a/core-libs/core/src/cms/page/routing/page-link.service.ts
+++ b/core-libs/core/src/cms/page/routing/page-link.service.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
+import { FeatureToggles } from '@spartacus/core';
 import { WindowRef } from '../../../window/window-ref';
 import {
   CanonicalUrlOptions,
@@ -21,6 +22,8 @@ export class PageLinkService {
     protected winRef: WindowRef
   ) {}
 
+  private featureToggles = inject(FeatureToggles);
+
   /**
    * Returns the canonical for the page.
    *
@@ -32,10 +35,23 @@ export class PageLinkService {
       ...this.pageMetaConfig?.pageMeta?.canonicalUrl,
       ...options,
     };
-    return this.buildCanonicalUrl(
-      url ?? this.winRef.location.href ?? '',
-      config
-    );
+    const rawUrl = url ?? this.winRef.location.href ?? '';
+    const safeUrl = this.featureToggles.pageLinkSanitizeCanonicalUrl
+      ? this.sanitizeUrl(rawUrl)
+      : rawUrl;
+    return this.buildCanonicalUrl(safeUrl, config);
+  }
+
+  protected sanitizeUrl(rawUrl: string): string {
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return '';
+      }
+      return parsed.toString();
+    } catch {
+      return '';
+    }
   }
 
   protected buildCanonicalUrl(

--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -523,6 +523,8 @@ export interface FeatureTogglesInterface {
    * When enabled, fixes a known issue where the last remembered route after logout is the route to which the logout has redirected
    */
   redirectOnlyOnTrueNavigationEnd?: boolean;
+
+  pageLinkSanitizeCanonicalUrl?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -588,4 +590,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   opfPaymentVerificationCheckProcessingCartOnErrorOnly: false,
   a11yCouponNotificationChannelsLinkStyling: false,
   redirectOnlyOnTrueNavigationEnd: false,
+  pageLinkSanitizeCanonicalUrl: false,
 };

--- a/core-libs/core/src/site-context/config/config-loader/site-context-config-initializer.ts
+++ b/core-libs/core/src/site-context/config/config-loader/site-context-config-initializer.ts
@@ -64,7 +64,7 @@ export class SiteContextConfigInitializer implements ConfigInitializer {
 
         if (!baseSite) {
           throw new Error(
-            `Error: Cannot get base site config! Current url (${url}) doesn't match any of url patterns of any base sites.`
+            `Error: Cannot get base site config! Current url (${encodeURI(url)}) doesn't match any of url patterns of any base sites.`
           );
         }
         return baseSite;

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -358,6 +358,7 @@ if (environment.cpq) {
         a11yCouponNotificationChannelsLinkStyling: true,
         opfPaymentVerificationCheckProcessingCartOnErrorOnly: true,
         redirectOnlyOnTrueNavigationEnd: true,
+        pageLinkSanitizeCanonicalUrl: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
### This PR addresses two high detections from Checkmarx

1. [Checkmarx Issue link](https://checkmarx.tools.sap/sast-results/435859e5-ea8b-4763-a9c2-92a6ca824cb7/45d82358-0bb9-4c2d-a42f-89aaa5ea0cb6?resultId=Q%2FDsQX8COxakzCcRyQYD7tioHzc%3D&pagination=pageSize%3D10%3BcurrentPage%3D1&grouping=groups%255B0%255D%3Dlanguage%3Bgroups%255B1%255D%3Dseverity%3Bgroups%255B2%255D%3DqueryName)

This is likely a false positive.

The source is winRef.location.href and the sink (output) flows into a string that's eventually emitted, in this case the thrown Error message at site-context-config-initializer.ts:67.

Issue: missing step between source and sink, no DomSanitizer, encodeURI, or escape function is called. The scanner can't tell where that Error string actually surfaces, so it conservatively assumes "embedded in the page" and reports XSS.

Resolution: sanitize url before emitting in Error

2. [Checkmarx Issue link](https://checkmarx.tools.sap/sast-results/435859e5-ea8b-4763-a9c2-92a6ca824cb7/45d82358-0bb9-4c2d-a42f-89aaa5ea0cb6?resultId=6gzwIb%2Bq9%2BYnxAxMdIui%2BBe1KrM%3D&pagination=pageSize%3D10%3BcurrentPage%3D1&grouping=groups%255B0%255D%3Dlanguage%3Bgroups%255B1%255D%3Dseverity%3Bgroups%255B2%255D%3DqueryNamehttps://checkmarx.tools.sap/sast-results/435859e5-ea8b-4763-a9c2-92a6ca824cb7/45d82358-0bb9-4c2d-a42f-89aaa5ea0cb6?resultId=6gzwIb%2Bq9%2BYnxAxMdIui%2BBe1KrM%3D&pagination=pageSize%3D10%3BcurrentPage%3D1&grouping=groups%255B0%255D%3Dlanguage%3Bgroups%255B1%255D%3Dseverity%3Bgroups%255B2%255D%3DqueryName)

This one is more substantive than the previous finding — the value really does flow into a DOM href attribute — but it's still not exploitable as XSS in practice, but worth fixing for SEO hygiene and to keep the scanner quiet.

Resolution: validate and re-serialize the URL through the URL API, then return the normalized form. This:
- Rejects malformed input (returns empty string)
- Re-encodes characters consistently
- Strips any non-http(s) protocol → kills javascript: and other schemes
- Gives the scanner the sanitization step it's looking for