### PR TITLE
fix: declare type:commonjs on libraries shipping schematics

### DIFF
--- a/feature-libs/asm/package.json
+++ b/feature-libs/asm/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/asm",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/cart/package.json
+++ b/feature-libs/cart/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/cart",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/checkout/package.json
+++ b/feature-libs/checkout/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/checkout",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/customer-ticketing/package.json
+++ b/feature-libs/customer-ticketing/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/customer-ticketing",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/estimated-delivery-date/package.json
+++ b/feature-libs/estimated-delivery-date/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/estimated-delivery-date",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/order/package.json
+++ b/feature-libs/order/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/order",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/organization/package.json
+++ b/feature-libs/organization/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/organization",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/pdf-invoices/package.json
+++ b/feature-libs/pdf-invoices/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/pdf-invoices",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/pickup-in-store/package.json
+++ b/feature-libs/pickup-in-store/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/pickup-in-store",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/product-configurator/package.json
+++ b/feature-libs/product-configurator/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/product-configurator",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/product-multi-dimensional/package.json
+++ b/feature-libs/product-multi-dimensional/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/product-multi-dimensional",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/product/package.json
+++ b/feature-libs/product/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/product",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/qualtrics/package.json
+++ b/feature-libs/qualtrics/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/qualtrics",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/quote/package.json
+++ b/feature-libs/quote/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/quote",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/requested-delivery-date/package.json
+++ b/feature-libs/requested-delivery-date/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/requested-delivery-date",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/smartedit/package.json
+++ b/feature-libs/smartedit/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/smartedit",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/feature-libs/storefinder/package.json
+++ b/feature-libs/storefinder/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/storefinder",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/subscription-billing/package.json
+++ b/feature-libs/subscription-billing/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     ".": {
       "sass": "./_index.scss"

--- a/feature-libs/tracking/package.json
+++ b/feature-libs/tracking/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/tracking",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/feature-libs/user/package.json
+++ b/feature-libs/user/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/user",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/cdc/package.json
+++ b/integration-libs/cdc/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/cdc",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/cdp/package.json
+++ b/integration-libs/cdp/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/cdp",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/cds/package.json
+++ b/integration-libs/cds/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/cds",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"src/schematics/**/*.js\" \"src/schematics/**/*.js.map\" \"src/schematics/**/*.d.ts\"",

--- a/integration-libs/cpq-quote/package.json
+++ b/integration-libs/cpq-quote/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/cpq-quote",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/digital-payments/package.json
+++ b/integration-libs/digital-payments/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/digital-payments",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/epd-visualization/package.json
+++ b/integration-libs/epd-visualization/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/epd-visualization",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/omf/package.json
+++ b/integration-libs/omf/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/opf/package.json
+++ b/integration-libs/opf/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/opf",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/opps/package.json
+++ b/integration-libs/opps/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/opps",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/punchout/package.json
+++ b/integration-libs/punchout/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/punchout",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/s4-service/package.json
+++ b/integration-libs/s4-service/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/s4-service",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/s4om/package.json
+++ b/integration-libs/s4om/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/segment-refs/package.json
+++ b/integration-libs/segment-refs/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",


### PR DESCRIPTION
Root cause
==========
Yesterday's Angular minor bump (PR #21554, commit 228db49338) raised ng-packagr from ^21.2.0 to ^21.2.3. In ng-packagr 21.2.3 the write-package.transform now applies `packageJson.type ??= 'module'` (see node_modules/ng-packagr/src/lib/ng-package/entry-point/write-package.transform.js line 189), so every published @spartacus/* package.json that did not declare a top-level "type" field was being emitted with "type":"module".

Spartacus libraries co-locate ESM runtime artefacts (.mjs files declared under exports) and CommonJS schematic factories (schematics/**/*.js, emitted by tsc with module:CommonJs). Once the published package.json became "type":"module", Node treated every .js file under that package as ESM by extension-resolution. When @angular-devkit/schematics' export-ref loader called require() on schematics/<add-feature>/index.js (CJS source using exports.* and require()), Node refused with either:

  "exports is not defined in ES module scope"

or, when the same module was concurrently being walked by the ESM loader during ng add orchestration:

  "Unexpected module status 5. Cannot require() ES Module ... not yet
   fully loaded ... race condition if the module is simultaneously
   dynamically import()-ed via Promise.all()."

Both messages are the same root cause — Node misclassifying CJS schematic factories as ESM because the package was marked type:module.

Fix
===
Declare "type": "commonjs" explicitly in each source package.json that ships schematic factories (33 libraries). The `??=` in ng-packagr is a no-op when the field is already set, so the published package.json keeps "type":"commonjs" and Node correctly treats the schematic .js files as CommonJS again.

Why this is the right fix
=========================
- The runtime is unaffected: ng-packagr's exports map points to .mjs files, and Node treats .mjs as ESM regardless of the package-level "type" field. Runtime imports (`import { X } from '@spartacus/foo'`) still resolve to the ESM entry points.
- The schematics are unaffected: emitted as .js with CommonJS syntax, loaded via require() by @angular-devkit/schematics, now correctly recognised as CJS because of the explicit package-level declaration.
- The fix propagates to both verdaccio publishes (./run.sh install) and future npm-registry publishes — consumers of either path get the same artefact shape.
- The change is a single line per package.json, fully reversible, and does not require any change to schematic source, tsconfig, or collection.json factory paths.
- core-libs/{core,storefront,setup,assets,styles} are deliberately left untouched — they are runtime-only ESM packages that do not ship CJS schematics, so ng-packagr's default "type":"module" emission is correct for them.

Verified end-to-end locally (Node 22.22.0, npm 10.9.4): full build:libs + verdaccio publish + ng new + ng add @spartacus/schematics + ng add @spartacus/tracking (both single and --features variants) complete with no schematic-loading errors.