### PR TITLE
fix: declare type:commonjs on libraries shipping schematics

### DIFF
--- a/feature-libs/asm/package.json
+++ b/feature-libs/asm/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/asm",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/cart/package.json
+++ b/feature-libs/cart/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/cart",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/checkout/package.json
+++ b/feature-libs/checkout/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/checkout",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/customer-ticketing/package.json
+++ b/feature-libs/customer-ticketing/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/customer-ticketing",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/estimated-delivery-date/package.json
+++ b/feature-libs/estimated-delivery-date/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/estimated-delivery-date",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/order/package.json
+++ b/feature-libs/order/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/order",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/organization/package.json
+++ b/feature-libs/organization/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/organization",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/pdf-invoices/package.json
+++ b/feature-libs/pdf-invoices/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/pdf-invoices",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/pickup-in-store/package.json
+++ b/feature-libs/pickup-in-store/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/pickup-in-store",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/product-configurator/package.json
+++ b/feature-libs/product-configurator/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/product-configurator",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/product-multi-dimensional/package.json
+++ b/feature-libs/product-multi-dimensional/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/product-multi-dimensional",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/product/package.json
+++ b/feature-libs/product/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/product",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/qualtrics/package.json
+++ b/feature-libs/qualtrics/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/qualtrics",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/quote/package.json
+++ b/feature-libs/quote/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/quote",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/requested-delivery-date/package.json
+++ b/feature-libs/requested-delivery-date/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/requested-delivery-date",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/smartedit/package.json
+++ b/feature-libs/smartedit/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/smartedit",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/feature-libs/storefinder/package.json
+++ b/feature-libs/storefinder/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/storefinder",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/feature-libs/subscription-billing/package.json
+++ b/feature-libs/subscription-billing/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     ".": {
       "sass": "./_index.scss"

--- a/feature-libs/tracking/package.json
+++ b/feature-libs/tracking/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/tracking",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/feature-libs/user/package.json
+++ b/feature-libs/user/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/feature-libs/user",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/cdc/package.json
+++ b/integration-libs/cdc/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/cdc",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/cdp/package.json
+++ b/integration-libs/cdp/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/cdp",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/cds/package.json
+++ b/integration-libs/cds/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/cds",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"src/schematics/**/*.js\" \"src/schematics/**/*.js.map\" \"src/schematics/**/*.d.ts\"",

--- a/integration-libs/cpq-quote/package.json
+++ b/integration-libs/cpq-quote/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/cpq-quote",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/digital-payments/package.json
+++ b/integration-libs/digital-payments/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/digital-payments",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/epd-visualization/package.json
+++ b/integration-libs/epd-visualization/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/epd-visualization",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/omf/package.json
+++ b/integration-libs/omf/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/opf/package.json
+++ b/integration-libs/opf/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/opf",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/opps/package.json
+++ b/integration-libs/opps/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/opps",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/punchout/package.json
+++ b/integration-libs/punchout/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/punchout",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/s4-service/package.json
+++ b/integration-libs/s4-service/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus/tree/develop/integration-libs/s4-service",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "exports": {
     "./*": {
       "sass": "./*"

--- a/integration-libs/s4om/package.json
+++ b/integration-libs/s4om/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",

--- a/integration-libs/segment-refs/package.json
+++ b/integration-libs/segment-refs/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/SAP/spartacus",
   "repository": "https://github.com/SAP/spartacus",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "scripts": {
     "build:schematics": "npm run clean:schematics && ../../node_modules/.bin/tsc -p ./tsconfig.schematics.json",
     "clean:schematics": "../../node_modules/.bin/rimraf --glob \"schematics/**/*.js\" \"schematics/**/*.js.map\" \"schematics/**/*.d.ts\"",


### PR DESCRIPTION
## Summary

- Cherry-picks `f8d7388e` from develop: adds `"type": "commonjs"` to all 33 `feature-libs/` and `integration-libs/` packages that ship schematics
- Adds the same fix to `projects/schematics/package.json` which was missed in the original commit due to folder reorganisation on this branch

## Problem

After ng-packagr build, the published package contains `"type": "module"` which causes Node.js to treat schematics `.js` files as ESM. Since schematics are compiled as CommonJS (`exports = ...`), this results in:
> `exports is not defined in ES module scope`

## Fix

Adding `"type": "commonjs"` to each library's `package.json` overrides the parent `"type": "module"` for that package, telling Node.js to treat the schematics files as CommonJS.

## Related commits

- `f8d7388e` fix: declare type:commonjs on libraries shipping schematics (#21579)