### PR TITLE
chore: (CXSPA-13513) remove limitCacheByMemory SSR feature toggle

### DIFF
--- a/core-libs/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/core-libs/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -236,11 +236,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import bootstrap from './main.server';
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
-  ssrFeatureToggles: {
-    limitCacheByMemory: true,
-  },
-});
+const ngExpressEngine = NgExpressEngineDecorator.get(engine);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/core-libs/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/core-libs/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -10,11 +10,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import bootstrap from './main.server';
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
-  ssrFeatureToggles: {
-    limitCacheByMemory: true,
-  },
-});
+const ngExpressEngine = NgExpressEngineDecorator.get(engine);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/core-libs/schematics/src/migrations/2211_36/ssr/ssr_spec.ts
+++ b/core-libs/schematics/src/migrations/2211_36/ssr/ssr_spec.ts
@@ -42,11 +42,7 @@ describe('Update SSR Migration', () => {
     import { fileURLToPath } from 'node:url';
     import AppServerModule from './main.server';
 
-    const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
-      ssrFeatureToggles: {
-        limitCacheByMemory: true,
-      },
-    });
+    const ngExpressEngine = NgExpressEngineDecorator.get(engine);
 
     // The Express app is exported so that it can be used by serverless Functions.
     export function app(): express.Express {

--- a/core-libs/schematics/src/modernize-app-migrated-from-2211_32-to-2211_36/integration-test/__fixtures__/app-ssr/server.ts.fixture
+++ b/core-libs/schematics/src/modernize-app-migrated-from-2211_32-to-2211_36/integration-test/__fixtures__/app-ssr/server.ts.fixture
@@ -10,11 +10,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import AppServerModule from './src/main.server';
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
-  ssrFeatureToggles: {
-    limitCacheByMemory: true,
-  },
-});
+const ngExpressEngine = NgExpressEngineDecorator.get(engine);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/core-libs/schematics/src/modernize-app-migrated-from-2211_32-to-2211_36/integration-test/__snapshots__/app-ssr_spec.ts.snap
+++ b/core-libs/schematics/src/modernize-app-migrated-from-2211_32-to-2211_36/integration-test/__snapshots__/app-ssr_spec.ts.snap
@@ -240,11 +240,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import AppServerModule from './main.server';
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine, {
-  ssrFeatureToggles: {
-    limitCacheByMemory: true,
-  },
-});
+const ngExpressEngine = NgExpressEngineDecorator.get(engine);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -250,7 +250,7 @@ describe('OptimizedSsrEngine', () => {
 
     it('should be initialized with the provided custom options', () => {
       const engineRunner = new TestEngineRunner({
-        cacheSizeMemory: 100,
+        cacheSizeMemory: 1_000_000,
         ttl: 200,
       });
       expect(engineRunner.optimizedSsrEngine['renderingCache']).toBeDefined();
@@ -258,7 +258,7 @@ describe('OptimizedSsrEngine', () => {
         engineRunner.optimizedSsrEngine['renderingCache']['options']
       ).toEqual({
         ...defaultSsrOptimizationOptions,
-        cacheSizeMemory: 100,
+        cacheSizeMemory: 1_000_000,
         ttl: 200,
       });
     });

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -189,7 +189,6 @@ describe('OptimizedSsrEngine', () => {
             timestamp: '2023-01-01T00:00:00.000Z',
             options: {
               cache: false,
-              cacheSize: 3000,
               cacheSizeMemory: 800000000,
               cacheEntrySizeCalculator: 'DefaultCacheEntrySizeCalculator',
               ttl: undefined,
@@ -204,7 +203,7 @@ describe('OptimizedSsrEngine', () => {
               renderKeyResolver: 'function getRequestUrl(req) {\\n' +
                 '    return (0, express_request_origin_1.getRequestOrigin)(req) + req.originalUrl;\\n' +
                 '}',
-              ssrFeatureToggles: { limitCacheByMemory: true }
+              ssrFeatureToggles: {}
             }
           }
         }",
@@ -251,7 +250,7 @@ describe('OptimizedSsrEngine', () => {
 
     it('should be initialized with the provided custom options', () => {
       const engineRunner = new TestEngineRunner({
-        cacheSize: 100,
+        cacheSizeMemory: 100,
         ttl: 200,
       });
       expect(engineRunner.optimizedSsrEngine['renderingCache']).toBeDefined();
@@ -259,7 +258,7 @@ describe('OptimizedSsrEngine', () => {
         engineRunner.optimizedSsrEngine['renderingCache']['options']
       ).toEqual({
         ...defaultSsrOptimizationOptions,
-        cacheSize: 100,
+        cacheSizeMemory: 100,
         ttl: 200,
       });
     });
@@ -1442,7 +1441,6 @@ describe('OptimizedSsrEngine', () => {
             "options": {
               "cache": false,
               "cacheEntrySizeCalculator": "DefaultCacheEntrySizeCalculator",
-              "cacheSize": 3000,
               "cacheSizeMemory": 800000000,
               "concurrency": 10,
               "forcedSsrTimeout": 60000,
@@ -1461,9 +1459,7 @@ describe('OptimizedSsrEngine', () => {
         }",
               "reuseCurrentRendering": true,
               "shouldCacheRenderingResult": "({ entry: { err } }) => !err",
-              "ssrFeatureToggles": {
-                "limitCacheByMemory": true,
-              },
+              "ssrFeatureToggles": {},
               "timeout": 3000,
               "ttl": undefined,
             },

--- a/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache-size-manager.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache-size-manager.spec.ts
@@ -20,7 +20,6 @@ describe('RenderingCacheSizeManager', () => {
     mockCalculator = { calculateSize: jest.fn() };
     options = {
       cacheSizeMemory: 1000,
-      ssrFeatureToggles: { limitCacheByMemory: true },
       logger: mockLogger,
       cacheEntrySizeCalculator: mockCalculator,
     };
@@ -30,17 +29,6 @@ describe('RenderingCacheSizeManager', () => {
   describe('constructor', () => {
     it('should initialize with valid options', () => {
       expect(renderingCacheSizeManager).toBeDefined();
-    });
-
-    it('should log error when `options.ssrFeatureToggles.limitCacheByMemory` is false', () => {
-      if (options.ssrFeatureToggles) {
-        options.ssrFeatureToggles.limitCacheByMemory = false;
-      }
-      new RenderingCacheSizeManager(options);
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'Cannot use `RenderingCacheSizeManager` when `ssrFeatureToggles.limitCacheByMemory` is false!',
-        {}
-      );
     });
 
     it('should log error when `options.cacheEntrySizeCalculator.calculateSize` is not a function', () => {

--- a/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache-size-manager.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache-size-manager.ts
@@ -33,12 +33,6 @@ export class RenderingCacheSizeManager {
    * In case of invalid options, it will log an error using the configured logger.
    */
   private validateOptions(): void {
-    if (!this.options?.ssrFeatureToggles?.limitCacheByMemory) {
-      this.options?.logger?.error?.(
-        'Cannot use `RenderingCacheSizeManager` when `ssrFeatureToggles.limitCacheByMemory` is false!',
-        {}
-      );
-    }
     if (
       typeof this.options?.cacheEntrySizeCalculator?.calculateSize !==
       'function'

--- a/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache.model.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache.model.ts
@@ -15,8 +15,6 @@ export interface RenderingEntry {
 
   /**
    * Approximate size of the entry in bytes.
-   *
-   * It's used only when `ssrFeatureToggles.limitCacheByMemory` is set to true.
    */
   _size?: number;
 }

--- a/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache.spec.ts
@@ -203,9 +203,6 @@ describe('RenderingCache', () => {
       const cache = new RenderingCache({
         ...options,
         cacheSizeMemory: 500, // ≥ 2 entries × 200 B with headroom
-        ssrFeatureToggles: {
-          limitCacheByMemory: true,
-        },
       });
       cache.store('a', null, 'x'.repeat(100)); // 200 B
       cache.store('b', null, 'y'.repeat(100)); // 200 B → usedSize 400

--- a/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache.spec.ts
@@ -11,6 +11,7 @@ const options: SsrOptimizationOptions = {
     defaultSsrOptimizationOptions.shouldCacheRenderingResult,
   cacheEntrySizeCalculator:
     defaultSsrOptimizationOptions.cacheEntrySizeCalculator,
+  cacheSizeMemory: defaultSsrOptimizationOptions.cacheSizeMemory,
   logger: defaultSsrOptimizationOptions.logger,
 };
 
@@ -26,9 +27,6 @@ describe('RenderingCache', () => {
       renderingCache = new RenderingCache({
         ...options,
         cacheSizeMemory: 1000,
-        ssrFeatureToggles: {
-          limitCacheByMemory: true,
-        },
       });
     });
 
@@ -69,9 +67,6 @@ describe('RenderingCache', () => {
         ...options,
         cacheSizeMemory: 1000,
         shouldCacheRenderingResult: () => true, // Cache everything including errors
-        ssrFeatureToggles: {
-          limitCacheByMemory: true,
-        },
       });
 
       const testErr: Error = {
@@ -213,6 +208,7 @@ describe('RenderingCache', () => {
       expect(renderingCache.get('test')).toEqual({
         err: null,
         html: 'testHtml',
+        _size: expect.any(Number),
       });
     });
 
@@ -296,81 +292,46 @@ describe('RenderingCache with ttl', () => {
   });
 });
 
-describe('RenderingCache with cacheSize', () => {
+describe('RenderingCache and shouldCacheRenderingResult', () => {
   let renderingCache: RenderingCache;
 
-  beforeEach(() => {
-    renderingCache = new RenderingCache({ ...options, cacheSize: 2 });
-  });
-
-  describe('get', () => {
-    it('should drop elements', () => {
-      renderingCache.store('a', null, 'a');
-      renderingCache.store('b', null, 'b');
-      renderingCache.store('c', null, 'c');
-      expect(renderingCache.get('a')).toBeFalsy();
-      expect(renderingCache.get('b')).toBeTruthy();
+  describe('if default shouldCacheRenderingResult', () => {
+    it('should cache HTML', () => {
+      renderingCache = new RenderingCache({
+        ...options,
+      });
+      renderingCache.store('a', undefined, 'a');
+      expect(renderingCache.get('a')).toEqual({
+        html: 'a',
+        err: undefined,
+        _size: expect.any(Number),
+      });
     });
 
-    it('should drop oldest elements', () => {
-      renderingCache.store('a', null, 'a');
-      renderingCache.store('b', null, 'b');
-      renderingCache.store('a', null, 'a1');
-      renderingCache.store('c', null, 'c');
-      renderingCache.store('a', null, 'a2');
-      expect(renderingCache.get('a')).toBeTruthy();
-      expect(renderingCache.get('b')).toBeFalsy();
-    });
-
-    it('should not drop oldest element, when setting a new value for existing key', () => {
-      renderingCache.store('a', null, 'a');
-      renderingCache.store('b', null, 'b');
-      renderingCache.store('c', null, 'c1');
-      renderingCache.store('c', null, 'c2');
-      renderingCache.store('c', null, 'c3');
+    it('should not cache errors', () => {
+      renderingCache = new RenderingCache({
+        ...options,
+      });
+      renderingCache.store('a', new Error('err'), 'a');
       expect(renderingCache.get('a')).toBeFalsy();
-      expect(renderingCache.get('b')).toBeTruthy();
-      expect(renderingCache.get('c')).toBeTruthy();
     });
   });
 
-  describe('RenderingCache and shouldCacheRenderingResult', () => {
-    let renderingCache: RenderingCache;
-
-    describe('if default shouldCacheRenderingResult', () => {
-      it('should cache HTML', () => {
-        renderingCache = new RenderingCache({
-          ...options,
-        });
-        renderingCache.store('a', undefined, 'a');
-        expect(renderingCache.get('a')).toEqual({ html: 'a', err: undefined });
-      });
-
-      it('should not cache errors', () => {
-        renderingCache = new RenderingCache({
-          ...options,
-        });
-        renderingCache.store('a', new Error('err'), 'a');
-        expect(renderingCache.get('a')).toBeFalsy();
+  describe('if shouldCacheRenderingResult is not defined', () => {
+    beforeEach(() => {
+      renderingCache = new RenderingCache({
+        ...options,
+        shouldCacheRenderingResult: undefined,
       });
     });
+    it('should not cache a html', () => {
+      renderingCache.store('a', undefined, 'a');
+      expect(renderingCache.get('a')).toBeFalsy();
+    });
 
-    describe('if shouldCacheRenderingResult is not defined', () => {
-      beforeEach(() => {
-        renderingCache = new RenderingCache({
-          ...options,
-          shouldCacheRenderingResult: undefined,
-        });
-      });
-      it('should not cache a html', () => {
-        renderingCache.store('a', undefined, 'a');
-        expect(renderingCache.get('a')).toBeFalsy();
-      });
-
-      it('should not cache an error', () => {
-        renderingCache.store('a', new Error('err'), 'a');
-        expect(renderingCache.get('a')).toBeFalsy();
-      });
+    it('should not cache an error', () => {
+      renderingCache.store('a', new Error('err'), 'a');
+      expect(renderingCache.get('a')).toBeFalsy();
     });
   });
 });

--- a/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache.ts
+++ b/core-libs/setup/ssr/optimized-engine/rendering-cache/rendering-cache.ts
@@ -14,7 +14,6 @@ export class RenderingCache {
   constructor(private options?: SsrOptimizationOptions) {}
 
   // Don't use directly, but use `sizeManager` getter instead
-  // The `sizeManager` should be used only when `ssrFeatureToggles.limitCacheByMemory` is set to true
   private _sizeManager: RenderingCacheSizeManager;
   private get sizeManager(): RenderingCacheSizeManager {
     if (!this._sizeManager) {
@@ -33,9 +32,6 @@ export class RenderingCache {
 
   /**
    * Store the entry, respecting the cache limit.
-   *
-   * Depending on the `ssrFeatureToggles.limitCacheByMemory` option,
-   * it will respect either the bytes limit (`options.cacheSizeBytes`) or the entries number limit (`options.cacheSize`).
    */
   store(key: string, err?: Error | null, html?: string) {
     const entry: RenderingEntry = { err, html };
@@ -55,12 +51,7 @@ export class RenderingCache {
       return;
     }
 
-    // Use the size manager only when `ssrFeatureToggles.limitCacheByMemory` is set to true:
-    if (this.options?.ssrFeatureToggles?.limitCacheByMemory) {
-      this.storeUsingMemoryLimit(key, entry);
-    } else {
-      this.storeUsingEntriesLimit(key, entry);
-    }
+    this.storeUsingMemoryLimit(key, entry);
   }
 
   /**
@@ -102,27 +93,6 @@ export class RenderingCache {
     }
   }
 
-  /**
-   * Store the entry, respecting the entries limit.
-   *
-   * If needed, removes oldest entry when number of entries limit is reached.
-   *
-   * @deprecated since v2211.42 - use `storeUsingBytesLimit` method instead.
-   *             This method will be removed together with the feature toggle `ssrFeatureToggles.limitCacheByMemory`.
-   */
-  private storeUsingEntriesLimit(key: string, entry: RenderingEntry): void {
-    if (
-      this.options?.cacheSize &&
-      this.renders.size >= this.options.cacheSize
-    ) {
-      const oldestKey = this.renders.keys().next().value;
-      if (oldestKey !== undefined) {
-        this.renders.delete(oldestKey);
-      }
-    }
-    this.renders.set(key, entry);
-  }
-
   get(key: string): RenderingEntry | undefined {
     return this.renders.get(key);
   }
@@ -131,10 +101,7 @@ export class RenderingCache {
     const entry = this.renders.get(key);
     this.renders.delete(key);
 
-    // Use the size manager only when `ssrFeatureToggles.limitCacheByMemory` is set to true.
-    if (this.options?.ssrFeatureToggles?.limitCacheByMemory) {
-      this.sizeManager.untrackEntrySize(entry?._size ?? 0);
-    }
+    this.sizeManager.untrackEntrySize(entry?._size ?? 0);
   }
 
   isReady(key: string): boolean {

--- a/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
+++ b/core-libs/setup/ssr/optimized-engine/ssr-optimization-options.ts
@@ -31,23 +31,6 @@ export interface SsrOptimizationOptions {
   cache?: boolean;
 
   /**
-   * Limit the cache size
-   *
-   * Specified number of entries that will be kept in cache, allows to keep
-   * memory usage under control.
-   *
-   * Can also be use when `cache` option is set to false. It will then limit the
-   * number of renders that timeouts and are kept in temporary cache, waiting
-   * to be served with next request.
-   *
-   * Default value is set to 3000.
-   *
-   * @deprecated since v2211.42. Use `cacheSizeBytes` option instead.
-   *             The `cacheSize` option will be removed eventually together with the feature toggle `ssrFeatureToggles.limitCacheByMemory`.
-   */
-  cacheSize?: number;
-
-  /**
    * Limits the cache size memory in bytes.
    *
    * Specifies the maximum memory (in bytes) allocated for cached entries,
@@ -68,8 +51,6 @@ export interface SsrOptimizationOptions {
   /**
    * Strategy for calculating the size of a cache entry. It's needed to keep track of the used cache size,
    * so the oldest entries can be removed when the cache size memory limit is reached.
-   *
-   * *Note*: This config option is used only when the `ssrFeatureToggles.limitCacheByMemory` is set to true.
    *
    * For details on how each entry's size is calculated by default, see {@link DefaultCacheEntrySizeCalculator}.
    */
@@ -196,13 +177,7 @@ export interface SsrOptimizationOptions {
    * Note: They are related only to the `OptimizedSsrEngine`. In particular, they
    * are different from Spartacus's regular feature toggles provided in the Angular app.
    */
-  ssrFeatureToggles?: {
-    /**
-     * When true, the cache size will be limited by memory defined via the `cacheSizeMemory` option.
-     * When false, the cache size will be limited by number of entries defined via the deprecated `cacheSize` option.
-     */
-    limitCacheByMemory?: boolean;
-  };
+  ssrFeatureToggles?: {};
 }
 
 export enum RenderingStrategy {
@@ -244,7 +219,6 @@ type DefaultSsrOptimizationOptions = Omit<
 
 export const defaultSsrOptimizationOptions: DefaultSsrOptimizationOptions = {
   cache: false,
-  cacheSize: 3000,
   cacheSizeMemory: 800_000_000,
   cacheEntrySizeCalculator: new DefaultCacheEntrySizeCalculator(),
   ttl: undefined,
@@ -259,7 +233,5 @@ export const defaultSsrOptimizationOptions: DefaultSsrOptimizationOptions = {
   logger: new DefaultExpressServerLogger(),
   shouldCacheRenderingResult: ({ entry: { err } }) => !err,
   renderKeyResolver: getDefaultRenderKey,
-  ssrFeatureToggles: {
-    limitCacheByMemory: true,
-  },
+  ssrFeatureToggles: {},
 };

--- a/projects/storefrontapp/src/server.ts
+++ b/projects/storefrontapp/src/server.ts
@@ -23,9 +23,6 @@ const ssrOptions: SsrOptimizationOptions = {
     process.env['SSR_TIMEOUT'] ?? defaultSsrOptimizationOptions.timeout
   ),
   cache: process.env['SSR_CACHE'] === 'true',
-  ssrFeatureToggles: {
-    limitCacheByMemory: true,
-  },
 };
 
 const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions);


### PR DESCRIPTION
## Changes

- **Core SSR (`core-libs/setup/ssr`)**:
  - Removed `limitCacheByMemory` from `SsrOptimizationOptions.ssrFeatureToggles` type and from `defaultSsrOptimizationOptions`.
  - Removed the deprecated `cacheSize` option (was tied to the toggle's lifecycle per its JSDoc).
  - `RenderingCache.store()` always uses `storeUsingMemoryLimit()`; removed the entries-limit code path.
  - `RenderingCache.clear()` always untracks size on the size manager.
  - `RenderingCacheSizeManager.validateOptions()` no longer checks the toggle.
  - Cleaned up JSDoc references.

- **Schematics**:
  - `add-ssr` template no longer emits the toggle in generated `server.ts`.
  - Updated migration fixtures and snapshots accordingly.

- **Demo app** (`projects/storefrontapp/src/server.ts`): removed the toggle.

- **Tests**: updated specs and inline snapshots to match the new always-memory-limited behavior.

closes [CXSPA-13513](https://jira.tools.sap/browse/CXSPA-13513)