### PR TITLE
chore: improve flakiness of scroll position restoration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,11 @@ const TAG = {
 export default defineConfig(
   globalIgnores(['**/schematics/**/*.d.ts']),
   {
-    ignores: ['**/dist', '**/out-tsc'],
+    ignores: [
+      '**/dist',
+      '**/out-tsc',
+      'projects/storefrontapp-e2e-cypress/**',
+    ],
   },
   {
     files: ['**/*.ts'],

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/scrolling/scroll-position-restoration.e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/scrolling/scroll-position-restoration.e2e.cy.ts
@@ -54,14 +54,13 @@ context('scroll Position Restoration', () => {
         cy.log('Go back to product list');
         cy.go(-1);
         waitForCategoryPageLoad();
+        cy.get('cx-product-list-item').should('have.length.at.least', 4);
         cy.window().its('scrollY').should('be.greaterThan', 0);
 
         cy.log('Go forward to product details');
         cy.go(1);
         verifyProductPageLoaded(productName);
-        cy.window().then(($window) => {
-          expect($window.scrollY).to.be.greaterThan(0);
-        });
+        cy.window().its('scrollY').should('be.greaterThan', 0);
       });
   });
 });


### PR DESCRIPTION
Two objectives with this PR.
1. Exclude storefrontapp-e2e-cypress from eslint config since it is using `tsconfig.eslint.json` for parsing options and the `tsconfig.eslint.json` extends `./tsconfig.json` which excludes cypress.
2. Improve flakiness of `scroll-position-restoration.e2e.cy.ts` by adding new assertion gates on at least 4 items being in the DOM so the page is tall enough for the restored scroll position to be non-zero, and the second change uses Cypress's built-in retry-ability: the command re-reads scrollY from the live window object until the assertion passes or the command times out.