### PR TITLE
fix(installation schematics): wrap verbose logs under --debug flag

### DIFF
--- a/core-libs/schematics/src/add-spartacus/add-storefront-component-to-app-component.ts
+++ b/core-libs/schematics/src/add-spartacus/add-storefront-component-to-app-component.ts
@@ -50,9 +50,11 @@ export function addStorefrontComponentToAppComponent(
           // Save changes to tree
           formatFile(sourceFile);
           tree.overwrite(sourceFile.getFilePath(), sourceFile.getFullText());
-          context.logger.info(
-            `✅ Added StorefrontComponent to ${APP_COMPONENT} imports`
-          );
+          if (options.debug) {
+            context.logger.info(
+              `✅ Added StorefrontComponent to ${APP_COMPONENT} imports`
+            );
+          }
           break;
         }
       }

--- a/core-libs/schematics/src/add-spartacus/create-app-module.ts
+++ b/core-libs/schematics/src/add-spartacus/create-app-module.ts
@@ -68,10 +68,8 @@ export class AppModule {}
       if (options.debug) {
         context.logger.info(`✅ Created ${appModulePath}`);
       }
-    } else {
-      if (options.debug) {
-        context.logger.info(`✅ ${APP_MODULE} already exists`);
-      }
+    } else if (options.debug) {
+      context.logger.info(`✅ ${APP_MODULE} already exists`);
     }
 
     if (options.debug) {

--- a/core-libs/schematics/src/add-spartacus/create-app-module.ts
+++ b/core-libs/schematics/src/add-spartacus/create-app-module.ts
@@ -38,9 +38,11 @@ export function createAppModule(options: SpartacusOptions): Rule {
     );
 
     if (!appModuleExists) {
-      context.logger.info(
-        `✏️ Creating app.module.ts for standalone application...`
-      );
+      if (options.debug) {
+        context.logger.info(
+          `✏️ Creating app.module.ts for standalone application...`
+        );
+      }
 
       // Find the app directory
       let appDir: string | null = null;
@@ -63,9 +65,13 @@ export class AppModule {}
 `;
 
       tree.create(appModulePath, appModuleContent);
-      context.logger.info(`✅ Created ${appModulePath}`);
+      if (options.debug) {
+        context.logger.info(`✅ Created ${appModulePath}`);
+      }
     } else {
-      context.logger.info(`✅ ${APP_MODULE} already exists`);
+      if (options.debug) {
+        context.logger.info(`✅ ${APP_MODULE} already exists`);
+      }
     }
 
     if (options.debug) {

--- a/core-libs/schematics/src/add-spartacus/update-app-module.ts
+++ b/core-libs/schematics/src/add-spartacus/update-app-module.ts
@@ -50,7 +50,7 @@ export function updateAppModule(options: SpartacusOptions): Rule {
 
       for (const sourceFile of appSourceFiles) {
         if (sourceFile.getFilePath().includes(APP_MODULE)) {
-          addAppRoutingModuleImport(tree, context, sourceFile);
+          addAppRoutingModuleImport(tree, context, sourceFile, options);
 
           formatFile(sourceFile);
           tree.overwrite(sourceFile.getFilePath(), sourceFile.getFullText());
@@ -80,43 +80,54 @@ export function updateAppModule(options: SpartacusOptions): Rule {
 function addAppRoutingModuleImport(
   tree: Tree,
   context: SchematicContext,
-  sourceFile: SourceFile
+  sourceFile: SourceFile,
+  options: SpartacusOptions
 ) {
-  context.logger.info(
-    `⌛️ Removing from AppModule's imports array a local AppRoutingModule, if exists`
-  );
+  if (options.debug) {
+    context.logger.info(
+      `⌛️ Removing from AppModule's imports array a local AppRoutingModule, if exists`
+    );
+  }
   // remove import of AppRoutingModule (NgModule import and module path import), if exists
   const removedImport = removeModuleImport(sourceFile, {
     importPath: APP_ROUTING_MODULE_LOCAL_PATH,
     content: APP_ROUTING_MODULE,
   });
-  context.logger.info(
-    removedImport
-      ? `✅ Removed from AppModule's imports array a local AppRoutingModule`
-      : `✅ No local AppRoutingModule found in AppModule's imports array`
-  );
+  if (options.debug) {
+    context.logger.info(
+      removedImport
+        ? `✅ Removed from AppModule's imports array a local AppRoutingModule`
+        : `✅ No local AppRoutingModule found in AppModule's imports array`
+    );
+  }
 
-  context.logger.info(
-    `⌛️ Deleting a local file "${APP_ROUTING_MODULE_LOCAL_FILENAME}", if exists`
-  );
+  if (options.debug) {
+    context.logger.info(
+      `⌛️ Deleting a local file "${APP_ROUTING_MODULE_LOCAL_FILENAME}", if exists`
+    );
+  }
   // delete local file of AppRoutingModule, if exists
   let deletedFile: Path | undefined;
   tree.visit((filePath: Path) => {
     if (filePath.endsWith(APP_ROUTING_MODULE_LOCAL_FILENAME)) {
       tree.delete(filePath);
-      context.logger.info(`✅ Deleted a local file: ${filePath}`);
+      if (options.debug) {
+        context.logger.info(`✅ Deleted a local file: ${filePath}`);
+      }
       deletedFile = filePath;
     }
   });
-  if (!deletedFile) {
+  if (!deletedFile && options.debug) {
     context.logger.info(
       `✅ No local file found with the path "${APP_ROUTING_MODULE_LOCAL_FILENAME}"`
     );
   }
 
-  context.logger.info(
-    `⌛️ Importing AppRoutingModule of Spartacus in AppModule`
-  );
+  if (options.debug) {
+    context.logger.info(
+      `⌛️ Importing AppRoutingModule of Spartacus in AppModule`
+    );
+  }
   // add import of AppRoutingModule from Spartacus
   addModuleImport(sourceFile, {
     order: 2,
@@ -126,5 +137,9 @@ function addAppRoutingModuleImport(
     },
     content: APP_ROUTING_MODULE,
   });
-  context.logger.info(`✅ Imported AppRoutingModule of Spartacus in AppModule`);
+  if (options.debug) {
+    context.logger.info(
+      `✅ Imported AppRoutingModule of Spartacus in AppModule`
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Wraps verbose schematics installation logs under the `--debug` flag, so a default `ng add @spartacus/schematics` run produces clean output.

## Problem

The following logs were printed **unconditionally** during the schematics installation, even without the `--debug` flag:

```
✏️ Creating app.module.ts for standalone application...
✅ Created /src/app/app.module.ts
✅ Added StorefrontComponent to app.component.ts imports
⌛️ Removing from AppModule's imports array a local AppRoutingModule, if exists
✅ No local AppRoutingModule found in AppModule's imports array
⌛️ Deleting a local file "app-routing.module.ts", if exists
✅ No local file found with the path "app-routing.module.ts"
⌛️ Importing AppRoutingModule of Spartacus in AppModule
✅ Imported AppRoutingModule of Spartacus in AppModule
```

These are low-level helper logs that should only be visible in debug mode, like the other guarded logs in the same files.

## Root cause

Introduced in PR #21059 (commit `6622a52`, _"feat: use standalone-friendly bootstrapApplication Angular API instead of bootstrapModule"_). That PR added `if (options.debug)` guards for the entry-level logs, but missed the inner verbose helper logs and their result branches.

## Changes

Wrapped all the affected `context.logger.info(...)` calls with the existing pattern:

```ts
if (options.debug) {
  context.logger.info(`...`);
}
```

## Behavior

- `ng add @spartacus/schematics` - clean output, no verbose helper logs.
- `ng add @spartacus/schematics --debug` - unchanged, still prints everything.
