### PR TITLE
chore(schematics testing): don't recommend running 'npm i -g verdaccio' in error message

### DIFF
--- a/tools/schematics/testing.ts
+++ b/tools/schematics/testing.ts
@@ -99,11 +99,10 @@ function startVerdaccio(): ChildProcess {
 
   console.log('Waiting for verdaccio to boot...');
   const res = exec('verdaccio --config ./scripts/install/config.yaml');
-  const timeoutSeconds = 10;
   try {
-    execSync(`npx wait-on ${verdaccioRegistryUrl} --timeout ${timeoutSeconds * 1000}`);
+    execSync(`npx wait-on ${verdaccioRegistryUrl} --timeout 10000`);
   } catch (error) {
-    console.log(chalk.red(`\n❌ Couldn't boot verdaccio in ${timeoutSeconds}s :\n${error}`));
+    console.log(chalk.red(`\n❌ Couldn't boot verdaccio:\n${error}`));
     process.exit(1);
   }
   console.log('Pointing npm to verdaccio');

--- a/tools/schematics/testing.ts
+++ b/tools/schematics/testing.ts
@@ -99,14 +99,11 @@ function startVerdaccio(): ChildProcess {
 
   console.log('Waiting for verdaccio to boot...');
   const res = exec('verdaccio --config ./scripts/install/config.yaml');
+  const timeoutSeconds = 10;
   try {
-    execSync(`npx wait-on ${verdaccioRegistryUrl} --timeout 10000`);
-  } catch (_e) {
-    console.log(
-      chalk.red(
-        `\n❌ Couldn't boot verdaccio. Make sure to install it globally: \n> npm i -g verdaccio@4`
-      )
-    );
+    execSync(`npx wait-on ${verdaccioRegistryUrl} --timeout ${timeoutSeconds * 1000}`);
+  } catch (error) {
+    console.log(chalk.red(`\n❌ Couldn't boot verdaccio in ${timeoutSeconds}s :\n${error}`));
     process.exit(1);
   }
   console.log('Pointing npm to verdaccio');


### PR DESCRIPTION
running `npm install -g` is not recommended. Project's package-lock.json should be used for locking installed versions