### PR TITLE
chore: Remove provideMockFeatureToggles from public API

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/index.ts
+++ b/core-libs/core/src/features-config/feature-toggles/index.ts
@@ -7,4 +7,3 @@
 // don't export from './config/feature-toggles' as it contains private API. The type `FeatureToggles` is exported from a different file
 export * from './feature-toggles-providers';
 export * from './feature-toggles-tokens';
-export * from './testing/index';

--- a/core-libs/core/src/global-message/http-interceptors/handlers/bad-request/bad-request.handler.spec.ts
+++ b/core-libs/core/src/global-message/http-interceptors/handlers/bad-request/bad-request.handler.spec.ts
@@ -4,7 +4,8 @@ import { GlobalMessageService } from '../../../facade';
 import { GlobalMessageType } from '../../../models/global-message.model';
 import { HttpResponseStatus } from '../../../models/response-status.model';
 import { BadRequestHandler } from './bad-request.handler';
-import { FeatureToggles, provideMockFeatureToggles } from '@spartacus/core';
+import { FeatureToggles } from '@spartacus/core';
+import { provideMockFeatureToggles } from '../../../../features-config/feature-toggles/testing';
 
 const MockRequest = {
   url: 'https://electronics-spa/occ/user/password',

--- a/core-libs/core/src/occ/adapters/user/occ-user-address.adapter.spec.ts
+++ b/core-libs/core/src/occ/adapters/user/occ-user-address.adapter.spec.ts
@@ -9,7 +9,6 @@ import {
   ADDRESS_VALIDATION_NORMALIZER,
   ConverterService,
   FeatureToggles,
-  provideMockFeatureToggles,
 } from '@spartacus/core';
 import { Address, AddressValidation } from '../../../model/address.model';
 import { OccConfig } from '../../config/occ-config';
@@ -24,6 +23,7 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
+import { provideMockFeatureToggles } from '../../../features-config/feature-toggles/testing';
 
 const username = 'mockUsername';
 const address: Address = {

--- a/core-libs/core/src/site-context/facade/currency.service.spec.ts
+++ b/core-libs/core/src/site-context/facade/currency.service.spec.ts
@@ -2,7 +2,7 @@ import { inject, TestBed } from '@angular/core/testing';
 import { EffectsModule } from '@ngrx/effects';
 import * as ngrxStore from '@ngrx/store';
 import { Store, StoreModule } from '@ngrx/store';
-import { provideMockFeatureToggles, SiteContextConfig } from '@spartacus/core';
+import { SiteContextConfig } from '@spartacus/core';
 import { of } from 'rxjs';
 import { FeatureToggles } from '../../features-config/feature-toggles/feature-toggles-tokens';
 import { Currency } from '../../model/misc.model';
@@ -11,6 +11,7 @@ import { SiteContextActions } from '../store/actions/index';
 import { SiteContextStoreModule } from '../store/site-context-store.module';
 import { StateWithSiteContext } from '../store/state';
 import { CurrencyService } from './currency.service';
+import { provideMockFeatureToggles } from '../../features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 const mockCurrencies: Currency[] = [

--- a/core-libs/storefront/cms-components/misc/site-context-selector/language-currency.component.spec.ts
+++ b/core-libs/storefront/cms-components/misc/site-context-selector/language-currency.component.spec.ts
@@ -14,13 +14,13 @@ import {
   LanguageService,
   TranslationService,
 } from '@spartacus/core';
-import { MockTranslationService } from '@spartacus/core/src/i18n/testing/mock-translation.service';
+import { MockTranslationService } from 'core-libs/core/src/i18n/testing/mock-translation.service';
 import { Observable, of } from 'rxjs';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 import { LanguageCurrencyComponent } from './language-currency.component';
 import { SiteContextComponentService } from './site-context-component.service';
 import { SiteContextSelectorComponent } from './site-context-selector.component';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-icon',

--- a/core-libs/storefront/cms-components/misc/site-context-selector/language-currency.component.spec.ts
+++ b/core-libs/storefront/cms-components/misc/site-context-selector/language-currency.component.spec.ts
@@ -12,15 +12,15 @@ import {
   I18nTestingModule,
   Language,
   LanguageService,
-  provideMockFeatureToggles,
   TranslationService,
 } from '@spartacus/core';
-import { MockTranslationService } from 'core-libs/core/src/i18n/testing/mock-translation.service';
+import { MockTranslationService } from '@spartacus/core/src/i18n/testing/mock-translation.service';
 import { Observable, of } from 'rxjs';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 import { LanguageCurrencyComponent } from './language-currency.component';
 import { SiteContextComponentService } from './site-context-component.service';
 import { SiteContextSelectorComponent } from './site-context-selector.component';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-icon',

--- a/core-libs/storefront/cms-components/misc/site-context-selector/site-context-selector.component.spec.ts
+++ b/core-libs/storefront/cms-components/misc/site-context-selector/site-context-selector.component.spec.ts
@@ -29,7 +29,7 @@ import { CmsComponentData } from '../../../cms-structure/page/model/cms-componen
 import { IconComponent } from '../icon';
 import { SiteContextComponentService } from './site-context-component.service';
 import { SiteContextSelectorComponent } from './site-context-selector.component';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 @Pipe({ name: 'cxUrl' })
 class MockUrlPipe implements PipeTransform {

--- a/core-libs/storefront/cms-components/misc/site-context-selector/site-context-selector.component.spec.ts
+++ b/core-libs/storefront/cms-components/misc/site-context-selector/site-context-selector.component.spec.ts
@@ -19,17 +19,17 @@ import {
   LANGUAGE_CONTEXT_ID,
   LanguageService,
   MockTranslatePipe,
-  provideMockFeatureToggles,
   TranslatePipe,
   TranslationService,
   UrlPipe,
 } from '@spartacus/core';
-import { MockTranslationService } from 'core-libs/core/src/i18n/testing/mock-translation.service';
+import { MockTranslationService } from '@spartacus/core/src/i18n/testing/mock-translation.service';
 import { Observable, of } from 'rxjs';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 import { IconComponent } from '../icon';
 import { SiteContextComponentService } from './site-context-component.service';
 import { SiteContextSelectorComponent } from './site-context-selector.component';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 @Pipe({ name: 'cxUrl' })
 class MockUrlPipe implements PipeTransform {

--- a/core-libs/storefront/cms-components/misc/site-theme-switcher/site-theme-switcher.component.spec.ts
+++ b/core-libs/storefront/cms-components/misc/site-theme-switcher/site-theme-switcher.component.spec.ts
@@ -10,7 +10,7 @@ import { IconModule } from '@spartacus/storefront';
 import { of } from 'rxjs';
 import { SiteThemeSwitcherComponent } from './site-theme-switcher.component';
 import { SiteThemeSwitcherComponentService } from './site-theme-switcher.component.service';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 class MockTranslationService {
   translate() {

--- a/core-libs/storefront/cms-components/misc/site-theme-switcher/site-theme-switcher.component.spec.ts
+++ b/core-libs/storefront/cms-components/misc/site-theme-switcher/site-theme-switcher.component.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import {
   I18nTestingModule,
-  provideMockFeatureToggles,
   SiteTheme,
   TranslationService,
 } from '@spartacus/core';
@@ -11,6 +10,7 @@ import { IconModule } from '@spartacus/storefront';
 import { of } from 'rxjs';
 import { SiteThemeSwitcherComponent } from './site-theme-switcher.component';
 import { SiteThemeSwitcherComponentService } from './site-theme-switcher.component.service';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 class MockTranslationService {
   translate() {

--- a/core-libs/storefront/cms-components/navigation/navigation/navigation-ui.component.spec.ts
+++ b/core-libs/storefront/cms-components/navigation/navigation/navigation-ui.component.spec.ts
@@ -22,7 +22,7 @@ import { of } from 'rxjs';
 import { HamburgerMenuService } from './../../../layout/header/hamburger-menu/hamburger-menu.service';
 import { NavigationNode } from './navigation-node.model';
 import { NavigationUIComponent } from './navigation-ui.component';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-icon',

--- a/core-libs/storefront/cms-components/navigation/navigation/navigation-ui.component.spec.ts
+++ b/core-libs/storefront/cms-components/navigation/navigation/navigation-ui.component.spec.ts
@@ -13,7 +13,6 @@ import {
   FeatureToggles,
   MockDatePipe,
   MockTranslatePipe,
-  provideMockFeatureToggles,
   TranslatePipe,
   WindowRef,
 } from '@spartacus/core';
@@ -23,6 +22,7 @@ import { of } from 'rxjs';
 import { HamburgerMenuService } from './../../../layout/header/hamburger-menu/hamburger-menu.service';
 import { NavigationNode } from './navigation-node.model';
 import { NavigationUIComponent } from './navigation-ui.component';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-icon',

--- a/core-libs/storefront/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
+++ b/core-libs/storefront/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
@@ -34,7 +34,7 @@ import { ProductCarouselComponent } from './product-carousel.component';
 import {
   MockFeatureTogglesController,
   provideMockFeatureToggles,
-} from '@spartacus/core/src/features-config/feature-toggles/testing';
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-carousel',

--- a/core-libs/storefront/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
+++ b/core-libs/storefront/cms-components/product/carousel/product-carousel/product-carousel.component.spec.ts
@@ -14,13 +14,11 @@ import {
   CxDatePipe,
   FeaturesConfigModule,
   MockDatePipe,
-  MockFeatureTogglesController,
   MockTranslatePipe,
   Product,
   ProductSearchByCategoryService,
   ProductSearchByCodeService,
   ProductService,
-  provideMockFeatureToggles,
   TranslatePipe,
   UrlPipe,
 } from '@spartacus/core';
@@ -33,6 +31,10 @@ import {
 import { Observable, of } from 'rxjs';
 import { CmsComponentData } from '../../../../cms-structure/page/model/cms-component-data';
 import { ProductCarouselComponent } from './product-carousel.component';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-carousel',

--- a/core-libs/storefront/cms-components/product/carousel/product-references/product-references.component.spec.ts
+++ b/core-libs/storefront/cms-components/product/carousel/product-references/product-references.component.spec.ts
@@ -31,7 +31,7 @@ import { ProductReferencesComponent } from './product-references.component';
 import {
   MockFeatureTogglesController,
   provideMockFeatureToggles,
-} from '@spartacus/core/src/features-config/feature-toggles/testing';
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-carousel',

--- a/core-libs/storefront/cms-components/product/carousel/product-references/product-references.component.spec.ts
+++ b/core-libs/storefront/cms-components/product/carousel/product-references/product-references.component.spec.ts
@@ -12,12 +12,10 @@ import { RouterModule } from '@angular/router';
 import {
   CmsProductReferencesComponent,
   FeaturesConfigModule,
-  MockFeatureTogglesController,
   MockTranslatePipe,
   Product,
   ProductReference,
   ProductReferenceService,
-  provideMockFeatureToggles,
   TranslatePipe,
   UrlPipe,
 } from '@spartacus/core';
@@ -30,6 +28,10 @@ import { Observable, of } from 'rxjs';
 import { CmsComponentData } from '../../../../cms-structure/page/model/cms-component-data';
 import { CurrentProductService } from '../../current-product.service';
 import { ProductReferencesComponent } from './product-references.component';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-carousel',

--- a/core-libs/storefront/cms-components/product/product-images/product-images.component.spec.ts
+++ b/core-libs/storefront/cms-components/product/product-images/product-images.component.spec.ts
@@ -2,12 +2,7 @@ import { AsyncPipe, NgFor, NgTemplateOutlet } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import {
-  FeaturesConfigModule,
-  MockFeatureTogglesController,
-  Product,
-  provideMockFeatureToggles,
-} from '@spartacus/core';
+import { FeaturesConfigModule, Product } from '@spartacus/core';
 import {
   CarouselComponent,
   CarouselScrollingComponent,
@@ -20,6 +15,10 @@ import {
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { CurrentProductService } from '../current-product.service';
 import { ProductImagesComponent } from './product-images.component';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const firstImage = {
   zoom: {

--- a/core-libs/storefront/cms-components/product/product-images/product-images.component.spec.ts
+++ b/core-libs/storefront/cms-components/product/product-images/product-images.component.spec.ts
@@ -18,7 +18,7 @@ import { ProductImagesComponent } from './product-images.component';
 import {
   MockFeatureTogglesController,
   provideMockFeatureToggles,
-} from '@spartacus/core/src/features-config/feature-toggles/testing';
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const firstImage = {
   zoom: {

--- a/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
+++ b/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
@@ -37,7 +37,7 @@ import { ProductListItemComponent } from './product-list-item.component';
 import {
   MockFeatureTogglesController,
   provideMockFeatureToggles,
-} from '@spartacus/core/src/features-config/feature-toggles/testing';
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-star-rating',

--- a/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
+++ b/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
@@ -15,10 +15,8 @@ import {
   FeaturesConfigModule,
   Image,
   ImageGroup,
-  MockFeatureTogglesController,
   MockTranslatePipe,
   ProductService,
-  provideMockFeatureToggles,
   RoutingService,
   TranslatePipe,
   UrlPipe,
@@ -36,6 +34,10 @@ import { BehaviorSubject } from 'rxjs';
 import { ProductListItemContextSource } from '../model/product-list-item-context-source.model';
 import { ProductListItemContext } from '../model/product-list-item-context.model';
 import { ProductListItemComponent } from './product-list-item.component';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 @Component({
   selector: 'cx-star-rating',

--- a/core-libs/storefront/layout/a11y/keyboard-focus/persist/persist-focus.directive.spec.ts
+++ b/core-libs/storefront/layout/a11y/keyboard-focus/persist/persist-focus.directive.spec.ts
@@ -1,10 +1,11 @@
 import { Component, Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { FeatureToggles, provideMockFeatureToggles } from '@spartacus/core';
+import { FeatureToggles } from '@spartacus/core';
 import { PersistFocusConfig } from '../keyboard-focus.model';
 import { PersistFocusDirective } from './persist-focus.directive';
 import { PersistFocusService } from './persist-focus.service';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 @Directive({ selector: '[cxPersistFocus]' })
 class CustomFocusDirective extends PersistFocusDirective {

--- a/core-libs/storefront/layout/a11y/keyboard-focus/persist/persist-focus.directive.spec.ts
+++ b/core-libs/storefront/layout/a11y/keyboard-focus/persist/persist-focus.directive.spec.ts
@@ -5,7 +5,7 @@ import { FeatureToggles } from '@spartacus/core';
 import { PersistFocusConfig } from '../keyboard-focus.model';
 import { PersistFocusDirective } from './persist-focus.directive';
 import { PersistFocusService } from './persist-focus.service';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 @Directive({ selector: '[cxPersistFocus]' })
 class CustomFocusDirective extends PersistFocusDirective {

--- a/core-libs/storefront/layout/a11y/keyboard-focus/visible/visible-focus.directive.spec.ts
+++ b/core-libs/storefront/layout/a11y/keyboard-focus/visible/visible-focus.directive.spec.ts
@@ -7,10 +7,11 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { FeatureToggles, provideMockFeatureToggles } from '@spartacus/core';
+import { FeatureToggles } from '@spartacus/core';
 import { BaseFocusService } from '../base/base-focus.service';
 import { VisibleFocusConfig } from '../keyboard-focus.model';
 import { VisibleFocusDirective } from './visible-focus.directive';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 @Directive({ selector: '[cxVisibleFocus]' })
 class CustomFocusDirective extends VisibleFocusDirective {

--- a/core-libs/storefront/layout/a11y/keyboard-focus/visible/visible-focus.directive.spec.ts
+++ b/core-libs/storefront/layout/a11y/keyboard-focus/visible/visible-focus.directive.spec.ts
@@ -11,7 +11,7 @@ import { FeatureToggles } from '@spartacus/core';
 import { BaseFocusService } from '../base/base-focus.service';
 import { VisibleFocusConfig } from '../keyboard-focus.model';
 import { VisibleFocusDirective } from './visible-focus.directive';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 @Directive({ selector: '[cxVisibleFocus]' })
 class CustomFocusDirective extends VisibleFocusDirective {

--- a/core-libs/storefront/shared/components/list-navigation/sorting/sorting.component.spec.ts
+++ b/core-libs/storefront/shared/components/list-navigation/sorting/sorting.component.spec.ts
@@ -8,12 +8,9 @@ import {
 } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { NgSelectModule } from '@ng-select/ng-select';
-import {
-  FeatureToggles,
-  I18nTestingModule,
-  provideMockFeatureToggles,
-} from '@spartacus/core';
+import { FeatureToggles, I18nTestingModule } from '@spartacus/core';
 import { SortingComponent } from './sorting.component';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 describe('SortingComponent', () => {
   @Directive({ selector: '[cxNgSelectA11y]' })

--- a/core-libs/storefront/shared/components/list-navigation/sorting/sorting.component.spec.ts
+++ b/core-libs/storefront/shared/components/list-navigation/sorting/sorting.component.spec.ts
@@ -10,7 +10,7 @@ import { FormsModule } from '@angular/forms';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { FeatureToggles, I18nTestingModule } from '@spartacus/core';
 import { SortingComponent } from './sorting.component';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 describe('SortingComponent', () => {
   @Directive({ selector: '[cxNgSelectA11y]' })

--- a/core-libs/storefront/shared/components/media/media.service.spec.ts
+++ b/core-libs/storefront/shared/components/media/media.service.spec.ts
@@ -1,15 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import {
-  Config,
-  FeatureToggles,
-  Image,
-  LoggerService,
-  provideMockFeatureToggles,
-} from '@spartacus/core';
+import { Config, FeatureToggles, Image, LoggerService } from '@spartacus/core';
 import { LayoutConfig } from '../../../layout/config/layout-config';
 import { ImageLoadingStrategy, MediaContainer } from './media.model';
 import { MediaService } from './media.service';
 import * as AngularCore from '@angular/core';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const MockStorefrontConfig: Config = {
   backend: {

--- a/core-libs/storefront/shared/components/media/media.service.spec.ts
+++ b/core-libs/storefront/shared/components/media/media.service.spec.ts
@@ -4,7 +4,7 @@ import { LayoutConfig } from '../../../layout/config/layout-config';
 import { ImageLoadingStrategy, MediaContainer } from './media.model';
 import { MediaService } from './media.service';
 import * as AngularCore from '@angular/core';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const MockStorefrontConfig: Config = {
   backend: {

--- a/core-libs/storefront/shared/components/ng-select-a11y/ng-select-a11y.directive.spec.ts
+++ b/core-libs/storefront/shared/components/ng-select-a11y/ng-select-a11y.directive.spec.ts
@@ -7,7 +7,7 @@ import { FeatureToggles, TranslationService } from '@spartacus/core';
 import { of } from 'rxjs';
 import { NgSelectA11yDirective } from './ng-select-a11y.directive';
 import { NgSelectA11yModule } from './ng-select-a11y.module';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 @Component({
   template: `

--- a/core-libs/storefront/shared/components/ng-select-a11y/ng-select-a11y.directive.spec.ts
+++ b/core-libs/storefront/shared/components/ng-select-a11y/ng-select-a11y.directive.spec.ts
@@ -3,14 +3,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NgSelectModule } from '@ng-select/ng-select';
-import {
-  FeatureToggles,
-  provideMockFeatureToggles,
-  TranslationService,
-} from '@spartacus/core';
+import { FeatureToggles, TranslationService } from '@spartacus/core';
 import { of } from 'rxjs';
 import { NgSelectA11yDirective } from './ng-select-a11y.directive';
 import { NgSelectA11yModule } from './ng-select-a11y.module';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 @Component({
   template: `

--- a/core-libs/storefront/shared/components/table/table.component.spec.ts
+++ b/core-libs/storefront/shared/components/table/table.component.spec.ts
@@ -8,7 +8,7 @@ import { TableComponent } from './table.component';
 import { Table, TableLayout } from './table.model';
 import createSpy = jasmine.createSpy;
 import { FeatureToggles } from '@spartacus/core';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const headers: string[] = ['key1', 'key2', 'key3'];
 

--- a/core-libs/storefront/shared/components/table/table.component.spec.ts
+++ b/core-libs/storefront/shared/components/table/table.component.spec.ts
@@ -7,7 +7,8 @@ import { TableRendererService } from './table-renderer.service';
 import { TableComponent } from './table.component';
 import { Table, TableLayout } from './table.model';
 import createSpy = jasmine.createSpy;
-import { FeatureToggles, provideMockFeatureToggles } from '@spartacus/core';
+import { FeatureToggles } from '@spartacus/core';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const headers: string[] = ['key1', 'key2', 'key3'];
 

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.spec.ts
@@ -18,7 +18,6 @@ import {
   MockTranslatePipe,
   Product,
   ProductCatalogService,
-  provideMockFeatureToggles,
   TranslatePipe,
   UserIdService,
 } from '@spartacus/core';
@@ -27,6 +26,7 @@ import { Observable, Subject, of } from 'rxjs';
 import { CartItemListRowComponent } from '../cart-item-list-row';
 import { CartItemComponent } from '../cart-item/cart-item.component';
 import { CartItemListComponent } from './cart-item-list.component';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 class MockActiveCartService {
   updateEntry() {}

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.spec.ts
@@ -26,7 +26,7 @@ import { Observable, Subject, of } from 'rxjs';
 import { CartItemListRowComponent } from '../cart-item-list-row';
 import { CartItemComponent } from '../cart-item/cart-item.component';
 import { CartItemListComponent } from './cart-item-list.component';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 class MockActiveCartService {
   updateEntry() {}

--- a/feature-libs/cart/base/core/facade/multi-cart.service.spec.ts
+++ b/feature-libs/cart/base/core/facade/multi-cart.service.spec.ts
@@ -1,11 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { Store, StoreModule } from '@ngrx/store';
 import { Cart, CartType } from '@spartacus/cart/base/root';
-import {
-  FeatureToggles,
-  provideMockFeatureToggles,
-  UserIdService,
-} from '@spartacus/core';
+import { FeatureToggles, UserIdService } from '@spartacus/core';
 import { of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { CartActions } from '../store/actions';
@@ -15,6 +11,7 @@ import {
 } from '../store/multi-cart-state';
 import * as fromReducers from '../store/reducers/index';
 import { MultiCartService } from './multi-cart.service';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 import createSpy = jasmine.createSpy;
 

--- a/feature-libs/cart/base/core/facade/multi-cart.service.spec.ts
+++ b/feature-libs/cart/base/core/facade/multi-cart.service.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../store/multi-cart-state';
 import * as fromReducers from '../store/reducers/index';
 import { MultiCartService } from './multi-cart.service';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 import createSpy = jasmine.createSpy;
 

--- a/feature-libs/cart/base/core/store/effects/cart.effect.spec.ts
+++ b/feature-libs/cart/base/core/store/effects/cart.effect.spec.ts
@@ -27,7 +27,7 @@ import * as fromCartReducers from '../../store/reducers/index';
 import { CartActions } from '../actions/index';
 import { MULTI_CART_FEATURE, StateWithMultiCart } from '../multi-cart-state';
 import * as fromEffects from './cart.effect';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 const testCart: Cart = {

--- a/feature-libs/cart/base/core/store/effects/cart.effect.spec.ts
+++ b/feature-libs/cart/base/core/store/effects/cart.effect.spec.ts
@@ -14,7 +14,6 @@ import {
   OCC_CART_ID_CURRENT,
   OCC_USER_ID_CURRENT,
   OccConfig,
-  provideMockFeatureToggles,
   SiteContextActions,
   USER_FEATURE,
   tryNormalizeHttpError,
@@ -28,6 +27,7 @@ import * as fromCartReducers from '../../store/reducers/index';
 import { CartActions } from '../actions/index';
 import { MULTI_CART_FEATURE, StateWithMultiCart } from '../multi-cart-state';
 import * as fromEffects from './cart.effect';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 const testCart: Cart = {

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.spec.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.spec.ts
@@ -12,7 +12,6 @@ import {
   GlobalMessageType,
   MockTranslatePipe,
   Product,
-  provideMockFeatureToggles,
   Translatable,
   TranslatePipe,
   WindowRef,
@@ -20,6 +19,7 @@ import {
 import { FormErrorsModule, IconComponent } from '@spartacus/storefront';
 import { BehaviorSubject, Observable, Subject, of } from 'rxjs';
 import { QuickOrderFormComponent } from './quick-order-form.component';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const mockProductCode: string = 'mockCode';
 const mockProductCode2: string = 'mockCode2';

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.spec.ts
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.spec.ts
@@ -19,7 +19,7 @@ import {
 import { FormErrorsModule, IconComponent } from '@spartacus/storefront';
 import { BehaviorSubject, Observable, Subject, of } from 'rxjs';
 import { QuickOrderFormComponent } from './quick-order-form.component';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const mockProductCode: string = 'mockCode';
 const mockProductCode2: string = 'mockCode2';

--- a/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.spec.ts
+++ b/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.spec.ts
@@ -9,7 +9,6 @@ import {
   FeatureToggles,
   GlobalMessageService,
   GlobalMessageType,
-  provideMockFeatureToggles,
   SemanticPathService,
   WindowRef,
 } from '@spartacus/core';
@@ -17,6 +16,7 @@ import { IS_GUEST_USER_CHECKOUT_KEY } from '@spartacus/storefront';
 import { User, UserAccountFacade } from '@spartacus/user/account/root';
 import { EMPTY, Observable, of } from 'rxjs';
 import { CheckoutB2BAuthGuard } from './checkout-b2b-auth.guard';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 import createSpy = jasmine.createSpy;
 

--- a/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.spec.ts
+++ b/feature-libs/checkout/b2b/components/guards/checkout-b2b-auth.guard.spec.ts
@@ -16,7 +16,7 @@ import { IS_GUEST_USER_CHECKOUT_KEY } from '@spartacus/storefront';
 import { User, UserAccountFacade } from '@spartacus/user/account/root';
 import { EMPTY, Observable, of } from 'rxjs';
 import { CheckoutB2BAuthGuard } from './checkout-b2b-auth.guard';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 import createSpy = jasmine.createSpy;
 

--- a/feature-libs/checkout/base/components/guards/checkout-auth.guard.spec.ts
+++ b/feature-libs/checkout/base/components/guards/checkout-auth.guard.spec.ts
@@ -14,7 +14,7 @@ import { User } from '@spartacus/user/account/root';
 import { EMPTY, of } from 'rxjs';
 import { CheckoutConfigService } from '../services/checkout-config.service';
 import { CheckoutAuthGuard } from './checkout-auth.guard';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 class AuthServiceStub implements Partial<AuthService> {

--- a/feature-libs/checkout/base/components/guards/checkout-auth.guard.spec.ts
+++ b/feature-libs/checkout/base/components/guards/checkout-auth.guard.spec.ts
@@ -6,7 +6,6 @@ import {
   AuthService,
   FeatureToggles,
   GlobalMessageService,
-  provideMockFeatureToggles,
   SemanticPathService,
   WindowRef,
 } from '@spartacus/core';
@@ -15,6 +14,7 @@ import { User } from '@spartacus/user/account/root';
 import { EMPTY, of } from 'rxjs';
 import { CheckoutConfigService } from '../services/checkout-config.service';
 import { CheckoutAuthGuard } from './checkout-auth.guard';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 class AuthServiceStub implements Partial<AuthService> {

--- a/feature-libs/organization/administration/components/cost-center/services/cost-center-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/cost-center/services/cost-center-list.service.spec.ts
@@ -9,7 +9,7 @@ import {
   CostCenterListService,
   CostCenterModel,
 } from './cost-center-list.service';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const mockCostCenterEntities: EntitiesModel<CostCenter> = {
   values: [

--- a/feature-libs/organization/administration/components/cost-center/services/cost-center-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/cost-center/services/cost-center-list.service.spec.ts
@@ -1,11 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import {
-  CostCenter,
-  EntitiesModel,
-  FeatureToggles,
-  provideMockFeatureToggles,
-} from '@spartacus/core';
+import { CostCenter, EntitiesModel, FeatureToggles } from '@spartacus/core';
 import { OrganizationUIConfig } from '@spartacus/organization/administration/root';
 import { CostCenterService } from '@spartacus/organization/administration/core';
 import { TableService, TableStructure } from '@spartacus/storefront';
@@ -14,6 +9,7 @@ import {
   CostCenterListService,
   CostCenterModel,
 } from './cost-center-list.service';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const mockCostCenterEntities: EntitiesModel<CostCenter> = {
   values: [

--- a/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.spec.ts
@@ -13,10 +13,10 @@ import {
 } from '@spartacus/core';
 import { ToggleLinkCellComponent } from '@spartacus/organization/administration/components';
 import { IconModule, OutletContextData } from '@spartacus/storefront';
-import { MockUrlPipe } from '@spartacus/core/src/routing/configurable-routes/url-translation/testing/mock-url.pipe';
+import { MockUrlPipe } from 'core-libs/core/src/routing/configurable-routes/url-translation/testing/mock-url.pipe';
 import { BehaviorSubject, of } from 'rxjs';
 import { UnitTreeService } from '../../services/unit-tree.service';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 const mockContext = {

--- a/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.spec.ts
+++ b/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.spec.ts
@@ -7,16 +7,16 @@ import {
   I18nTestingModule,
   MockDatePipe,
   MockTranslatePipe,
-  provideMockFeatureToggles,
   RoutingService,
   TranslatePipe,
   UrlPipe,
 } from '@spartacus/core';
 import { ToggleLinkCellComponent } from '@spartacus/organization/administration/components';
 import { IconModule, OutletContextData } from '@spartacus/storefront';
-import { MockUrlPipe } from 'core-libs/core/src/routing/configurable-routes/url-translation/testing/mock-url.pipe';
+import { MockUrlPipe } from '@spartacus/core/src/routing/configurable-routes/url-translation/testing/mock-url.pipe';
 import { BehaviorSubject, of } from 'rxjs';
 import { UnitTreeService } from '../../services/unit-tree.service';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 const mockContext = {

--- a/feature-libs/organization/administration/components/unit/services/unit-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/unit/services/unit-list.service.spec.ts
@@ -6,11 +6,7 @@
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import {
-  EntitiesModel,
-  FeatureToggles,
-  provideMockFeatureToggles,
-} from '@spartacus/core';
+import { EntitiesModel, FeatureToggles } from '@spartacus/core';
 import {
   B2BUnitNode,
   B2BUnitTreeNode,
@@ -22,6 +18,7 @@ import { UnitItemService } from './unit-item.service';
 import { UnitListService } from './unit-list.service';
 import { TREE_TOGGLE } from './unit-tree.model';
 import { UnitTreeService } from './unit-tree.service';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 import createSpy = jasmine.createSpy;
 

--- a/feature-libs/organization/administration/components/unit/services/unit-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/unit/services/unit-list.service.spec.ts
@@ -18,7 +18,7 @@ import { UnitItemService } from './unit-item.service';
 import { UnitListService } from './unit-list.service';
 import { TREE_TOGGLE } from './unit-tree.model';
 import { UnitTreeService } from './unit-tree.service';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 import createSpy = jasmine.createSpy;
 

--- a/feature-libs/organization/administration/components/user/services/user-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user/services/user-list.service.spec.ts
@@ -12,7 +12,7 @@ import { B2BUserService } from '@spartacus/organization/administration/core';
 import { TableService, TableStructure } from '@spartacus/storefront';
 import { Observable, of } from 'rxjs';
 import { UserListService } from './user-list.service';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const uid = 'user';
 const mockUserEntities: EntitiesModel<B2BUser> = {

--- a/feature-libs/organization/administration/components/user/services/user-list.service.spec.ts
+++ b/feature-libs/organization/administration/components/user/services/user-list.service.spec.ts
@@ -6,13 +6,13 @@ import {
   B2BUserRole,
   EntitiesModel,
   FeatureToggles,
-  provideMockFeatureToggles,
   User,
 } from '@spartacus/core';
 import { B2BUserService } from '@spartacus/organization/administration/core';
 import { TableService, TableStructure } from '@spartacus/storefront';
 import { Observable, of } from 'rxjs';
 import { UserListService } from './user-list.service';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const uid = 'user';
 const mockUserEntities: EntitiesModel<B2BUser> = {

--- a/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.spec.ts
@@ -33,7 +33,7 @@ import { ConfiguratorOverviewFormComponent } from './configurator-overview-form.
 import {
   MockFeatureTogglesController,
   provideMockFeatureToggles,
-} from '@spartacus/core/src/features-config/feature-toggles/testing';
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const owner: CommonConfigurator.Owner =
   ConfigurationTestData.productConfiguration.owner;

--- a/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.spec.ts
@@ -7,9 +7,7 @@ import {
   FeaturesConfigModule,
   FeatureToggles,
   I18nTestingModule,
-  MockFeatureTogglesController,
   MockTranslatePipe,
-  provideMockFeatureToggles,
   RoutingService,
   TranslatePipe,
 } from '@spartacus/core';
@@ -32,6 +30,10 @@ import {
 } from '../price/configurator-price.component';
 import { ConfiguratorStorefrontUtilsService } from '../service/configurator-storefront-utils.service';
 import { ConfiguratorOverviewFormComponent } from './configurator-overview-form.component';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const owner: CommonConfigurator.Owner =
   ConfigurationTestData.productConfiguration.owner;

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.spec.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.spec.ts
@@ -7,10 +7,8 @@ import {
   FeaturesConfigModule,
   ImageGroup,
   MockDatePipe,
-  MockFeatureTogglesController,
   MockTranslatePipe,
   Product,
-  provideMockFeatureToggles,
   TranslatePipe,
 } from '@spartacus/core';
 import {
@@ -27,6 +25,10 @@ import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { ProductImageZoomTriggerComponent } from '../product-image-zoom-trigger/product-image-zoom-trigger.component';
 import { ProductImageZoomProductImagesComponent } from './product-image-zoom-product-images.component';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const firstImage = {
   zoom: {

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.spec.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.spec.ts
@@ -28,7 +28,7 @@ import { ProductImageZoomProductImagesComponent } from './product-image-zoom-pro
 import {
   MockFeatureTogglesController,
   provideMockFeatureToggles,
-} from '@spartacus/core/src/features-config/feature-toggles/testing';
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const firstImage = {
   zoom: {

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.spec.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.spec.ts
@@ -21,7 +21,6 @@ import {
   MockDatePipe,
   MockTranslatePipe,
   Product,
-  provideMockFeatureToggles,
   TranslatePipe,
 } from '@spartacus/core';
 import { ThumbnailsGroup } from '@spartacus/product/image-zoom/root';
@@ -36,6 +35,7 @@ import { EMPTY, Observable, of } from 'rxjs';
 
 import { ProductImageZoomThumbnailsComponent } from '../product-image-zoom-thumbnails/product-image-zoom-thumbnails.component';
 import { ProductImageZoomViewComponent } from './product-image-zoom-view.component';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const firstImage = {
   zoom: {

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.spec.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.spec.ts
@@ -35,7 +35,7 @@ import { EMPTY, Observable, of } from 'rxjs';
 
 import { ProductImageZoomThumbnailsComponent } from '../product-image-zoom-thumbnails/product-image-zoom-thumbnails.component';
 import { ProductImageZoomViewComponent } from './product-image-zoom-view.component';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const firstImage = {
   zoom: {

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
@@ -23,7 +23,7 @@ import { EMPTY } from 'rxjs';
 import { StoreFinderMapComponent } from '../../store-finder-map/store-finder-map.component';
 import { StoreFinderListComponent } from './store-finder-list.component';
 import { LocationDisplayMode } from './store-finder-list.model';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 const location: PointOfService = {

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.spec.ts
@@ -11,7 +11,6 @@ import {
   MockTranslatePipe,
   MockTranslationService,
   PointOfService,
-  provideMockFeatureToggles,
   TranslatePipe,
   TranslationService,
 } from '@spartacus/core';
@@ -24,6 +23,7 @@ import { EMPTY } from 'rxjs';
 import { StoreFinderMapComponent } from '../../store-finder-map/store-finder-map.component';
 import { StoreFinderListComponent } from './store-finder-list.component';
 import { LocationDisplayMode } from './store-finder-list.model';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 const location: PointOfService = {

--- a/feature-libs/user/account/components/guards/login-as-guest.guard.spec.ts
+++ b/feature-libs/user/account/components/guards/login-as-guest.guard.spec.ts
@@ -4,12 +4,12 @@ import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import {
   FeatureToggles,
-  provideMockFeatureToggles,
   SemanticPathService,
   WindowRef,
 } from '@spartacus/core';
 import { IS_GUEST_USER_CHECKOUT_KEY } from '@spartacus/storefront';
 import { LoginAsGuestGuard } from './login-as-guest.guard';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const mockFeatureToggles: FeatureToggles = {
   authorizationCodeFlowByDefault: true,

--- a/feature-libs/user/account/components/guards/login-as-guest.guard.spec.ts
+++ b/feature-libs/user/account/components/guards/login-as-guest.guard.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@spartacus/core';
 import { IS_GUEST_USER_CHECKOUT_KEY } from '@spartacus/storefront';
 import { LoginAsGuestGuard } from './login-as-guest.guard';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const mockFeatureToggles: FeatureToggles = {
   authorizationCodeFlowByDefault: true,

--- a/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
@@ -15,7 +15,6 @@ import {
   GlobalMessageType,
   I18nTestingModule,
   OAUTH_REDIRECT_FLOW_KEY,
-  provideMockFeatureToggles,
   WindowRef,
 } from '@spartacus/core';
 import { FormErrorsModule } from '@spartacus/storefront';
@@ -25,6 +24,7 @@ import {
   LOGIN_ERROR_KEY,
   SESSION_EXPIRED_ERROR,
 } from '../user-account-constants';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 class MockWinRef {

--- a/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/login-form/login-form-component.service.spec.ts
@@ -24,7 +24,7 @@ import {
   LOGIN_ERROR_KEY,
   SESSION_EXPIRED_ERROR,
 } from '../user-account-constants';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 class MockWinRef {

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.spec.ts
@@ -6,13 +6,13 @@ import {
   FeatureToggles,
   GlobalMessageService,
   I18nTestingModule,
-  provideMockFeatureToggles,
 } from '@spartacus/core';
 import { FormErrorsModule } from '@spartacus/storefront';
 import { of } from 'rxjs';
 import { VerificationTokenFacade } from '../../root/facade';
 import { VerificationTokenFormComponentService } from './verification-token-form-component.service';
 import createSpy = jasmine.createSpy;
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 class MockAuthService implements Partial<AuthService> {
   otpLoginWithCredentials = createSpy().and.returnValue(of({}));

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.spec.ts
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form-component.service.spec.ts
@@ -12,7 +12,7 @@ import { of } from 'rxjs';
 import { VerificationTokenFacade } from '../../root/facade';
 import { VerificationTokenFormComponentService } from './verification-token-form-component.service';
 import createSpy = jasmine.createSpy;
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 class MockAuthService implements Partial<AuthService> {
   otpLoginWithCredentials = createSpy().and.returnValue(of({}));

--- a/feature-libs/user/profile/components/address-book/address-book.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-book.component.spec.ts
@@ -18,7 +18,6 @@ import {
   LanguageService,
   MockDatePipe,
   MockTranslatePipe,
-  provideMockFeatureToggles,
   TranslatePipe,
   User,
 } from '@spartacus/core';
@@ -28,6 +27,7 @@ import { BehaviorSubject, Observable, of } from 'rxjs';
 import { AddressFormComponent } from '../public_api';
 import { AddressBookComponent } from './address-book.component';
 import { AddressBookComponentService } from './address-book.component.service';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 class MockGlobalMessageService {
   add = jasmine.createSpy();

--- a/feature-libs/user/profile/components/address-book/address-book.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-book.component.spec.ts
@@ -27,7 +27,7 @@ import { BehaviorSubject, Observable, of } from 'rxjs';
 import { AddressFormComponent } from '../public_api';
 import { AddressBookComponent } from './address-book.component';
 import { AddressBookComponentService } from './address-book.component.service';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 class MockGlobalMessageService {
   add = jasmine.createSpy();

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
@@ -17,7 +17,6 @@ import {
   HierarchicalAddressConfig,
   I18nTestingModule,
   LanguageService,
-  provideMockFeatureToggles,
   Region,
   Title,
   UserAddressService,
@@ -28,6 +27,7 @@ import { MockFeatureDirective } from 'core-libs/storefront/shared/test/mock-feat
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { AddressFormComponent } from './address-form.component';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 const mockTitles: Title[] = [

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
@@ -27,7 +27,7 @@ import { MockFeatureDirective } from 'core-libs/storefront/shared/test/mock-feat
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { AddressFormComponent } from './address-form.component';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 const mockTitles: Title[] = [

--- a/feature-libs/user/profile/core/facade/user-register.service.spec.ts
+++ b/feature-libs/user/profile/core/facade/user-register.service.spec.ts
@@ -13,7 +13,7 @@ import { UserSignUp } from '@spartacus/user/profile/root';
 import { Observable, of } from 'rxjs';
 import { UserProfileService } from './user-profile.service';
 import { UserRegisterService } from './user-register.service';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 class MockUserProfileService implements Partial<UserProfileService> {

--- a/feature-libs/user/profile/core/facade/user-register.service.spec.ts
+++ b/feature-libs/user/profile/core/facade/user-register.service.spec.ts
@@ -3,7 +3,6 @@ import {
   AuthService,
   FeatureToggles,
   OCC_USER_ID_CURRENT,
-  provideMockFeatureToggles,
   RoutingService,
   User,
 } from '@spartacus/core';
@@ -14,6 +13,7 @@ import { UserSignUp } from '@spartacus/user/profile/root';
 import { Observable, of } from 'rxjs';
 import { UserProfileService } from './user-profile.service';
 import { UserRegisterService } from './user-register.service';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 import createSpy = jasmine.createSpy;
 
 class MockUserProfileService implements Partial<UserProfileService> {

--- a/integration-libs/cdc/root/guards/cdc-login-as-guest.guard.spec.ts
+++ b/integration-libs/cdc/root/guards/cdc-login-as-guest.guard.spec.ts
@@ -6,7 +6,7 @@ import {
   WindowRef,
 } from '@spartacus/core';
 import { CdcLoginAsGuestGuard } from './cdc-login-as-guest.guard';
-import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 
 const mockFeatureToggles: FeatureToggles = {
   authorizationCodeFlowByDefault: true,

--- a/integration-libs/cdc/root/guards/cdc-login-as-guest.guard.spec.ts
+++ b/integration-libs/cdc/root/guards/cdc-login-as-guest.guard.spec.ts
@@ -2,11 +2,11 @@ import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import {
   FeatureToggles,
-  provideMockFeatureToggles,
   SemanticPathService,
   WindowRef,
 } from '@spartacus/core';
 import { CdcLoginAsGuestGuard } from './cdc-login-as-guest.guard';
+import { provideMockFeatureToggles } from '@spartacus/core/src/features-config/feature-toggles/testing';
 
 const mockFeatureToggles: FeatureToggles = {
   authorizationCodeFlowByDefault: true,


### PR DESCRIPTION
Revert of unintended publication of testing utils (provideMockFeatureToggles, MockFeatureTogglesController)