### PR TITLE
fix: exclude sub-folder/ from @spartacus/skills npm publish

### DIFF
--- a/core-libs/skills/.npmignore
+++ b/core-libs/skills/.npmignore
@@ -1,2 +1,4 @@
 # Publish only the skills tree and the README. Exclude dev tooling.
 project.json
+sub-folder/
+.pipeline/


### PR DESCRIPTION
## Problem
CI publish of `@spartacus/skills` failed with `ERR_STRING_TOO_LONG`

## Reason
`release-packer.sh` stashes the full monorepo in `sub-folder/` at the repo root, then copies `core-libs/skills/*` on top. The skills `.npmignore` didn't exclude `sub-folder/`, so npm included the entire monorepo on publish.

## Fix
Added `sub-folder/` and `.pipeline/` to `core-libs/skills/.npmignore`, matching the pattern already used by `styles` and `schematics`.
