### PR TITLE
fix: update payment session on giftcard operations

### DIFF
--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-applied/opf-gift-card-applied.component.spec.ts
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-applied/opf-gift-card-applied.component.spec.ts
@@ -4,20 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BehaviorSubject, of, throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   GlobalMessageService,
   GlobalMessageType,
   I18nTestingModule,
-  RoutingService,
   TranslatePipe,
   TranslationService,
 } from '@spartacus/core';
-import { LaunchRenderStrategy, OutletContextData } from '@spartacus/storefront';
 
 import { ActiveCartFacade } from '@spartacus/cart/base/root';
-import { OpfGiftCardApplyComponent } from '../opf-gift-card-apply';
+import { OpfGiftCardAppliedComponent } from './opf-gift-card-applied.component';
 import { OpfGiftCardFacade } from '@spartacus/opf/gift-card/root';
 import { OpfPaymentEventsService } from '@spartacus/opf/payment/root';
 
@@ -27,44 +25,22 @@ class MockTranslationService {
   }
 }
 
-describe('OpfGiftCardApplyComponent', () => {
-  let component: OpfGiftCardApplyComponent;
-  let fixture: ComponentFixture<OpfGiftCardApplyComponent>;
+describe('OpfGiftCardAppliedComponent', () => {
+  let component: OpfGiftCardAppliedComponent;
+  let fixture: ComponentFixture<OpfGiftCardAppliedComponent>;
 
   let mockActiveCartFacade: jasmine.SpyObj<ActiveCartFacade>;
   let mockGiftCardFacade: jasmine.SpyObj<OpfGiftCardFacade>;
   let mockGlobalMessageService: jasmine.SpyObj<GlobalMessageService>;
   let mockPaymentEventsService: jasmine.SpyObj<OpfPaymentEventsService>;
 
-  const cartSubject = new BehaviorSubject<any>({
-    opfGiftCards: [],
-    _availableOperations: [
-      { key: 'applyGiftCard', value: { available: true } },
-    ],
-  });
-
-  const mockGiftCard = {
-    id: 'GC1',
-    maskedNumber: '****1111',
-    balance: { currencyIso: 'USD', formattedValue: '$100', value: 100 },
-    appliedAmount: { currencyIso: 'USD', formattedValue: '$20', value: 20 },
-    remainingBalance: {
-      currencyIso: 'USD',
-      formattedValue: '$80',
-      value: 80,
-    },
-  };
-
   beforeEach(async () => {
     mockActiveCartFacade = jasmine.createSpyObj('ActiveCartFacade', [
-      'getActive',
       'reloadActiveCart',
     ]);
 
     mockGiftCardFacade = jasmine.createSpyObj('OpfGiftCardFacade', [
-      'applyGiftCard',
-      'isGiftCardEnabled',
-      'isGiftCardCoveredTotalAmount',
+      'removeGiftCard',
     ]);
 
     mockGlobalMessageService = jasmine.createSpyObj('GlobalMessageService', [
@@ -72,15 +48,11 @@ describe('OpfGiftCardApplyComponent', () => {
     ]);
 
     mockPaymentEventsService = jasmine.createSpyObj('OpfPaymentEventsService', [
-      'emitIsGiftCardCoveredTotalAmountEvent',
+      'emitReinitiatePaymentEvent',
     ]);
 
-    mockActiveCartFacade.getActive.and.returnValue(cartSubject.asObservable());
-    mockGiftCardFacade.isGiftCardEnabled.and.returnValue(of(true));
-    mockGiftCardFacade.isGiftCardCoveredTotalAmount.and.returnValue(of(false));
-
     await TestBed.configureTestingModule({
-      imports: [OpfGiftCardApplyComponent, I18nTestingModule],
+      imports: [OpfGiftCardAppliedComponent, I18nTestingModule],
       providers: [
         { provide: ActiveCartFacade, useValue: mockActiveCartFacade },
         { provide: OpfGiftCardFacade, useValue: mockGiftCardFacade },
@@ -89,22 +61,14 @@ describe('OpfGiftCardApplyComponent', () => {
           provide: OpfPaymentEventsService,
           useValue: mockPaymentEventsService,
         },
-        {
-          provide: OutletContextData,
-          useValue: { context$: of({ disabled: false }) },
-        },
         { provide: TranslationService, useClass: MockTranslationService },
-        { provide: RoutingService, useValue: {} },
-        {
-          provide: LaunchRenderStrategy,
-          useValue: {},
-        },
         TranslatePipe,
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(OpfGiftCardApplyComponent);
+    fixture = TestBed.createComponent(OpfGiftCardAppliedComponent);
     component = fixture.componentInstance;
+    component.opfGiftCards = [];
     fixture.detectChanges();
   });
 
@@ -112,96 +76,38 @@ describe('OpfGiftCardApplyComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should build form on init', () => {
-    expect(component.giftCardForm).toBeTruthy();
-    expect(component.giftCardForm.controls['cardNumber']).toBeDefined();
-    expect(component.giftCardForm.controls['pin']).toBeDefined();
-  });
+  it('should remove gift card successfully', () => {
+    mockGiftCardFacade.removeGiftCard.and.returnValue(of(void 0));
 
-  it('should mark form as touched if invalid on addGiftCard', () => {
-    spyOn(component.giftCardForm, 'markAllAsTouched');
+    component.removeGiftCard('GC1');
 
-    component.addGiftCard();
-
-    expect(component.giftCardForm.markAllAsTouched).toHaveBeenCalled();
-  });
-
-  it('should apply gift card successfully', () => {
-    component.giftCardForm.setValue({
-      cardNumber: '12345678',
-      pin: '123',
-    });
-
-    mockGiftCardFacade.applyGiftCard.and.returnValue(of(void 0));
-
-    component.addGiftCard();
-
-    expect(mockGiftCardFacade.applyGiftCard).toHaveBeenCalled();
+    expect(mockGiftCardFacade.removeGiftCard).toHaveBeenCalledWith('GC1');
     expect(mockActiveCartFacade.reloadActiveCart).toHaveBeenCalled();
     expect(mockGlobalMessageService.add).toHaveBeenCalledWith(
-      { key: 'opfGiftCard.appliedSuccessfully' },
+      { key: 'opfGiftCard.removedSuccessfully' },
       GlobalMessageType.MSG_TYPE_CONFIRMATION
     );
   });
 
-  it('should handle error when applying gift card fails', () => {
-    component.giftCardForm.setValue({
-      cardNumber: '12345678',
-      pin: '123',
-    });
+  it('should emit reinitiatePaymentEvent after removing gift card', () => {
+    mockGiftCardFacade.removeGiftCard.and.returnValue(of(void 0));
 
-    const error = {
-      message: 'Apply failed',
-      details: [{ message: 'Detailed error' }],
-    };
+    component.removeGiftCard('GC1');
 
-    mockGiftCardFacade.applyGiftCard.and.returnValue(throwError(() => error));
+    expect(
+      mockPaymentEventsService.emitReinitiatePaymentEvent
+    ).toHaveBeenCalled();
+  });
 
-    component.addGiftCard();
+  it('should handle error when removing gift card fails', () => {
+    const error = { details: [{ message: 'Remove failed' }] };
+    mockGiftCardFacade.removeGiftCard.and.returnValue(throwError(() => error));
+
+    component.removeGiftCard('GC1');
 
     expect(mockGlobalMessageService.add).toHaveBeenCalledWith(
-      { raw: 'Detailed error' },
+      { raw: 'Remove failed' },
       GlobalMessageType.MSG_TYPE_ERROR
     );
-  });
-
-  it('should toggle gift card form', () => {
-    const initial = component['showGiftCardForm']();
-
-    component.toggleGiftCardForm();
-
-    expect(component['showGiftCardForm']()).toBe(!initial);
-  });
-
-  it('should reset form', () => {
-    component.giftCardForm.setValue({
-      cardNumber: '12345678',
-      pin: '123',
-    });
-
-    component['resetForm']();
-
-    expect(component.giftCardForm.value).toEqual({
-      cardNumber: null,
-      pin: null,
-    });
-  });
-
-  it('should emit gift card coverage event on init', () => {
-    expect(
-      mockPaymentEventsService.emitIsGiftCardCoveredTotalAmountEvent
-    ).toHaveBeenCalledWith(false);
-  });
-
-  it('should return applied gift cards from cart$', (done) => {
-    cartSubject.next({
-      opfGiftCards: [mockGiftCard],
-    });
-
-    component['appliedGiftCards$'].subscribe((cards) => {
-      expect(cards.length).toBe(1);
-      expect(cards[0].id).toBe('GC1');
-      done();
-    });
   });
 });

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-applied/opf-gift-card-applied.component.ts
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-applied/opf-gift-card-applied.component.ts
@@ -21,6 +21,7 @@ import { ActiveCartFacade } from '@spartacus/cart/base/root';
 import { OpfGiftCardFacade } from '../../facade';
 import { OpfGiftCards } from '../../model';
 import { OutletModule } from '@spartacus/storefront';
+import { OpfPaymentEventsService } from '@spartacus/opf/payment/root';
 
 @Component({
   selector: 'cx-opf-gift-card-applied',
@@ -32,6 +33,7 @@ export class OpfGiftCardAppliedComponent {
   protected globalMessageService = inject(GlobalMessageService);
   protected giftCardFacade = inject(OpfGiftCardFacade);
   protected activeCartFacade = inject(ActiveCartFacade);
+  protected opfPaymentEventsService = inject(OpfPaymentEventsService);
 
   @Input() opfGiftCards: OpfGiftCards[];
 
@@ -43,6 +45,7 @@ export class OpfGiftCardAppliedComponent {
           { key: 'opfGiftCard.removedSuccessfully' },
           GlobalMessageType.MSG_TYPE_CONFIRMATION
         );
+        this.opfPaymentEventsService.emitReinitiatePaymentEvent();
       },
       error: (error) => {
         const message = error.details?.[0]?.message;

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-apply/opf-gift-card-apply.component.spec.ts
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-apply/opf-gift-card-apply.component.spec.ts
@@ -55,6 +55,8 @@ describe('OpfGiftCardApplyComponent', () => {
     },
   };
 
+  const isGiftCardCoveredSubject = new BehaviorSubject<boolean>(false);
+
   beforeEach(async () => {
     mockActiveCartFacade = jasmine.createSpyObj('ActiveCartFacade', [
       'getActive',
@@ -73,7 +75,10 @@ describe('OpfGiftCardApplyComponent', () => {
 
     mockPaymentEventsService = jasmine.createSpyObj('OpfPaymentEventsService', [
       'emitIsGiftCardCoveredTotalAmountEvent',
+      'emitReinitiatePaymentEvent',
     ]);
+    mockPaymentEventsService.isGiftCardCoveredTotalAmountEvent$ =
+      isGiftCardCoveredSubject.asObservable();
 
     mockActiveCartFacade.getActive.and.returnValue(cartSubject.asObservable());
     mockGiftCardFacade.isGiftCardEnabled.and.returnValue(of(true));
@@ -144,6 +149,17 @@ describe('OpfGiftCardApplyComponent', () => {
       { key: 'opfGiftCard.appliedSuccessfully' },
       GlobalMessageType.MSG_TYPE_CONFIRMATION
     );
+  });
+
+  it('should emit reinitiatePaymentEvent after applying gift card', () => {
+    component.giftCardForm.setValue({ cardNumber: '12345678', pin: '123' });
+    mockGiftCardFacade.applyGiftCard.and.returnValue(of(void 0));
+
+    component.addGiftCard();
+
+    expect(
+      mockPaymentEventsService.emitReinitiatePaymentEvent
+    ).toHaveBeenCalled();
   });
 
   it('should handle error when applying gift card fails', () => {

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-apply/opf-gift-card-apply.component.ts
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-apply/opf-gift-card-apply.component.ts
@@ -129,6 +129,7 @@ export class OpfGiftCardApplyComponent implements OnInit, OnDestroy {
           this.resetForm();
           this.toggleGiftCardForm();
           this.loadingSubject.next(false);
+          this.opfPaymentEventsService.emitReinitiatePaymentEvent();
         },
         error: (error: HttpErrorModel) => this.handleGiftCardError(error),
       });


### PR DESCRIPTION
Problem: If a user selects a PSP payment option (e.g., Klarna) → applies a gift card → then completes payment with the PSP, the transaction fails. This is because the PSP was already initiated with the full amount before the gift card was applied.

Solution: An update call should have been triggered when any operation is performed on giftcard . Earlier, for any change, an initiate call used to be triggered. But now, if the configId and paymentSessionId are the same, the initiate call is no longer triggered

jira ticket: https://jira.tools.sap/browse/CXSPA-13650