### PR TITLE
fix: skip strategy HTTP call in SSR environment

### DIFF
--- a/integration-libs/cds/src/merchandising/adapters/strategy/cds-merchandising-strategy.adapter.spec.ts
+++ b/integration-libs/cds/src/merchandising/adapters/strategy/cds-merchandising-strategy.adapter.spec.ts
@@ -11,7 +11,7 @@ import { CdsEndpointsService } from '../../../services/cds-endpoints.service';
 import { StrategyProducts } from '../../model/strategy-products.model';
 import { CdsMerchandisingStrategyAdapter } from './cds-merchandising-strategy.adapter';
 import createSpy = jasmine.createSpy;
-import { BaseSiteService } from '@spartacus/core';
+import { BaseSiteService, WindowRef } from '@spartacus/core';
 import { of } from 'rxjs';
 
 const STRATEGY_ID = 'test-strategy-id';
@@ -67,12 +67,19 @@ class MockBaseSiteService {
   );
 }
 
+class MockWindowRef {
+  isBrowser = createSpy('MockWindowRef.isBrowser').and.returnValue(true);
+}
+
 describe('MerchandisingStrategyAdapter', () => {
   let strategyAdapter: CdsMerchandisingStrategyAdapter;
   let httpMock: HttpTestingController;
   let cdsEndpointsService: CdsEndpointsService;
+  let mockWindowRef: MockWindowRef;
 
   beforeEach(() => {
+    mockWindowRef = new MockWindowRef();
+
     TestBed.configureTestingModule({
       providers: [
         {
@@ -82,6 +89,10 @@ describe('MerchandisingStrategyAdapter', () => {
         {
           provide: BaseSiteService,
           useClass: MockBaseSiteService,
+        },
+        {
+          provide: WindowRef,
+          useValue: mockWindowRef,
         },
         CdsMerchandisingStrategyAdapter,
         provideHttpClient(withInterceptorsFromDi()),
@@ -100,6 +111,20 @@ describe('MerchandisingStrategyAdapter', () => {
 
   it('should be created', () => {
     expect(strategyAdapter).toBeTruthy();
+  });
+
+  describe('SSR (non-browser) environment', () => {
+    it('should return empty products and not make an HTTP call when not in browser', () => {
+      mockWindowRef.isBrowser.and.returnValue(false);
+
+      strategyAdapter
+        .loadProductsForStrategy(STRATEGY_ID)
+        .subscribe((products) => {
+          expect(products).toEqual({ products: [] });
+        });
+
+      httpMock.expectNone(STRATEGY_PRODUCTS_ENDPOINT_KEY);
+    });
   });
 
   describe('load products for strategy', () => {

--- a/integration-libs/cds/src/merchandising/adapters/strategy/cds-merchandising-strategy.adapter.ts
+++ b/integration-libs/cds/src/merchandising/adapters/strategy/cds-merchandising-strategy.adapter.ts
@@ -5,13 +5,13 @@
  */
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { Observable, switchMap, take } from 'rxjs';
+import { inject, Injectable } from '@angular/core';
+import { Observable, of, switchMap, take } from 'rxjs';
 import { CdsEndpointsService } from '../../../services/cds-endpoints.service';
 import { MerchandisingStrategyAdapter } from '../../connectors/strategy/merchandising-strategy.adapter';
 import { StrategyProducts } from '../../model/strategy-products.model';
 import { StrategyRequest } from './../../../cds-models/cds-strategy-request.model';
-import { BaseSiteService } from '@spartacus/core';
+import { BaseSiteService, WindowRef } from '@spartacus/core';
 
 const STRATEGY_PRODUCTS_ENDPOINT_KEY = 'strategyProducts';
 
@@ -19,6 +19,8 @@ const STRATEGY_PRODUCTS_ENDPOINT_KEY = 'strategyProducts';
 export class CdsMerchandisingStrategyAdapter
   implements MerchandisingStrategyAdapter
 {
+  protected windowRef = inject(WindowRef);
+
   constructor(
     private cdsEndpointsService: CdsEndpointsService,
     private baseSiteService: BaseSiteService,
@@ -29,6 +31,10 @@ export class CdsMerchandisingStrategyAdapter
     strategyId: string,
     strategyRequest: StrategyRequest = {}
   ): Observable<StrategyProducts> {
+    if (!this.windowRef.isBrowser()) {
+      return of({ products: [] });
+    }
+
     let headers: HttpHeaders = new HttpHeaders();
     if (strategyRequest.headers && strategyRequest.headers.consentReference) {
       headers = headers.set(


### PR DESCRIPTION
CXCDS-18446

## Summary

- Guard `loadProductsForStrategy` with `WindowRef.isBrowser()` so no
  HTTP request is made during server-side rendering
- Returns `{ products: [] }` immediately in non-browser (SSR) contexts
- Adds a unit test for the SSR code path via a `MockWindowRef` spy

## Test plan

- [ ] `ng test cds` — existing tests pass
- [ ] New SSR test passes: "should return empty products and not make an HTTP call when not in browser"
- [ ] No regressions when `isBrowser()` returns `true`