### PR TITLE
chore: CXSPA-13712 deprecate toggle disableCxPageSlotMarginAnimation

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -96,17 +96,6 @@ export interface FeatureTogglesInterface {
   consistentSizeProductCards?: boolean;
 
   /**
-   * Feature flag to disable the margin animation for the cx-page-slot component.
-   * Disables the CSS animation on the `margin` property in the `cx-page-slot` component.
-   * This animation was originally part of the legacy "defer loading" and "below the fold"
-   * mechanism in Spartacus. Since this mechanism is no longer used in the current storefront,
-   * the animation causes unnecessary layout shifts (CLS) and increased rendering cost (TBT).
-   *
-   * Enabling this flag removes the margin animation to improve performance and user experience.
-   */
-  disableCxPageSlotMarginAnimation?: boolean;
-
-  /**
    * Updates recent-searches UX in `SearchBoxComponent` and CDS recent searches.
    *
    * Before (disabled):
@@ -687,7 +676,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   productReviewCharactersLeft: true,
   a11yFutureStockAccordionAriaControls: true,
   consistentSizeProductCards: true,
-  disableCxPageSlotMarginAnimation: true,
   productCarouselScrolling: true,
   cdsLoginEventsToken: true,
   createMediaPreconnectLink: true,

--- a/core-libs/storefront/cms-structure/page/page-layout/page-layout.component.ts
+++ b/core-libs/storefront/cms-structure/page/page-layout/page-layout.component.ts
@@ -53,7 +53,6 @@ export class PageLayoutComponent {
     );
 
   constructor(protected pageLayoutService: PageLayoutService) {
-    useFeatureStyles('disableCxPageSlotMarginAnimation');
     useFeatureStyles('a11yB2BRegisterComponent');
   }
 }

--- a/core-libs/styles/scss/layout/_page-fold.scss
+++ b/core-libs/styles/scss/layout/_page-fold.scss
@@ -14,12 +14,6 @@
 
 cx-page-layout {
   cx-page-slot {
-    transition:
-      margin-top 0s,
-      min-height 0s;
-    // we delay the minimal real estate for pending slots
-    transition-delay: var(--btf-delay);
-
     min-height: initial;
     margin-top: initial;
 

--- a/core-libs/styles/scss/layout/_page-fold.scss
+++ b/core-libs/styles/scss/layout/_page-fold.scss
@@ -23,10 +23,8 @@ cx-page-layout {
     min-height: initial;
     margin-top: initial;
 
-    @include forFeature('disableCxPageSlotMarginAnimation') {
-      transition: none;
-      transition-delay: 0s;
-    }
+    transition: none;
+    transition-delay: 0s;
 
     &.cx-pending {
       // we need a minimum height for pending items, as the slot would

--- a/core-libs/styles/scss/layout/_page-fold.scss
+++ b/core-libs/styles/scss/layout/_page-fold.scss
@@ -16,7 +16,9 @@ cx-page-layout {
   cx-page-slot {
     min-height: initial;
     margin-top: initial;
-
+    // Guard against consumer/vendor CSS animating these properties —
+    // the below-the-fold logic manipulates them programmatically and
+    // any transition would cause ghosting or delay IntersectionObserver
     transition: none;
     transition-delay: 0s;
 

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -312,7 +312,6 @@ if (environment.cpq) {
         productReviewCharactersLeft: true,
         a11yFutureStockAccordionAriaControls: true,
         consistentSizeProductCards: true,
-        disableCxPageSlotMarginAnimation: true,
         productCarouselScrolling: true,
         cdsLoginEventsToken: true,
         createMediaPreconnectLink: true,


### PR DESCRIPTION
This PR deprecates feature toggle added in https://github.com/SAP/spartacus/commit/5734ddaa9e04334008d1947adbc44a42d62e31c0