### PR TITLE
chore: CXSPA-13715 deprecate toggle createMediaPreconnectLink

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -178,18 +178,6 @@ export interface FeatureTogglesInterface {
   cdsLoginEventsToken?: boolean;
 
   /**
-   * Feature flag to enable using <link rel=preconnect> in the index.html.
-   *
-   * ## When enabled:
-   * Adding rel=preconnect to a <link> informs the browser that your page intends to establish a connection to another domain,
-   * and that you'd like the process to start as soon as possible. Resources will load more quickly because the setup process
-   * has already been completed by the time the browser requests them.
-   *
-   * Note: Preconnecting is not needed (and won't be performed) if the domain of the media base url is the same as the storefront's domain.
-   */
-  createMediaPreconnectLink?: boolean;
-
-  /**
    * When enabled, sets the default oAuth configuration to use authorization code flow with PKCE.
    * This results in a more secure authorization scheme as the default configuration.
    *
@@ -690,7 +678,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   disableCxPageSlotMarginAnimation: true,
   productCarouselScrolling: true,
   cdsLoginEventsToken: true,
-  createMediaPreconnectLink: true,
   unifiedDefaultHeaderSlotsAcrossBreakpoints: true,
   reserveSpaceForImagesOnPdpAndPlp: true,
   lazyLoadImagesByDefault: true,

--- a/core-libs/storefront/cms-structure/seo/media-preconnect.service.spec.ts
+++ b/core-libs/storefront/cms-structure/seo/media-preconnect.service.spec.ts
@@ -1,9 +1,8 @@
 import { TestBed } from '@angular/core/testing';
+import { WindowRef } from '@spartacus/core';
+import { MediaService } from '../../shared/components/media/media.service';
 import { MediaPreconnectService } from './media-preconnect.service';
 import { PageMetaLinkService } from './page-meta-link.service';
-import { MediaService } from '../../shared/components/media/media.service';
-import { FeatureToggles } from '@spartacus/core';
-import { WindowRef } from '@spartacus/core';
 
 class MockPageMetaLinkService {
   addPreconnectLink = jasmine.createSpy('addPreconnectLink');
@@ -13,9 +12,7 @@ class MockMediaService {
     .createSpy('getBaseUrl')
     .and.returnValue('https://media.example.com');
 }
-class MockFeatureToggles {
-  createMediaPreconnectLink = true;
-}
+
 class MockWindowRef {
   location = { origin: 'https://storefront.example.com' };
 }
@@ -24,7 +21,6 @@ describe('MediaPreconnectService', () => {
   let service: MediaPreconnectService;
   let pageMetaLinkService: MockPageMetaLinkService;
   let mediaService: MockMediaService;
-  let featureToggles: MockFeatureToggles;
   let windowRef: MockWindowRef;
 
   beforeEach(() => {
@@ -33,7 +29,6 @@ describe('MediaPreconnectService', () => {
         MediaPreconnectService,
         { provide: PageMetaLinkService, useClass: MockPageMetaLinkService },
         { provide: MediaService, useClass: MockMediaService },
-        { provide: FeatureToggles, useClass: MockFeatureToggles },
         { provide: WindowRef, useClass: MockWindowRef },
       ],
     });
@@ -41,7 +36,6 @@ describe('MediaPreconnectService', () => {
     service = TestBed.inject(MediaPreconnectService);
     pageMetaLinkService = TestBed.inject(PageMetaLinkService) as any;
     mediaService = TestBed.inject(MediaService) as any;
-    featureToggles = TestBed.inject(FeatureToggles) as any;
     windowRef = TestBed.inject(WindowRef) as any;
   });
 
@@ -57,14 +51,6 @@ describe('MediaPreconnectService', () => {
     expect(pageMetaLinkService.addPreconnectLink).toHaveBeenCalledWith(
       'https://media.example.com'
     );
-  });
-
-  it('should not add preconnect link if feature toggle is disabled', () => {
-    featureToggles.createMediaPreconnectLink = false;
-    windowRef.location.origin = 'https://storefront.example.com';
-    mediaService.getBaseUrl.and.returnValue('https://media.example.com');
-    service.addPreconnectLink();
-    expect(pageMetaLinkService.addPreconnectLink).not.toHaveBeenCalled();
   });
 
   it('should not add preconnect link if media domain is same as window origin', () => {

--- a/core-libs/storefront/cms-structure/seo/media-preconnect.service.ts
+++ b/core-libs/storefront/cms-structure/seo/media-preconnect.service.ts
@@ -5,9 +5,9 @@
  */
 
 import { inject, Injectable } from '@angular/core';
-import { PageMetaLinkService } from './page-meta-link.service';
-import { WindowRef, FeatureToggles } from '@spartacus/core';
+import { WindowRef } from '@spartacus/core';
 import { MediaService } from '../../shared/components/media/media.service';
+import { PageMetaLinkService } from './page-meta-link.service';
 
 @Injectable({
   providedIn: 'root',
@@ -15,14 +15,9 @@ import { MediaService } from '../../shared/components/media/media.service';
 export class MediaPreconnectService {
   protected pageMetaLinkService = inject(PageMetaLinkService);
   protected mediaService = inject(MediaService);
-  private featureToggles = inject(FeatureToggles);
   protected windowRef = inject(WindowRef);
 
   addPreconnectLink(): void {
-    if (!this.featureToggles.createMediaPreconnectLink) {
-      return;
-    }
-
     const url = this.mediaService.getBaseUrl();
     let domain: string | undefined;
     try {

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -315,7 +315,6 @@ if (environment.cpq) {
         disableCxPageSlotMarginAnimation: true,
         productCarouselScrolling: true,
         cdsLoginEventsToken: true,
-        createMediaPreconnectLink: true,
         unifiedDefaultHeaderSlotsAcrossBreakpoints: true,
         reserveSpaceForImagesOnPdpAndPlp: true,
         lazyLoadImagesByDefault: true,


### PR DESCRIPTION
This PR deprecates the feature toggle added in https://github.com/SAP/spartacus/commit/2e27bf7c969806506018b67ab1c84e1f16e44872