### PR TITLE
feat: remove consistentSizeProductCards feature flag

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -90,12 +90,6 @@ export interface FeatureTogglesInterface {
   a11yPreventWindowsHighContrastOverride?: boolean;
 
   /**
-   * When enabled, the product cards in the product list page will have a forced consistent size.
-   * Affects the styles of: ProductGridItemComponent, ProductListItemComponent.
-   */
-  consistentSizeProductCards?: boolean;
-
-  /**
    * Feature flag to disable the margin animation for the cx-page-slot component.
    * Disables the CSS animation on the `margin` property in the `cx-page-slot` component.
    * This animation was originally part of the legacy "defer loading" and "below the fold"
@@ -686,7 +680,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   productListItemSummaryReadMore: false,
   productReviewCharactersLeft: true,
   a11yFutureStockAccordionAriaControls: true,
-  consistentSizeProductCards: true,
   disableCxPageSlotMarginAnimation: true,
   productCarouselScrolling: true,
   cdsLoginEventsToken: true,

--- a/core-libs/storefront/cms-components/product/product-list/product-grid-item/product-grid-item.component.ts
+++ b/core-libs/storefront/cms-components/product/product-list/product-grid-item/product-grid-item.component.ts
@@ -68,7 +68,6 @@ export class ProductGridItemComponent implements OnChanges {
   constructor(
     protected productListItemContextSource: ProductListItemContextSource
   ) {
-    useFeatureStyles('consistentSizeProductCards');
     useFeatureStyles('a11yProductListItemNameMargin');
   }
 

--- a/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
+++ b/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.spec.ts
@@ -115,7 +115,6 @@ describe('ProductListItemComponent in product-list', () => {
           useClass: MockProductService,
         },
         provideMockFeatureToggles({
-          consistentSizeProductCards: true,
           productListItemSummaryReadMore: false,
           a11yProductListItemNameMargin: true,
         }),

--- a/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.ts
+++ b/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.ts
@@ -77,7 +77,6 @@ export class ProductListItemComponent implements OnChanges {
   constructor(
     protected productListItemContextSource: ProductListItemContextSource
   ) {
-    useFeatureStyles('consistentSizeProductCards');
     useFeatureStyles('productListItemSummaryReadMore');
     useFeatureStyles('a11yProductListItemNameMargin');
   }

--- a/core-libs/styles/scss/components/product/list/_product-grid-item.scss
+++ b/core-libs/styles/scss/components/product/list/_product-grid-item.scss
@@ -27,22 +27,18 @@
   .cx-product-image-container {
     display: block;
     text-align: center;
-    @include forFeature('consistentSizeProductCards') {
-      @include media-breakpoint-up(md) {
-        margin-top: auto;
-        margin-bottom: auto;
-      }
+    @include media-breakpoint-up(md) {
+      margin-top: auto;
+      margin-bottom: auto;
     }
   }
 
   .cx-product-image {
     width: 100%;
     margin: 3rem 0;
-    @include forFeature('consistentSizeProductCards') {
-      @include media-breakpoint-up(md) {
-        img {
-          max-height: 255px;
-        }
+    @include media-breakpoint-up(md) {
+      img {
+        max-height: 255px;
       }
     }
   }

--- a/core-libs/styles/scss/components/product/list/_product-list-item.scss
+++ b/core-libs/styles/scss/components/product/list/_product-list-item.scss
@@ -1,19 +1,17 @@
 %cx-product-list-item {
   padding-bottom: 1rem;
-  @include forFeature('consistentSizeProductCards') {
-    @include media-breakpoint-up(md) {
-      height: 272px;
-      & > div {
-        height: 100%;
-      }
+  @include media-breakpoint-up(md) {
+    height: 272px;
+    & > div {
+      height: 100%;
+    }
 
-      .cx-product-summary {
-        display: -webkit-box;
-        -webkit-line-clamp: 5;
-        line-clamp: 5;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-      }
+    .cx-product-summary {
+      display: -webkit-box;
+      -webkit-line-clamp: 5;
+      line-clamp: 5;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
     }
   }
 
@@ -58,14 +56,12 @@
     width: 100%;
     height: 100%;
     display: block;
-    @include forFeature('consistentSizeProductCards') {
-      @include media-breakpoint-up(md) {
-        display: flex;
-        img {
-          margin-top: auto;
-          margin-bottom: auto;
-          max-height: 255px;
-        }
+    @include media-breakpoint-up(md) {
+      display: flex;
+      img {
+        margin-top: auto;
+        margin-bottom: auto;
+        max-height: 255px;
       }
     }
   }

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -311,7 +311,6 @@ if (environment.cpq) {
         productListItemSummaryReadMore: true,
         productReviewCharactersLeft: true,
         a11yFutureStockAccordionAriaControls: true,
-        consistentSizeProductCards: true,
         disableCxPageSlotMarginAnimation: true,
         productCarouselScrolling: true,
         cdsLoginEventsToken: true,


### PR DESCRIPTION
CXSPA-13710

## Summary

- Removes the `consistentSizeProductCards` feature flag, keeping only the `true`-branch behavior (consistent product card sizes) as the permanent default.
- Removes the flag from `FeatureTogglesInterface`, `defaultFeatureToggles`, and the schematics copy.
- Unwraps `@include forFeature('consistentSizeProductCards')` guards in `_product-grid-item.scss` and `_product-list-item.scss` so the styles apply unconditionally.
- Removes `useFeatureStyles('consistentSizeProductCards')` from `ProductGridItemComponent` and `ProductListItemComponent`.
- Removes the flag from the spec mock (`provideMockFeatureToggles`) and the storefrontapp `provideFeatureTogglesFactory`.

## Test plan

- [x] Run `nx run storefrontlib:test --include="**/product-list-item.component.spec.ts"` — all tests should pass.
- [x] Verify product list/grid pages render with consistent card heights on `md+` breakpoints.
- [x] Confirm no TypeScript compilation errors (`nx build storefrontlib`).
