### PR TITLE
chore: remove deprecated angularCompilerOptions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -961,11 +961,7 @@
     "./projects/storefrontapp-e2e-cypress"
   ],
   "angularCompilerOptions": {
-    "skipTemplateCodegen": true,
-    "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
-    "enableResourceInlining": true,
     "strictTemplates": true,
     "strictInputAccessModifiers": true
   }


### PR DESCRIPTION
<img width="373" height="70" alt="image" src="https://github.com/user-attachments/assets/0607bae5-a1e8-469f-a95c-212d2906ebfd" />

<img width="361" height="61" alt="image" src="https://github.com/user-attachments/assets/b09f6744-65b4-4883-beff-c27abf794828" />

<img width="381" height="60" alt="image" src="https://github.com/user-attachments/assets/6d729859-f7bb-4030-84c7-95331e374692" />

<img width="409" height="99" alt="image" src="https://github.com/user-attachments/assets/1b0e3c1c-54a2-4602-8403-922186835ed6" />

**TL;DR:** All 4 removed flags are safe to drop under Angular 21 — no replacements needed.

| Flag | Status | Why safe to remove |
|---|---|---|
| `enableResourceInlining` | Removed in v21 (schema error) | Build tooling handles inlining automatically |
| `fullTemplateTypeCheck` | Deprecated | Superseded by `strictTemplates` (already set) |
| `strictMetadataEmit` | Dead flag | Zero references in Ivy bundles; View Engine only |
| `skipTemplateCodegen` | Dead flag under Ivy | Only used by the legacy `ngc` CLI path; ng-packagr/`@angular/build` never reads it |