### PR TITLE
fix: set authorizationCodeFlowByDefaultCsrfTokenRefresh feature toggle to correct value

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -650,7 +650,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   reserveSpaceForImagesOnPdpAndPlp: true,
   lazyLoadImagesByDefault: true,
   authorizationCodeFlowByDefault: true,
-  authorizationCodeFlowByDefaultCsrfTokenRefresh: true,
+  authorizationCodeFlowByDefaultCsrfTokenRefresh: false,
   incrementProcessesCountForMergeCart: true,
   dispatchLoginActionOnlyWhenTokenReceived: true,
   defaultLayoutConfigWithoutPageFold: true,


### PR DESCRIPTION
Fixing initial default value of `authorizationCodeFlowByDefaultCsrfTokenRefresh` feature toggle in `core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts`