### PR TITLE
fix: Introduce an intermediate abstract base class (CXSPA-13057)

### DIFF
--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-multi-selection-base.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-multi-selection-base.component.ts
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Directive, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Subscription } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { Directive } from '@angular/core';
+import { map } from 'rxjs/operators';
 import { Configurator } from '../../../../core/model/configurator.model';
 import { ConfiguratorAttributeCompositionContext } from '../../composition/configurator-attribute-composition.model';
 
@@ -14,21 +13,14 @@ import { ConfiguratorCommonsService } from '../../../../core/facade/configurator
 import { ConfiguratorPriceComponentOptions } from '../../../price/configurator-price.component';
 import { ConfiguratorAttributeQuantityComponentOptions } from '../../quantity/configurator-attribute-quantity.component';
 import { ConfiguratorAttributeQuantityService } from '../../quantity/configurator-attribute-quantity.service';
-import { ConfiguratorAttributeBaseComponent } from './configurator-attribute-base.component';
+import { ConfiguratorAttributeSelectionBaseComponent } from './configurator-attribute-selection-base.component';
 
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
-export abstract class ConfiguratorAttributeMultiSelectionBaseComponent
-  extends ConfiguratorAttributeBaseComponent
-  implements OnDestroy
-{
-  loading$ = new BehaviorSubject<boolean>(false);
-
+export abstract class ConfiguratorAttributeMultiSelectionBaseComponent extends ConfiguratorAttributeSelectionBaseComponent {
   attribute: Configurator.Attribute;
   ownerKey: string;
   expMode: boolean;
-
-  protected subscription = new Subscription();
 
   constructor(
     protected quantityService: ConfiguratorAttributeQuantityService,
@@ -43,27 +35,6 @@ export abstract class ConfiguratorAttributeMultiSelectionBaseComponent
       attributeComponentContext.isPricingAsync,
       attributeComponentContext.attribute.key
     );
-    this.resetLoadingOnConfigurationUpdate();
-  }
-
-  /**
-   * Resets the loading state once the configuration update round trip has
-   * finished, regardless of whether the attribute content actually changed.
-   * This is required because the attribute component is only re-created (which
-   * would reset `loading$`) when its content changes. With CPQ API V2 a round
-   * trip might not change the attribute, leaving action buttons disabled.
-   */
-  protected resetLoadingOnConfigurationUpdate(): void {
-    this.subscription.add(
-      this.configuratorCommonsService
-        .isConfigurationLoading(this.attributeComponentContext.owner)
-        .pipe(filter((loading) => !loading))
-        .subscribe(() => this.loading$.next(false))
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
   }
 
   /**

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-selection-base.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-selection-base.component.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { I18nTestingModule } from '@spartacus/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { ConfiguratorCommonsService } from '../../../../core/facade/configurator-commons.service';
+import { ConfiguratorTestUtils } from '../../../../testing/configurator-test-utils';
+import { ConfiguratorStorefrontUtilsService } from '../../../service/configurator-storefront-utils.service';
+import { ConfiguratorAttributeCompositionContext } from '../../composition/configurator-attribute-composition.model';
+import { ConfiguratorAttributeSelectionBaseComponent } from './configurator-attribute-selection-base.component';
+
+const isConfigurationLoading$ = new BehaviorSubject<boolean>(false);
+
+class MockConfiguratorCommonsService {
+  isConfigurationLoading(): Observable<boolean> {
+    return isConfigurationLoading$.asObservable();
+  }
+}
+
+@Component({
+  selector: 'cx-configurator-attribute-selection',
+  template: 'test-configurator-attribute-selection',
+})
+class ExampleConfiguratorAttributeSelectionComponent extends ConfiguratorAttributeSelectionBaseComponent {}
+
+describe('ConfiguratorAttributeSelectionBaseComponent', () => {
+  let component: ConfiguratorAttributeSelectionBaseComponent;
+  let fixture: ComponentFixture<ExampleConfiguratorAttributeSelectionComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        I18nTestingModule,
+        ExampleConfiguratorAttributeSelectionComponent,
+      ],
+      providers: [
+        {
+          provide: ConfiguratorAttributeCompositionContext,
+          useValue: ConfiguratorTestUtils.getAttributeContext(),
+        },
+        {
+          provide: ConfiguratorCommonsService,
+          useClass: MockConfiguratorCommonsService,
+        },
+        {
+          provide: ConfiguratorStorefrontUtilsService,
+          useValue: {},
+        },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    isConfigurationLoading$.next(false);
+    fixture = TestBed.createComponent(
+      ExampleConfiguratorAttributeSelectionComponent
+    );
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('resetLoadingOnConfigurationUpdate', () => {
+    it('should reset loading$ once the configuration update round trip finished, even if the attribute did not change', () => {
+      component.loading$.next(true);
+      expect(component.loading$.value).toBe(true);
+
+      isConfigurationLoading$.next(false);
+      expect(component.loading$.value).toBe(false);
+    });
+
+    it('should keep loading$ untouched while the configuration is still loading', () => {
+      component.loading$.next(true);
+
+      isConfigurationLoading$.next(true);
+      expect(component.loading$.value).toBe(true);
+    });
+
+    it('should stop resetting loading$ after component destruction', () => {
+      component.ngOnDestroy();
+      component.loading$.next(true);
+
+      isConfigurationLoading$.next(false);
+      expect(component.loading$.value).toBe(true);
+    });
+  });
+});

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-selection-base.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-selection-base.component.ts
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Directive, OnDestroy, inject } from '@angular/core';
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { ConfiguratorCommonsService } from '../../../../core/facade/configurator-commons.service';
+import { ConfiguratorAttributeCompositionContext } from '../../composition/configurator-attribute-composition.model';
+import { ConfiguratorAttributeBaseComponent } from './configurator-attribute-base.component';
+
+/**
+ * Common base for attribute types that offer selectable values (single- and
+ * multi-selection). It owns the component level `loading$` flag and takes care
+ * of resetting it once a configuration update round trip has finished.
+ *
+ * This behavior is intentionally not placed on `ConfiguratorAttributeBaseComponent`,
+ * as several of its other children (e.g. the input field, header, footer or
+ * read-only component) neither maintain a `loading$` flag nor rely on this reset.
+ */
+@Directive()
+// eslint-disable-next-line @angular-eslint/directive-class-suffix
+export abstract class ConfiguratorAttributeSelectionBaseComponent
+  extends ConfiguratorAttributeBaseComponent
+  implements OnDestroy
+{
+  loading$ = new BehaviorSubject<boolean>(false);
+
+  protected subscription = new Subscription();
+
+  protected configuratorCommonsService = inject(ConfiguratorCommonsService);
+  protected attributeComponentContext = inject(
+    ConfiguratorAttributeCompositionContext
+  );
+
+  constructor() {
+    super();
+    this.resetLoadingOnConfigurationUpdate();
+  }
+
+  /**
+   * Resets the loading state once the configuration update round trip has
+   * finished, regardless of whether the attribute content actually changed.
+   * This is required because the attribute component is only re-created (which
+   * would reset `loading$`) when its content changes. With CPQ API V2 a round
+   * trip might not change the attribute, leaving action buttons disabled.
+   */
+  protected resetLoadingOnConfigurationUpdate(): void {
+    this.subscription.add(
+      this.configuratorCommonsService
+        .isConfigurationLoading(this.attributeComponentContext.owner)
+        .pipe(filter((loading) => !loading))
+        .subscribe(() => this.loading$.next(false))
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+}

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/configurator-attribute-single-selection-base.component.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Directive, OnDestroy } from '@angular/core';
+import { Directive } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { TranslationService } from '@spartacus/core';
-import { BehaviorSubject, Observable, of, Subscription } from 'rxjs';
-import { filter, map, take } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { map, take } from 'rxjs/operators';
 import { ConfiguratorCommonsService } from '../../../../core/facade/configurator-commons.service';
 import { Configurator } from '../../../../core/model/configurator.model';
 import { ConfigFormUpdateEvent } from '../../../form/configurator-form.event';
@@ -17,16 +17,11 @@ import { ConfiguratorStorefrontUtilsService } from '../../../service/configurato
 import { ConfiguratorAttributeCompositionContext } from '../../composition/configurator-attribute-composition.model';
 import { ConfiguratorAttributeQuantityComponentOptions } from '../../quantity/configurator-attribute-quantity.component';
 import { ConfiguratorAttributeQuantityService } from '../../quantity/configurator-attribute-quantity.service';
-import { ConfiguratorAttributeBaseComponent } from './configurator-attribute-base.component';
+import { ConfiguratorAttributeSelectionBaseComponent } from './configurator-attribute-selection-base.component';
 
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
-export abstract class ConfiguratorAttributeSingleSelectionBaseComponent
-  extends ConfiguratorAttributeBaseComponent
-  implements OnDestroy
-{
-  loading$ = new BehaviorSubject<boolean>(false);
-
+export abstract class ConfiguratorAttributeSingleSelectionBaseComponent extends ConfiguratorAttributeSelectionBaseComponent {
   attribute: Configurator.Attribute;
   ownerKey: string;
   ownerType: string;
@@ -34,8 +29,6 @@ export abstract class ConfiguratorAttributeSingleSelectionBaseComponent
   expMode: boolean;
 
   showRequiredErrorMessage$: Observable<boolean> = of(false);
-
-  protected subscription = new Subscription();
 
   constructor(
     protected quantityService: ConfiguratorAttributeQuantityService,
@@ -71,27 +64,6 @@ export abstract class ConfiguratorAttributeSingleSelectionBaseComponent
       attributeComponentContext.isPricingAsync,
       attributeComponentContext.attribute.key
     );
-    this.resetLoadingOnConfigurationUpdate();
-  }
-
-  /**
-   * Resets the loading state once the configuration update round trip has
-   * finished, regardless of whether the attribute content actually changed.
-   * This is required because the attribute component is only re-created (which
-   * would reset `loading$`) when its content changes. With CPQ API V2 a round
-   * trip might not change the attribute, leaving action buttons disabled.
-   */
-  protected resetLoadingOnConfigurationUpdate(): void {
-    this.subscription.add(
-      this.configuratorCommonsService
-        .isConfigurationLoading(this.attributeComponentContext.owner)
-        .pipe(filter((loading) => !loading))
-        .subscribe(() => this.loading$.next(false))
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
   }
 
   /**

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/base/index.ts
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/base/index.ts
@@ -5,5 +5,6 @@
  */
 
 export * from './configurator-attribute-base.component';
+export * from './configurator-attribute-selection-base.component';
 export * from './configurator-attribute-single-selection-base.component';
 export * from './configurator-attribute-multi-selection-base.component';


### PR DESCRIPTION
`ConfiguratorAttributeSelectionBaseComponent` between `ConfiguratorAttributeBaseComponent` and the single-/multi-selection base components. It now owns the `loading$` flag, the subscription lifecycle (`ngOnDestroy`) and `resetLoadingOnConfigurationUpdate()`, removing the duplication previously present in both selection base components.

This addresses the review request to consolidate the loading reset logic without pushing it onto `ConfiguratorAttributeBaseComponent`, whose other children (input field, header, footer, read-only, ...) neither maintain a `loading$` flag nor need this behavior. Services are obtained via `inject()` so the intermediate constructor stays parameterless and the existing selection component constructors remain unchanged.