### PR TITLE
test: apply waitForCsrFallbackTimeout in e2e checkout search product test (CXSPA-13762)

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-flow.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/regression/checkout/checkout-flow.core-e2e.cy.ts
@@ -58,7 +58,7 @@ context('Checkout flow', () => {
         clickSearchIcon();
       });
       searchForProduct(product.name);
-      checkout.checkoutFirstDisplayedProduct(user);
+      checkout.checkoutFirstDisplayedProduct(user, true);
     });
   });
 });

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/checkout-flow.ts
@@ -685,7 +685,10 @@ export function viewOrderHistoryWithCheapProduct() {
     .should('not.be.empty');
 }
 
-export function addFirstResultToCartFromSearchAndLogin(sampleUser: SampleUser) {
+export function addFirstResultToCartFromSearchAndLogin(
+  sampleUser: SampleUser,
+  waitForCsrFallback = false
+) {
   addToCart();
   cy.whenJDK17(() => {
     const loginPage = waitForPage('/login', 'getLoginPage');
@@ -699,13 +702,16 @@ export function addFirstResultToCartFromSearchAndLogin(sampleUser: SampleUser) {
     '/checkout/delivery-address',
     'getDeliveryAddressPage'
   );
-  loginUser(sampleUser);
+  loginUser(sampleUser, waitForCsrFallback);
   cy.wait(`@${deliveryAddressPage}`, { timeout: 30000 })
     .its('response.statusCode')
     .should('eq', 200);
 }
 
-export function checkoutFirstDisplayedProduct(user: SampleUser) {
+export function checkoutFirstDisplayedProduct(
+  user: SampleUser,
+  waitForCsrFallback = false
+) {
   cy.intercept(
     'POST',
     `${Cypress.env('OCC_PREFIX')}/${Cypress.env(
@@ -720,7 +726,7 @@ export function checkoutFirstDisplayedProduct(user: SampleUser) {
     )}/users/current/carts?fields*`
   ).as('carts');
 
-  addFirstResultToCartFromSearchAndLogin(user);
+  addFirstResultToCartFromSearchAndLogin(user, waitForCsrFallback);
 
   cy.wait('@addToCart').its('response.statusCode').should('eq', 200);
   cy.wait('@carts').its('response.statusCode').should('eq', 201);


### PR DESCRIPTION

##Context

CCV2 is running SSR, thus triggering e2e failure on Register and LoginPage form filling as CSR fallback clear the form.
worakround -> wait CSR fallback before filling the form.
2nd part of CXSPA-13762 as workaround was missing for login page after searching product.

## Problem

The test `should checkout with a registered user by searching a product` was not applying
the CSR fallback wait during login, causing login form inputs to be cleared after CSR
loading on CCV2.

The workaround `waitForCsrFallbackTimeout` (8s wait) was already applied for registration
via `registerUser(..., true)`, but was missing for the login step inside
`checkoutFirstDisplayedProduct`.

## Changes

- Added `waitForCsrFallback` parameter (default `false`) to `addFirstResultToCartFromSearchAndLogin`
  and `checkoutFirstDisplayedProduct` in `checkout-flow.ts`
- Propagated the parameter to `loginUser` → `fillCustomLoginForm` where
  `waitForCsrFallbackTimeout` is invoked
- Passed `true` from the core-e2e test call site so the wait applies only for that test

## Notes

- All other callers default to `false` and are unaffected
- Temporary workaround pending CXSPA-13800 ([SSR] Login form inputs cleared after CSR loading)
