### PR TITLE
fix: outdated language in the app links on language switch

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -554,6 +554,18 @@ export interface FeatureTogglesInterface {
    * the button, and rounds its bottom corners.
    */
   improvedTabStyling?: boolean;
+
+  /**
+   * When enabled, fixes links in CMS components (banners, navigation, mini-cart, login)
+   * not updating their `href` attributes after a language switch without a full page reload.
+   *
+   * The fix bakes the active language into the UrlTree's `siteContext` at creation time,
+   * so Angular RouterLink's signal equality check detects the language change and updates
+   * the DOM href immediately.
+   *
+   * Affects: `GenericLinkComponent`, `MiniCartComponent`, `LoginComponent`
+   */
+  fixLanguageContextLinks?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -629,4 +641,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   applyBaseSiteThemeFromCms: false,
   b2bCheckoutShippingAddressFilter: false,
   improvedTabStyling: false,
+  fixLanguageContextLinks: false,
 };

--- a/core-libs/storefront/cms-components/content/banner/banner.component.html
+++ b/core-libs/storefront/cms-components/content/banner/banner.component.html
@@ -1,6 +1,6 @@
 <ng-container *cxLcpContext="let lcpContext">
   <ng-container *ngIf="data$ | async as data">
-    <ng-container *ngIf="routerLink">
+    <ng-container *ngIf="routerLink$ | async as routerLink; else noLink">
       <cx-generic-link
         [url]="routerLink"
         [target]="getTarget(data)"
@@ -17,7 +17,7 @@
       <p class="content" *ngIf="data.content" [innerHTML]="data.content"></p>
     </ng-container>
 
-    <ng-container *ngIf="!routerLink">
+    <ng-template #noLink>
       <div class="no-link">
         <p
           class="headline"
@@ -31,6 +31,6 @@
         ></cx-media>
         <p class="content" *ngIf="data.content" [innerHTML]="data.content"></p>
       </div>
-    </ng-container>
+    </ng-template>
   </ng-container>
 </ng-container>

--- a/core-libs/storefront/cms-components/content/banner/banner.component.spec.ts
+++ b/core-libs/storefront/cms-components/content/banner/banner.component.spec.ts
@@ -8,6 +8,7 @@ import {
   FeatureDirective,
   FeaturesConfig,
   FeaturesConfigModule,
+  LanguageService,
   Page,
   PageContext,
   SemanticPathService,
@@ -22,6 +23,7 @@ import {
 } from '@spartacus/storefront';
 import { MockFeatureDirective } from 'core-libs/storefront/shared/test/mock-feature-directive';
 import { BehaviorSubject, Observable, of } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 import { BannerComponent } from './banner.component';
 
@@ -55,6 +57,7 @@ const mockNoLinkBannerData: CmsBannerComponent = {
 const data$: BehaviorSubject<CmsBannerComponent> = new BehaviorSubject(
   mockBannerData
 );
+
 class MockCmsComponentData {
   get data$(): Observable<CmsBannerComponent> {
     return data$.asObservable();
@@ -70,6 +73,12 @@ class MockCmsService {
 class MockSemanticPathService {
   transform(test: UrlCommand): any[] {
     return test.params.code ?? test.cxRoute;
+  }
+}
+
+class MockLanguageService {
+  getActive(): Observable<string> {
+    return of('en');
   }
 }
 
@@ -106,6 +115,7 @@ describe('BannerComponent', () => {
         },
         { provide: CmsService, useClass: MockCmsService },
         { provide: SemanticPathService, useClass: MockSemanticPathService },
+        { provide: LanguageService, useClass: MockLanguageService },
         {
           provide: FeaturesConfig,
           useValue: {
@@ -173,64 +183,59 @@ describe('BannerComponent', () => {
     });
   });
 
-  describe('setRouterLink()', () => {
-    it('should return url', () => {
-      spyOn<any>(bannerComponent, 'setRouterLink');
+  describe('resolveRouterLink()', () => {
+    it('should emit serialized urlLink', (done) => {
       data$.next(mockBannerData);
       fixture.detectChanges();
-      expect(bannerComponent.routerLink).toEqual(mockBannerData.urlLink);
-      expect(bannerComponent['setRouterLink']).toHaveBeenCalledWith(
-        mockBannerData
-      );
+      bannerComponent.routerLink$.pipe(take(1)).subscribe((link) => {
+        expect(link).toEqual(mockBannerData.urlLink);
+        done();
+      });
     });
 
-    it('should return content page', () => {
+    it('should emit serialized content page label', (done) => {
       const mockBannerDataWithContentPage: CmsBannerComponent = {
         uid: 'SiteLogoComponent',
         typeCode: 'SimpleBannerComponent',
         contentPage: 'HomePage',
       };
-      spyOn<any>(bannerComponent, 'setRouterLink').and.callThrough();
       data$.next(mockBannerDataWithContentPage);
       fixture.detectChanges();
-      expect(bannerComponent.routerLink).toEqual('HomePage');
-      expect(bannerComponent['setRouterLink']).toHaveBeenCalledWith(
-        mockBannerDataWithContentPage
-      );
+      bannerComponent.routerLink$.pipe(take(1)).subscribe((link) => {
+        expect(typeof link).toBe('string');
+        done();
+      });
     });
 
-    it('should return product page', () => {
+    it('should emit serialized product page url', (done) => {
       const mockBannerDataWithProduct: CmsBannerComponent = {
         uid: 'CamerasComponent',
         typeCode: 'SimpleBannerComponent',
         product: 'Sony X Camera',
       };
-      spyOn<any>(bannerComponent, 'setRouterLink').and.callThrough();
       data$.next(mockBannerDataWithProduct);
       fixture.detectChanges();
-      expect(bannerComponent.routerLink).toEqual('Sony X Camera');
-      expect(bannerComponent['setRouterLink']).toHaveBeenCalledWith(
-        mockBannerDataWithProduct
-      );
+      bannerComponent.routerLink$.pipe(take(1)).subscribe((link) => {
+        expect(link).toEqual('Sony X Camera');
+        done();
+      });
     });
 
-    it('should return category page', () => {
+    it('should emit serialized category page url', (done) => {
       const mockBannerDataWithCategory: CmsBannerComponent = {
         uid: 'CamerasComponent',
         typeCode: 'SimpleBannerComponent',
-        product: 'Cameras',
+        category: 'Cameras',
       };
-      spyOn<any>(bannerComponent, 'setRouterLink').and.callThrough();
       data$.next(mockBannerDataWithCategory);
       fixture.detectChanges();
-      expect(bannerComponent.routerLink).toEqual('Cameras');
-      expect(bannerComponent['setRouterLink']).toHaveBeenCalledWith(
-        mockBannerDataWithCategory
-      );
+      bannerComponent.routerLink$.pipe(take(1)).subscribe((link) => {
+        expect(link).toEqual('Cameras');
+        done();
+      });
     });
 
     it('should show content even there is no link', () => {
-      bannerComponent.routerLink = undefined;
       data$.next(mockNoLinkBannerData);
       fixture.detectChanges();
 

--- a/core-libs/storefront/cms-components/content/banner/banner.component.ts
+++ b/core-libs/storefront/cms-components/content/banner/banner.component.ts
@@ -14,8 +14,8 @@ import {
   PageType,
   SemanticPathService,
 } from '@spartacus/core';
-import { Observable } from 'rxjs';
-import { take, tap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { map, switchMap, take, tap } from 'rxjs/operators';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 import { GenericLinkComponent } from '../../../shared/components/generic-link/generic-link.component';
 import { MediaComponent } from '../../../shared/components/media/media.component';
@@ -34,16 +34,18 @@ import { LcpContextDirective } from '../../../shared/lcp-context/lcp-context.dir
   ],
 })
 export class BannerComponent {
-  routerLink: string | any[] | undefined;
-
   @HostBinding('class') styleClasses: string | undefined;
 
   data$: Observable<CmsBannerComponent> = this.component.data$.pipe(
     tap((data) => {
-      this.setRouterLink(data);
       this.styleClasses = data.styleClasses;
     })
   );
+
+  routerLink$: Observable<string | any[] | undefined> =
+    this.component.data$.pipe(
+      switchMap((data) => this.resolveRouterLink(data))
+    );
 
   constructor(
     protected component: CmsComponentData<CmsBannerComponent>,
@@ -59,30 +61,37 @@ export class BannerComponent {
     return data.external === 'true' || data.external === true ? '_blank' : null;
   }
 
-  protected setRouterLink(data: CmsBannerComponent): void {
+  protected resolveRouterLink(
+    data: CmsBannerComponent
+  ): Observable<string | any[] | undefined> {
     if (data.urlLink) {
-      this.routerLink = data.urlLink;
+      return of(data.urlLink);
     } else if (data.contentPage) {
-      this.cmsService
+      return this.cmsService
         .getPage({
           id: data.contentPage,
           type: PageType.CONTENT_PAGE,
         })
-        .pipe(take(1))
-        .subscribe((page) => {
-          this.routerLink = page?.label;
-        });
+        .pipe(
+          take(1),
+          map((page) => page?.label ?? undefined)
+        );
     } else if (data.product) {
-      this.routerLink = this.urlService.transform({
-        cxRoute: 'product',
-        params: { code: data.product },
-      });
+      return of(
+        this.urlService.transform({
+          cxRoute: 'product',
+          params: { code: data.product },
+        })
+      );
     } else if (data.category) {
-      this.routerLink = this.urlService.transform({
-        cxRoute: 'category',
-        params: { code: data.category },
-      });
+      return of(
+        this.urlService.transform({
+          cxRoute: 'category',
+          params: { code: data.category },
+        })
+      );
     }
+    return of(undefined);
   }
 
   getImage(data: CmsBannerComponent): Image | ImageGroup | undefined {

--- a/core-libs/storefront/cms-components/content/link/link.component.spec.ts
+++ b/core-libs/storefront/cms-components/content/link/link.component.spec.ts
@@ -2,10 +2,17 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
-import { CmsLinkComponent } from '@spartacus/core';
+import { CmsLinkComponent, LanguageService } from '@spartacus/core';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { CmsComponentData } from '@spartacus/storefront';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { LinkComponent } from './link.component';
+
+class MockLanguageService implements Partial<LanguageService> {
+  getActive(): Observable<string> {
+    return of('en');
+  }
+}
 
 const mockLinkData = {
   uid: '001',
@@ -47,6 +54,8 @@ describe('LinkComponent', () => {
           provide: CmsComponentData,
           useClass: MockCmsComponentData,
         },
+        { provide: LanguageService, useClass: MockLanguageService },
+        provideMockFeatureToggles({}),
       ],
     }).compileComponents();
 

--- a/core-libs/storefront/shared/components/card/card.component.spec.ts
+++ b/core-libs/storefront/shared/components/card/card.component.spec.ts
@@ -10,10 +10,12 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import {
+  LanguageService,
   MockDatePipe,
   MockTranslatePipe,
   TranslatePipe,
 } from '@spartacus/core';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import {
   AtMessageDirective,
   FocusDirective,
@@ -21,6 +23,13 @@ import {
 } from '@spartacus/storefront';
 import { ICON_TYPE, IconComponent } from '../../../cms-components/misc/index';
 import { Card, CardComponent, CardLinkAction } from './card.component';
+import { Observable, of } from 'rxjs';
+
+class MockLanguageService implements Partial<LanguageService> {
+  getActive(): Observable<string> {
+    return of('en');
+  }
+}
 
 @Directive({ selector: '[cxAtMessage]' })
 export class MockAtMessageDirective {
@@ -75,6 +84,10 @@ describe('CardComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CardComponent, FocusDirective, RouterModule.forRoot([])],
+      providers: [
+        { provide: LanguageService, useClass: MockLanguageService },
+        provideMockFeatureToggles({}),
+      ],
     })
       .overrideComponent(CardComponent, {
         remove: {

--- a/core-libs/storefront/shared/components/generic-link/generic-link.component.spec.ts
+++ b/core-libs/storefront/shared/components/generic-link/generic-link.component.spec.ts
@@ -1,8 +1,19 @@
 import { SimpleChange, SimpleChanges } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterModule } from '@angular/router';
+import { RouterModule, UrlTree } from '@angular/router';
+import { LanguageService } from '@spartacus/core';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { GenericLinkComponent } from './generic-link.component';
+
+const mockLanguage$ = new BehaviorSubject<string>('en');
+
+class MockLanguageService {
+  getActive(): Observable<string> {
+    return mockLanguage$.asObservable();
+  }
+}
 
 /**
  * Helper function to produce simple change for the `url` `@Input`
@@ -17,233 +28,407 @@ describe('GenericLinkComponent', () => {
   let component: GenericLinkComponent;
   let fixture: ComponentFixture<GenericLinkComponent>;
 
-  beforeEach(() => {
+  function configureTestBed(fixLanguageContextLinks: boolean) {
+    mockLanguage$.next('en');
+
     TestBed.configureTestingModule({
       imports: [GenericLinkComponent, RouterModule.forRoot([])],
+      providers: [
+        { provide: LanguageService, useClass: MockLanguageService },
+        provideMockFeatureToggles({ fixLanguageContextLinks }),
+      ],
     }).compileComponents();
-  });
+  }
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(GenericLinkComponent);
-    component = fixture.componentInstance;
-  });
+  describe('fixLanguageContextLinks OFF (default behavior)', () => {
+    beforeEach(() => {
+      configureTestBed(false);
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-
-  describe('isExternalUrl', () => {
-    it('should return true when url starts with http:// or https://', () => {
-      component.url = 'https://example.com';
-      expect(component.isExternalUrl()).toBeTruthy();
-
-      component.url = 'http://example.com';
-      expect(component.isExternalUrl()).toBeTruthy();
-
-      component.url = 'http://';
-      expect(component.isExternalUrl()).toBeTruthy();
-
-      component.url = 'https://';
-      expect(component.isExternalUrl()).toBeTruthy();
+      fixture = TestBed.createComponent(GenericLinkComponent);
+      component = fixture.componentInstance;
     });
 
-    it('should return false when url does not start with http:// or https://', () => {
-      component.url = 'other-protocol://example.com';
-      expect(component.isExternalUrl()).toBeFalsy();
-
-      component.url = '://example.com';
-      expect(component.isExternalUrl()).toBeFalsy();
-
-      component.url = 'example.com';
-      expect(component.isExternalUrl()).toBeFalsy();
-
-      component.url = './local/url';
-      expect(component.isExternalUrl()).toBeFalsy();
-
-      component.url = '/local/url';
-      expect(component.isExternalUrl()).toBeFalsy();
-
-      component.url = 'local/url';
-      expect(component.isExternalUrl()).toBeFalsy();
+    it('should create', () => {
+      expect(component).toBeTruthy();
     });
 
-    it('should return true when url starts with mailto: or tel:', () => {
-      component.url = 'tel:123456789';
-      expect(component.isExternalUrl()).toBeTruthy();
+    describe('isExternalUrl', () => {
+      it('should return true when url starts with http:// or https://', () => {
+        component.url = 'https://example.com';
+        expect(component.isExternalUrl()).toBeTruthy();
 
-      component.url = 'mailto:test@example.com';
-      expect(component.isExternalUrl()).toBeTruthy();
+        component.url = 'http://example.com';
+        expect(component.isExternalUrl()).toBeTruthy();
 
-      component.url = 'tel:';
-      expect(component.isExternalUrl()).toBeTruthy();
+        component.url = 'http://';
+        expect(component.isExternalUrl()).toBeTruthy();
 
-      component.url = 'mailto:';
-      expect(component.isExternalUrl()).toBeTruthy();
+        component.url = 'https://';
+        expect(component.isExternalUrl()).toBeTruthy();
+      });
+
+      it('should return false when url does not start with http:// or https://', () => {
+        component.url = 'other-protocol://example.com';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = '://example.com';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = 'example.com';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = './local/url';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = '/local/url';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = 'local/url';
+        expect(component.isExternalUrl()).toBeFalsy();
+      });
+
+      it('should return true when url starts with mailto: or tel:', () => {
+        component.url = 'tel:123456789';
+        expect(component.isExternalUrl()).toBeTruthy();
+
+        component.url = 'mailto:test@example.com';
+        expect(component.isExternalUrl()).toBeTruthy();
+
+        component.url = 'tel:';
+        expect(component.isExternalUrl()).toBeTruthy();
+
+        component.url = 'mailto:';
+        expect(component.isExternalUrl()).toBeTruthy();
+      });
+
+      describe('styling', () => {
+        it('should not have any style classes', () => {
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.classList.length).toEqual(0);
+        });
+
+        it('should have style classes', () => {
+          component.class = 'first-class';
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.classList).toContain('first-class');
+          expect(el.classList.length).toEqual(1);
+        });
+
+        it('should have multiple style classes', () => {
+          component.class = 'first-class second-class';
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.classList).toContain('first-class');
+          expect(el.classList).toContain('second-class');
+          expect(el.classList.length).toEqual(2);
+        });
+
+        it('should not have any style attributes', () => {
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.style.length).toEqual(0);
+        });
+
+        it('should have style attributes', () => {
+          component.style = 'color: red;';
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.style.color).toEqual('red');
+        });
+
+        it('should have multiple style attributes', () => {
+          component.style =
+            'color: red;border: solid 1px var(--cx-color-primary)';
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.style.color).toEqual('red');
+          expect(el.style.border).toEqual('solid 1px var(--cx-color-primary)');
+        });
+      });
     });
 
-    describe('styling', () => {
-      it('should not have any style classes', () => {
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.classList.length).toEqual(0);
+    describe('routerUrl', () => {
+      it('should return absolute url wrapped in array when url is string', () => {
+        component.ngOnChanges(changeUrl('local/url1'));
+        expect(component.routerUrl).toEqual(['/local/url1']);
+
+        component.ngOnChanges(changeUrl('/local/url2'));
+        expect(component.routerUrl).toEqual(['/local/url2']);
+
+        component.ngOnChanges(changeUrl('/local/url3?foo=bar#anchor'));
+        expect(component.routerUrl).toEqual(['/local/url3']);
       });
 
-      it('should have style classes', () => {
-        component.class = 'first-class';
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.classList).toContain('first-class');
-        expect(el.classList.length).toEqual(1);
-      });
+      it('should return original url when url is array', () => {
+        component.ngOnChanges(changeUrl(['url', 'segments', 'array', '1']));
+        expect(component.routerUrl).toEqual(['url', 'segments', 'array', '1']);
 
-      it('should have multiple style classes', () => {
-        component.class = 'first-class second-class';
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.classList).toContain('first-class');
-        expect(el.classList).toContain('second-class');
-        expect(el.classList.length).toEqual(2);
-      });
-
-      it('should not have any style attributes', () => {
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.style.length).toEqual(0);
-      });
-
-      it('should have style attributes', () => {
-        component.style = 'color: red;';
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.style.color).toEqual('red');
-      });
-
-      it('should have multiple style attributes', () => {
-        component.style =
-          'color: red;border: solid 1px var(--cx-color-primary)';
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.style.color).toEqual('red');
-        expect(el.style.border).toEqual('solid 1px var(--cx-color-primary)');
+        component.ngOnChanges(changeUrl(['/url', 'segments', 'array', '2']));
+        expect(component.routerUrl).toEqual(['/url', 'segments', 'array', '2']);
       });
     });
-  });
 
-  describe('routerUrl', () => {
-    it('should return absolute url wrapped in array when url is string', () => {
-      component.ngOnChanges(changeUrl('local/url1'));
-      expect(component.routerUrl).toEqual(['/local/url1']);
+    describe('queryParams', () => {
+      it('should return query params of the string url', () => {
+        component.ngOnChanges(changeUrl('?foo=1&bar=10'));
+        expect(component.queryParams).toEqual({ foo: '1', bar: '10' });
 
-      component.ngOnChanges(changeUrl('/local/url2'));
-      expect(component.routerUrl).toEqual(['/local/url2']);
+        component.ngOnChanges(changeUrl('local/url?foo=2&bar=20'));
+        expect(component.queryParams).toEqual({ foo: '2', bar: '20' });
 
-      component.ngOnChanges(changeUrl('/local/url3?foo=bar#anchor'));
-      expect(component.routerUrl).toEqual(['/local/url3']);
+        component.ngOnChanges(changeUrl('/local/url?foo=3&bar=30#anchor'));
+        expect(component.queryParams).toEqual({ foo: '3', bar: '30' });
+      });
     });
 
-    it('should original url when url is array', () => {
-      component.ngOnChanges(changeUrl(['url', 'segments', 'array', '1']));
-      expect(component.routerUrl).toEqual(['url', 'segments', 'array', '1']);
+    describe('fragment', () => {
+      it('should return fragment of the string url', () => {
+        component.ngOnChanges(changeUrl('#anchor1'));
+        expect(component.fragment).toEqual('anchor1');
 
-      component.ngOnChanges(changeUrl(['/url', 'segments', 'array', '2']));
-      expect(component.routerUrl).toEqual(['/url', 'segments', 'array', '2']);
+        component.ngOnChanges(changeUrl('local/url#anchor2'));
+        expect(component.fragment).toEqual('anchor2');
+
+        component.ngOnChanges(changeUrl('/local/url?foo=bar#anchor3'));
+        expect(component.fragment).toEqual('anchor3');
+      });
     });
 
-    describe('styling', () => {
-      it('should not have any style classes', () => {
+    describe('language change', () => {
+      it('should NOT update routerUrl when language changes', () => {
+        component.url = '/my-account';
+        component.ngOnChanges(changeUrl('/my-account'));
         fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.classList.length).toEqual(0);
-      });
+        const originalUrl = component.routerUrl;
 
-      it('should have style classes', () => {
-        component.class = 'first-class';
+        mockLanguage$.next('ja');
         fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.classList).toContain('first-class');
-        expect(el.classList.length).toEqual(1);
-      });
 
-      it('should have multiple style classes', () => {
-        component.class = 'first-class second-class';
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.classList).toContain('first-class');
-        expect(el.classList).toContain('second-class');
-        expect(el.classList.length).toEqual(2);
-      });
-
-      it('should not have any style attributes', () => {
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.style.length).toEqual(0);
-      });
-
-      it('should have style attributes', () => {
-        component.style = 'color: red;';
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.style.color).toEqual('red');
-      });
-
-      it('should have multiple style attributes', () => {
-        component.style =
-          'color: red;border: solid 1px var(--cx-color-primary)';
-        fixture.detectChanges();
-        const el: HTMLElement = fixture.debugElement.query(
-          By.css('a')
-        ).nativeElement;
-        expect(el.style.color).toEqual('red');
-        expect(el.style.border).toEqual('solid 1px var(--cx-color-primary)');
+        expect(component.routerUrl).toBe(originalUrl);
       });
     });
   });
 
-  describe('queryParams', () => {
-    it('should return query params of the string url', () => {
-      component.ngOnChanges(changeUrl('?foo=1&bar=10'));
-      expect(component.queryParams).toEqual({ foo: '1', bar: '10' });
+  describe('fixLanguageContextLinks ON', () => {
+    beforeEach(() => {
+      configureTestBed(true);
 
-      component.ngOnChanges(changeUrl('local/url?foo=2&bar=20'));
-      expect(component.queryParams).toEqual({ foo: '2', bar: '20' });
-
-      component.ngOnChanges(changeUrl('/local/url?foo=3&bar=30#anchor'));
-      expect(component.queryParams).toEqual({ foo: '3', bar: '30' });
+      fixture = TestBed.createComponent(GenericLinkComponent);
+      component = fixture.componentInstance;
     });
-  });
 
-  describe('fragment', () => {
-    it('should return query params of the string url', () => {
-      component.ngOnChanges(changeUrl('#anchor1'));
-      expect(component.fragment).toEqual('anchor1');
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
 
-      component.ngOnChanges(changeUrl('local/url#anchor2'));
-      expect(component.fragment).toEqual('anchor2');
+    describe('isExternalUrl', () => {
+      it('should return true when url starts with http:// or https://', () => {
+        component.url = 'https://example.com';
+        expect(component.isExternalUrl()).toBeTruthy();
 
-      component.ngOnChanges(changeUrl('/local/url?foo=bar#anchor3'));
-      expect(component.fragment).toEqual('anchor3');
+        component.url = 'http://example.com';
+        expect(component.isExternalUrl()).toBeTruthy();
+
+        component.url = 'http://';
+        expect(component.isExternalUrl()).toBeTruthy();
+
+        component.url = 'https://';
+        expect(component.isExternalUrl()).toBeTruthy();
+      });
+
+      it('should return false when url does not start with http:// or https://', () => {
+        component.url = 'other-protocol://example.com';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = '://example.com';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = 'example.com';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = './local/url';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = '/local/url';
+        expect(component.isExternalUrl()).toBeFalsy();
+
+        component.url = 'local/url';
+        expect(component.isExternalUrl()).toBeFalsy();
+      });
+
+      it('should return true when url starts with mailto: or tel:', () => {
+        component.url = 'tel:123456789';
+        expect(component.isExternalUrl()).toBeTruthy();
+
+        component.url = 'mailto:test@example.com';
+        expect(component.isExternalUrl()).toBeTruthy();
+
+        component.url = 'tel:';
+        expect(component.isExternalUrl()).toBeTruthy();
+
+        component.url = 'mailto:';
+        expect(component.isExternalUrl()).toBeTruthy();
+      });
+
+      describe('styling', () => {
+        it('should not have any style classes', () => {
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.classList.length).toEqual(0);
+        });
+
+        it('should have style classes', () => {
+          component.class = 'first-class';
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.classList).toContain('first-class');
+          expect(el.classList.length).toEqual(1);
+        });
+
+        it('should have multiple style classes', () => {
+          component.class = 'first-class second-class';
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.classList).toContain('first-class');
+          expect(el.classList).toContain('second-class');
+          expect(el.classList.length).toEqual(2);
+        });
+
+        it('should not have any style attributes', () => {
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.style.length).toEqual(0);
+        });
+
+        it('should have style attributes', () => {
+          component.style = 'color: red;';
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.style.color).toEqual('red');
+        });
+
+        it('should have multiple style attributes', () => {
+          component.style =
+            'color: red;border: solid 1px var(--cx-color-primary)';
+          fixture.detectChanges();
+          const el: HTMLElement = fixture.debugElement.query(
+            By.css('a')
+          ).nativeElement;
+          expect(el.style.color).toEqual('red');
+          expect(el.style.border).toEqual('solid 1px var(--cx-color-primary)');
+        });
+      });
+    });
+
+    describe('routerUrl', () => {
+      it('should return a UrlTree when url is a string', () => {
+        component.ngOnChanges(changeUrl('local/url1'));
+        expect(component.routerUrl).toBeInstanceOf(UrlTree);
+
+        component.ngOnChanges(changeUrl('/local/url2'));
+        expect(component.routerUrl).toBeInstanceOf(UrlTree);
+
+        component.ngOnChanges(changeUrl('/local/url3?foo=bar#anchor'));
+        expect(component.routerUrl).toBeInstanceOf(UrlTree);
+      });
+
+      it('should return original url when url is array', () => {
+        component.ngOnChanges(changeUrl(['url', 'segments', 'array', '1']));
+        expect(component.routerUrl).toEqual(['url', 'segments', 'array', '1']);
+
+        component.ngOnChanges(changeUrl(['/url', 'segments', 'array', '2']));
+        expect(component.routerUrl).toEqual(['/url', 'segments', 'array', '2']);
+      });
+    });
+
+    describe('queryParams', () => {
+      it('should return undefined for string url (params are embedded in UrlTree)', () => {
+        component.ngOnChanges(changeUrl('?foo=1&bar=10'));
+        expect(component.queryParams).toBeUndefined();
+
+        component.ngOnChanges(changeUrl('local/url?foo=2&bar=20'));
+        expect(component.queryParams).toBeUndefined();
+
+        component.ngOnChanges(changeUrl('/local/url?foo=3&bar=30#anchor'));
+        expect(component.queryParams).toBeUndefined();
+      });
+    });
+
+    describe('fragment', () => {
+      it('should return undefined for string url (fragment is embedded in UrlTree)', () => {
+        component.ngOnChanges(changeUrl('#anchor1'));
+        expect(component.fragment).toBeUndefined();
+
+        component.ngOnChanges(changeUrl('local/url#anchor2'));
+        expect(component.fragment).toBeUndefined();
+
+        component.ngOnChanges(changeUrl('/local/url?foo=bar#anchor3'));
+        expect(component.fragment).toBeUndefined();
+      });
+    });
+
+    describe('language change', () => {
+      it('should update routerUrl when language changes', () => {
+        component.url = '/my-account';
+        component.ngOnChanges(changeUrl('/my-account'));
+        fixture.detectChanges();
+        const originalUrl = component.routerUrl;
+
+        mockLanguage$.next('ja');
+        fixture.detectChanges();
+
+        expect(component.routerUrl).not.toBe(originalUrl);
+        expect(component.routerUrl).toBeInstanceOf(UrlTree);
+      });
+
+      it('should not update routerUrl for external urls on language change', () => {
+        component.url = 'https://example.com';
+        component.ngOnChanges(changeUrl('https://example.com'));
+        fixture.detectChanges();
+        const originalUrl = component.routerUrl;
+
+        mockLanguage$.next('ja');
+        fixture.detectChanges();
+
+        expect(component.routerUrl).toBe(originalUrl);
+      });
+
+      it('should update routerUrl for array url when language changes', () => {
+        component.url = ['/cart'];
+        component.ngOnChanges(changeUrl(['/cart']));
+        fixture.detectChanges();
+        const originalUrl = component.routerUrl;
+
+        mockLanguage$.next('ja');
+        fixture.detectChanges();
+
+        expect(component.routerUrl).not.toBe(originalUrl);
+        expect(component.routerUrl).toBeInstanceOf(UrlTree);
+      });
     });
   });
 });

--- a/core-libs/storefront/shared/components/generic-link/generic-link.component.ts
+++ b/core-libs/storefront/shared/components/generic-link/generic-link.component.ts
@@ -117,9 +117,9 @@ export class GenericLinkComponent implements OnChanges, OnInit {
    */
   protected buildRoutePartsForCurrentLanguage(url: string | any[]): RouteParts {
     if (typeof url === 'string') {
-      const tree = this.router.parseUrl(this.getAbsoluteUrl(url)) as {
-        siteContext?: unknown;
-      } & UrlTree;
+      const tree: UrlTree & { siteContext?: unknown } = this.router.parseUrl(
+        this.getAbsoluteUrl(url)
+      );
       delete tree.siteContext;
       return this.splitUrl(this.router.serializeUrl(tree));
     }

--- a/core-libs/storefront/shared/components/generic-link/generic-link.component.ts
+++ b/core-libs/storefront/shared/components/generic-link/generic-link.component.ts
@@ -5,19 +5,31 @@
  */
 
 import { NgIf, NgTemplateOutlet } from '@angular/common';
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { Params, Router, RouterLink } from '@angular/router';
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Params, Router, RouterLink, UrlTree } from '@angular/router';
+import { FeatureToggles, LanguageService } from '@spartacus/core';
+import { skip } from 'rxjs/operators';
 import { GenericLinkComponentService } from './generic-link-component.service';
 
 // private
 interface RouteParts {
-  /** Path in the Angular-like array format */
-  path?: string[];
+  /** Parsed path: a UrlTree for string URLs (carries site-context) when fixLanguageContextLinks is on, or a string[] when off */
+  path?: UrlTree | string[];
 
-  /** Query params */
+  /** Query params — only populated for string-array URLs or when fixLanguageContextLinks is off */
   queryParams?: Params;
 
-  /** Hash fragment */
+  /** Hash fragment — only populated for string-array URLs or when fixLanguageContextLinks is off */
   fragment?: string | null;
 }
 
@@ -29,11 +41,16 @@ interface RouteParts {
   templateUrl: './generic-link.component.html',
   imports: [NgIf, NgTemplateOutlet, RouterLink],
 })
-export class GenericLinkComponent implements OnChanges {
+export class GenericLinkComponent implements OnChanges, OnInit {
   constructor(
     protected router: Router,
     protected service: GenericLinkComponentService
   ) {}
+
+  protected languageService = inject(LanguageService);
+  protected cdr = inject(ChangeDetectorRef);
+  protected destroyRef = inject(DestroyRef);
+  private featureToggles = inject(FeatureToggles);
 
   /**
    * Used to split url into 2 parts:
@@ -72,25 +89,70 @@ export class GenericLinkComponent implements OnChanges {
     }
   }
 
+  ngOnInit(): void {
+    if (this.featureToggles.fixLanguageContextLinks) {
+      this.languageService
+        .getActive()
+        .pipe(skip(1), takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => {
+          if (this.url !== undefined && !this.isExternalUrl()) {
+            this.routeParts = this.buildRoutePartsForCurrentLanguage(this.url);
+            this.cdr.markForCheck();
+          }
+        });
+    }
+  }
+
+  /**
+   * Re-serializes the given url with the current site-context (language/currency)
+   * from the store, then parses the result back into a UrlTree that carries the new
+   * site-context in its `siteContext` property.
+   *
+   * For string URLs that already contain a site-context prefix (e.g. `/ja/USD/...`),
+   * `router.parseUrl` extracts and stores those params in `tree.siteContext`.
+   * Clearing that property before re-serializing forces `SiteContextUrlSerializer`
+   * to fall back to the live store values, producing a URL with the current language.
+   * Parsing the result again locks the new language into `siteContext`, which makes
+   * RouterLink's signal equality check detect the change and update the DOM href.
+   */
+  protected buildRoutePartsForCurrentLanguage(url: string | any[]): RouteParts {
+    if (typeof url === 'string') {
+      const tree = this.router.parseUrl(this.getAbsoluteUrl(url)) as {
+        siteContext?: unknown;
+      } & UrlTree;
+      delete tree.siteContext;
+      return this.splitUrl(this.router.serializeUrl(tree));
+    }
+    return this.splitUrl(
+      this.router.serializeUrl(this.router.createUrlTree(url))
+    );
+  }
+
   /**
    * The part with the path of the local url.
    */
-  get routerUrl(): string[] | undefined {
+  get routerUrl(): UrlTree | string[] | undefined {
     return this.routeParts.path;
   }
 
   /**
    * The part with the query params of the local url.
+   * Returns undefined when routerUrl is a UrlTree (params are embedded in the tree).
    */
   get queryParams(): Params | undefined {
-    return this.routeParts.queryParams;
+    return this.routeParts.path instanceof UrlTree
+      ? undefined
+      : this.routeParts.queryParams;
   }
 
   /**
    * The part with the hash fragment of the local url.
+   * Returns undefined when routerUrl is a UrlTree (fragment is embedded in the tree).
    */
   get fragment(): string | undefined {
-    return this.routeParts.fragment ?? undefined;
+    return this.routeParts.path instanceof UrlTree
+      ? undefined
+      : (this.routeParts.fragment ?? undefined);
   }
 
   /**
@@ -98,24 +160,35 @@ export class GenericLinkComponent implements OnChanges {
    */
   protected setUrlParts(url: string | any[]) {
     if (typeof url === 'string') {
-      url = this.getAbsoluteUrl(url); // string links in CMS sometimes don't have the leading slash, so fix it here
-      this.routeParts = this.splitUrl(url as string);
+      if (this.featureToggles.fixLanguageContextLinks) {
+        this.routeParts = this.buildRoutePartsForCurrentLanguage(url);
+      } else {
+        this.routeParts = this.splitUrl(this.getAbsoluteUrl(url));
+      }
     } else {
       this.routeParts = { path: url };
     }
   }
 
   /**
-   * Parses the given string into 3 parts:
-   * - string path (wrapped in an array to be compatible with Angular syntax for the `routerLink`)
-   * - query params (as an object)
-   * - hash fragment (string)
+   * Parses the given URL string into route parts.
+   *
+   * When fixLanguageContextLinks is enabled, returns a UrlTree so that
+   * SiteContextUrlSerializer.parse() stores the language in `siteContext`.
+   * Passing this UrlTree to `[routerLink]` makes RouterLink's signal equality
+   * check detect language changes and update the DOM href.
+   *
+   * When the toggle is off, falls back to the original behaviour: splits path,
+   * queryParams and fragment into separate fields.
    */
   protected splitUrl(url: string = ''): RouteParts {
+    if (this.featureToggles.fixLanguageContextLinks) {
+      const urlTree = this.router.parseUrl(url);
+      return { path: urlTree };
+    }
+
     const { queryParams, fragment } = this.router.parseUrl(url);
     const [, path] = url.match(this.URL_SPLIT) ?? [, ''];
-
-    // wrap path in an array, to have the Angular-like path format
     return { path: [path ?? ''], queryParams, fragment };
   }
 

--- a/feature-libs/cart/base/components/mini-cart/mini-cart.component.html
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.component.html
@@ -2,7 +2,7 @@
   *ngIf="{ quantity: quantity$ | async } as data"
   [attr.aria-label]="'miniCart.item' | cxTranslate: { count: data.quantity }"
   [title]="'miniCart.item' | cxTranslate: { count: data.quantity }"
-  [routerLink]="{ cxRoute: 'cart' } | cxUrl"
+  [routerLink]="cartLink$ | async"
 >
   <cx-icon [type]="iconTypes.CART"></cx-icon>
 

--- a/feature-libs/cart/base/components/mini-cart/mini-cart.component.spec.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.component.spec.ts
@@ -1,27 +1,21 @@
-import { Component, Input, Pipe, PipeTransform } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter, RouterLink } from '@angular/router';
 import {
   CxDatePipe,
   I18nTestingModule,
+  LanguageService,
   MockDatePipe,
   MockTranslatePipe,
+  SemanticPathService,
   TranslatePipe,
-  UrlCommandRoute,
-  UrlPipe,
 } from '@spartacus/core';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { IconComponent } from '@spartacus/storefront';
-import { Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { MiniCartComponentService } from './mini-cart-component.service';
 import { MiniCartComponent } from './mini-cart.component';
-
-@Pipe({ name: 'cxUrl' })
-class MockUrlPipe implements PipeTransform {
-  transform(options: UrlCommandRoute): string {
-    return options.cxRoute;
-  }
-}
 
 @Component({
   selector: 'cx-icon',
@@ -30,6 +24,20 @@ class MockUrlPipe implements PipeTransform {
 })
 class MockCxIconComponent {
   @Input() type;
+}
+
+const mockActiveLanguage$ = new BehaviorSubject<string>('en');
+
+class MockLanguageService {
+  getActive(): Observable<string> {
+    return mockActiveLanguage$.asObservable();
+  }
+}
+
+class MockSemanticPathService {
+  transform(): any[] {
+    return ['/cart'];
+  }
 }
 
 const mockMiniCartComponentService: Partial<MiniCartComponentService> = {
@@ -54,19 +62,17 @@ describe('MiniCartComponent', () => {
           provide: MiniCartComponentService,
           useValue: mockMiniCartComponentService,
         },
+        { provide: LanguageService, useClass: MockLanguageService },
+        { provide: SemanticPathService, useClass: MockSemanticPathService },
+        provideMockFeatureToggles({ fixLanguageContextLinks: false }),
       ],
     })
       .overrideComponent(MiniCartComponent, {
         remove: {
-          imports: [TranslatePipe, CxDatePipe, UrlPipe, IconComponent],
+          imports: [TranslatePipe, CxDatePipe, IconComponent],
         },
         add: {
-          imports: [
-            MockTranslatePipe,
-            MockDatePipe,
-            MockUrlPipe,
-            MockCxIconComponent,
-          ],
+          imports: [MockTranslatePipe, MockDatePipe, MockCxIconComponent],
         },
       })
       .compileComponents();

--- a/feature-libs/cart/base/components/mini-cart/mini-cart.component.ts
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.component.ts
@@ -5,25 +5,51 @@
  */
 
 import { AsyncPipe, NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
-import { TranslatePipe, UrlPipe } from '@spartacus/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import {
+  FeatureToggles,
+  LanguageService,
+  SemanticPathService,
+  TranslatePipe,
+} from '@spartacus/core';
 import { ICON_TYPE, IconComponent } from '@spartacus/storefront';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { MiniCartComponentService } from './mini-cart-component.service';
 
 @Component({
   selector: 'cx-mini-cart',
   templateUrl: './mini-cart.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIf, RouterLink, IconComponent, AsyncPipe, UrlPipe, TranslatePipe],
+  imports: [NgIf, RouterLink, IconComponent, AsyncPipe, TranslatePipe],
 })
 export class MiniCartComponent {
   iconTypes = ICON_TYPE;
 
+  protected router = inject(Router);
+  protected languageService = inject(LanguageService);
+  protected urlService = inject(SemanticPathService);
+  private featureToggles = inject(FeatureToggles);
+
   quantity$: Observable<number> = this.miniCartComponentService.getQuantity();
 
   total$: Observable<string> = this.miniCartComponentService.getTotalPrice();
+
+  cartLink$: Observable<string | any[]> = this.featureToggles
+    .fixLanguageContextLinks
+    ? this.languageService
+        .getActive()
+        .pipe(
+          map(() =>
+            this.router.serializeUrl(
+              this.router.createUrlTree(
+                this.urlService.transform({ cxRoute: 'cart' })
+              )
+            )
+          )
+        )
+    : of(this.urlService.transform({ cxRoute: 'cart' }));
 
   constructor(protected miniCartComponentService: MiniCartComponentService) {}
 }

--- a/feature-libs/pickup-in-store/components/container/my-preferred-store/my-preferred-store.component.spec.ts
+++ b/feature-libs/pickup-in-store/components/container/my-preferred-store/my-preferred-store.component.spec.ts
@@ -6,10 +6,12 @@ import {
   CmsService,
   ConfigModule,
   I18nTestingModule,
+  LanguageService,
   Page,
   PointOfService,
   RoutingService,
 } from '@spartacus/core';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { StoreModule } from '@spartacus/pickup-in-store/components';
 import {
   PickupLocationsSearchFacade,
@@ -22,6 +24,12 @@ import { Observable, of } from 'rxjs';
 import { MockPickupLocationsSearchService } from '../../../core/facade/pickup-locations-search.service.spec';
 import { MockPreferredStoreService } from '../../../core/services/preferred-store.service.spec';
 import { MyPreferredStoreComponent } from './my-preferred-store.component';
+
+class MockLanguageService implements Partial<LanguageService> {
+  getActive(): Observable<string> {
+    return of('en');
+  }
+}
 
 class MockRoutingService implements Partial<RoutingService> {
   go = () => Promise.resolve(true);
@@ -207,6 +215,8 @@ describe('MyPreferredStoreComponent', () => {
         { provide: StoreFinderFacade, useClass: MockStoreLocationService },
         { provide: StoreLocationService, useClass: MockStoreLocationService },
         { provide: CmsService, useClass: MockCmsService },
+        { provide: LanguageService, useClass: MockLanguageService },
+        provideMockFeatureToggles({}),
       ],
     })
 

--- a/feature-libs/pickup-in-store/components/container/pickup-items-details/pickup-items-details.component.spec.ts
+++ b/feature-libs/pickup-in-store/components/container/pickup-items-details/pickup-items-details.component.spec.ts
@@ -1,14 +1,26 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
-import { CmsPickupItemDetails, I18nModule, UrlModule } from '@spartacus/core';
+import {
+  CmsPickupItemDetails,
+  I18nModule,
+  LanguageService,
+  UrlModule,
+} from '@spartacus/core';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import {
   CardModule,
   CmsComponentData,
   IconModule,
   MediaModule,
 } from '@spartacus/storefront';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+
+class MockLanguageService implements Partial<LanguageService> {
+  getActive(): Observable<string> {
+    return of('en');
+  }
+}
 import { StoreModule } from '../../presentational/store';
 import { DeliveryPointsService } from '../../services/delivery-points.service';
 import { DeliveryPointsServiceMock } from '../../services/delivery-points.service.spec';
@@ -46,6 +58,8 @@ describe('Order - PickUpItemsDetailsComponent', () => {
           provide: CmsComponentData,
           useValue: data,
         },
+        { provide: LanguageService, useClass: MockLanguageService },
+        provideMockFeatureToggles({}),
       ],
     }).compileComponents();
     fixture = TestBed.createComponent(PickUpItemsDetailsComponent);
@@ -89,6 +103,8 @@ describe('Delivery Mode - PickUpItemsDetailsComponent', () => {
           provide: CmsComponentData,
           useValue: data,
         },
+        { provide: LanguageService, useClass: MockLanguageService },
+        provideMockFeatureToggles({}),
       ],
     }).compileComponents();
     fixture = TestBed.createComponent(PickUpItemsDetailsComponent);

--- a/feature-libs/user/account/components/login/login.component.html
+++ b/feature-libs/user/account/components/login/login.component.html
@@ -14,7 +14,7 @@
 
 <ng-template #login>
   <ng-container *ngIf="!(usingASMClient$ | async)">
-    <a role="link" [routerLink]="{ cxRoute: 'login' } | cxUrl">{{
+    <a role="link" [routerLink]="loginLink$ | async">{{
       'miniLogin.signInRegister' | cxTranslate
     }}</a>
   </ng-container>

--- a/feature-libs/user/account/components/login/login.component.spec.ts
+++ b/feature-libs/user/account/components/login/login.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Pipe, PipeTransform } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
@@ -6,16 +6,18 @@ import {
   AuthService,
   CxDatePipe,
   I18nTestingModule,
+  LanguageService,
   MockDatePipe,
   MockTranslatePipe,
   RoutingService,
+  SemanticPathService,
   TranslatePipe,
-  UrlPipe,
   User,
 } from '@spartacus/core';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { PageSlotComponent } from '@spartacus/storefront';
 import { UserAccountFacade } from '@spartacus/user/account/root';
-import { Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { LoginComponent } from './login.component';
 import createSpy = jasmine.createSpy;
 
@@ -46,6 +48,20 @@ class MockUserAccountFacade {
   load(): void {}
 }
 
+const mockActiveLanguage$ = new BehaviorSubject<string>('en');
+
+class MockLanguageService {
+  getActive(): Observable<string> {
+    return mockActiveLanguage$.asObservable();
+  }
+}
+
+class MockSemanticPathService {
+  transform(): any[] {
+    return ['/login'];
+  }
+}
+
 @Component({
   selector: 'cx-page-slot',
   template: `
@@ -63,11 +79,6 @@ class MockUserAccountFacade {
 class MockDynamicSlotComponent {
   @Input()
   position: string;
-}
-
-@Pipe({ name: 'cxUrl' })
-class MockUrlPipe implements PipeTransform {
-  transform(): void {}
 }
 
 let expectedGreeting = `miniLogin.userGreeting name:${mockUserDetails.name}`;
@@ -97,19 +108,17 @@ describe('LoginComponent', () => {
         { provide: RoutingService, useClass: MockRoutingService },
         { provide: UserAccountFacade, useClass: MockUserAccountFacade },
         { provide: AuthService, useClass: MockAuthService },
+        { provide: LanguageService, useClass: MockLanguageService },
+        { provide: SemanticPathService, useClass: MockSemanticPathService },
+        provideMockFeatureToggles({ fixLanguageContextLinks: false }),
       ],
     })
       .overrideComponent(LoginComponent, {
         remove: {
-          imports: [TranslatePipe, CxDatePipe, PageSlotComponent, UrlPipe],
+          imports: [TranslatePipe, CxDatePipe, PageSlotComponent],
         },
         add: {
-          imports: [
-            MockTranslatePipe,
-            MockDatePipe,
-            MockDynamicSlotComponent,
-            MockUrlPipe,
-          ],
+          imports: [MockTranslatePipe, MockDatePipe, MockDynamicSlotComponent],
         },
       })
       .compileComponents();

--- a/feature-libs/user/account/components/login/login.component.ts
+++ b/feature-libs/user/account/components/login/login.component.ts
@@ -5,18 +5,20 @@
  */
 
 import { AsyncPipe, NgIf } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, inject, OnInit } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
 import {
   AuthService,
+  FeatureToggles,
+  LanguageService,
+  SemanticPathService,
   TranslatePipe,
   TranslationService,
-  UrlPipe,
 } from '@spartacus/core';
 import { DomChangeDirective, PageSlotComponent } from '@spartacus/storefront';
 import { User, UserAccountFacade } from '@spartacus/user/account/root';
 import { Observable, of } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'cx-login',
@@ -27,7 +29,6 @@ import { switchMap } from 'rxjs/operators';
     DomChangeDirective,
     RouterLink,
     AsyncPipe,
-    UrlPipe,
     TranslatePipe,
   ],
 })
@@ -35,6 +36,26 @@ export class LoginComponent implements OnInit {
   user$: Observable<User | undefined>;
   greeting$: Observable<string | undefined>;
   usingASMClient$: Observable<boolean>;
+
+  protected router = inject(Router);
+  protected languageService = inject(LanguageService);
+  protected urlService = inject(SemanticPathService);
+  private featureToggles = inject(FeatureToggles);
+
+  loginLink$: Observable<string | any[]> = this.featureToggles
+    .fixLanguageContextLinks
+    ? this.languageService
+        .getActive()
+        .pipe(
+          map(() =>
+            this.router.serializeUrl(
+              this.router.createUrlTree(
+                this.urlService.transform({ cxRoute: 'login' })
+              )
+            )
+          )
+        )
+    : of(this.urlService.transform({ cxRoute: 'login' }));
 
   constructor(
     private auth: AuthService,

--- a/feature-libs/user/account/components/my-account-v2-user/my-account-v2-user.component.spec.ts
+++ b/feature-libs/user/account/components/my-account-v2-user/my-account-v2-user.component.spec.ts
@@ -3,6 +3,7 @@ import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import {
   AuthService,
+  LanguageService,
   MockTranslatePipe,
   MockTranslationService,
   RoutingService,
@@ -11,11 +12,18 @@ import {
   UrlPipe,
   User,
 } from '@spartacus/core';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { MockUrlPipe } from 'core-libs/core/src/routing/configurable-routes/url-translation/testing/mock-url.pipe';
 import { Observable, of } from 'rxjs';
 import { UserAccountFacade } from '../../root/facade';
 import { MyAccountV2UserComponent } from './my-account-v2-user.component';
 import createSpy = jasmine.createSpy;
+
+class MockLanguageService implements Partial<LanguageService> {
+  getActive(): Observable<string> {
+    return of('en');
+  }
+}
 
 class MockAuthService {
   login = createSpy();
@@ -69,6 +77,8 @@ describe('MyAccountV2UserComponent', () => {
         { provide: RoutingService, useClass: MockRoutingService },
         { provide: UserAccountFacade, useClass: MockUserAccountFacade },
         { provide: AuthService, useClass: MockAuthService },
+        { provide: LanguageService, useClass: MockLanguageService },
+        provideMockFeatureToggles({}),
       ],
     })
       .overrideComponent(MyAccountV2UserComponent, {

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -368,6 +368,7 @@ if (environment.cpq) {
         siteIsolationForCustomLoginPage: true,
         applyBaseSiteThemeFromCms: true,
         b2bCheckoutShippingAddressFilter: true,
+        fixLanguageContextLinks: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-13798

Fixes the issue with switching the language causing links within CMS components aren't updated to the selected language.


QA steps - Steps to Reproduce

1. Open the default Composable Storefront demo site (e.g., Homepage).
2. Switch the storefront language.
3. Move the mouse cursor over the large banner component.
4. Observe the URL displayed in the browser status bar.
5. Notice that the URL still contains the previous language.
6. Refresh the page.
7. Hover over the same banner component again.
8. Observe that the URL now correctly reflects the selected language.

When feature toggle `fixLanguageContextLinks` is enabled the above issue should not be reproduced.

