### PR TITLE
fix: section details is not read out by screen reader

### DIFF
--- a/core-libs/assets/src/translations/en/myAccount.json
+++ b/core-libs/assets/src/translations/en/myAccount.json
@@ -24,7 +24,8 @@
     },
     "bothPasswordMustMatch": "Both password must match",
     "passwordUpdateSuccess": "Password updated with success",
-    "accessDeniedError": "Access is denied"
+    "accessDeniedError": "Access is denied",
+    "heading": "Update Password"
   },
   "updateProfileForm": {
     "title": "Title",
@@ -40,11 +41,13 @@
     },
     "lastNameIsRequired": "Last name is required.",
     "profileUpdateSuccess": "Personal details successfully updated",
-    "customerId": "Customer #"
+    "customerId": "Customer #",
+    "heading": "Update Personal Details"
   },
   "consentManagementForm": {
     "clearAll": "Clear all",
     "selectAll": "Select all",
+    "heading": "Privacy Consent Management",
     "message": {
       "success": {
         "given": "Consent successfully given.",

--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -396,6 +396,17 @@ export interface FeatureTogglesInterface {
   a11yDeliveryModeFocusPreservation?: boolean;
 
   /**
+   * When enabled, wraps form controls in a `<fieldset>` with a visually-hidden `<legend>`
+   * that names the section, so screen readers announce the section heading when any
+   * field in the group receives focus.
+   * Affects: UpdateProfileComponent, MyAccountV2ProfileComponent,
+   *          UpdatePasswordComponent, MyAccountV2PasswordComponent,
+   *          UpdateEmailComponent, MyAccountV2EmailComponent,
+   *          ConsentManagementComponent
+   */
+  a11yFormFieldSectionLegend?: boolean;
+
+  /**
    * When enabled, `AuthHttpHeaderService` executes DI-provided
    * `ExpiredRefreshTokenHandler` to take over `handleExpiredRefreshToken()` behavior in case of expired refresh token scenarios.
    * It avoids the need to override the entire AuthHttpHeaderService just to handle expired refresh token scenarios in a custom way, for example by ending punchout session when it's active.
@@ -602,6 +613,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yCartQuickOrderFormEnableSubmitAndAddValidation: false,
   a11yConsentManagementFocusPreservation: false,
   a11yDeliveryModeFocusPreservation: false,
+  a11yFormFieldSectionLegend: false,
   a11yVocalizeDropdownItemCount: false,
   a11yRestoreFocusOnNgSelect: false,
   a11yKeepFocusOnConsentManagementButtons: false,

--- a/core-libs/storefront/cms-components/myaccount/consent-management/components/consent-management.component.html
+++ b/core-libs/storefront/cms-components/myaccount/consent-management/components/consent-management.component.html
@@ -52,20 +52,43 @@
     </div>
 
     <ng-container *ngIf="!data.allConsentsLoading">
-      <div class="cx-consent-toggles">
-        <div class="col-sm-12 col-md-8 col-lg-6">
-          <cx-consent-management-form
-            *ngFor="
-              let consentTemplate of templateList;
-              trackBy: trackByTemplateId
-            "
-            [consentTemplate]="consentTemplate"
-            [requiredConsents]="requiredConsents"
-            [disabled]="!!data.loading"
-            (consentChanged)="onConsentChange($event)"
-          ></cx-consent-management-form>
+      <ng-container *cxFeature="'a11yFormFieldSectionLegend'">
+        <fieldset>
+          <legend class="cx-visually-hidden">
+            {{ 'consentManagementForm.heading' | cxTranslate }}
+          </legend>
+          <div class="cx-consent-toggles">
+            <div class="col-sm-12 col-md-8 col-lg-6">
+              <cx-consent-management-form
+                *ngFor="
+                  let consentTemplate of templateList;
+                  trackBy: trackByTemplateId
+                "
+                [consentTemplate]="consentTemplate"
+                [requiredConsents]="requiredConsents"
+                [disabled]="!!data.loading"
+                (consentChanged)="onConsentChange($event)"
+              ></cx-consent-management-form>
+            </div>
+          </div>
+        </fieldset>
+      </ng-container>
+      <ng-container *cxFeature="'!a11yFormFieldSectionLegend'">
+        <div class="cx-consent-toggles">
+          <div class="col-sm-12 col-md-8 col-lg-6">
+            <cx-consent-management-form
+              *ngFor="
+                let consentTemplate of templateList;
+                trackBy: trackByTemplateId
+              "
+              [consentTemplate]="consentTemplate"
+              [requiredConsents]="requiredConsents"
+              [disabled]="!!data.loading"
+              (consentChanged)="onConsentChange($event)"
+            ></cx-consent-management-form>
+          </div>
         </div>
-      </div>
+      </ng-container>
     </ng-container>
   </ng-container>
 </ng-container>

--- a/core-libs/storefront/cms-components/myaccount/consent-management/components/consent-management.component.spec.ts
+++ b/core-libs/storefront/cms-components/myaccount/consent-management/components/consent-management.component.spec.ts
@@ -31,6 +31,7 @@ import { SpinnerComponent } from '../../../../shared/components/spinner/spinner.
 import { ConsentManagementFormComponent } from './consent-form/consent-management-form.component';
 import { ConsentManagementComponentService } from '../consent-management-component.service';
 import { ConsentManagementComponent } from './consent-management.component';
+import { MockFeatureDirective } from 'core-libs/storefront/shared/test/mock-feature-directive';
 
 @Component({
   selector: 'cx-spinner',
@@ -168,6 +169,7 @@ describe('ConsentManagementComponent', () => {
             MockTranslatePipe,
             MockCxSpinnerComponent,
             MockConsentManagementFormComponent,
+            MockFeatureDirective,
           ],
         },
       })
@@ -802,6 +804,19 @@ describe('ConsentManagementComponent', () => {
           ).toEqual(3);
         });
       });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should render a fieldset with a visually-hidden legend when consents are loaded', () => {
+      spyOn(userService, 'getConsents').and.returnValue(
+        of([mockConsentTemplate])
+      );
+      component.ngOnInit();
+      fixture.detectChanges();
+      const legend = el.query(By.css('fieldset legend'));
+      expect(legend).toBeTruthy();
+      expect(legend.nativeElement.classList).toContain('cx-visually-hidden');
     });
   });
 });

--- a/feature-libs/user/_index.scss
+++ b/feature-libs/user/_index.scss
@@ -46,6 +46,10 @@ body {
   form {
     display: contents;
 
+    fieldset {
+      display: contents;
+    }
+
     label {
       all: unset;
       flex: 100%;

--- a/feature-libs/user/profile/assets/translations/en/myAccountV2Password.json
+++ b/feature-libs/user/profile/assets/translations/en/myAccountV2Password.json
@@ -18,6 +18,7 @@
     "bothPasswordMustMatch": "Both password must match",
     "passwordUpdateSuccess": "Password updated with success",
     "accessDeniedError": "Access is denied",
-    "newPasswordTitle": "My Password"
+    "newPasswordTitle": "My Password",
+    "heading": "Change Password"
   }
 }

--- a/feature-libs/user/profile/assets/translations/en/userProfile.json
+++ b/feature-libs/user/profile/assets/translations/en/userProfile.json
@@ -15,7 +15,8 @@
       "placeholder": "Enter password"
     },
     "pleaseInputPassword": "Please input password",
-    "emailUpdateSuccess": "Success. Please sign in with {{ newUid }}"
+    "emailUpdateSuccess": "Success. Please sign in with {{ newUid }}",
+    "heading": "Update Email Address"
   },
   "register": {
     "confirmPassword": {

--- a/feature-libs/user/profile/components/update-email/my-account-v2-email.component.html
+++ b/feature-libs/user/profile/components/update-email/my-account-v2-email.component.html
@@ -32,116 +32,245 @@
   ></cx-message>
   <div *ngIf="isEditing" class="email-editing-area">
     <form (ngSubmit)="onSubmit()" [formGroup]="form">
-      <label>
-        <span class="text-head">{{
-          'myAccountV2Email.emailAddress' | cxTranslate
-        }}</span>
-        <input
-          type="text"
-          class="form-control"
-          [value]="(user$ | async)?.uid"
-          readonly
-        />
-      </label>
+      <ng-container *cxFeature="'a11yFormFieldSectionLegend'">
+        <fieldset>
+          <legend class="cx-visually-hidden">
+            {{ 'myAccountV2Email.myEmailAddress' | cxTranslate }}
+          </legend>
+          <label>
+            <span class="text-head">{{
+              'myAccountV2Email.emailAddress' | cxTranslate
+            }}</span>
+            <input
+              type="text"
+              class="form-control"
+              [value]="(user$ | async)?.uid"
+              readonly
+            />
+          </label>
 
-      <label>
-        <span class="text-head">{{
-          'myAccountV2Email.newEmailAddress' | cxTranslate
-        }}</span>
-        <input
-          required="true"
-          type="email"
-          name="email"
-          formControlName="email"
-          placeholder="{{ 'myAccountV2Email.emailPlaceHolder' | cxTranslate }}"
-          class="form-control"
-          [attr.aria-invalid]="
-            form.get('email')?.touched && form.get('email')?.invalid
-          "
-          [attr.aria-errormessage]="'emailError'"
-        />
+          <label>
+            <span class="text-head">{{
+              'myAccountV2Email.newEmailAddress' | cxTranslate
+            }}</span>
+            <input
+              required="true"
+              type="email"
+              name="email"
+              formControlName="email"
+              placeholder="{{
+                'myAccountV2Email.emailPlaceHolder' | cxTranslate
+              }}"
+              class="form-control"
+              [attr.aria-invalid]="
+                form.get('email')?.touched && form.get('email')?.invalid
+              "
+              [attr.aria-errormessage]="'emailError'"
+            />
 
-        <cx-form-errors
-          id="emailError"
-          [translationParams]="{
-            label: 'updateEmailForm.newEmailAddress.label' | cxTranslate,
-          }"
-          [control]="form.get('email')"
-        ></cx-form-errors>
-      </label>
+            <cx-form-errors
+              id="emailError"
+              [translationParams]="{
+                label: 'updateEmailForm.newEmailAddress.label' | cxTranslate,
+              }"
+              [control]="form.get('email')"
+            ></cx-form-errors>
+          </label>
 
-      <label>
-        <span class="text-head">{{
-          'myAccountV2Email.confirmNewEmailAddress' | cxTranslate
-        }}</span>
-        <input
-          required="true"
-          type="email"
-          name="confirmEmail"
-          formControlName="confirmEmail"
-          placeholder="{{ 'myAccountV2Email.emailPlaceHolder' | cxTranslate }}"
-          class="form-control"
-          [attr.aria-invalid]="
-            form.get('confirmEmail')?.touched &&
-            form.get('confirmEmail')?.invalid
-          "
-          [attr.aria-errormessage]="'confirmEmailError'"
-        />
+          <label>
+            <span class="text-head">{{
+              'myAccountV2Email.confirmNewEmailAddress' | cxTranslate
+            }}</span>
+            <input
+              required="true"
+              type="email"
+              name="confirmEmail"
+              formControlName="confirmEmail"
+              placeholder="{{
+                'myAccountV2Email.emailPlaceHolder' | cxTranslate
+              }}"
+              class="form-control"
+              [attr.aria-invalid]="
+                form.get('confirmEmail')?.touched &&
+                form.get('confirmEmail')?.invalid
+              "
+              [attr.aria-errormessage]="'confirmEmailError'"
+            />
 
-        <cx-form-errors
-          id="confirmEmailError"
-          [translationParams]="{
-            label: 'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate,
-          }"
-          [control]="form.get('confirmEmail')"
-        ></cx-form-errors>
-      </label>
+            <cx-form-errors
+              id="confirmEmailError"
+              [translationParams]="{
+                label:
+                  'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate,
+              }"
+              [control]="form.get('confirmEmail')"
+            ></cx-form-errors>
+          </label>
 
-      <label>
-        <span class="label-content, text-head">{{
-          'myAccountV2Email.password' | cxTranslate
-        }}</span>
-        <input
-          required="true"
-          type="password"
-          name="password"
-          formControlName="password"
-          placeholder="{{
-            'myAccountV2Email.passwordPlaceHolder' | cxTranslate
-          }}"
-          class="form-control"
-          autocomplete="new-password"
-          [attr.aria-label]="
-            'myAccountV2Email.passwordPlaceHolder' | cxTranslate
-          "
-          [attr.aria-invalid]="
-            form.get('password')?.touched && form.get('password')?.invalid
-          "
-          [attr.aria-errormessage]="'passwordError'"
-          cxPasswordVisibilitySwitch
-        />
+          <label>
+            <span class="label-content, text-head">{{
+              'myAccountV2Email.password' | cxTranslate
+            }}</span>
+            <input
+              required="true"
+              type="password"
+              name="password"
+              formControlName="password"
+              placeholder="{{
+                'myAccountV2Email.passwordPlaceHolder' | cxTranslate
+              }}"
+              class="form-control"
+              autocomplete="new-password"
+              [attr.aria-label]="
+                'myAccountV2Email.passwordPlaceHolder' | cxTranslate
+              "
+              [attr.aria-invalid]="
+                form.get('password')?.touched && form.get('password')?.invalid
+              "
+              [attr.aria-errormessage]="'passwordError'"
+              cxPasswordVisibilitySwitch
+            />
 
-        <cx-form-errors
-          id="passwordError"
-          [translationParams]="{
-            label: 'updateEmailForm.password.label' | cxTranslate,
-          }"
-          [control]="form.get('password')"
-        ></cx-form-errors>
-      </label>
+            <cx-form-errors
+              id="passwordError"
+              [translationParams]="{
+                label: 'updateEmailForm.password.label' | cxTranslate,
+              }"
+              [control]="form.get('password')"
+            ></cx-form-errors>
+          </label>
 
-      <div class="btn-group">
-        <button class="btn button-cancel button" (click)="cancelEdit()">
-          {{ 'common.cancel' | cxTranslate }}
-        </button>
-        <button
-          class="btn btn-primary button"
-          (click)="onSubmit()"
-          [disabled]="form.disabled"
-        >
-          {{ 'common.save' | cxTranslate }}
-        </button>
-      </div>
+          <div class="btn-group">
+            <button class="btn button-cancel button" (click)="cancelEdit()">
+              {{ 'common.cancel' | cxTranslate }}
+            </button>
+            <button
+              class="btn btn-primary button"
+              (click)="onSubmit()"
+              [disabled]="form.disabled"
+            >
+              {{ 'common.save' | cxTranslate }}
+            </button>
+          </div>
+        </fieldset>
+      </ng-container>
+      <ng-container *cxFeature="'!a11yFormFieldSectionLegend'">
+        <label>
+          <span class="text-head">{{
+            'myAccountV2Email.emailAddress' | cxTranslate
+          }}</span>
+          <input
+            type="text"
+            class="form-control"
+            [value]="(user$ | async)?.uid"
+            readonly
+          />
+        </label>
+
+        <label>
+          <span class="text-head">{{
+            'myAccountV2Email.newEmailAddress' | cxTranslate
+          }}</span>
+          <input
+            required="true"
+            type="email"
+            name="email"
+            formControlName="email"
+            placeholder="{{
+              'myAccountV2Email.emailPlaceHolder' | cxTranslate
+            }}"
+            class="form-control"
+            [attr.aria-invalid]="
+              form.get('email')?.touched && form.get('email')?.invalid
+            "
+            [attr.aria-errormessage]="'emailError'"
+          />
+
+          <cx-form-errors
+            id="emailError"
+            [translationParams]="{
+              label: 'updateEmailForm.newEmailAddress.label' | cxTranslate,
+            }"
+            [control]="form.get('email')"
+          ></cx-form-errors>
+        </label>
+
+        <label>
+          <span class="text-head">{{
+            'myAccountV2Email.confirmNewEmailAddress' | cxTranslate
+          }}</span>
+          <input
+            required="true"
+            type="email"
+            name="confirmEmail"
+            formControlName="confirmEmail"
+            placeholder="{{
+              'myAccountV2Email.emailPlaceHolder' | cxTranslate
+            }}"
+            class="form-control"
+            [attr.aria-invalid]="
+              form.get('confirmEmail')?.touched &&
+              form.get('confirmEmail')?.invalid
+            "
+            [attr.aria-errormessage]="'confirmEmailError'"
+          />
+
+          <cx-form-errors
+            id="confirmEmailError"
+            [translationParams]="{
+              label:
+                'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate,
+            }"
+            [control]="form.get('confirmEmail')"
+          ></cx-form-errors>
+        </label>
+
+        <label>
+          <span class="label-content, text-head">{{
+            'myAccountV2Email.password' | cxTranslate
+          }}</span>
+          <input
+            required="true"
+            type="password"
+            name="password"
+            formControlName="password"
+            placeholder="{{
+              'myAccountV2Email.passwordPlaceHolder' | cxTranslate
+            }}"
+            class="form-control"
+            autocomplete="new-password"
+            [attr.aria-label]="
+              'myAccountV2Email.passwordPlaceHolder' | cxTranslate
+            "
+            [attr.aria-invalid]="
+              form.get('password')?.touched && form.get('password')?.invalid
+            "
+            [attr.aria-errormessage]="'passwordError'"
+            cxPasswordVisibilitySwitch
+          />
+
+          <cx-form-errors
+            id="passwordError"
+            [translationParams]="{
+              label: 'updateEmailForm.password.label' | cxTranslate,
+            }"
+            [control]="form.get('password')"
+          ></cx-form-errors>
+        </label>
+
+        <div class="btn-group">
+          <button class="btn button-cancel button" (click)="cancelEdit()">
+            {{ 'common.cancel' | cxTranslate }}
+          </button>
+          <button
+            class="btn btn-primary button"
+            (click)="onSubmit()"
+            [disabled]="form.disabled"
+          >
+            {{ 'common.save' | cxTranslate }}
+          </button>
+        </div>
+      </ng-container>
     </form>
   </div>
 </div>

--- a/feature-libs/user/profile/components/update-email/my-account-v2-email.component.spec.ts
+++ b/feature-libs/user/profile/components/update-email/my-account-v2-email.component.spec.ts
@@ -12,6 +12,7 @@ import {
 import { By } from '@angular/platform-browser';
 import {
   CxDatePipe,
+  FeatureDirective,
   GlobalMessageService,
   I18nTestingModule,
   MockDatePipe,
@@ -27,6 +28,7 @@ import {
 } from '@spartacus/storefront';
 import { MockUrlPipe } from 'core-libs/core/src/routing/configurable-routes/url-translation/testing/mock-url.pipe';
 import { UrlTestingModule } from 'core-libs/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
+import { MockFeatureDirective } from 'core-libs/storefront/shared/test/mock-feature-directive';
 import { BehaviorSubject, Subject, of } from 'rxjs';
 import { UserProfileFacade } from '../../root/facade';
 import { MyAccountV2EmailComponent } from './my-account-v2-email.component';
@@ -89,6 +91,7 @@ describe('MyAccountV2EmailComponent', () => {
         FormErrorsModule,
         PasswordVisibilityToggleModule,
         MyAccountV2EmailComponent,
+        MockFeatureDirective,
       ],
       providers: [
         {
@@ -104,7 +107,13 @@ describe('MyAccountV2EmailComponent', () => {
     })
       .overrideComponent(MyAccountV2EmailComponent, {
         remove: {
-          imports: [TranslatePipe, CxDatePipe, UrlPipe, SpinnerComponent],
+          imports: [
+            TranslatePipe,
+            CxDatePipe,
+            UrlPipe,
+            SpinnerComponent,
+            FeatureDirective,
+          ],
         },
         add: {
           imports: [
@@ -112,6 +121,7 @@ describe('MyAccountV2EmailComponent', () => {
             MockDatePipe,
             MockUrlPipe,
             MockCxSpinnerComponent,
+            MockFeatureDirective,
           ],
           changeDetection: ChangeDetectionStrategy.Default,
         },
@@ -213,6 +223,16 @@ describe('MyAccountV2EmailComponent', () => {
       fixture.detectChanges();
       const submitBtn = el.query(By.css('button.btn-primary'));
       expect(submitBtn).toBeNull();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should render a fieldset with a visually-hidden legend inside the form when editing', () => {
+      component.onEdit();
+      fixture.detectChanges();
+      const legend = el.query(By.css('fieldset legend'));
+      expect(legend).toBeTruthy();
+      expect(legend.nativeElement.classList).toContain('cx-visually-hidden');
     });
   });
 });

--- a/feature-libs/user/profile/components/update-email/my-account-v2-email.component.ts
+++ b/feature-libs/user/profile/components/update-email/my-account-v2-email.component.ts
@@ -16,7 +16,12 @@ import {
   ReactiveFormsModule,
   UntypedFormGroup,
 } from '@angular/forms';
-import { GlobalMessageType, TranslatePipe, User } from '@spartacus/core';
+import {
+  FeatureDirective,
+  GlobalMessageType,
+  TranslatePipe,
+  User,
+} from '@spartacus/core';
 import {
   FormErrorsComponent,
   MessageComponent,
@@ -43,6 +48,7 @@ import { UpdateEmailComponentService } from './update-email-component.service';
     PasswordVisibilityToggleDirective,
     AsyncPipe,
     TranslatePipe,
+    FeatureDirective,
   ],
 })
 export class MyAccountV2EmailComponent implements OnInit {

--- a/feature-libs/user/profile/components/update-email/update-email.component.html
+++ b/feature-libs/user/profile/components/update-email/update-email.component.html
@@ -1,103 +1,216 @@
 <cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
 <cx-form-required-legend />
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
-  <label>
-    <span class="label-content"
-      >{{ 'updateEmailForm.newEmailAddress.label' | cxTranslate }}
+  <ng-container *cxFeature="'a11yFormFieldSectionLegend'">
+    <fieldset>
+      <legend class="cx-visually-hidden">
+        {{ 'updateEmailForm.heading' | cxTranslate }}
+      </legend>
+      <label>
+        <span class="label-content"
+          >{{ 'updateEmailForm.newEmailAddress.label' | cxTranslate }}
 
-      <cx-form-required-asterisks />
-    </span>
-    <input
-      required="true"
-      type="email"
-      name="email"
-      formControlName="email"
-      placeholder="{{
-        'updateEmailForm.newEmailAddress.placeholder' | cxTranslate
-      }}"
-      [attr.aria-invalid]="
-        form.get('email')?.touched && form.get('email')?.invalid
-      "
-      [attr.aria-errormessage]="'emailError'"
-      class="form-control"
-    />
+          <cx-form-required-asterisks />
+        </span>
+        <input
+          required="true"
+          type="email"
+          name="email"
+          formControlName="email"
+          placeholder="{{
+            'updateEmailForm.newEmailAddress.placeholder' | cxTranslate
+          }}"
+          [attr.aria-invalid]="
+            form.get('email')?.touched && form.get('email')?.invalid
+          "
+          [attr.aria-errormessage]="'emailError'"
+          class="form-control"
+        />
 
-    <cx-form-errors
-      id="emailError"
-      [translationParams]="{
-        label: 'updateEmailForm.newEmailAddress.label' | cxTranslate,
-      }"
-      [control]="form.get('email')"
-    ></cx-form-errors>
-  </label>
+        <cx-form-errors
+          id="emailError"
+          [translationParams]="{
+            label: 'updateEmailForm.newEmailAddress.label' | cxTranslate,
+          }"
+          [control]="form.get('email')"
+        ></cx-form-errors>
+      </label>
 
-  <label>
-    <span class="label-content"
-      >{{ 'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate }}
+      <label>
+        <span class="label-content"
+          >{{ 'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate }}
 
-      <cx-form-required-asterisks />
-    </span>
-    <input
-      required="true"
-      type="email"
-      name="confirmEmail"
-      formControlName="confirmEmail"
-      placeholder="{{
-        'updateEmailForm.confirmNewEmailAddress.placeholder' | cxTranslate
-      }}"
-      [attr.aria-invalid]="
-        form.get('confirmEmail')?.touched && form.get('confirmEmail')?.invalid
-      "
-      [attr.aria-errormessage]="'confirmEmailError'"
-      class="form-control"
-    />
+          <cx-form-required-asterisks />
+        </span>
+        <input
+          required="true"
+          type="email"
+          name="confirmEmail"
+          formControlName="confirmEmail"
+          placeholder="{{
+            'updateEmailForm.confirmNewEmailAddress.placeholder' | cxTranslate
+          }}"
+          [attr.aria-invalid]="
+            form.get('confirmEmail')?.touched &&
+            form.get('confirmEmail')?.invalid
+          "
+          [attr.aria-errormessage]="'confirmEmailError'"
+          class="form-control"
+        />
 
-    <cx-form-errors
-      id="confirmEmailError"
-      [translationParams]="{
-        label: 'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate,
-      }"
-      [control]="form.get('confirmEmail')"
-    ></cx-form-errors>
-  </label>
+        <cx-form-errors
+          id="confirmEmailError"
+          [translationParams]="{
+            label: 'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate,
+          }"
+          [control]="form.get('confirmEmail')"
+        ></cx-form-errors>
+      </label>
 
-  <label>
-    <span class="label-content"
-      >{{ 'updateEmailForm.password.label' | cxTranslate }}
+      <label>
+        <span class="label-content"
+          >{{ 'updateEmailForm.password.label' | cxTranslate }}
 
-      <cx-form-required-asterisks />
-    </span>
-    <input
-      required="true"
-      type="password"
-      name="password"
-      formControlName="password"
-      placeholder="{{ 'updateEmailForm.password.placeholder' | cxTranslate }}"
-      class="form-control"
-      autocomplete="new-password"
-      [attr.aria-label]="'updateEmailForm.password.placeholder' | cxTranslate"
-      [attr.aria-describedby]="'passwordError'"
-      cxPasswordVisibilitySwitch
-    />
+          <cx-form-required-asterisks />
+        </span>
+        <input
+          required="true"
+          type="password"
+          name="password"
+          formControlName="password"
+          placeholder="{{
+            'updateEmailForm.password.placeholder' | cxTranslate
+          }}"
+          class="form-control"
+          autocomplete="new-password"
+          [attr.aria-label]="
+            'updateEmailForm.password.placeholder' | cxTranslate
+          "
+          [attr.aria-describedby]="'passwordError'"
+          cxPasswordVisibilitySwitch
+        />
 
-    <cx-form-errors
-      id="passwordError"
-      [translationParams]="{
-        label: 'updateEmailForm.password.label' | cxTranslate,
-      }"
-      [control]="form.get('password')"
-    ></cx-form-errors>
-  </label>
+        <cx-form-errors
+          id="passwordError"
+          [translationParams]="{
+            label: 'updateEmailForm.password.label' | cxTranslate,
+          }"
+          [control]="form.get('password')"
+        ></cx-form-errors>
+      </label>
 
-  <a
-    class="btn btn-block btn-secondary"
-    [routerLink]="{ cxRoute: 'home' } | cxUrl"
-    cxBtnLikeLink
-  >
-    {{ 'common.cancel' | cxTranslate }}
-  </a>
+      <a
+        class="btn btn-block btn-secondary"
+        [routerLink]="{ cxRoute: 'home' } | cxUrl"
+        cxBtnLikeLink
+      >
+        {{ 'common.cancel' | cxTranslate }}
+      </a>
 
-  <button class="btn btn-block btn-primary" [disabled]="form.disabled">
-    {{ 'common.save' | cxTranslate }}
-  </button>
+      <button class="btn btn-block btn-primary" [disabled]="form.disabled">
+        {{ 'common.save' | cxTranslate }}
+      </button>
+    </fieldset>
+  </ng-container>
+  <ng-container *cxFeature="'!a11yFormFieldSectionLegend'">
+    <label>
+      <span class="label-content"
+        >{{ 'updateEmailForm.newEmailAddress.label' | cxTranslate }}
+
+        <cx-form-required-asterisks />
+      </span>
+      <input
+        required="true"
+        type="email"
+        name="email"
+        formControlName="email"
+        placeholder="{{
+          'updateEmailForm.newEmailAddress.placeholder' | cxTranslate
+        }}"
+        [attr.aria-invalid]="
+          form.get('email')?.touched && form.get('email')?.invalid
+        "
+        [attr.aria-errormessage]="'emailError'"
+        class="form-control"
+      />
+
+      <cx-form-errors
+        id="emailError"
+        [translationParams]="{
+          label: 'updateEmailForm.newEmailAddress.label' | cxTranslate,
+        }"
+        [control]="form.get('email')"
+      ></cx-form-errors>
+    </label>
+
+    <label>
+      <span class="label-content"
+        >{{ 'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate }}
+
+        <cx-form-required-asterisks />
+      </span>
+      <input
+        required="true"
+        type="email"
+        name="confirmEmail"
+        formControlName="confirmEmail"
+        placeholder="{{
+          'updateEmailForm.confirmNewEmailAddress.placeholder' | cxTranslate
+        }}"
+        [attr.aria-invalid]="
+          form.get('confirmEmail')?.touched && form.get('confirmEmail')?.invalid
+        "
+        [attr.aria-errormessage]="'confirmEmailError'"
+        class="form-control"
+      />
+
+      <cx-form-errors
+        id="confirmEmailError"
+        [translationParams]="{
+          label: 'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate,
+        }"
+        [control]="form.get('confirmEmail')"
+      ></cx-form-errors>
+    </label>
+
+    <label>
+      <span class="label-content"
+        >{{ 'updateEmailForm.password.label' | cxTranslate }}
+
+        <cx-form-required-asterisks />
+      </span>
+      <input
+        required="true"
+        type="password"
+        name="password"
+        formControlName="password"
+        placeholder="{{ 'updateEmailForm.password.placeholder' | cxTranslate }}"
+        class="form-control"
+        autocomplete="new-password"
+        [attr.aria-label]="'updateEmailForm.password.placeholder' | cxTranslate"
+        [attr.aria-describedby]="'passwordError'"
+        cxPasswordVisibilitySwitch
+      />
+
+      <cx-form-errors
+        id="passwordError"
+        [translationParams]="{
+          label: 'updateEmailForm.password.label' | cxTranslate,
+        }"
+        [control]="form.get('password')"
+      ></cx-form-errors>
+    </label>
+
+    <a
+      class="btn btn-block btn-secondary"
+      [routerLink]="{ cxRoute: 'home' } | cxUrl"
+      cxBtnLikeLink
+    >
+      {{ 'common.cancel' | cxTranslate }}
+    </a>
+
+    <button class="btn btn-block btn-primary" [disabled]="form.disabled">
+      {{ 'common.save' | cxTranslate }}
+    </button>
+  </ng-container>
 </form>

--- a/feature-libs/user/profile/components/update-email/update-email.component.spec.ts
+++ b/feature-libs/user/profile/components/update-email/update-email.component.spec.ts
@@ -163,4 +163,12 @@ describe('UpdateEmailComponent', () => {
       expect(service.save).toHaveBeenCalled();
     });
   });
+
+  describe('Accessibility', () => {
+    it('should render a fieldset with a visually-hidden legend inside the form', () => {
+      const legend = el.query(By.css('fieldset legend'));
+      expect(legend).toBeTruthy();
+      expect(legend.nativeElement.classList).toContain('cx-visually-hidden');
+    });
+  });
 });

--- a/feature-libs/user/profile/components/update-email/update-email.component.ts
+++ b/feature-libs/user/profile/components/update-email/update-email.component.ts
@@ -12,7 +12,7 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { TranslatePipe, UrlPipe } from '@spartacus/core';
+import { FeatureDirective, TranslatePipe, UrlPipe } from '@spartacus/core';
 import {
   BtnLikeLinkDirective,
   FormErrorsComponent,
@@ -43,6 +43,7 @@ import { UpdateEmailComponentService } from './update-email-component.service';
     AsyncPipe,
     UrlPipe,
     TranslatePipe,
+    FeatureDirective,
   ],
 })
 export class UpdateEmailComponent {

--- a/feature-libs/user/profile/components/update-password/my-account-v2-password.component.html
+++ b/feature-libs/user/profile/components/update-password/my-account-v2-password.component.html
@@ -1,130 +1,265 @@
 <cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
 
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
-  <label class="myaccount-password-header"
-    >{{ 'myAccountV2PasswordForm.newPasswordTitle' | cxTranslate }}
-  </label>
+  <ng-container *cxFeature="'a11yFormFieldSectionLegend'">
+    <fieldset>
+      <legend class="cx-visually-hidden">
+        {{ 'myAccountV2PasswordForm.heading' | cxTranslate }}
+      </legend>
+      <label class="myaccount-password-header"
+        >{{ 'myAccountV2PasswordForm.newPasswordTitle' | cxTranslate }}
+      </label>
 
-  <cx-message
-    *ngIf="showingAlert"
-    [text]="'myAccountV2PasswordForm.reloginIndicator' | cxTranslate"
-    [type]="globalMessageType.MSG_TYPE_INFO"
-    (closeMessage)="closeDialogConfirmationAlert()"
-  >
-  </cx-message>
+      <cx-message
+        *ngIf="showingAlert"
+        [text]="'myAccountV2PasswordForm.reloginIndicator' | cxTranslate"
+        [type]="globalMessageType.MSG_TYPE_INFO"
+        (closeMessage)="closeDialogConfirmationAlert()"
+      >
+      </cx-message>
 
-  <label class="myaccount-label-padding">
-    <span class="label-content myaccount-password-label">{{
-      'myAccountV2PasswordForm.oldPassword.label' | cxTranslate
-    }}</span>
-    <input
-      required="true"
-      class="form-control"
-      [(ngModel)]="oldPassword"
-      type="password"
-      name="oldPassword"
-      placeholder="{{
-        'myAccountV2PasswordForm.oldPassword.placeholder' | cxTranslate
-      }}"
-      formControlName="oldPassword"
-      [attr.aria-label]="
-        'myAccountV2PasswordForm.oldPassword.placeholder' | cxTranslate
-      "
-      [attr.aria-invalid]="
-        form.get('oldPassword')?.touched && form.get('oldPassword')?.invalid
-      "
-      [attr.aria-errormessage]="'oldPasswordError'"
-      cxPasswordVisibilitySwitch
-    />
+      <label class="myaccount-label-padding">
+        <span class="label-content myaccount-password-label">{{
+          'myAccountV2PasswordForm.oldPassword.label' | cxTranslate
+        }}</span>
+        <input
+          required="true"
+          class="form-control"
+          [(ngModel)]="oldPassword"
+          type="password"
+          name="oldPassword"
+          placeholder="{{
+            'myAccountV2PasswordForm.oldPassword.placeholder' | cxTranslate
+          }}"
+          formControlName="oldPassword"
+          [attr.aria-label]="
+            'myAccountV2PasswordForm.oldPassword.placeholder' | cxTranslate
+          "
+          [attr.aria-invalid]="
+            form.get('oldPassword')?.touched && form.get('oldPassword')?.invalid
+          "
+          [attr.aria-errormessage]="'oldPasswordError'"
+          cxPasswordVisibilitySwitch
+        />
 
-    <cx-form-errors
-      id="oldPasswordError"
-      [translationParams]="{
-        label: 'updatePasswordForm.oldPassword.label' | cxTranslate,
-      }"
-      [control]="form.get('oldPassword')"
-    ></cx-form-errors>
-  </label>
+        <cx-form-errors
+          id="oldPasswordError"
+          [translationParams]="{
+            label: 'updatePasswordForm.oldPassword.label' | cxTranslate,
+          }"
+          [control]="form.get('oldPassword')"
+        ></cx-form-errors>
+      </label>
 
-  <label class="myaccount-label-padding">
-    <span class="label-content myaccount-password-label">{{
-      'myAccountV2PasswordForm.newPassword.label' | cxTranslate
-    }}</span>
-    <input
-      required="true"
-      class="form-control"
-      [(ngModel)]="newPassword"
-      type="password"
-      name="newPassword"
-      placeholder="{{
-        'myAccountV2PasswordForm.newPassword.placeholder' | cxTranslate
-      }}"
-      formControlName="newPassword"
-      [attr.aria-label]="
-        'myAccountV2PasswordForm.newPassword.placeholder' | cxTranslate
-      "
-      [attr.aria-invalid]="
-        form.get('newPassword')?.touched && form.get('newPassword')?.invalid
-      "
-      [attr.aria-errormessage]="'newPasswordError'"
-      cxPasswordVisibilitySwitch
-    />
+      <label class="myaccount-label-padding">
+        <span class="label-content myaccount-password-label">{{
+          'myAccountV2PasswordForm.newPassword.label' | cxTranslate
+        }}</span>
+        <input
+          required="true"
+          class="form-control"
+          [(ngModel)]="newPassword"
+          type="password"
+          name="newPassword"
+          placeholder="{{
+            'myAccountV2PasswordForm.newPassword.placeholder' | cxTranslate
+          }}"
+          formControlName="newPassword"
+          [attr.aria-label]="
+            'myAccountV2PasswordForm.newPassword.placeholder' | cxTranslate
+          "
+          [attr.aria-invalid]="
+            form.get('newPassword')?.touched && form.get('newPassword')?.invalid
+          "
+          [attr.aria-errormessage]="'newPasswordError'"
+          cxPasswordVisibilitySwitch
+        />
 
-    <cx-form-errors
-      id="newPasswordError"
-      [translationParams]="{
-        label: 'updatePasswordForm.newPassword.label' | cxTranslate,
-      }"
-      [control]="form.get('newPassword')"
-    ></cx-form-errors>
-  </label>
+        <cx-form-errors
+          id="newPasswordError"
+          [translationParams]="{
+            label: 'updatePasswordForm.newPassword.label' | cxTranslate,
+          }"
+          [control]="form.get('newPassword')"
+        ></cx-form-errors>
+      </label>
 
-  <label class="myaccount-label-padding">
-    <span class="label-content myaccount-password-label">{{
-      'myAccountV2PasswordForm.confirmPassword.label' | cxTranslate
-    }}</span>
-    <input
-      required="true"
-      class="form-control"
-      [(ngModel)]="newPasswordConfirm"
-      type="password"
-      name="newPasswordConfirm"
-      placeholder="{{
-        'myAccountV2PasswordForm.confirmPassword.placeholder' | cxTranslate
-      }}"
-      formControlName="newPasswordConfirm"
-      [attr.aria-label]="
-        'myAccountV2PasswordForm.confirmPassword.placeholder' | cxTranslate
-      "
-      [attr.aria-invalid]="
-        form.get('newPasswordConfirm')?.touched &&
-        form.get('newPasswordConfirm')?.invalid
-      "
-      [attr.aria-errormessage]="'newPasswordConfirmError'"
-      cxPasswordVisibilitySwitch
-    />
+      <label class="myaccount-label-padding">
+        <span class="label-content myaccount-password-label">{{
+          'myAccountV2PasswordForm.confirmPassword.label' | cxTranslate
+        }}</span>
+        <input
+          required="true"
+          class="form-control"
+          [(ngModel)]="newPasswordConfirm"
+          type="password"
+          name="newPasswordConfirm"
+          placeholder="{{
+            'myAccountV2PasswordForm.confirmPassword.placeholder' | cxTranslate
+          }}"
+          formControlName="newPasswordConfirm"
+          [attr.aria-label]="
+            'myAccountV2PasswordForm.confirmPassword.placeholder' | cxTranslate
+          "
+          [attr.aria-invalid]="
+            form.get('newPasswordConfirm')?.touched &&
+            form.get('newPasswordConfirm')?.invalid
+          "
+          [attr.aria-errormessage]="'newPasswordConfirmError'"
+          cxPasswordVisibilitySwitch
+        />
 
-    <cx-form-errors
-      id="newPasswordConfirmError"
-      [translationParams]="{
-        label: 'updatePasswordForm.confirmPassword.label' | cxTranslate,
-      }"
-      [control]="form.get('newPasswordConfirm')"
-    ></cx-form-errors>
-  </label>
+        <cx-form-errors
+          id="newPasswordConfirmError"
+          [translationParams]="{
+            label: 'updatePasswordForm.confirmPassword.label' | cxTranslate,
+          }"
+          [control]="form.get('newPasswordConfirm')"
+        ></cx-form-errors>
+      </label>
 
-  <div class="password-btn-group">
-    <button
-      class="btn myaccount-password-button myaccount-password-button-cancel"
-      (click)="onCancel()"
+      <div class="password-btn-group">
+        <button
+          class="btn myaccount-password-button myaccount-password-button-cancel"
+          (click)="onCancel()"
+        >
+          {{ 'common.cancel' | cxTranslate }}
+        </button>
+        <button
+          class="btn btn-primary myaccount-password-button"
+          [disabled]="form.disabled"
+        >
+          {{ 'common.save' | cxTranslate }}
+        </button>
+      </div>
+    </fieldset>
+  </ng-container>
+  <ng-container *cxFeature="'!a11yFormFieldSectionLegend'">
+    <label class="myaccount-password-header"
+      >{{ 'myAccountV2PasswordForm.newPasswordTitle' | cxTranslate }}
+    </label>
+
+    <cx-message
+      *ngIf="showingAlert"
+      [text]="'myAccountV2PasswordForm.reloginIndicator' | cxTranslate"
+      [type]="globalMessageType.MSG_TYPE_INFO"
+      (closeMessage)="closeDialogConfirmationAlert()"
     >
-      {{ 'common.cancel' | cxTranslate }}
-    </button>
-    <button
-      class="btn btn-primary myaccount-password-button"
-      [disabled]="form.disabled"
-    >
-      {{ 'common.save' | cxTranslate }}
-    </button>
-  </div>
+    </cx-message>
+
+    <label class="myaccount-label-padding">
+      <span class="label-content myaccount-password-label">{{
+        'myAccountV2PasswordForm.oldPassword.label' | cxTranslate
+      }}</span>
+      <input
+        required="true"
+        class="form-control"
+        [(ngModel)]="oldPassword"
+        type="password"
+        name="oldPassword"
+        placeholder="{{
+          'myAccountV2PasswordForm.oldPassword.placeholder' | cxTranslate
+        }}"
+        formControlName="oldPassword"
+        [attr.aria-label]="
+          'myAccountV2PasswordForm.oldPassword.placeholder' | cxTranslate
+        "
+        [attr.aria-invalid]="
+          form.get('oldPassword')?.touched && form.get('oldPassword')?.invalid
+        "
+        [attr.aria-errormessage]="'oldPasswordError'"
+        cxPasswordVisibilitySwitch
+      />
+
+      <cx-form-errors
+        id="oldPasswordError"
+        [translationParams]="{
+          label: 'updatePasswordForm.oldPassword.label' | cxTranslate,
+        }"
+        [control]="form.get('oldPassword')"
+      ></cx-form-errors>
+    </label>
+
+    <label class="myaccount-label-padding">
+      <span class="label-content myaccount-password-label">{{
+        'myAccountV2PasswordForm.newPassword.label' | cxTranslate
+      }}</span>
+      <input
+        required="true"
+        class="form-control"
+        [(ngModel)]="newPassword"
+        type="password"
+        name="newPassword"
+        placeholder="{{
+          'myAccountV2PasswordForm.newPassword.placeholder' | cxTranslate
+        }}"
+        formControlName="newPassword"
+        [attr.aria-label]="
+          'myAccountV2PasswordForm.newPassword.placeholder' | cxTranslate
+        "
+        [attr.aria-invalid]="
+          form.get('newPassword')?.touched && form.get('newPassword')?.invalid
+        "
+        [attr.aria-errormessage]="'newPasswordError'"
+        cxPasswordVisibilitySwitch
+      />
+
+      <cx-form-errors
+        id="newPasswordError"
+        [translationParams]="{
+          label: 'updatePasswordForm.newPassword.label' | cxTranslate,
+        }"
+        [control]="form.get('newPassword')"
+      ></cx-form-errors>
+    </label>
+
+    <label class="myaccount-label-padding">
+      <span class="label-content myaccount-password-label">{{
+        'myAccountV2PasswordForm.confirmPassword.label' | cxTranslate
+      }}</span>
+      <input
+        required="true"
+        class="form-control"
+        [(ngModel)]="newPasswordConfirm"
+        type="password"
+        name="newPasswordConfirm"
+        placeholder="{{
+          'myAccountV2PasswordForm.confirmPassword.placeholder' | cxTranslate
+        }}"
+        formControlName="newPasswordConfirm"
+        [attr.aria-label]="
+          'myAccountV2PasswordForm.confirmPassword.placeholder' | cxTranslate
+        "
+        [attr.aria-invalid]="
+          form.get('newPasswordConfirm')?.touched &&
+          form.get('newPasswordConfirm')?.invalid
+        "
+        [attr.aria-errormessage]="'newPasswordConfirmError'"
+        cxPasswordVisibilitySwitch
+      />
+
+      <cx-form-errors
+        id="newPasswordConfirmError"
+        [translationParams]="{
+          label: 'updatePasswordForm.confirmPassword.label' | cxTranslate,
+        }"
+        [control]="form.get('newPasswordConfirm')"
+      ></cx-form-errors>
+    </label>
+
+    <div class="password-btn-group">
+      <button
+        class="btn myaccount-password-button myaccount-password-button-cancel"
+        (click)="onCancel()"
+      >
+        {{ 'common.cancel' | cxTranslate }}
+      </button>
+      <button
+        class="btn btn-primary myaccount-password-button"
+        [disabled]="form.disabled"
+      >
+        {{ 'common.save' | cxTranslate }}
+      </button>
+    </div>
+  </ng-container>
 </form>

--- a/feature-libs/user/profile/components/update-password/my-account-v2-password.component.spec.ts
+++ b/feature-libs/user/profile/components/update-password/my-account-v2-password.component.spec.ts
@@ -12,6 +12,7 @@ import {
 import { By } from '@angular/platform-browser';
 import {
   CxDatePipe,
+  FeatureDirective,
   GlobalMessageService,
   I18nTestingModule,
   MockDatePipe,
@@ -26,6 +27,7 @@ import {
 } from '@spartacus/storefront';
 import { MockUrlPipe } from 'core-libs/core/src/routing/configurable-routes/url-translation/testing/mock-url.pipe';
 import { UrlTestingModule } from 'core-libs/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
+import { MockFeatureDirective } from 'core-libs/storefront/shared/test/mock-feature-directive';
 import { BehaviorSubject } from 'rxjs';
 import { MyAccountV2PasswordComponent } from './my-account-v2-password.component';
 import { UpdatePasswordComponentService } from './update-password-component.service';
@@ -76,6 +78,7 @@ describe('MyAccountV2PasswordComponent', () => {
         FormErrorsModule,
         PasswordVisibilityToggleModule,
         MyAccountV2PasswordComponent,
+        MockFeatureDirective,
       ],
       providers: [
         {
@@ -87,7 +90,13 @@ describe('MyAccountV2PasswordComponent', () => {
     })
       .overrideComponent(MyAccountV2PasswordComponent, {
         remove: {
-          imports: [TranslatePipe, CxDatePipe, UrlPipe, SpinnerComponent],
+          imports: [
+            TranslatePipe,
+            CxDatePipe,
+            UrlPipe,
+            SpinnerComponent,
+            FeatureDirective,
+          ],
         },
         add: {
           imports: [
@@ -95,6 +104,7 @@ describe('MyAccountV2PasswordComponent', () => {
             MockDatePipe,
             MockUrlPipe,
             MockCxSpinnerComponent,
+            MockFeatureDirective,
           ],
           changeDetection: ChangeDetectionStrategy.Default,
         },
@@ -173,6 +183,14 @@ describe('MyAccountV2PasswordComponent', () => {
       fixture.detectChanges();
       const cxMsg = el.query(By.css('cx-message'));
       expect(cxMsg).toBeNull();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should render a fieldset with a visually-hidden legend inside the form', () => {
+      const legend = el.query(By.css('fieldset legend'));
+      expect(legend).toBeTruthy();
+      expect(legend.nativeElement.classList).toContain('cx-visually-hidden');
     });
   });
 });

--- a/feature-libs/user/profile/components/update-password/my-account-v2-password.component.ts
+++ b/feature-libs/user/profile/components/update-password/my-account-v2-password.component.ts
@@ -11,7 +11,11 @@ import {
   ReactiveFormsModule,
   UntypedFormGroup,
 } from '@angular/forms';
-import { GlobalMessageType, TranslatePipe } from '@spartacus/core';
+import {
+  FeatureDirective,
+  GlobalMessageType,
+  TranslatePipe,
+} from '@spartacus/core';
 import {
   FormErrorsComponent,
   MessageComponent,
@@ -36,6 +40,7 @@ import { UpdatePasswordComponentService } from './update-password-component.serv
     FormErrorsComponent,
     AsyncPipe,
     TranslatePipe,
+    FeatureDirective,
   ],
 })
 export class MyAccountV2PasswordComponent {

--- a/feature-libs/user/profile/components/update-password/update-password.component.html
+++ b/feature-libs/user/profile/components/update-password/update-password.component.html
@@ -1,110 +1,225 @@
 <cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
 <cx-form-required-legend />
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
-  <label>
-    <span class="label-content"
-      >{{ 'updatePasswordForm.oldPassword.label' | cxTranslate }}
-      <cx-form-required-asterisks />
-    </span>
-    <input
-      required="true"
-      class="form-control"
-      type="password"
-      name="oldPassword"
-      placeholder="{{
-        'updatePasswordForm.oldPassword.placeholder' | cxTranslate
-      }}"
-      formControlName="oldPassword"
-      [attr.aria-label]="
-        'updatePasswordForm.oldPassword.placeholder' | cxTranslate
-      "
-      [attr.aria-invalid]="
-        form.get('oldPassword')?.touched && form.get('oldPassword')?.invalid
-      "
-      [attr.aria-errormessage]="'oldPasswordError'"
-      cxPasswordVisibilitySwitch
-    />
+  <ng-container *cxFeature="'a11yFormFieldSectionLegend'">
+    <fieldset>
+      <legend class="cx-visually-hidden">
+        {{ 'updatePasswordForm.heading' | cxTranslate }}
+      </legend>
+      <label>
+        <span class="label-content"
+          >{{ 'updatePasswordForm.oldPassword.label' | cxTranslate }}
+          <cx-form-required-asterisks />
+        </span>
+        <input
+          required="true"
+          class="form-control"
+          type="password"
+          name="oldPassword"
+          placeholder="{{
+            'updatePasswordForm.oldPassword.placeholder' | cxTranslate
+          }}"
+          formControlName="oldPassword"
+          [attr.aria-label]="
+            'updatePasswordForm.oldPassword.placeholder' | cxTranslate
+          "
+          [attr.aria-invalid]="
+            form.get('oldPassword')?.touched && form.get('oldPassword')?.invalid
+          "
+          [attr.aria-errormessage]="'oldPasswordError'"
+          cxPasswordVisibilitySwitch
+        />
 
-    <cx-form-errors
-      id="oldPasswordError"
-      [translationParams]="{
-        label: 'updatePasswordForm.oldPassword.label' | cxTranslate,
-      }"
-      [control]="form.get('oldPassword')"
-    ></cx-form-errors>
-  </label>
+        <cx-form-errors
+          id="oldPasswordError"
+          [translationParams]="{
+            label: 'updatePasswordForm.oldPassword.label' | cxTranslate,
+          }"
+          [control]="form.get('oldPassword')"
+        ></cx-form-errors>
+      </label>
 
-  <label>
-    <span class="label-content"
-      >{{ 'updatePasswordForm.newPassword.label' | cxTranslate }}
-      <cx-form-required-asterisks />
-    </span>
-    <input
-      required="true"
-      class="form-control"
-      type="password"
-      name="newPassword"
-      placeholder="{{
-        'updatePasswordForm.newPassword.placeholder' | cxTranslate
-      }}"
-      formControlName="newPassword"
-      [attr.aria-label]="
-        'updatePasswordForm.newPassword.placeholder' | cxTranslate
-      "
-      [attr.aria-invalid]="
-        form.get('newPassword')?.touched && form.get('newPassword')?.invalid
-      "
-      [attr.aria-errormessage]="'newPasswordError'"
-      cxPasswordVisibilitySwitch
-    />
+      <label>
+        <span class="label-content"
+          >{{ 'updatePasswordForm.newPassword.label' | cxTranslate }}
+          <cx-form-required-asterisks />
+        </span>
+        <input
+          required="true"
+          class="form-control"
+          type="password"
+          name="newPassword"
+          placeholder="{{
+            'updatePasswordForm.newPassword.placeholder' | cxTranslate
+          }}"
+          formControlName="newPassword"
+          [attr.aria-label]="
+            'updatePasswordForm.newPassword.placeholder' | cxTranslate
+          "
+          [attr.aria-invalid]="
+            form.get('newPassword')?.touched && form.get('newPassword')?.invalid
+          "
+          [attr.aria-errormessage]="'newPasswordError'"
+          cxPasswordVisibilitySwitch
+        />
 
-    <cx-form-errors
-      id="newPasswordError"
-      [translationParams]="{
-        label: 'updatePasswordForm.newPassword.label' | cxTranslate,
-      }"
-      [control]="form.get('newPassword')"
-    ></cx-form-errors>
-  </label>
+        <cx-form-errors
+          id="newPasswordError"
+          [translationParams]="{
+            label: 'updatePasswordForm.newPassword.label' | cxTranslate,
+          }"
+          [control]="form.get('newPassword')"
+        ></cx-form-errors>
+      </label>
 
-  <label>
-    <span class="label-content"
-      >{{ 'updatePasswordForm.confirmPassword.label' | cxTranslate }}
-      <cx-form-required-asterisks />
-    </span>
-    <input
-      required="true"
-      class="form-control"
-      type="password"
-      name="newPasswordConfirm"
-      placeholder="{{
-        'updatePasswordForm.confirmPassword.placeholder' | cxTranslate
-      }}"
-      formControlName="newPasswordConfirm"
-      [attr.aria-label]="
-        'updatePasswordForm.confirmPassword.placeholder' | cxTranslate
-      "
-      [attr.aria-invalid]="
-        form.get('newPasswordConfirm')?.touched &&
-        form.get('newPasswordConfirm')?.invalid
-      "
-      [attr.aria-errormessage]="'newPasswordConfirmError'"
-      cxPasswordVisibilitySwitch
-    />
+      <label>
+        <span class="label-content"
+          >{{ 'updatePasswordForm.confirmPassword.label' | cxTranslate }}
+          <cx-form-required-asterisks />
+        </span>
+        <input
+          required="true"
+          class="form-control"
+          type="password"
+          name="newPasswordConfirm"
+          placeholder="{{
+            'updatePasswordForm.confirmPassword.placeholder' | cxTranslate
+          }}"
+          formControlName="newPasswordConfirm"
+          [attr.aria-label]="
+            'updatePasswordForm.confirmPassword.placeholder' | cxTranslate
+          "
+          [attr.aria-invalid]="
+            form.get('newPasswordConfirm')?.touched &&
+            form.get('newPasswordConfirm')?.invalid
+          "
+          [attr.aria-errormessage]="'newPasswordConfirmError'"
+          cxPasswordVisibilitySwitch
+        />
 
-    <cx-form-errors
-      id="newPasswordConfirmError"
-      [translationParams]="{
-        label: 'updatePasswordForm.confirmPassword.label' | cxTranslate,
-      }"
-      [control]="form.get('newPasswordConfirm')"
-    ></cx-form-errors>
-  </label>
+        <cx-form-errors
+          id="newPasswordConfirmError"
+          [translationParams]="{
+            label: 'updatePasswordForm.confirmPassword.label' | cxTranslate,
+          }"
+          [control]="form.get('newPasswordConfirm')"
+        ></cx-form-errors>
+      </label>
 
-  <button class="btn btn-block btn-secondary" (click)="navigateTo('home')">
-    {{ 'common.cancel' | cxTranslate }}
-  </button>
-  <button class="btn btn-block btn-primary" [disabled]="form.disabled">
-    {{ 'common.save' | cxTranslate }}
-  </button>
+      <button class="btn btn-block btn-secondary" (click)="navigateTo('home')">
+        {{ 'common.cancel' | cxTranslate }}
+      </button>
+      <button class="btn btn-block btn-primary" [disabled]="form.disabled">
+        {{ 'common.save' | cxTranslate }}
+      </button>
+    </fieldset>
+  </ng-container>
+  <ng-container *cxFeature="'!a11yFormFieldSectionLegend'">
+    <label>
+      <span class="label-content"
+        >{{ 'updatePasswordForm.oldPassword.label' | cxTranslate }}
+        <cx-form-required-asterisks />
+      </span>
+      <input
+        required="true"
+        class="form-control"
+        type="password"
+        name="oldPassword"
+        placeholder="{{
+          'updatePasswordForm.oldPassword.placeholder' | cxTranslate
+        }}"
+        formControlName="oldPassword"
+        [attr.aria-label]="
+          'updatePasswordForm.oldPassword.placeholder' | cxTranslate
+        "
+        [attr.aria-invalid]="
+          form.get('oldPassword')?.touched && form.get('oldPassword')?.invalid
+        "
+        [attr.aria-errormessage]="'oldPasswordError'"
+        cxPasswordVisibilitySwitch
+      />
+
+      <cx-form-errors
+        id="oldPasswordError"
+        [translationParams]="{
+          label: 'updatePasswordForm.oldPassword.label' | cxTranslate,
+        }"
+        [control]="form.get('oldPassword')"
+      ></cx-form-errors>
+    </label>
+
+    <label>
+      <span class="label-content"
+        >{{ 'updatePasswordForm.newPassword.label' | cxTranslate }}
+        <cx-form-required-asterisks />
+      </span>
+      <input
+        required="true"
+        class="form-control"
+        type="password"
+        name="newPassword"
+        placeholder="{{
+          'updatePasswordForm.newPassword.placeholder' | cxTranslate
+        }}"
+        formControlName="newPassword"
+        [attr.aria-label]="
+          'updatePasswordForm.newPassword.placeholder' | cxTranslate
+        "
+        [attr.aria-invalid]="
+          form.get('newPassword')?.touched && form.get('newPassword')?.invalid
+        "
+        [attr.aria-errormessage]="'newPasswordError'"
+        cxPasswordVisibilitySwitch
+      />
+
+      <cx-form-errors
+        id="newPasswordError"
+        [translationParams]="{
+          label: 'updatePasswordForm.newPassword.label' | cxTranslate,
+        }"
+        [control]="form.get('newPassword')"
+      ></cx-form-errors>
+    </label>
+
+    <label>
+      <span class="label-content"
+        >{{ 'updatePasswordForm.confirmPassword.label' | cxTranslate }}
+        <cx-form-required-asterisks />
+      </span>
+      <input
+        required="true"
+        class="form-control"
+        type="password"
+        name="newPasswordConfirm"
+        placeholder="{{
+          'updatePasswordForm.confirmPassword.placeholder' | cxTranslate
+        }}"
+        formControlName="newPasswordConfirm"
+        [attr.aria-label]="
+          'updatePasswordForm.confirmPassword.placeholder' | cxTranslate
+        "
+        [attr.aria-invalid]="
+          form.get('newPasswordConfirm')?.touched &&
+          form.get('newPasswordConfirm')?.invalid
+        "
+        [attr.aria-errormessage]="'newPasswordConfirmError'"
+        cxPasswordVisibilitySwitch
+      />
+
+      <cx-form-errors
+        id="newPasswordConfirmError"
+        [translationParams]="{
+          label: 'updatePasswordForm.confirmPassword.label' | cxTranslate,
+        }"
+        [control]="form.get('newPasswordConfirm')"
+      ></cx-form-errors>
+    </label>
+
+    <button class="btn btn-block btn-secondary" (click)="navigateTo('home')">
+      {{ 'common.cancel' | cxTranslate }}
+    </button>
+    <button class="btn btn-block btn-primary" [disabled]="form.disabled">
+      {{ 'common.save' | cxTranslate }}
+    </button>
+  </ng-container>
 </form>

--- a/feature-libs/user/profile/components/update-password/update-password.component.spec.ts
+++ b/feature-libs/user/profile/components/update-password/update-password.component.spec.ts
@@ -10,7 +10,11 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { I18nTestingModule, RoutingService } from '@spartacus/core';
+import {
+  FeatureDirective,
+  I18nTestingModule,
+  RoutingService,
+} from '@spartacus/core';
 import {
   FormErrorsModule,
   PasswordVisibilityToggleModule,
@@ -81,7 +85,11 @@ describe('UpdatePasswordComponent', () => {
       ],
     })
       .overrideComponent(UpdatePasswordComponent, {
-        set: { changeDetection: ChangeDetectionStrategy.Default },
+        remove: { imports: [FeatureDirective] },
+        add: {
+          imports: [MockFeatureDirective],
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
       })
       .compileComponents();
   }));
@@ -150,6 +158,14 @@ describe('UpdatePasswordComponent', () => {
       const cancelBtn = el.query(By.css('button.btn-secondary'));
       cancelBtn.triggerEventHandler('click');
       expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'home' });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should render a fieldset with a visually-hidden legend inside the form', () => {
+      const legend = el.query(By.css('fieldset legend'));
+      expect(legend).toBeTruthy();
+      expect(legend.nativeElement.classList).toContain('cx-visually-hidden');
     });
   });
 });

--- a/feature-libs/user/profile/components/update-password/update-password.component.ts
+++ b/feature-libs/user/profile/components/update-password/update-password.component.ts
@@ -16,7 +16,11 @@ import {
   ReactiveFormsModule,
   UntypedFormGroup,
 } from '@angular/forms';
-import { RoutingService, TranslatePipe } from '@spartacus/core';
+import {
+  FeatureDirective,
+  RoutingService,
+  TranslatePipe,
+} from '@spartacus/core';
 import {
   FormErrorsComponent,
   FormRequiredAsterisksComponent,
@@ -43,6 +47,7 @@ import { UpdatePasswordComponentService } from './update-password-component.serv
     FormErrorsComponent,
     AsyncPipe,
     TranslatePipe,
+    FeatureDirective,
   ],
 })
 export class UpdatePasswordComponent {

--- a/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.html
+++ b/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.html
@@ -39,102 +39,208 @@
   </div>
   <div *ngIf="isEditing" class="myaccount-editing-area">
     <form (ngSubmit)="onSubmit()" [formGroup]="form">
-      <label>
-        <span class="label-content, text-head">{{
-          'myAccountV2UserProfile.title' | cxTranslate
-        }}</span>
-        <ng-select
-          [clearable]="false"
-          [searchable]="false"
-          formControlName="titleCode"
-          id="title-select"
-          ariaLabelDropdown="{{
-            'common.ngSelectDropdownOptionsList' | cxTranslate
-          }}"
-          [cxNgSelectA11y]="{
-            ariaLabel: 'myAccountV2UserProfile.title' | cxTranslate,
-          }"
-        >
-          <ng-option
-            *ngFor="let title of titles$ | async"
-            [value]="title.code"
-            >{{ title.name }}</ng-option
+      <ng-container *cxFeature="'a11yFormFieldSectionLegend'">
+        <fieldset>
+          <legend class="cx-visually-hidden">
+            {{ 'myAccountV2UserProfile.myInformation' | cxTranslate }}
+          </legend>
+          <label>
+            <span class="label-content, text-head">{{
+              'myAccountV2UserProfile.title' | cxTranslate
+            }}</span>
+            <ng-select
+              [clearable]="false"
+              [searchable]="false"
+              formControlName="titleCode"
+              id="title-select"
+              ariaLabelDropdown="{{
+                'common.ngSelectDropdownOptionsList' | cxTranslate
+              }}"
+              [cxNgSelectA11y]="{
+                ariaLabel: 'myAccountV2UserProfile.title' | cxTranslate,
+              }"
+            >
+              <ng-option
+                *ngFor="let title of titles$ | async"
+                [value]="title.code"
+                >{{ title.name }}</ng-option
+              >
+            </ng-select>
+          </label>
+          <label>
+            <span class="label-content, text-head">{{
+              'myAccountV2UserProfile.firstName' | cxTranslate
+            }}</span>
+            <input
+              required="true"
+              type="text"
+              class="form-control"
+              name="firstName"
+              formControlName="firstName"
+              [attr.aria-invalid]="
+                form.get('firstName')?.touched && form.get('firstName')?.invalid
+              "
+              [attr.aria-errormessage]="'firstNameError'"
+            />
+            <cx-form-errors
+              id="firstNameError"
+              [translationParams]="{
+                label: 'updateProfileForm.firstName.label' | cxTranslate,
+              }"
+              [control]="form.get('firstName')"
+            ></cx-form-errors>
+          </label>
+
+          <label>
+            <span class="label-content, text-head">{{
+              'myAccountV2UserProfile.lastName' | cxTranslate
+            }}</span>
+            <input
+              required="true"
+              type="text"
+              class="form-control"
+              name="lastName"
+              formControlName="lastName"
+              [attr.aria-invalid]="
+                form.get('lastName')?.touched && form.get('lastName')?.invalid
+              "
+              [attr.aria-errormessage]="'lastNameError'"
+            />
+            <cx-form-errors
+              id="lastNameError"
+              [translationParams]="{
+                label: 'updateProfileForm.lastName.label' | cxTranslate,
+              }"
+              [control]="form.get('lastName')"
+            ></cx-form-errors>
+          </label>
+
+          <label>
+            <span class="label-content, text-head">{{
+              'myAccountV2UserProfile.customerId' | cxTranslate
+            }}</span>
+            <input
+              required="true"
+              type="text"
+              class="form-control"
+              name="customerId"
+              formControlName="customerId"
+              cxTruncationTooltip
+              [attr.aria-invalid]="
+                form.get('customerId')?.touched &&
+                form.get('customerId')?.invalid
+              "
+              [attr.aria-errormessage]="'customerIdError'"
+              readonly
+            />
+            <cx-form-errors
+              id="customerIdError"
+              [translationParams]="{
+                label: 'updateProfileForm.customerId' | cxTranslate,
+              }"
+              [control]="form.get('customerId')"
+            ></cx-form-errors>
+          </label>
+        </fieldset>
+      </ng-container>
+      <ng-container *cxFeature="'!a11yFormFieldSectionLegend'">
+        <label>
+          <span class="label-content, text-head">{{
+            'myAccountV2UserProfile.title' | cxTranslate
+          }}</span>
+          <ng-select
+            [clearable]="false"
+            [searchable]="false"
+            formControlName="titleCode"
+            id="title-select"
+            ariaLabelDropdown="{{
+              'common.ngSelectDropdownOptionsList' | cxTranslate
+            }}"
+            [cxNgSelectA11y]="{
+              ariaLabel: 'myAccountV2UserProfile.title' | cxTranslate,
+            }"
           >
-        </ng-select>
-      </label>
-      <label>
-        <span class="label-content, text-head">{{
-          'myAccountV2UserProfile.firstName' | cxTranslate
-        }}</span>
-        <input
-          required="true"
-          type="text"
-          class="form-control"
-          name="firstName"
-          formControlName="firstName"
-          [attr.aria-invalid]="
-            form.get('firstName')?.touched && form.get('firstName')?.invalid
-          "
-          [attr.aria-errormessage]="'firstNameError'"
-        />
-        <cx-form-errors
-          id="firstNameError"
-          [translationParams]="{
-            label: 'updateProfileForm.firstName.label' | cxTranslate,
-          }"
-          [control]="form.get('firstName')"
-        ></cx-form-errors>
-      </label>
+            <ng-option
+              *ngFor="let title of titles$ | async"
+              [value]="title.code"
+              >{{ title.name }}</ng-option
+            >
+          </ng-select>
+        </label>
+        <label>
+          <span class="label-content, text-head">{{
+            'myAccountV2UserProfile.firstName' | cxTranslate
+          }}</span>
+          <input
+            required="true"
+            type="text"
+            class="form-control"
+            name="firstName"
+            formControlName="firstName"
+            [attr.aria-invalid]="
+              form.get('firstName')?.touched && form.get('firstName')?.invalid
+            "
+            [attr.aria-errormessage]="'firstNameError'"
+          />
+          <cx-form-errors
+            id="firstNameError"
+            [translationParams]="{
+              label: 'updateProfileForm.firstName.label' | cxTranslate,
+            }"
+            [control]="form.get('firstName')"
+          ></cx-form-errors>
+        </label>
 
-      <label>
-        <span class="label-content, text-head">{{
-          'myAccountV2UserProfile.lastName' | cxTranslate
-        }}</span>
-        <input
-          required="true"
-          type="text"
-          class="form-control"
-          name="lastName"
-          formControlName="lastName"
-          [attr.aria-invalid]="
-            form.get('lastName')?.touched && form.get('lastName')?.invalid
-          "
-          [attr.aria-errormessage]="'lastNameError'"
-        />
-        <cx-form-errors
-          id="lastNameError"
-          [translationParams]="{
-            label: 'updateProfileForm.lastName.label' | cxTranslate,
-          }"
-          [control]="form.get('lastName')"
-        ></cx-form-errors>
-      </label>
+        <label>
+          <span class="label-content, text-head">{{
+            'myAccountV2UserProfile.lastName' | cxTranslate
+          }}</span>
+          <input
+            required="true"
+            type="text"
+            class="form-control"
+            name="lastName"
+            formControlName="lastName"
+            [attr.aria-invalid]="
+              form.get('lastName')?.touched && form.get('lastName')?.invalid
+            "
+            [attr.aria-errormessage]="'lastNameError'"
+          />
+          <cx-form-errors
+            id="lastNameError"
+            [translationParams]="{
+              label: 'updateProfileForm.lastName.label' | cxTranslate,
+            }"
+            [control]="form.get('lastName')"
+          ></cx-form-errors>
+        </label>
 
-      <label>
-        <span class="label-content, text-head">{{
-          'myAccountV2UserProfile.customerId' | cxTranslate
-        }}</span>
-        <input
-          required="true"
-          type="text"
-          class="form-control"
-          name="customerId"
-          formControlName="customerId"
-          cxTruncationTooltip
-          [attr.aria-invalid]="
-            form.get('customerId')?.touched && form.get('customerId')?.invalid
-          "
-          [attr.aria-errormessage]="'customerIdError'"
-          readonly
-        />
-        <cx-form-errors
-          id="customerIdError"
-          [translationParams]="{
-            label: 'updateProfileForm.customerId' | cxTranslate,
-          }"
-          [control]="form.get('customerId')"
-        ></cx-form-errors>
-      </label>
+        <label>
+          <span class="label-content, text-head">{{
+            'myAccountV2UserProfile.customerId' | cxTranslate
+          }}</span>
+          <input
+            required="true"
+            type="text"
+            class="form-control"
+            name="customerId"
+            formControlName="customerId"
+            cxTruncationTooltip
+            [attr.aria-invalid]="
+              form.get('customerId')?.touched && form.get('customerId')?.invalid
+            "
+            [attr.aria-errormessage]="'customerIdError'"
+            readonly
+          />
+          <cx-form-errors
+            id="customerIdError"
+            [translationParams]="{
+              label: 'updateProfileForm.customerId' | cxTranslate,
+            }"
+            [control]="form.get('customerId')"
+          ></cx-form-errors>
+        </label>
+      </ng-container>
     </form>
 
     <div class="btn-group">

--- a/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.spec.ts
+++ b/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.spec.ts
@@ -12,7 +12,11 @@ import {
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NgSelectModule } from '@ng-select/ng-select';
-import { FeaturesConfigModule, I18nTestingModule } from '@spartacus/core';
+import {
+  FeaturesConfig,
+  FeaturesConfigModule,
+  I18nTestingModule,
+} from '@spartacus/core';
 import { FormErrorsModule } from '@spartacus/storefront';
 import { UrlTestingModule } from 'core-libs/core/src/routing/configurable-routes/url-translation/testing/url-testing.module';
 import { BehaviorSubject, Subject, of } from 'rxjs';
@@ -74,6 +78,12 @@ describe('MyAccountV2ProfileComponent', () => {
         {
           provide: UpdateProfileComponentService,
           useClass: MockProfileService,
+        },
+        {
+          provide: FeaturesConfig,
+          useValue: {
+            features: { level: '7.0', a11yFormFieldSectionLegend: true },
+          },
         },
       ],
     })
@@ -160,6 +170,16 @@ describe('MyAccountV2ProfileComponent', () => {
       component.cancelEdit();
       const submitBtn = el.query(By.css('button.btn-primary'));
       expect(submitBtn).toBeNull();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should render a fieldset with a visually-hidden legend inside the form when editing', () => {
+      component.onEdit();
+      fixture.detectChanges();
+      const legend = el.query(By.css('fieldset legend'));
+      expect(legend).toBeTruthy();
+      expect(legend.nativeElement.classList).toContain('cx-visually-hidden');
     });
   });
 });

--- a/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.ts
+++ b/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.ts
@@ -17,7 +17,7 @@ import {
   UntypedFormGroup,
 } from '@angular/forms';
 import { NgOptionComponent, NgSelectComponent } from '@ng-select/ng-select';
-import { TranslatePipe } from '@spartacus/core';
+import { FeatureDirective, TranslatePipe } from '@spartacus/core';
 import {
   FormErrorsComponent,
   NgSelectA11yDirective,
@@ -45,6 +45,7 @@ import { UpdateProfileComponentService } from './update-profile-component.servic
     FormErrorsComponent,
     AsyncPipe,
     TranslatePipe,
+    FeatureDirective,
     TruncationTooltipDirective,
   ],
 })

--- a/feature-libs/user/profile/components/update-profile/update-profile.component.html
+++ b/feature-libs/user/profile/components/update-profile/update-profile.component.html
@@ -1,119 +1,249 @@
 <cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
 <cx-form-required-legend />
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
-  <label>
-    <span class="label-content">{{
-      'updateProfileForm.title' | cxTranslate
-    }}</span>
-    <ng-select
-      [clearable]="false"
-      [searchable]="false"
-      formControlName="titleCode"
-      id="title-select"
-      ariaLabelDropdown="{{
-        'common.ngSelectDropdownOptionsList' | cxTranslate
-      }}"
-      [cxNgSelectA11y]="{
-        ariaLabel: 'updateProfileForm.title' | cxTranslate,
-      }"
+  <ng-container *cxFeature="'a11yFormFieldSectionLegend'">
+    <fieldset>
+      <legend class="cx-visually-hidden">
+        {{ 'updateProfileForm.heading' | cxTranslate }}
+      </legend>
+      <label>
+        <span class="label-content">{{
+          'updateProfileForm.title' | cxTranslate
+        }}</span>
+        <ng-select
+          [clearable]="false"
+          [searchable]="false"
+          formControlName="titleCode"
+          id="title-select"
+          ariaLabelDropdown="{{
+            'common.ngSelectDropdownOptionsList' | cxTranslate
+          }}"
+          [cxNgSelectA11y]="{
+            ariaLabel: 'updateProfileForm.title' | cxTranslate,
+          }"
+        >
+          <ng-option
+            *ngFor="let title of titles$ | async"
+            [value]="title.code"
+            >{{ title.name }}</ng-option
+          >
+        </ng-select>
+      </label>
+      <label>
+        <span class="label-content"
+          >{{ 'updateProfileForm.firstName.label' | cxTranslate }}
+          <cx-form-required-asterisks />
+        </span>
+        <input
+          required="true"
+          type="text"
+          class="form-control"
+          name="firstName"
+          placeholder="{{
+            'updateProfileForm.firstName.placeholder' | cxTranslate
+          }}"
+          formControlName="firstName"
+          [attr.aria-invalid]="
+            form.get('firstName')?.touched && form.get('firstName')?.invalid
+          "
+          [attr.aria-errormessage]="'firstNameError'"
+        />
+
+        <cx-form-errors
+          id="firstNameError"
+          [translationParams]="{
+            label: 'updateProfileForm.firstName.label' | cxTranslate,
+          }"
+          [control]="form.get('firstName')"
+        ></cx-form-errors>
+      </label>
+
+      <label>
+        <span class="label-content"
+          >{{ 'updateProfileForm.lastName.label' | cxTranslate }}
+          <cx-form-required-asterisks />
+        </span>
+        <input
+          required="true"
+          type="text"
+          class="form-control"
+          name="lastName"
+          placeholder="{{
+            'updateProfileForm.lastName.placeholder' | cxTranslate
+          }}"
+          formControlName="lastName"
+          [attr.aria-invalid]="
+            form.get('lastName')?.touched && form.get('lastName')?.invalid
+          "
+          [attr.aria-errormessage]="'lastNameError'"
+        />
+
+        <cx-form-errors
+          id="lastNameError"
+          [translationParams]="{
+            label: 'updateProfileForm.lastName.label' | cxTranslate,
+          }"
+          [control]="form.get('lastName')"
+        ></cx-form-errors>
+      </label>
+
+      <label>
+        <span class="label-content"
+          >{{ 'updateProfileForm.customerId' | cxTranslate }}
+          <cx-form-required-asterisks *cxFeature="'showRequiredAsterisks'" />
+        </span>
+        <input
+          required="true"
+          type="text"
+          class="form-control"
+          name="customerId"
+          formControlName="customerId"
+          cxTruncationTooltip
+          [attr.aria-invalid]="
+            form.get('customerId')?.touched && form.get('customerId')?.invalid
+          "
+          [attr.aria-errormessage]="'customerIdError'"
+          readonly
+        />
+
+        <cx-form-errors
+          id="customerIdError"
+          [translationParams]="{
+            label: 'updateProfileForm.customerId' | cxTranslate,
+          }"
+          [control]="form.get('customerId')"
+        ></cx-form-errors>
+      </label>
+
+      <button
+        type="button"
+        class="btn btn-block btn-secondary"
+        (click)="navigateTo('home')"
+      >
+        {{ 'common.cancel' | cxTranslate }}
+      </button>
+      <button class="btn btn-block btn-primary" [disabled]="form.disabled">
+        {{ 'common.save' | cxTranslate }}
+      </button>
+    </fieldset>
+  </ng-container>
+  <ng-container *cxFeature="'!a11yFormFieldSectionLegend'">
+    <label>
+      <span class="label-content">{{
+        'updateProfileForm.title' | cxTranslate
+      }}</span>
+      <ng-select
+        [clearable]="false"
+        [searchable]="false"
+        formControlName="titleCode"
+        id="title-select"
+        ariaLabelDropdown="{{
+          'common.ngSelectDropdownOptionsList' | cxTranslate
+        }}"
+        [cxNgSelectA11y]="{
+          ariaLabel: 'updateProfileForm.title' | cxTranslate,
+        }"
+      >
+        <ng-option *ngFor="let title of titles$ | async" [value]="title.code">{{
+          title.name
+        }}</ng-option>
+      </ng-select>
+    </label>
+    <label>
+      <span class="label-content"
+        >{{ 'updateProfileForm.firstName.label' | cxTranslate }}
+        <cx-form-required-asterisks />
+      </span>
+      <input
+        required="true"
+        type="text"
+        class="form-control"
+        name="firstName"
+        placeholder="{{
+          'updateProfileForm.firstName.placeholder' | cxTranslate
+        }}"
+        formControlName="firstName"
+        [attr.aria-invalid]="
+          form.get('firstName')?.touched && form.get('firstName')?.invalid
+        "
+        [attr.aria-errormessage]="'firstNameError'"
+      />
+
+      <cx-form-errors
+        id="firstNameError"
+        [translationParams]="{
+          label: 'updateProfileForm.firstName.label' | cxTranslate,
+        }"
+        [control]="form.get('firstName')"
+      ></cx-form-errors>
+    </label>
+
+    <label>
+      <span class="label-content"
+        >{{ 'updateProfileForm.lastName.label' | cxTranslate }}
+        <cx-form-required-asterisks />
+      </span>
+      <input
+        required="true"
+        type="text"
+        class="form-control"
+        name="lastName"
+        placeholder="{{
+          'updateProfileForm.lastName.placeholder' | cxTranslate
+        }}"
+        formControlName="lastName"
+        [attr.aria-invalid]="
+          form.get('lastName')?.touched && form.get('lastName')?.invalid
+        "
+        [attr.aria-errormessage]="'lastNameError'"
+      />
+
+      <cx-form-errors
+        id="lastNameError"
+        [translationParams]="{
+          label: 'updateProfileForm.lastName.label' | cxTranslate,
+        }"
+        [control]="form.get('lastName')"
+      ></cx-form-errors>
+    </label>
+
+    <label>
+      <span class="label-content"
+        >{{ 'updateProfileForm.customerId' | cxTranslate }}
+        <cx-form-required-asterisks *cxFeature="'showRequiredAsterisks'" />
+      </span>
+      <input
+        required="true"
+        type="text"
+        class="form-control"
+        name="customerId"
+        formControlName="customerId"
+        cxTruncationTooltip
+        [attr.aria-invalid]="
+          form.get('customerId')?.touched && form.get('customerId')?.invalid
+        "
+        [attr.aria-errormessage]="'customerIdError'"
+        readonly
+      />
+
+      <cx-form-errors
+        id="customerIdError"
+        [translationParams]="{
+          label: 'updateProfileForm.customerId' | cxTranslate,
+        }"
+        [control]="form.get('customerId')"
+      ></cx-form-errors>
+    </label>
+
+    <button
+      type="button"
+      class="btn btn-block btn-secondary"
+      (click)="navigateTo('home')"
     >
-      <ng-option *ngFor="let title of titles$ | async" [value]="title.code">{{
-        title.name
-      }}</ng-option>
-    </ng-select>
-  </label>
-  <label>
-    <span class="label-content"
-      >{{ 'updateProfileForm.firstName.label' | cxTranslate }}
-      <cx-form-required-asterisks />
-    </span>
-    <input
-      required="true"
-      type="text"
-      class="form-control"
-      name="firstName"
-      placeholder="{{
-        'updateProfileForm.firstName.placeholder' | cxTranslate
-      }}"
-      formControlName="firstName"
-      [attr.aria-invalid]="
-        form.get('firstName')?.touched && form.get('firstName')?.invalid
-      "
-      [attr.aria-errormessage]="'firstNameError'"
-    />
-
-    <cx-form-errors
-      id="firstNameError"
-      [translationParams]="{
-        label: 'updateProfileForm.firstName.label' | cxTranslate,
-      }"
-      [control]="form.get('firstName')"
-    ></cx-form-errors>
-  </label>
-
-  <label>
-    <span class="label-content"
-      >{{ 'updateProfileForm.lastName.label' | cxTranslate }}
-      <cx-form-required-asterisks />
-    </span>
-    <input
-      required="true"
-      type="text"
-      class="form-control"
-      name="lastName"
-      placeholder="{{ 'updateProfileForm.lastName.placeholder' | cxTranslate }}"
-      formControlName="lastName"
-      [attr.aria-invalid]="
-        form.get('lastName')?.touched && form.get('lastName')?.invalid
-      "
-      [attr.aria-errormessage]="'lastNameError'"
-    />
-
-    <cx-form-errors
-      id="lastNameError"
-      [translationParams]="{
-        label: 'updateProfileForm.lastName.label' | cxTranslate,
-      }"
-      [control]="form.get('lastName')"
-    ></cx-form-errors>
-  </label>
-
-  <label>
-    <span class="label-content"
-      >{{ 'updateProfileForm.customerId' | cxTranslate }}
-      <cx-form-required-asterisks *cxFeature="'showRequiredAsterisks'" />
-    </span>
-    <input
-      required="true"
-      type="text"
-      class="form-control"
-      name="customerId"
-      formControlName="customerId"
-      cxTruncationTooltip
-      [attr.aria-invalid]="
-        form.get('customerId')?.touched && form.get('customerId')?.invalid
-      "
-      [attr.aria-errormessage]="'customerIdError'"
-      readonly
-    />
-
-    <cx-form-errors
-      id="customerIdError"
-      [translationParams]="{
-        label: 'updateProfileForm.customerId' | cxTranslate,
-      }"
-      [control]="form.get('customerId')"
-    ></cx-form-errors>
-  </label>
-
-  <button
-    type="button"
-    class="btn btn-block btn-secondary"
-    (click)="navigateTo('home')"
-  >
-    {{ 'common.cancel' | cxTranslate }}
-  </button>
-  <button class="btn btn-block btn-primary" [disabled]="form.disabled">
-    {{ 'common.save' | cxTranslate }}
-  </button>
+      {{ 'common.cancel' | cxTranslate }}
+    </button>
+    <button class="btn btn-block btn-primary" [disabled]="form.disabled">
+      {{ 'common.save' | cxTranslate }}
+    </button>
+  </ng-container>
 </form>

--- a/feature-libs/user/profile/components/update-profile/update-profile.component.spec.ts
+++ b/feature-libs/user/profile/components/update-profile/update-profile.component.spec.ts
@@ -86,7 +86,7 @@ describe('UpdateProfileComponent', () => {
         {
           provide: FeaturesConfig,
           useValue: {
-            features: { level: '5.2' },
+            features: { level: '5.2', a11yFormFieldSectionLegend: true },
           },
         },
         { provide: RoutingService, useClass: MockRoutingService },
@@ -173,6 +173,14 @@ describe('UpdateProfileComponent', () => {
       const cancelBtn = el.query(By.css('button.btn-secondary'));
       cancelBtn.triggerEventHandler('click');
       expect(routingService.go).toHaveBeenCalledWith({ cxRoute: 'home' });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should render a fieldset with a visually-hidden legend inside the form', () => {
+      const legend = el.query(By.css('fieldset legend'));
+      expect(legend).toBeTruthy();
+      expect(legend.nativeElement.classList).toContain('cx-visually-hidden');
     });
   });
 });

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -342,6 +342,7 @@ if (environment.cpq) {
         a11yCartQuickOrderFormEnableSubmitAndAddValidation: true,
         a11yConsentManagementFocusPreservation: true,
         a11yDeliveryModeFocusPreservation: true,
+        a11yFormFieldSectionLegend: true,
         a11yVocalizeDropdownItemCount: true,
         a11yRestoreFocusOnNgSelect: true,
         a11yKeepFocusOnConsentManagementButtons: true,


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-12707

**QA - Reproduction Steps:**
1. Launch the application & login -> Home page appears 
2. Select ‘Update personal details’
**Observed Behavior:** Upon accessing the ‘Title’ input field present under ‘Update Personal Details’ section , screen reader is not reading any details for the correspondence section name associated with the input field.
**Expected Behavior:** Upon accessing the ‘Title’ input field present under ‘Update Personal Details’ section , screen reader should read the details for the correspondence section name associated with the input field. Note: as title is the first interactive UI within the ‘Update Personal Details’ section so screen reader should read the section header name .

Same stands for My Account -> Password, My Account -> Email Address, My Account -> Consent Management forms as well.

New Feature Toggle introduced "a11yFormFieldSectionLegend" (when enabled) should fix the issue.