### PR TITLE
fix: CXSPA-12803 increase error icon contrast

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -572,6 +572,16 @@ export interface FeatureTogglesInterface {
    * Affects: `ConfiguratorAttributeProductCardComponent`
    */
   productConfiguratorConsolidatedButtonDisabling?: boolean;
+
+  /**
+   * When enabled, the form-error icon glyph (`cx-form-errors`) uses the
+   * `--cx-color-danger-accent` color instead of `--cx-color-inverse`, so it
+   * stays legible on the danger background in the high-contrast dark theme
+   * (black glyph instead of white).
+   *
+   * Affects: `FormErrorsComponent`
+   */
+  a11yFormErrorIconContrast?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -649,4 +659,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   b2bCheckoutShippingAddressFilter: false,
   improvedTabStyling: false,
   productConfiguratorConsolidatedButtonDisabling: false,
+  a11yFormErrorIconContrast: false,
 };

--- a/core-libs/storefront/shared/components/form/form-errors/form-errors.component.ts
+++ b/core-libs/storefront/shared/components/form/form-errors/form-errors.component.ts
@@ -17,7 +17,7 @@ import {
   inject,
 } from '@angular/core';
 import { AbstractControl, UntypedFormControl } from '@angular/forms';
-import { TranslatePipe, isObject } from '@spartacus/core';
+import { TranslatePipe, isObject, useFeatureStyles } from '@spartacus/core';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
@@ -42,7 +42,9 @@ export class FormErrorsComponent implements DoCheck {
     optional: true,
   });
 
-  constructor(protected ChangeDetectionRef: ChangeDetectorRef) {}
+  constructor(protected ChangeDetectionRef: ChangeDetectorRef) {
+    useFeatureStyles('a11yFormErrorIconContrast');
+  }
 
   _control: UntypedFormControl | AbstractControl;
 

--- a/core-libs/styles/scss/cxbase/blocks/forms.scss
+++ b/core-libs/styles/scss/cxbase/blocks/forms.scss
@@ -68,6 +68,15 @@ cx-form-errors {
     &::after {
       content: '!' / '';
       color: var(--cx-color-inverse);
+
+      // The `::before` circle uses `--cx-color-danger` as its background, so the
+      // glyph on top should use the matching accent color for legibility across
+      // all themes (e.g. black on the red circle in the high-contrast dark
+      // theme). Falls back to `--cx-color-inverse` for themes that don't define
+      // the accent.
+      @include forFeature('a11yFormErrorIconContrast') {
+        color: var(--cx-color-danger-accent, var(--cx-color-inverse));
+      }
       font-weight: var(--cx-font-weight-bold);
       text-align: center;
       line-height: 20px;

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -370,6 +370,7 @@ if (environment.cpq) {
         siteIsolationForCustomLoginPage: true,
         applyBaseSiteThemeFromCms: true,
         b2bCheckoutShippingAddressFilter: true,
+        a11yFormErrorIconContrast: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
Now that the inside of the error icon is black on the dark high contrast theme, the contrast is 7:1
<img width="700" height="395" alt="image" src="https://github.com/user-attachments/assets/3c780399-b1df-418e-926f-8429827a42fb" />

Before:
<img width="60" height="50" alt="image" src="https://github.com/user-attachments/assets/2dcafc7d-3250-46a6-939b-1e1ccb1652b1" />

After:
<img width="57" height="44" alt="image" src="https://github.com/user-attachments/assets/878f2fa4-6bd3-4dd5-ab2e-33307fa62420" />

