### PR TITLE
style: indent order details in order overview container

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -229,6 +229,13 @@ export interface FeatureTogglesInterface {
   a11yCustomerTicketingVisualFocusFix?: boolean;
 
   /**
+   * Applies a `10rem` inline-start padding to the order overview cards
+   * (`.cx-order-details-cards`) on large screens. When disabled, the cards are
+   * not pushed inward, avoiding the horizontal shift on wide viewports.
+   */
+  orderOverviewCardsInlinePadding?: boolean;
+
+  /**
    * Adds Filter By label to product facets when in desktop mode.
    */
   a11yFacetFilterByLabel?: boolean;
@@ -609,6 +616,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   enableReturnOrderReturnableQuantityConsigmentFallback: true,
   enableMediaPrefix: false,
   a11yCustomerTicketingVisualFocusFix: false,
+  orderOverviewCardsInlinePadding: false,
   a11yStoreFinderListItemFocus: false,
   a11yFixSearchBoxDoubleFocus: false,
   a11yFacetFilterByLabel: false,

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.html
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.html
@@ -8,11 +8,11 @@
               getReplenishmentCodeCardContent(order?.replenishmentOrderCode)
                 | async
             "
-          ></cx-card>
+          />
 
           <cx-card
             [content]="getReplenishmentActiveCardContent(order?.active) | async"
-          ></cx-card>
+          />
         </div>
 
         <div class="cx-summary-card">
@@ -21,7 +21,7 @@
               getReplenishmentStartOnCardContent(order?.firstDate | cxDate)
                 | async
             "
-          ></cx-card>
+          />
 
           <cx-card
             [content]="
@@ -29,7 +29,7 @@
                 order?.trigger?.displayTimeTable
               ) | async
             "
-          ></cx-card>
+          />
 
           <cx-card
             [content]="
@@ -37,44 +37,40 @@
                 order?.trigger?.activationTime | cxDate
               ) | async
             "
-          ></cx-card>
+          />
 
           <ng-template
             [cxOutlet]="cartOutlets.ORDER_OVERVIEW"
             [cxOutletContext]="{ item: order, readonly: true }"
-          >
-          </ng-template>
+          />
         </div>
       </ng-container>
 
       <ng-template #otherOrder>
         <div class="cx-summary-card">
-          <cx-card
-            [content]="getOrderCodeCardContent(order?.code) | async"
-          ></cx-card>
+          <cx-card [content]="getOrderCodeCardContent(order?.code) | async" />
 
           <cx-card
             [content]="
               getOrderCurrentDateCardContent(order?.created | cxDate) | async
             "
-          ></cx-card>
+          />
 
           <cx-card
             [content]="getOrderStatusCardContent(order.statusDisplay) | async"
-          ></cx-card>
+          />
 
           <ng-container
             *ngTemplateOutlet="
               showQuoteCode;
               context: { sapQuoteCode: order.sapQuoteCode }
             "
-          ></ng-container>
+          />
 
           <ng-template
             [cxOutlet]="cartOutlets.ORDER_OVERVIEW"
             [cxOutletContext]="{ item: order, readonly: true }"
-          >
-          </ng-template>
+          />
         </div>
       </ng-template>
 
@@ -86,16 +82,16 @@
             [content]="
               getPurchaseOrderNumber(order?.purchaseOrderNumber) | async
             "
-          ></cx-card>
+          />
 
           <cx-card
             [content]="getMethodOfPaymentCardContent(order.paymentInfo) | async"
-          ></cx-card>
+          />
 
           <ng-container *ngIf="order.costCenter">
             <cx-card
               [content]="getCostCenterCardContent(order?.costCenter) | async"
-            ></cx-card>
+            />
           </ng-container>
         </div>
       </ng-container>
@@ -104,20 +100,19 @@
         <ng-container *ngIf="order.deliveryAddress">
           <cx-card
             [content]="getAddressCardContent(order?.deliveryAddress) | async"
-          ></cx-card>
+          />
         </ng-container>
 
         <ng-container *ngIf="shouldShowDeliveryMode(order.deliveryMode)">
           <cx-card
             [content]="getDeliveryModeCardContent(order?.deliveryMode) | async"
-          ></cx-card>
+          />
         </ng-container>
 
         <ng-template
           [cxOutlet]="orderOutlets.SERVICE_DETAILS"
           [cxOutletContext]="{ item: order, readonly: true }"
-        >
-        </ng-template>
+        />
       </div>
 
       <ng-container *ngIf="order.paymentInfo">
@@ -131,7 +126,7 @@
           <ng-container *ngIf="isPaymentInfoCardFull(order?.paymentInfo)">
             <cx-card
               [content]="getPaymentInfoCardContent(order?.paymentInfo) | async"
-            ></cx-card>
+            />
           </ng-container>
 
           <cx-card
@@ -139,46 +134,43 @@
               getBillingAddressCardContent(order?.paymentInfo?.billingAddress)
                 | async
             "
-          ></cx-card>
+          />
         </div>
       </ng-container>
     </div>
 
     <div *ngIf="simple$ | async" class="container">
       <div class="cx-order-details-cards">
-        <cx-card
-          [content]="getOrderCodeCardContent(order?.code) | async"
-        ></cx-card>
+        <cx-card [content]="getOrderCodeCardContent(order?.code) | async" />
 
         <cx-card
           [content]="
             getOrderCurrentDateCardContent(order?.created | cxDate) | async
           "
-        ></cx-card>
+        />
 
         <cx-card
           [content]="getOrderStatusCardContent(order.statusDisplay) | async"
-        ></cx-card>
+        />
 
         <ng-container
           *ngTemplateOutlet="
             showQuoteCode;
             context: { sapQuoteCode: order.sapQuoteCode }
           "
-        ></ng-container>
+        />
 
         <ng-template
           [cxOutlet]="cartOutlets.ORDER_OVERVIEW"
           [cxOutletContext]="{ item: order, readonly: true }"
-        >
-        </ng-template>
+        />
       </div>
       <cx-order-detail-billing
         *ngIf="
           isPaymentInfoCardFull(order?.paymentInfo) ||
           order?.paymentInfo?.billingAddress
         "
-      ></cx-order-detail-billing>
+      />
     </div>
   </ng-container>
 </div>

--- a/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
+++ b/feature-libs/order/components/order-details/order-overview/order-overview.component.ts
@@ -17,6 +17,7 @@ import {
   TranslatePipe,
   TranslationService,
   UrlPipe,
+  useFeatureStyles,
 } from '@spartacus/core';
 import {
   OrderConfig,
@@ -74,7 +75,9 @@ export class OrderOverviewComponent {
     protected translation: TranslationService,
     protected orderDetailsService: OrderDetailsService,
     protected component: CmsComponentData<CmsOrderDetailOverviewComponent>
-  ) {}
+  ) {
+    useFeatureStyles('orderOverviewCardsInlinePadding');
+  }
 
   getReplenishmentCodeCardContent(orderCode: string): Observable<Card> {
     return this.translation.translate('orderDetails.replenishmentId').pipe(

--- a/feature-libs/order/styles/components/order-overview/_order-overview.scss
+++ b/feature-libs/order/styles/components/order-overview/_order-overview.scss
@@ -22,6 +22,9 @@
         flex-grow: 1;
 
         @include media-breakpoint-up(lg) {
+          @include forFeature('orderOverviewCardsInlinePadding') {
+            padding-inline-start: 10rem;
+          }
           cx-card {
             padding: 10px 0;
             display: block;

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -320,6 +320,7 @@ if (environment.cpq) {
         enableReturnOrderReturnableQuantityConsigmentFallback: true,
         enableMediaPrefix: true,
         a11yCustomerTicketingVisualFocusFix: true,
+        orderOverviewCardsInlinePadding: true,
         a11yStoreFinderListItemFocus: true,
         a11yFixSearchBoxDoubleFocus: true,
         a11yFacetFilterByLabel: true,


### PR DESCRIPTION
Current UI:
<img width="1142" height="534" alt="image" src="https://github.com/user-attachments/assets/eb99ca4e-1023-47b1-97dc-805881e23563" />

After:
<img width="1144" height="531" alt="image" src="https://github.com/user-attachments/assets/58e7510e-81cd-4471-8269-a8b989a591cf" />

Does not affect medium or smaller viewports