### PR TITLE
fix: a11y readers able to read out customer-ticketing-details section content

### DIFF
--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.html
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.html
@@ -1,5 +1,63 @@
 <ng-container *ngIf="ticketDetails$ | async as ticket; else spinner">
-  <ng-template #cards>
+  <div
+    *cxFeature="'a11yMessagingListKeyboardFocus'"
+    class="cx-ticket-details"
+    role="region"
+    tabindex="0"
+    [attr.aria-label]="
+      'customerTicketingDetails.a11y.ticketDetailsRegion' | cxTranslate
+    "
+  >
+    <div class="container">
+      <div class="cx-details-card">
+        <cx-card
+          [border]="true"
+          [content]="
+            prepareCardContent(ticket.id, 'customerTicketing.ticketId') | async
+          "
+        />
+      </div>
+
+      <div class="cx-details-card">
+        <cx-card
+          [border]="true"
+          [content]="
+            prepareCardContent(
+              (ticket.createdAt | cxDate: dateFormat) ?? dateFormat,
+              'customerTicketing.createdOn'
+            ) | async
+          "
+        />
+      </div>
+
+      <div class="cx-details-card">
+        <cx-card
+          [border]="true"
+          [content]="
+            prepareCardContent(
+              (ticket.modifiedAt | cxDate: dateFormat) ?? dateFormat,
+              'customerTicketing.changedOn'
+            ) | async
+          "
+        />
+      </div>
+
+      <div class="cx-details-card">
+        <cx-card
+          [border]="true"
+          [content]="
+            prepareCardContent(
+              ticket.status ? ticket.status.name : undefined,
+              'customerTicketing.status',
+              ticket.status ? ticket.status.id : undefined
+            ) | async
+          "
+        />
+      </div>
+    </div>
+  </div>
+
+  <div *cxFeature="'!a11yMessagingListKeyboardFocus'" class="cx-ticket-details">
     <div class="container">
       <div class="cx-details-card">
         <cx-card
@@ -43,21 +101,6 @@
         />
       </div>
     </div>
-  </ng-template>
-
-  <div
-    *cxFeature="'a11yMessagingListKeyboardFocus'"
-    class="cx-ticket-details"
-    role="region"
-    [attr.aria-label]="
-      'customerTicketingDetails.a11y.ticketDetailsRegion' | cxTranslate
-    "
-  >
-    <ng-container *ngTemplateOutlet="cards" />
-  </div>
-
-  <div *cxFeature="'!a11yMessagingListKeyboardFocus'" class="cx-ticket-details">
-    <ng-container *ngTemplateOutlet="cards" />
   </div>
 </ng-container>
 <ng-template #spinner>

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.html
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.html
@@ -1,65 +1,23 @@
 <ng-container *ngIf="ticketDetails$ | async as ticket; else spinner">
   <div
-    *cxFeature="'a11yMessagingListKeyboardFocus'"
     class="cx-ticket-details"
-    role="region"
-    tabindex="0"
+    [attr.role]="
+      featureToggles.a11yMessagingListKeyboardFocus ? 'region' : null
+    "
+    [attr.tabindex]="featureToggles.a11yMessagingListKeyboardFocus ? 0 : null"
     [attr.aria-label]="
-      'customerTicketingDetails.a11y.ticketDetailsRegion' | cxTranslate
+      featureToggles.a11yMessagingListKeyboardFocus
+        ? ('customerTicketingDetails.a11y.ticketDetailsRegion' | cxTranslate)
+        : null
     "
   >
     <div class="container">
-      <div class="cx-details-card">
-        <cx-card
-          [border]="true"
-          [content]="
-            prepareCardContent(ticket.id, 'customerTicketing.ticketId') | async
-          "
-        />
-      </div>
-
-      <div class="cx-details-card">
-        <cx-card
-          [border]="true"
-          [content]="
-            prepareCardContent(
-              (ticket.createdAt | cxDate: dateFormat) ?? dateFormat,
-              'customerTicketing.createdOn'
-            ) | async
-          "
-        />
-      </div>
-
-      <div class="cx-details-card">
-        <cx-card
-          [border]="true"
-          [content]="
-            prepareCardContent(
-              (ticket.modifiedAt | cxDate: dateFormat) ?? dateFormat,
-              'customerTicketing.changedOn'
-            ) | async
-          "
-        />
-      </div>
-
-      <div class="cx-details-card">
-        <cx-card
-          [border]="true"
-          [content]="
-            prepareCardContent(
-              ticket.status ? ticket.status.name : undefined,
-              'customerTicketing.status',
-              ticket.status ? ticket.status.id : undefined
-            ) | async
-          "
-        />
-      </div>
-    </div>
-  </div>
-
-  <div *cxFeature="'!a11yMessagingListKeyboardFocus'" class="cx-ticket-details">
-    <div class="container">
-      <div class="cx-details-card">
+      <div
+        class="cx-details-card"
+        [attr.tabindex]="
+          featureToggles.a11yMessagingListKeyboardFocus ? 0 : null
+        "
+      >
         <cx-card
           [content]="
             prepareCardContent(ticket.id, 'customerTicketing.ticketId') | async
@@ -67,7 +25,12 @@
         />
       </div>
 
-      <div class="cx-details-card">
+      <div
+        class="cx-details-card"
+        [attr.tabindex]="
+          featureToggles.a11yMessagingListKeyboardFocus ? 0 : null
+        "
+      >
         <cx-card
           [content]="
             prepareCardContent(
@@ -78,7 +41,12 @@
         />
       </div>
 
-      <div class="cx-details-card">
+      <div
+        class="cx-details-card"
+        [attr.tabindex]="
+          featureToggles.a11yMessagingListKeyboardFocus ? 0 : null
+        "
+      >
         <cx-card
           [content]="
             prepareCardContent(
@@ -89,7 +57,12 @@
         />
       </div>
 
-      <div class="cx-details-card">
+      <div
+        class="cx-details-card"
+        [attr.tabindex]="
+          featureToggles.a11yMessagingListKeyboardFocus ? 0 : null
+        "
+      >
         <cx-card
           [content]="
             prepareCardContent(

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.spec.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.spec.ts
@@ -176,11 +176,14 @@ describe('CustomerTicketingDetailsComponent', () => {
         expect(
           f.debugElement.query(By.css('.cx-ticket-details[tabindex]'))
         ).toBeNull();
+        expect(
+          f.debugElement.query(By.css('.cx-details-card[tabindex]'))
+        ).toBeNull();
       });
     });
 
     describe('when toggle is ON', () => {
-      it('should render ticket details with role="region", aria-label and tabindex="0"', () => {
+      it('should render ticket details with role="region", aria-label, tabindex="0" and focusable cards', () => {
         toggleController.set('a11yMessagingListKeyboardFocus', true);
         const f = TestBed.createComponent(CustomerTicketingDetailsComponent);
         f.detectChanges();
@@ -190,6 +193,10 @@ describe('CustomerTicketingDetailsComponent', () => {
         expect(region).toBeTruthy();
         expect(region.attributes['aria-label']).toBeDefined();
         expect(region.attributes['tabindex']).toBe('0');
+        const cards = f.debugElement.queryAll(
+          By.css('.cx-details-card[tabindex="0"]')
+        );
+        expect(cards.length).toBe(4);
       });
     });
   });

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.spec.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.spec.ts
@@ -166,18 +166,21 @@ describe('CustomerTicketingDetailsComponent', () => {
     });
 
     describe('when toggle is OFF (default)', () => {
-      it('should render ticket details without role="region"', () => {
+      it('should render ticket details without role="region" or tabindex', () => {
         toggleController.set('a11yMessagingListKeyboardFocus', false);
         const f = TestBed.createComponent(CustomerTicketingDetailsComponent);
         f.detectChanges();
         expect(
           f.debugElement.query(By.css('.cx-ticket-details[role="region"]'))
         ).toBeNull();
+        expect(
+          f.debugElement.query(By.css('.cx-ticket-details[tabindex]'))
+        ).toBeNull();
       });
     });
 
     describe('when toggle is ON', () => {
-      it('should render ticket details with role="region" and aria-label', () => {
+      it('should render ticket details with role="region", aria-label and tabindex="0"', () => {
         toggleController.set('a11yMessagingListKeyboardFocus', true);
         const f = TestBed.createComponent(CustomerTicketingDetailsComponent);
         f.detectChanges();
@@ -186,6 +189,7 @@ describe('CustomerTicketingDetailsComponent', () => {
         );
         expect(region).toBeTruthy();
         expect(region.attributes['aria-label']).toBeDefined();
+        expect(region.attributes['tabindex']).toBe('0');
       });
     });
   });

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.ts
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-details/customer-ticketing-details.component.ts
@@ -4,12 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AsyncPipe, NgIf, NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
+import { AsyncPipe, NgIf } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  inject,
+} from '@angular/core';
 import {
   CxDatePipe,
   EventService,
-  FeatureDirective,
+  FeatureToggles,
   RoutingService,
   TranslatePipe,
   TranslationService,
@@ -32,16 +37,15 @@ import { filter, map, take, tap } from 'rxjs/operators';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     NgIf,
-    NgTemplateOutlet,
     CardComponent,
     SpinnerComponent,
     AsyncPipe,
     CxDatePipe,
-    FeatureDirective,
     TranslatePipe,
   ],
 })
 export class CustomerTicketingDetailsComponent implements OnDestroy {
+  protected featureToggles = inject(FeatureToggles);
   dateFormat = DATE_FORMAT;
   subscription = new Subscription();
   ticketDetails$: Observable<TicketDetails | undefined> =


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-12800

Huge part of CXSPA-12800 was implemented and merged in the [PR](https://github.com/SAP/spartacus/pull/21777). 
But what is missing is the Vocalisation and focusability of the customer-ticketing-details component on the UI using VoiceOver. This PR is fixing that.

QA:
1. Login to the app and navigate to My Account / Customer Service
2. Select a service created - U're brought to the details page
3. Using VoiceOver tab the page and customer-ticketing-details section should now be picked up (read out) correctly

Feature is controlled by previously added featureToggle **a11yMessagingListKeyboardFocus**.

<img width="1064" height="639" alt="Screenshot 2026-07-24 at 16 01 56" src="https://github.com/user-attachments/assets/ddbe0d6f-1ceb-4892-860e-e61772faee43" />