### PR TITLE
fix: Stabilize flaky product configurator conflict-dialog E2E test (CXSPA-13935)

### DIFF
--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-conflict-dialog.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-conflict-dialog.ts
@@ -114,15 +114,29 @@ export function selectAttributeAndWait(
   uiType: configuration.uiType,
   value: string
 ) {
+  // The dialog re-renders on every config/pricing store update (conflictGroup$
+  // is driven by getConfiguration). Clicking while a re-render is in flight
+  // yields a flaky "element detached from DOM" error on the radio input.
+  cy.get('cx-configurator-conflict-solver-dialog').should('be.visible');
+  configuration.checkUpdatingMessageNotDisplayed();
+
   cy.get('cx-configurator-conflict-solver-dialog').within(() =>
+    // force=true: skip scrollIntoView + actionability waits that race with
+    // Angular replacing the input inside the modal.
+    // isPricingEnabled=true: wait for pricing so a late pricing response does
+    // not detach the value element of the *next* click.
     configurationVc.selectAttributeAndWait(
       attributeName,
       uiType,
       value,
+      true,
       false,
-      false
+      true
     )
   );
+
+  // Network wait resolves before Angular CD finishes; ensure UI is idle again.
+  configuration.checkUpdatingMessageNotDisplayed();
 }
 /**
  * closes the conflict solver dialog via the close button

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-vc.ts
@@ -700,19 +700,22 @@ export function registerConfigurationPricingRoute() {
  * @param {string} valueName - Value name
  * @param {boolean} isPricingEnabled - will wait for pricing request in case pricing is enabled
  * @param {boolean} waitForUpdateMsg - will wait for update message to disappear
+ * @param {boolean} force - will click with { force: true } (see configuration.selectAttribute)
  */
 export function selectAttributeAndWait(
   attributeName: string,
   uiType: configuration.uiType,
   valueName: string,
   isPricingEnabled: boolean = true,
-  waitForUpdateMsg: boolean = true
+  waitForUpdateMsg: boolean = true,
+  force: boolean = false
 ): void {
   configuration.selectAttribute(
     attributeName,
     uiType,
     valueName,
-    waitForUpdateMsg
+    waitForUpdateMsg,
+    force
   );
   waitForRequest(UPDATE_CONFIG_ALIAS, isPricingEnabled);
 }

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator.ts
@@ -301,27 +301,35 @@ export function getAttributeLabelId(attributeName: string): string {
  * @param {uiType} uiType - UI type
  * @param {string} valueName - Value name
  * @param {boolean} waitForUpdateMsg - optional, default is true. if set to false, will not wait for update message to disappear
+ * @param {boolean} force - optional, default is false. if true, clicks with { force: true } and skips scrollIntoView
+ *   (useful in modals where Angular re-renders can detach the element during actionability checks)
  */
 export function selectAttribute(
   attributeName: string,
   uiType: uiType,
   valueName: string,
-  waitForUpdateMsg: boolean = true
+  waitForUpdateMsg: boolean = true,
+  force: boolean = false
 ): void {
   const attributeId = getAttributeId(attributeName, uiType);
   cy.log('attributeId: ' + attributeId);
   let valueId = `${attributeId}--${valueName}`;
   valueId = this.maskCharacter(valueId, '#');
   cy.log('valueId: ' + valueId);
+  const clickOptions = force ? { force: true } : undefined;
 
   switch (uiType) {
     case 'radioGroup':
     case 'checkBoxList':
     case 'multi_selection_image':
-      cy.get(`#${valueId}`).scrollIntoView();
+      // Break get → assert → click into separate commands so Cypress re-queries
+      // after Angular re-renders (avoids "detached from DOM" on the subject).
+      if (!force) {
+        cy.get(`#${valueId}`).scrollIntoView();
+      }
+      cy.get(`#${valueId}`).should('be.visible');
       cy.get(`#${valueId}`)
-        .should('be.visible')
-        .click()
+        .click(clickOptions)
         .then(() => {
           if (waitForUpdateMsg) {
             checkUpdatingMessageNotDisplayed();
@@ -331,10 +339,12 @@ export function selectAttribute(
     case 'single_selection_image':
       const labelId = `cx-configurator--label--${attributeName}--${valueName}`;
       cy.log('labelId: ' + labelId);
-      cy.get(`#${labelId}`).scrollIntoView();
+      if (!force) {
+        cy.get(`#${labelId}`).scrollIntoView();
+      }
+      cy.get(`#${labelId}`).should('be.visible');
       cy.get(`#${labelId}`)
-        .should('be.visible')
-        .click()
+        .click(clickOptions)
         .then(() => {
           if (waitForUpdateMsg) {
             checkUpdatingMessageNotDisplayed();
@@ -354,10 +364,12 @@ export function selectAttribute(
     case 'checkBoxListProduct':
       const btnLoc = `#${valueId} .cx-product-card-action button`;
       cy.get(btnLoc).then((el) => cy.log(`text before click: '${el.text()}'`));
-      cy.get(btnLoc).scrollIntoView();
+      if (!force) {
+        cy.get(btnLoc).scrollIntoView();
+      }
+      cy.get(btnLoc).should('be.visible');
       cy.get(btnLoc)
-        .should('be.visible')
-        .click()
+        .click(clickOptions)
         .then(() => {
           if (waitForUpdateMsg) {
             checkUpdatingMessageNotDisplayed();


### PR DESCRIPTION
## CXSPA-13935: Stabilize flaky product configurator conflict-dialog E2E test

### Problem
The `product-configurator-vc-conflict-dialog.e2e-flaky.cy.ts` spec frequently
failed on the test server with:

> `cy.click()` failed because the page updated while this command was executing
> … the element has detached from the DOM
> (`https://on.cypress.io/element-has-detached-from-dom`)

### Root cause
The conflict solver dialog re-renders on **every** configuration/pricing store
update: `conflictGroup$` is driven by `getConfiguration`, and the radio inputs
are additionally wrapped by the `changedPrices$` async pipe. When Cypress had
already located a radio input and was waiting for it to become *actionable*
(scroll into view + visibility/animation checks), an in-flight update or a late
pricing response replaced that element, so the subject detached from the DOM and
the click timed out.

This became more visible after `updateConfiguration$` was switched from
`mergeMap` to `concatMap` in `configurator-basic.effect.ts`: updates are now
queued and processed strictly one after another, which changes the timing of the
re-renders relative to the test interaction.

### Fix
Make the interaction resilient to asynchronous re-renders instead of relying on
Cypress' default actionability timing:

- **`product-configurator.ts` – `selectAttribute()`**
  - Added an optional `force` parameter (default `false`).
  - Split the chained `get().should('be.visible').click()` into **separate**
    commands so Cypress re-queries the element after a re-render (avoids acting on
    a stale/detached subject).
  - When `force` is set, skip `scrollIntoView` and click with `{ force: true }`,
    bypassing the actionability waits that race with Angular replacing the input.
  - Applies to `radioGroup`, `checkBoxList`, `multi_selection_image`,
    `single_selection_image` and `checkBoxListProduct`.

- **`product-configurator-vc.ts` – `selectAttributeAndWait()`**
  - Forwards the new `force` flag down to `selectAttribute()`.

- **`product-configurator-conflict-dialog.ts` – `selectAttributeAndWait()`**
  - Assert the dialog is visible and the "updating" message is gone *before*
    interacting.
  - Call the helper with `isPricingEnabled=true` and `force=true` so a late
    pricing response cannot detach the next value element.
  - Re-check that the "updating" message is gone *after* the network wait, since
    the network wait resolves before Angular change detection finishes.

No production code was changed – this is a test-stability fix only.