### PR TITLE
fix: post navigation links click focus issues

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -660,10 +660,12 @@ export interface FeatureTogglesInterface {
   a11yAddressFormInitialFocus?: boolean;
 
   /**
-   * When enabled, after navigating via a header/navigation link the keyboard
-   * focus moves to the first anchor inside the breadcrumb (`#cx-breadcrumb a`)
+   * When enabled, after navigating to a `CategoryPage` (e.g. a Product Listing Page)
+   * via a header navigation link, keyboard focus moves to the first anchor inside
+   * `cx-breadcrumb` (resolved via `StorefrontComponent.categoryPageFocusSelector`)
    * rather than the first focusable element in `<main>`.
-   * Falls back to the existing `cx-main` skip-link target when no breadcrumb is present.
+   * Falls back to the existing `cx-main` skip-link target when no breadcrumb is present
+   * or the destination is not a CategoryPage.
    *
    * Affects: `StorefrontComponent`
    */

--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -626,7 +626,7 @@ export interface FeatureTogglesInterface {
    * rather than the first focusable element in `<main>`.
    * Falls back to the existing `cx-main` skip-link target when no breadcrumb is present.
    *
-   * Affects: `StorefrontComponent`, `BreadcrumbComponent`
+   * Affects: `StorefrontComponent`
    */
   a11yFocusBreadcrumbOnNavigation?: boolean;
 }

--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -619,6 +619,16 @@ export interface FeatureTogglesInterface {
    * Affects: `AddressFormComponent`
    */
   a11yAddressFormInitialFocus?: boolean;
+
+  /**
+   * When enabled, after navigating via a header/navigation link the keyboard
+   * focus moves to the first anchor inside the breadcrumb (`#cx-breadcrumb a`)
+   * rather than the first focusable element in `<main>`.
+   * Falls back to the existing `cx-main` skip-link target when no breadcrumb is present.
+   *
+   * Affects: `StorefrontComponent`, `BreadcrumbComponent`
+   */
+  a11yFocusBreadcrumbOnNavigation?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -702,4 +712,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   productConfiguratorConsolidatedButtonDisabling: false,
   a11yFormErrorIconContrast: false,
   a11yAddressFormInitialFocus: false,
+  a11yFocusBreadcrumbOnNavigation: false,
 };

--- a/core-libs/storefront/layout/main/storefront.component.spec.ts
+++ b/core-libs/storefront/layout/main/storefront.component.spec.ts
@@ -1,8 +1,16 @@
 import { Component, DebugElement, Directive, Input } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+  waitForAsync,
+} from '@angular/core/testing';
 import {
   FeatureDirective,
   FeatureToggles,
+  PageContext,
+  PageType,
   RoutingService,
   provideFeatureToggles,
 } from '@spartacus/core';
@@ -46,6 +54,9 @@ class MockFooterComponent {}
 class MockRoutingService {
   isNavigating(): Observable<boolean> {
     return EMPTY;
+  }
+  getPageContext(): Observable<PageContext> {
+    return of(new PageContext('homepage'));
   }
 }
 
@@ -258,8 +269,11 @@ describe('StorefrontComponent', () => {
       expect(skipLinkService.scrollToTarget).toHaveBeenCalledWith('cx-main');
     });
 
-    it('should focus breadcrumb first link when toggle is on and breadcrumb is present', () => {
+    it('should focus breadcrumb first link when toggle is on, page is CategoryPage and breadcrumb is present', fakeAsync(() => {
       spyOn(skipLinkService, 'scrollToTarget');
+      spyOn(routingService, 'getPageContext').and.returnValue(
+        of(new PageContext('category', PageType.CATEGORY_PAGE))
+      );
       featureToggles.a11yFocusBreadcrumbOnNavigation = true;
 
       const mockAnchor = document.createElement('a');
@@ -274,13 +288,37 @@ describe('StorefrontComponent', () => {
       component['document'] = mockDocument as any;
 
       component['onNavigation'](false);
+      tick();
 
       expect(mockAnchor.focus).toHaveBeenCalled();
       expect(skipLinkService.scrollToTarget).not.toHaveBeenCalled();
-    });
+    }));
 
-    it('should fall back to scrollToTarget cx-main when toggle is on but no breadcrumb is present', () => {
+    it('should fall back to scrollToTarget cx-main when toggle is on, page is CategoryPage but no breadcrumb is present', fakeAsync(() => {
       spyOn(skipLinkService, 'scrollToTarget');
+      spyOn(routingService, 'getPageContext').and.returnValue(
+        of(new PageContext('category', PageType.CATEGORY_PAGE))
+      );
+      featureToggles.a11yFocusBreadcrumbOnNavigation = true;
+
+      const mockDocument = {
+        activeElement: document.createElement('button'),
+        body: document.createElement('body'),
+        querySelector: () => null,
+      };
+      component['document'] = mockDocument as any;
+
+      component['onNavigation'](false);
+      tick();
+
+      expect(skipLinkService.scrollToTarget).toHaveBeenCalledWith('cx-main');
+    }));
+
+    it('should call scrollToTarget cx-main when toggle is on but page is not CategoryPage', () => {
+      spyOn(skipLinkService, 'scrollToTarget');
+      spyOn(routingService, 'getPageContext').and.returnValue(
+        of(new PageContext('my-account', PageType.CONTENT_PAGE))
+      );
       featureToggles.a11yFocusBreadcrumbOnNavigation = true;
 
       const mockDocument = {

--- a/core-libs/storefront/layout/main/storefront.component.spec.ts
+++ b/core-libs/storefront/layout/main/storefront.component.spec.ts
@@ -1,6 +1,11 @@
 import { Component, DebugElement, Directive, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { FeatureDirective, RoutingService } from '@spartacus/core';
+import {
+  FeatureDirective,
+  FeatureToggles,
+  RoutingService,
+  provideFeatureToggles,
+} from '@spartacus/core';
 import { GlobalMessageComponent } from '@spartacus/storefront';
 import { EMPTY, Observable, of } from 'rxjs';
 import {
@@ -88,6 +93,7 @@ describe('StorefrontComponent', () => {
   let el: DebugElement;
   let routingService: RoutingService;
   let skipLinkService: SkipLinkService;
+  let featureToggles: FeatureToggles;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -104,6 +110,7 @@ describe('StorefrontComponent', () => {
           provide: SkipLinkService,
           useClass: MockSkipLinkService,
         },
+        provideFeatureToggles({ a11yFocusBreadcrumbOnNavigation: false }),
       ],
     })
       .overrideComponent(StorefrontComponent, {
@@ -141,6 +148,7 @@ describe('StorefrontComponent', () => {
     el = fixture.debugElement;
     routingService = TestBed.inject(RoutingService);
     skipLinkService = TestBed.inject(SkipLinkService);
+    featureToggles = TestBed.inject(FeatureToggles);
   });
 
   it('should create', () => {
@@ -205,10 +213,12 @@ describe('StorefrontComponent', () => {
 
     it('should call skipLinkService.scrollToTarget when navigation ends and document has active element', () => {
       spyOn(skipLinkService, 'scrollToTarget');
+      featureToggles.a11yFocusBreadcrumbOnNavigation = false;
 
       const mockDocument = {
         activeElement: document.createElement('button'),
         body: document.createElement('body'),
+        querySelector: () => null,
       };
       component['document'] = mockDocument as any;
 
@@ -223,12 +233,66 @@ describe('StorefrontComponent', () => {
       const mockDocument = {
         activeElement: body,
         body,
+        querySelector: () => null,
       };
       component['document'] = mockDocument as any;
 
       component['onNavigation'](false);
 
       expect(skipLinkService.scrollToTarget).not.toHaveBeenCalled();
+    });
+
+    it('should call scrollToTarget cx-main when toggle is off', () => {
+      spyOn(skipLinkService, 'scrollToTarget');
+      featureToggles.a11yFocusBreadcrumbOnNavigation = false;
+
+      const mockDocument = {
+        activeElement: document.createElement('button'),
+        body: document.createElement('body'),
+        querySelector: () => null,
+      };
+      component['document'] = mockDocument as any;
+
+      component['onNavigation'](false);
+
+      expect(skipLinkService.scrollToTarget).toHaveBeenCalledWith('cx-main');
+    });
+
+    it('should focus breadcrumb first link when toggle is on and breadcrumb is present', () => {
+      spyOn(skipLinkService, 'scrollToTarget');
+      featureToggles.a11yFocusBreadcrumbOnNavigation = true;
+
+      const mockAnchor = document.createElement('a');
+      spyOn(mockAnchor, 'focus');
+
+      const mockDocument = {
+        activeElement: document.createElement('button'),
+        body: document.createElement('body'),
+        querySelector: (selector: string) =>
+          selector === 'cx-breadcrumb nav a' ? mockAnchor : null,
+      };
+      component['document'] = mockDocument as any;
+
+      component['onNavigation'](false);
+
+      expect(mockAnchor.focus).toHaveBeenCalled();
+      expect(skipLinkService.scrollToTarget).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to scrollToTarget cx-main when toggle is on but no breadcrumb is present', () => {
+      spyOn(skipLinkService, 'scrollToTarget');
+      featureToggles.a11yFocusBreadcrumbOnNavigation = true;
+
+      const mockDocument = {
+        activeElement: document.createElement('button'),
+        body: document.createElement('body'),
+        querySelector: () => null,
+      };
+      component['document'] = mockDocument as any;
+
+      component['onNavigation'](false);
+
+      expect(skipLinkService.scrollToTarget).toHaveBeenCalledWith('cx-main');
     });
   });
 });

--- a/core-libs/storefront/layout/main/storefront.component.spec.ts
+++ b/core-libs/storefront/layout/main/storefront.component.spec.ts
@@ -12,8 +12,8 @@ import {
   PageContext,
   PageType,
   RoutingService,
-  provideFeatureToggles,
 } from '@spartacus/core';
+import { provideMockFeatureToggles } from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { GlobalMessageComponent } from '@spartacus/storefront';
 import { EMPTY, Observable, of } from 'rxjs';
 import {
@@ -121,7 +121,7 @@ describe('StorefrontComponent', () => {
           provide: SkipLinkService,
           useClass: MockSkipLinkService,
         },
-        provideFeatureToggles({ a11yFocusBreadcrumbOnNavigation: false }),
+        provideMockFeatureToggles({ a11yFocusBreadcrumbOnNavigation: false }),
       ],
     })
       .overrideComponent(StorefrontComponent, {
@@ -283,7 +283,9 @@ describe('StorefrontComponent', () => {
         activeElement: document.createElement('button'),
         body: document.createElement('body'),
         querySelector: (selector: string) =>
-          selector === 'cx-breadcrumb nav a' ? mockAnchor : null,
+          selector === component['categoryPageFocusSelector']
+            ? mockAnchor
+            : null,
       };
       component['document'] = mockDocument as any;
 

--- a/core-libs/storefront/layout/main/storefront.component.ts
+++ b/core-libs/storefront/layout/main/storefront.component.ts
@@ -194,6 +194,15 @@ export class StorefrontComponent implements OnInit, OnDestroy {
       this.stopNavigating &&
       this.document?.activeElement !== this.document?.body
     ) {
+      if (this.featureToggles.a11yFocusBreadcrumbOnNavigation) {
+        const breadcrumbLink = this.document?.querySelector<HTMLElement>(
+          'cx-breadcrumb nav a'
+        );
+        if (breadcrumbLink) {
+          breadcrumbLink.focus();
+          return;
+        }
+      }
       this.skipLinkService?.scrollToTarget('cx-main');
     }
   }

--- a/core-libs/storefront/layout/main/storefront.component.ts
+++ b/core-libs/storefront/layout/main/storefront.component.ts
@@ -107,6 +107,8 @@ export class StorefrontComponent implements OnInit, OnDestroy {
 
   private featureToggles = inject(FeatureToggles);
 
+  protected categoryPageFocusSelector = 'cx-breadcrumb nav a';
+
   constructor(
     private hamburgerMenuService: HamburgerMenuService,
     private routingService: RoutingService,
@@ -206,7 +208,7 @@ export class StorefrontComponent implements OnInit, OnDestroy {
               setTimeout(() => {
                 const breadcrumbLink =
                   this.document?.querySelector<HTMLElement>(
-                    'cx-breadcrumb nav a'
+                    this.categoryPageFocusSelector
                   );
                 if (breadcrumbLink) {
                   breadcrumbLink.focus();

--- a/core-libs/storefront/layout/main/storefront.component.ts
+++ b/core-libs/storefront/layout/main/storefront.component.ts
@@ -22,11 +22,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterModule } from '@angular/router';
 import {
   FeatureToggles,
+  PageType,
   RoutingService,
   useFeatureStyles,
 } from '@spartacus/core';
 import { Observable, Subscription, tap } from 'rxjs';
-import { distinctUntilChanged } from 'rxjs/operators';
+import { distinctUntilChanged, take } from 'rxjs/operators';
 import { GlobalMessageComponent } from '../../cms-components/misc/global-message/global-message.component';
 import { OutletDirective } from '../../cms-structure/outlet/outlet.directive';
 import { PageLayoutComponent } from '../../cms-structure/page/page-layout/page-layout.component';
@@ -197,15 +198,29 @@ export class StorefrontComponent implements OnInit, OnDestroy {
       this.document?.activeElement !== this.document?.body
     ) {
       if (this.featureToggles.a11yFocusBreadcrumbOnNavigation) {
-        const breadcrumbLink = this.document?.querySelector<HTMLElement>(
-          'cx-breadcrumb nav a'
-        );
-        if (breadcrumbLink) {
-          breadcrumbLink.focus();
-          return;
-        }
+        this.routingService
+          .getPageContext()
+          .pipe(take(1))
+          .subscribe((pageContext) => {
+            if (pageContext.type === PageType.CATEGORY_PAGE) {
+              setTimeout(() => {
+                const breadcrumbLink =
+                  this.document?.querySelector<HTMLElement>(
+                    'cx-breadcrumb nav a'
+                  );
+                if (breadcrumbLink) {
+                  breadcrumbLink.focus();
+                  return;
+                }
+                this.skipLinkService?.scrollToTarget('cx-main');
+              });
+            } else {
+              this.skipLinkService?.scrollToTarget('cx-main');
+            }
+          });
+      } else {
+        this.skipLinkService?.scrollToTarget('cx-main');
       }
-      this.skipLinkService?.scrollToTarget('cx-main');
     }
   }
 }

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -376,6 +376,7 @@ if (environment.cpq) {
         b2bCheckoutShippingAddressFilter: true,
         a11yFormErrorIconContrast: true,
         a11yAddressFormInitialFocus: true,
+        a11yFocusBreadcrumbOnNavigation: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-12687

- Fixing WCAG focus order after header nav clicks: after navigation, focus should land on the breadcrumb's first link instead of the filter sidebar.
- The `storefront.component.ts` changed since it already owns `onNavigation()` for exactly this purpose. This is the minimal impact to address the issue

QA Steps:
1. Lunch the app and click on any Navigation link
2. Focus is set on Facets filter

Expectation:
Focus should move to first link within the Breadcrumbs component. This is addressed when enabling `a11yFocusBreadcrumbOnNavigation` feature toggle.