### PR TITLE
fix: introduce opt-in guard on X-Forwarded-Host

### DIFF
--- a/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
+++ b/core-libs/setup/ssr/engine-decorator/ng-express-engine-decorator.ts
@@ -17,6 +17,7 @@ import {
   SsrOptimizationOptions,
   defaultSsrOptimizationOptions,
 } from '../optimized-engine/ssr-optimization-options';
+import { ServerOptions } from '../providers/model';
 import { getServerRequestProviders } from '../providers/ssr-providers';
 
 export type NgExpressEngineInstance = (
@@ -38,12 +39,20 @@ export class NgExpressEngineDecorator {
    * Returns the higher order ngExpressEngine with provided tokens for Spartacus
    *
    * @param ngExpressEngine
+   * @param optimizationOptions SSR optimization options
+   * @param serverOptions server options; e.g. `allowedOrigins` for
+   *   defense-in-depth request-origin validation in SSR mode.
    */
   static get(
     ngExpressEngine: NgExpressEngine,
-    optimizationOptions?: SsrOptimizationOptions | null
+    optimizationOptions?: SsrOptimizationOptions | null,
+    serverOptions?: ServerOptions
   ): NgExpressEngine {
-    return decorateExpressEngine(ngExpressEngine, optimizationOptions);
+    return decorateExpressEngine(
+      ngExpressEngine,
+      optimizationOptions,
+      serverOptions
+    );
   }
 }
 
@@ -52,14 +61,15 @@ export function decorateExpressEngine(
   optimizationOptions:
     | SsrOptimizationOptions
     | null
-    | undefined = defaultSsrOptimizationOptions
+    | undefined = defaultSsrOptimizationOptions,
+  serverOptions?: ServerOptions
 ): NgExpressEngine {
   return function (setupOptions: NgSetupOptions) {
     const engineInstance = ngExpressEngine({
       ...setupOptions,
       providers: [
         // add spartacus related providers
-        ...getServerRequestProviders(),
+        ...getServerRequestProviders(serverOptions),
         ...(setupOptions.providers ?? []),
       ],
     });

--- a/core-libs/setup/ssr/express-utils/express-request-origin.spec.ts
+++ b/core-libs/setup/ssr/express-utils/express-request-origin.spec.ts
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Request } from 'express';
+import { getRequestOrigin } from './express-request-origin';
+
+function createMockRequest({
+  protocol = 'https',
+  host = 'origin.com',
+  forwardedHost,
+  trustProxy = true,
+}: {
+  protocol?: string;
+  host?: string;
+  forwardedHost?: string;
+  trustProxy?: boolean;
+}): Request {
+  const headers: Record<string, string | undefined> = {
+    host,
+    'x-forwarded-host': forwardedHost,
+  };
+  return {
+    protocol,
+    connection: { remoteAddress: '127.0.0.1' },
+    app: {
+      get: (key: string) =>
+        key === 'trust proxy fn' ? () => trustProxy : undefined,
+    },
+    get: (name: string) => headers[name.toLowerCase()],
+  } as unknown as Request;
+}
+
+describe('getRequestOrigin', () => {
+  describe('without an allowlist (default behavior)', () => {
+    it('should use X-Forwarded-Host when the proxy is trusted', () => {
+      const req = createMockRequest({
+        forwardedHost: 'forwarded.com',
+        trustProxy: true,
+      });
+      expect(getRequestOrigin(req)).toBe('https://forwarded.com');
+    });
+
+    it('should fall back to Host when the proxy is not trusted', () => {
+      const req = createMockRequest({
+        host: 'origin.com',
+        forwardedHost: 'forwarded.com',
+        trustProxy: false,
+      });
+      expect(getRequestOrigin(req)).toBe('https://origin.com');
+    });
+
+    it('should use the left-most (original public-facing) entry of X-Forwarded-Host chain', () => {
+      const req = createMockRequest({
+        forwardedHost: 'real-host.com, internal-proxy.local',
+        trustProxy: true,
+      });
+      expect(getRequestOrigin(req)).toBe('https://real-host.com');
+    });
+  });
+
+  describe('with an allowlist (defense-in-depth)', () => {
+    it('should return the resolved origin when it is allowed', () => {
+      const req = createMockRequest({ forwardedHost: 'shop.com' });
+      expect(getRequestOrigin(req, ['https://shop.com'])).toBe(
+        'https://shop.com'
+      );
+    });
+
+    it('should fall back to the first allowed origin when not allowed', () => {
+      const req = createMockRequest({ forwardedHost: 'evil.com' });
+      expect(
+        getRequestOrigin(req, ['https://shop.com', 'https://other.com'])
+      ).toBe('https://shop.com');
+    });
+
+    it('should match case-insensitively', () => {
+      const req = createMockRequest({ forwardedHost: 'SHOP.com' });
+      expect(getRequestOrigin(req, ['https://shop.com'])).toBe(
+        'https://SHOP.com'
+      );
+    });
+
+    it('should support a leading-label wildcard for subdomains', () => {
+      const req = createMockRequest({ forwardedHost: 'store.shop.com' });
+      expect(getRequestOrigin(req, ['https://*.shop.com'])).toBe(
+        'https://store.shop.com'
+      );
+    });
+
+    it('should not match the apex domain with a subdomain wildcard', () => {
+      const req = createMockRequest({ forwardedHost: 'shop.com' });
+      expect(getRequestOrigin(req, ['https://*.shop.com'])).toBe(
+        'https://*.shop.com'
+      );
+    });
+
+    it('should not let the wildcard cross a dot boundary', () => {
+      const req = createMockRequest({ forwardedHost: 'a.b.shop.com' });
+      // `*` matches a single label only, so `a.b.shop.com` is rejected
+      expect(getRequestOrigin(req, ['https://*.shop.com'])).toBe(
+        'https://*.shop.com'
+      );
+    });
+
+    it('should match an origin that includes a port', () => {
+      const req = createMockRequest({ forwardedHost: 'shop.com:4200' });
+      expect(getRequestOrigin(req, ['https://shop.com:4200'])).toBe(
+        'https://shop.com:4200'
+      );
+    });
+
+    it('should fall back when only the port differs', () => {
+      const req = createMockRequest({ forwardedHost: 'shop.com:9999' });
+      expect(getRequestOrigin(req, ['https://shop.com:4200'])).toBe(
+        'https://shop.com:4200'
+      );
+    });
+
+    it('should fall back when only the protocol differs', () => {
+      // resolved origin is http, allowlist only trusts https
+      const req = createMockRequest({
+        protocol: 'http',
+        forwardedHost: 'shop.com',
+      });
+      expect(getRequestOrigin(req, ['https://shop.com'])).toBe(
+        'https://shop.com'
+      );
+    });
+
+    it('should match against any entry in a multi-entry allowlist', () => {
+      const req = createMockRequest({ forwardedHost: 'other.com' });
+      expect(
+        getRequestOrigin(req, ['https://shop.com', 'https://other.com'])
+      ).toBe('https://other.com');
+    });
+
+    it('should support multiple wildcards across separate labels', () => {
+      const req = createMockRequest({ forwardedHost: 'store.eu.shop.com' });
+      expect(getRequestOrigin(req, ['https://*.*.shop.com'])).toBe(
+        'https://store.eu.shop.com'
+      );
+    });
+
+    it('should not treat regex metacharacters in the pattern as special', () => {
+      // the dots must match literal dots, not "any char"
+      const req = createMockRequest({ forwardedHost: 'shopxcom' });
+      expect(getRequestOrigin(req, ['https://shop.com'])).toBe(
+        'https://shop.com'
+      );
+    });
+  });
+
+  describe('with an empty allowlist (explicit opt-out)', () => {
+    it('should behave like the default (no allowlisting) for []', () => {
+      const req = createMockRequest({ forwardedHost: 'anything.com' });
+      // `[]` has length 0 → old path → resolved origin is trusted as-is
+      expect(getRequestOrigin(req, [])).toBe('https://anything.com');
+    });
+  });
+});

--- a/core-libs/setup/ssr/express-utils/express-request-origin.ts
+++ b/core-libs/setup/ssr/express-utils/express-request-origin.ts
@@ -6,15 +6,51 @@
 
 import { Request } from 'express';
 
-export function getRequestOrigin(req: Request): string {
+/**
+ * Resolves the origin (`protocol://host`) of the incoming request.
+ *
+ * The host is taken from the `X-Forwarded-Host` header only when Express is
+ * configured to trust the proxy that delivered the request (`trust proxy`),
+ * which in a CCv2 deployment is the platform reverse proxy. Otherwise it falls
+ * back to the `Host` header.
+ *
+ * When `allowedOrigins` is non-empty, the resolved origin is validated against
+ * it as a defense-in-depth measure: if it matches no entry, the first entry is
+ * returned instead of the (potentially spoofed) resolved origin.
+ */
+export function getRequestOrigin(
+  req: Request,
+  allowedOrigins?: string[]
+): string {
+  const resolvedOrigin = resolveOriginFromRequest(req);
+
+  // Defense-in-depth: only when the operator opted in by providing an
+  // allowlist. Spartacus does NOT know the valid hosts otherwise, so with no
+  // allowlist we trust the (trusted) reverse proxy as before.
+  if (allowedOrigins?.length) {
+    return isAllowedOrigin(resolvedOrigin, allowedOrigins)
+      ? resolvedOrigin
+      : allowedOrigins[0];
+  }
+
+  return resolvedOrigin;
+}
+
+/**
+ * Resolves the origin from the request headers, honoring Express' `trust proxy`
+ * setting for `X-Forwarded-Host`. This preserves the original Spartacus behavior.
+ */
+function resolveOriginFromRequest(req: Request): string {
   // If express is resolving and trusting X-Forwarded-Host, we want to take it
   // into an account to properly generate request origin.
   const trustProxyFn = req.app.get('trust proxy fn');
   let forwardedHost = req.get('X-Forwarded-Host');
   if (forwardedHost && trustProxyFn(req.connection.remoteAddress, 0)) {
     if (forwardedHost.indexOf(',') !== -1) {
-      // Note: X-Forwarded-Host is normally only ever a
-      //       single value, but this is to be safe.
+      // Note: X-Forwarded-Host is normally only ever a single value (the
+      //       trusted reverse proxy sets it), but to be safe we take the
+      //       left-most entry, which by convention is the original
+      //       public-facing host.
       forwardedHost = forwardedHost
         .substring(0, forwardedHost.indexOf(','))
         .trimRight();
@@ -23,4 +59,43 @@ export function getRequestOrigin(req: Request): string {
   } else {
     return `${req.protocol}://${req.get('host')}`;
   }
+}
+
+/**
+ * Checks whether the given origin matches any entry in the allowlist.
+ *
+ * Entries are compared case-insensitively. A `*` wildcard matches exactly one
+ * host label: it never crosses a dot and never matches the apex domain. One or
+ * more wildcards are allowed, e.g. `https://*.my.domain.com` matches
+ * `https://shop.my.domain.com` but neither `https://my.domain.com` (apex) nor
+ * `https://a.b.my.domain.com` (two labels).
+ */
+function isAllowedOrigin(origin: string, allowedOrigins: string[]): boolean {
+  const normalizedOrigin = origin.toLowerCase();
+  return allowedOrigins.some((allowed) => {
+    const normalizedAllowed = allowed.toLowerCase();
+    if (normalizedAllowed.includes('*')) {
+      // Turn the wildcard pattern into a strict, anchored regex. Only `*` is
+      // treated specially; every other character is escaped so it can't be
+      // interpreted as a regex metacharacter.
+      //
+      // NOTE: a matching origin is reflected verbatim (see `getRequestOrigin`),
+      // so a wildcard entry does NOT bound the host dimension of the SSR cache
+      // key. An attacker able to spoof `X-Forwarded-Host` can cycle through
+      // arbitrary labels (e.g. `a.shop.com`, `b.shop.com`, ...) that all match
+      // `*.shop.com`, each producing a distinct cache key. This preserves
+      // cache-poisoning protection (every reflected host is a domain the
+      // operator controls) but reopens the cache fragmentation/exhaustion
+      // vector. Operators who need exhaustion resistance should prefer exact
+      // entries.
+      const pattern = normalizedAllowed
+        .split('*')
+        .map((segment) =>
+          segment.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+        )
+        .join('[^.]+');
+      return new RegExp(`^${pattern}$`).test(normalizedOrigin);
+    }
+    return normalizedAllowed === normalizedOrigin;
+  });
 }

--- a/core-libs/setup/ssr/express-utils/express-request-url.ts
+++ b/core-libs/setup/ssr/express-utils/express-request-url.ts
@@ -7,6 +7,6 @@
 import { Request } from 'express';
 import { getRequestOrigin } from './express-request-origin';
 
-export function getRequestUrl(req: Request): string {
-  return getRequestOrigin(req) + req.originalUrl;
+export function getRequestUrl(req: Request, allowedOrigins?: string[]): string {
+  return getRequestOrigin(req, allowedOrigins) + req.originalUrl;
 }

--- a/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
+++ b/core-libs/setup/ssr/optimized-engine/optimized-ssr-engine.spec.ts
@@ -200,8 +200,8 @@ describe('OptimizedSsrEngine', () => {
               renderingStrategyResolver: '() => ssr_optimization_options_1.RenderingStrategy.ALWAYS_SSR',
               logger: 'DefaultExpressServerLogger',
               shouldCacheRenderingResult: '({ entry: { err } }) => !err',
-              renderKeyResolver: 'function getRequestUrl(req) {\\n' +
-                '    return (0, express_request_origin_1.getRequestOrigin)(req) + req.originalUrl;\\n' +
+              renderKeyResolver: 'function getRequestUrl(req, allowedOrigins) {\\n' +
+                '    return (0, express_request_origin_1.getRequestOrigin)(req, allowedOrigins) + req.originalUrl;\\n' +
                 '}',
               ssrFeatureToggles: {}
             }
@@ -1446,8 +1446,8 @@ describe('OptimizedSsrEngine', () => {
               "forcedSsrTimeout": 60000,
               "logger": "MockExpressServerLogger",
               "maxRenderTime": 300000,
-              "renderKeyResolver": "function getRequestUrl(req) {
-            return (0, express_request_origin_1.getRequestOrigin)(req) + req.originalUrl;
+              "renderKeyResolver": "function getRequestUrl(req, allowedOrigins) {
+            return (0, express_request_origin_1.getRequestOrigin)(req, allowedOrigins) + req.originalUrl;
         }",
               "renderingStrategyResolver": "(request) => {
             if (hasExcludedUrl(request, defaultAlwaysCsrOptions.excludedUrls)) {

--- a/core-libs/setup/ssr/providers/model.ts
+++ b/core-libs/setup/ssr/providers/model.ts
@@ -20,4 +20,44 @@ export interface ServerOptions {
    * automatically resolved.
    */
   serverRequestOrigin?: string;
+
+  /**
+   * Optional allowlist of trusted origins used as an additional (defense-in-depth)
+   * check when the request origin is resolved from the incoming request
+   * (i.e. from the `Host` / `X-Forwarded-Host` headers) in SSR mode.
+   *
+   * Each entry must be a full origin (`protocol://host`) without a trailing
+   * slash, e.g. `"https://my.domain.com"`. Matching is case-insensitive.
+   *
+   * A `*` wildcard matches exactly one host label: it never crosses a dot and
+   * never matches the apex domain. One or more wildcards are allowed, e.g.
+   * `"https://*.my.domain.com"` matches `"https://shop.my.domain.com"` but
+   * neither `"https://my.domain.com"` (apex) nor `"https://a.b.my.domain.com"`
+   * (two labels).
+   *
+   * Entries are not validated or normalized: a malformed entry (wrong protocol,
+   * trailing slash, etc.) is not rejected — it simply never matches, and such a
+   * request falls back to the first entry (see below).
+   *
+   * ### Behavior
+   * - **When NOT set (default), or set to an empty array:** Spartacus does _not_
+   *   perform any host allowlisting. The resolved origin is trusted as delivered
+   *   by the (trusted) reverse proxy, gated only by Express' `trust proxy`
+   *   setting. This preserves the existing behavior and keeps trusting the CCv2
+   *   reverse proxy.
+   * - **When set to a non-empty array:** if the resolved origin does not match
+   *   any entry, Spartacus falls back to the first entry in this list instead of
+   *   reflecting the incoming (potentially spoofed) host. This mitigates Host
+   *   header injection and shared-cache poisoning for deployments that _do_ know
+   *   their set of valid domains. List the primary/canonical domain first, since
+   *   it is used as the fallback.
+   *
+   * @remarks
+   * This is intentionally opt-in. Spartacus can not know which hosts are valid
+   * for a given deployment, so the allowlist must be provided by the operator.
+   * It is _not_ a replacement for correctly configuring `trust proxy` and the
+   * reverse proxy / edge — it is an extra guardrail at the point where the
+   * origin is consumed.
+   */
+  allowedOrigins?: string[];
 }

--- a/core-libs/setup/ssr/providers/ssr-providers.ts
+++ b/core-libs/setup/ssr/providers/ssr-providers.ts
@@ -11,6 +11,7 @@ import {
   SERVER_REQUEST_ORIGIN,
   SERVER_REQUEST_URL,
 } from '@spartacus/core';
+import { Request } from 'express';
 
 import { PropagatingToServerErrorHandler } from '../error-handling/multi-error-handlers';
 import { getRequestOrigin } from '../express-utils/express-request-origin';
@@ -48,18 +49,22 @@ export function provideServer(options?: ServerOptions): Provider[] {
 /**
  * Returns Spartacus providers to be passed to the Angular express engine (in SSR)
  *
- * @param options
+ * @param options server options; `allowedOrigins`, when non-empty, is used as a
+ *   defense-in-depth allowlist while resolving the request origin from headers.
  */
-export function getServerRequestProviders(): StaticProvider[] {
+export function getServerRequestProviders(
+  options?: ServerOptions
+): StaticProvider[] {
   return [
     {
       provide: SERVER_REQUEST_ORIGIN,
-      useFactory: getRequestOrigin,
+      useFactory: (req: Request) =>
+        getRequestOrigin(req, options?.allowedOrigins),
       deps: [REQUEST],
     },
     {
       provide: SERVER_REQUEST_URL,
-      useFactory: getRequestUrl,
+      useFactory: (req: Request) => getRequestUrl(req, options?.allowedOrigins),
       deps: [REQUEST],
     },
   ];

--- a/projects/storefrontapp/src/server.ts
+++ b/projects/storefrontapp/src/server.ts
@@ -25,7 +25,30 @@ const ssrOptions: SsrOptimizationOptions = {
   cache: process.env['SSR_CACHE'] === 'true',
 };
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions);
+// By default (no `allowedOrigins`), Spartacus trusts the request origin as
+// delivered by the trusted reverse proxy, gated by the `trust proxy` setting
+// below. Deployments that know their set of valid domains can additionally
+// pass a defense-in-depth allowlist against Host header injection / cache
+// poisoning.
+//
+// The allowlist is read from the `SSR_ALLOWED_ORIGINS` environment variable
+// (comma-separated), so it can be configured per environment without code
+// changes, e.g.:
+//   SSR_ALLOWED_ORIGINS="https://my.storefront.com,https://*.my.storefront.com"
+// Each entry must be a full origin with no trailing slash. A `*` wildcard
+// matches exactly one host label (it never crosses a dot or matches the apex),
+// and the first entry is used as the fallback when a request origin is not
+// allowed, so list the primary/canonical domain first. When the variable is
+// unset or empty, `allowedOrigins` is `undefined` / `[]` and the default
+// (opt-in) behavior is preserved.
+const allowedOrigins = process.env['SSR_ALLOWED_ORIGINS']
+  ?.split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions, {
+  allowedOrigins,
+});
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-13837
Adds an opt-in origin allowlist as defense-in-depth against Host-header injection / shared-cache poisoning in SSR:

`getRequestOrigin()` now accepts an optional allowedOrigins. Existing header resolution (honoring trust proxy) is unchanged; when an allowlist is provided and the resolved origin isn't in it, it falls back to the first allowed origin instead of reflecting a spoofed host. Matching is case-insensitive with single-label wildcard support (https://*.shop.com).

`allowedOrigins?: string[]` added to `ServerOptions`, threaded through `getRequestUrl()`, the SSR providers, and `NgExpressEngineDecorator.get()` / `decorateExpressEngine()`.

Sample usage documented in the storefront app's `server.ts`.

New spec covering default behavior, allowlist fallback, case-insensitivity, and wildcard edge cases; updated engine snapshots.

The feature is intentionally opt-in — with no allowlist, behavior is unchanged. 