### PR TITLE
fix(CXSPA-1268): expose SSR optimization options in generated server.ts

### DIFF
--- a/core-libs/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/core-libs/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -227,16 +227,32 @@ exports[`add-ssr server.ts should be configured properly 1`] = `
 "import { APP_BASE_HREF } from '@angular/common';
 import {
   NgExpressEngineDecorator,
+  SsrOptimizationOptions,
   defaultExpressErrorHandlers,
+  defaultSsrOptimizationOptions,
   ngExpressEngine as engine,
 } from '@spartacus/setup/ssr';
 import express from 'express';
 import { readFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
 import bootstrap from './main.server';
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine);
+const ssrOptions: SsrOptimizationOptions = {
+  timeout: Number(
+    process.env['SSR_TIMEOUT'] ?? defaultSsrOptimizationOptions.timeout
+  ),
+  cache: process.env['SSR_CACHE'] === 'true',
+};
+
+const allowedOrigins = process.env['SSR_ALLOWED_ORIGINS']
+  ?.split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions, {
+  allowedOrigins,
+});
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/core-libs/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/core-libs/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -9,7 +9,7 @@ import {
 import express from 'express';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, join, resolve } from 'path';
+import { dirname, join, resolve } from 'node:path';
 import bootstrap from './main.server';
 
 const ssrOptions: SsrOptimizationOptions = {

--- a/core-libs/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/core-libs/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -1,16 +1,32 @@
 import { APP_BASE_HREF } from '@angular/common';
 import {
   NgExpressEngineDecorator,
+  SsrOptimizationOptions,
   defaultExpressErrorHandlers,
+  defaultSsrOptimizationOptions,
   ngExpressEngine as engine,
 } from '@spartacus/setup/ssr';
 import express from 'express';
 import { readFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'path';
 import bootstrap from './main.server';
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine);
+const ssrOptions: SsrOptimizationOptions = {
+  timeout: Number(
+    process.env['SSR_TIMEOUT'] ?? defaultSsrOptimizationOptions.timeout
+  ),
+  cache: process.env['SSR_CACHE'] === 'true',
+};
+
+const allowedOrigins = process.env['SSR_ALLOWED_ORIGINS']
+  ?.split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions, {
+  allowedOrigins,
+});
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {


### PR DESCRIPTION
## Summary

- Wire `SsrOptimizationOptions` in the generated `server.ts` schematic template
  so projects get SSR tuning out of the box after `ng add`
- `SSR_TIMEOUT` and `SSR_CACHE` are read from environment variables
  (falling back to `defaultSsrOptimizationOptions.timeout`)
- `SSR_ALLOWED_ORIGINS` is read as a comma-separated list and forwarded
  to `NgExpressEngineDecorator.get()` as `allowedOrigins`
- Switch `node:path` → `path` for broader Node.js compatibility

## Test plan

- [ ] Run `ng add @spartacus/schematics` and verify the generated `server.ts`
  contains the SSR options block
- [ ] Start the SSR server with `SSR_TIMEOUT`, `SSR_CACHE`, and
  `SSR_ALLOWED_ORIGINS` set and confirm the values are picked up at runtime
