### PR TITLE
fix(CXSPA-1268): simplify SSR engine setup and expose allowedOrigins in server template

### DIFF
--- a/core-libs/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
+++ b/core-libs/schematics/src/add-ssr/__snapshots__/index_spec.ts.snap
@@ -227,9 +227,7 @@ exports[`add-ssr server.ts should be configured properly 1`] = `
 "import { APP_BASE_HREF } from '@angular/common';
 import {
   NgExpressEngineDecorator,
-  SsrOptimizationOptions,
   defaultExpressErrorHandlers,
-  defaultSsrOptimizationOptions,
   ngExpressEngine as engine,
 } from '@spartacus/setup/ssr';
 import express from 'express';
@@ -238,19 +236,12 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import bootstrap from './main.server';
 
-const ssrOptions: SsrOptimizationOptions = {
-  timeout: Number(
-    process.env['SSR_TIMEOUT'] ?? defaultSsrOptimizationOptions.timeout
-  ),
-  cache: process.env['SSR_CACHE'] === 'true',
-};
-
 const allowedOrigins = process.env['SSR_ALLOWED_ORIGINS']
   ?.split(',')
   .map((origin) => origin.trim())
   .filter(Boolean);
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions, {
+const ngExpressEngine = NgExpressEngineDecorator.get(engine, undefined, {
   allowedOrigins,
 });
 

--- a/core-libs/schematics/src/add-ssr/files/server.__typescriptExt__
+++ b/core-libs/schematics/src/add-ssr/files/server.__typescriptExt__
@@ -1,9 +1,7 @@
 import { APP_BASE_HREF } from '@angular/common';
 import {
   NgExpressEngineDecorator,
-  SsrOptimizationOptions,
   defaultExpressErrorHandlers,
-  defaultSsrOptimizationOptions,
   ngExpressEngine as engine,
 } from '@spartacus/setup/ssr';
 import express from 'express';
@@ -12,19 +10,12 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import bootstrap from './main.server';
 
-const ssrOptions: SsrOptimizationOptions = {
-  timeout: Number(
-    process.env['SSR_TIMEOUT'] ?? defaultSsrOptimizationOptions.timeout
-  ),
-  cache: process.env['SSR_CACHE'] === 'true',
-};
-
 const allowedOrigins = process.env['SSR_ALLOWED_ORIGINS']
   ?.split(',')
   .map((origin) => origin.trim())
   .filter(Boolean);
 
-const ngExpressEngine = NgExpressEngineDecorator.get(engine, ssrOptions, {
+const ngExpressEngine = NgExpressEngineDecorator.get(engine, undefined, {
   allowedOrigins,
 });
 


### PR DESCRIPTION
## Summary

- Replace explicit `SsrOptimizationOptions` wiring with `undefined` so
  `decorateExpressEngine` falls back to `defaultSsrOptimizationOptions`
  automatically — passing `{}` would bypass the default, `undefined` does not
- Wire `allowedOrigins` from the `SSR_ALLOWED_ORIGINS` env var
  (comma-separated) for defense-in-depth origin validation against Host header
  injection / cache poisoning
- Apply the same simplification to the `ng add` schematic template
  (`server.__typescriptExt__`) so generated projects get the same setup
- Update the schematic snapshot to match the new template

## Test plan

- [ ] Run `nx run schematics:test --include="**/index_spec*"` — snapshot test should pass
- [ ] Verify generated `server.ts` after `ng add` contains `allowedOrigins` wiring
- [ ] Start SSR server with `SSR_ALLOWED_ORIGINS` set and confirm origin validation works
