### PR TITLE
fix: AuthConfigInitializer uses correct default redirectUri when inactive

### DIFF
--- a/core-libs/core/src/auth/user-auth/config/auth-config-initializer.spec.ts
+++ b/core-libs/core/src/auth/user-auth/config/auth-config-initializer.spec.ts
@@ -14,7 +14,7 @@ const mockAuthConfig = {
   authentication: {
     client_id: mockClientId,
     OAuthLibConfig: {
-      redirectUri: undefined,
+      redirectUri: undefined as string | undefined,
     },
     initializerOptions: {
       baseSiteSuffix: false as NonNullable<
@@ -60,7 +60,7 @@ class MockWindowRef implements Partial<WindowRef> {
 
 describe('AuthConfigInitializer', () => {
   let service: AuthConfigInitializer;
-  let authConfig: AuthConfig;
+  let authConfig: typeof mockAuthConfig;
   let siteContextParamsService: SiteContextParamsService;
   let baseSiteService: BaseSiteService;
   let configInitializerService: ConfigInitializerService;
@@ -68,7 +68,7 @@ describe('AuthConfigInitializer', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        { provide: AuthConfig, useValue: mockAuthConfig },
+        { provide: AuthConfig, useValue: structuredClone(mockAuthConfig) },
         {
           provide: SiteContextParamsService,
           useClass: MockSiteContextParamsService,
@@ -82,7 +82,7 @@ describe('AuthConfigInitializer', () => {
       ],
     });
 
-    authConfig = TestBed.inject(AuthConfig);
+    authConfig = TestBed.inject(AuthConfig) as typeof mockAuthConfig;
     configInitializerService = TestBed.inject(ConfigInitializerService);
     spyOn(configInitializerService, 'getStable').and.returnValue(
       of(authConfig)
@@ -100,29 +100,54 @@ describe('AuthConfigInitializer', () => {
   describe('configFactory()', () => {
     describe('when addBaseSiteToRedirectUri is false', () => {
       beforeEach(() => {
-        mockAuthConfig.authentication.initializerOptions.addBaseSiteToRedirectUri =
+        authConfig.authentication.initializerOptions.addBaseSiteToRedirectUri =
           false;
       });
 
-      it('should not initialize the auth config', async () => {
-        const expected: AuthConfig = {
-          authentication: {
-            client_id: mockClientId,
-            OAuthLibConfig: {
-              redirectUri: undefined,
+      describe('when redirectUri is undefined', () => {
+        it('should initialize the auth config redirectUri to the default', async () => {
+          const expected: AuthConfig = {
+            authentication: {
+              client_id: mockClientId,
+              OAuthLibConfig: {
+                redirectUri: mockOrigin,
+              },
             },
-          },
-        };
+          };
 
-        const config = await service.configFactory();
+          const config = await service.configFactory();
 
-        expect(config).toEqual(expected);
+          expect(config).toEqual(expected);
+        });
+      });
+
+      describe('when a redirectUri is defined', () => {
+        const definedRedirectUri = 'https://example.com';
+        beforeEach(() => {
+          authConfig.authentication.OAuthLibConfig.redirectUri =
+            definedRedirectUri;
+        });
+
+        it('should initialize the auth config to the existing redirectUri', async () => {
+          const expected: AuthConfig = {
+            authentication: {
+              client_id: mockClientId,
+              OAuthLibConfig: {
+                redirectUri: definedRedirectUri,
+              },
+            },
+          };
+
+          const config = await service.configFactory();
+
+          expect(config).toEqual(expected);
+        });
       });
     });
 
     describe('when addBaseSiteToRedirectUri is true', () => {
       beforeEach(() => {
-        mockAuthConfig.authentication.initializerOptions.addBaseSiteToRedirectUri =
+        authConfig.authentication.initializerOptions.addBaseSiteToRedirectUri =
           true;
       });
 
@@ -150,7 +175,7 @@ describe('AuthConfigInitializer', () => {
 
     describe('when addBaseSiteToRedirectUri is auto', () => {
       beforeEach(() => {
-        mockAuthConfig.authentication.initializerOptions.addBaseSiteToRedirectUri =
+        authConfig.authentication.initializerOptions.addBaseSiteToRedirectUri =
           'auto';
       });
       it('should initialize the redirect URI when baseSite is in the URL context parameters', async () => {
@@ -169,15 +194,15 @@ describe('AuthConfigInitializer', () => {
 
     describe('when baseSiteSuffix is false', () => {
       beforeEach(() => {
-        mockAuthConfig.authentication.initializerOptions.baseSiteSuffix = false;
+        authConfig.authentication.initializerOptions.baseSiteSuffix = false;
       });
 
-      it('should not initialize the auth config', async () => {
+      it('should not change client ID', async () => {
         const expected: AuthConfig = {
           authentication: {
             client_id: mockClientId,
             OAuthLibConfig: {
-              redirectUri: undefined,
+              redirectUri: mockOrigin,
             },
           },
         };
@@ -190,7 +215,7 @@ describe('AuthConfigInitializer', () => {
 
     describe('when baseSiteSuffix is true', () => {
       beforeEach(() => {
-        mockAuthConfig.authentication.initializerOptions.baseSiteSuffix = true;
+        authConfig.authentication.initializerOptions.baseSiteSuffix = true;
       });
 
       it('should suffix the client ID with the base site', async () => {
@@ -204,8 +229,7 @@ describe('AuthConfigInitializer', () => {
 
     describe('when baseSiteSuffix is auto', () => {
       beforeEach(() => {
-        mockAuthConfig.authentication.initializerOptions.baseSiteSuffix =
-          'auto';
+        authConfig.authentication.initializerOptions.baseSiteSuffix = 'auto';
       });
       it('should suffix the client ID with the base site when baseSite is in the URL context parameters', async () => {
         spyOn(
@@ -222,8 +246,8 @@ describe('AuthConfigInitializer', () => {
     describe('initialization race conditions', () => {
       let expected: Config;
       beforeEach(() => {
-        mockAuthConfig.authentication.initializerOptions.baseSiteSuffix = true;
-        mockAuthConfig.authentication.initializerOptions.addBaseSiteToRedirectUri =
+        authConfig.authentication.initializerOptions.baseSiteSuffix = true;
+        authConfig.authentication.initializerOptions.addBaseSiteToRedirectUri =
           true;
 
         expected = <Config>{

--- a/core-libs/core/src/auth/user-auth/config/auth-config-initializer.ts
+++ b/core-libs/core/src/auth/user-auth/config/auth-config-initializer.ts
@@ -63,17 +63,18 @@ export class AuthConfigInitializer implements ConfigInitializer {
     const addBaseSiteToRedirectUri =
       config.authentication?.initializerOptions?.addBaseSiteToRedirectUri;
 
+    // urlRoot is the provided config value or the system default
+    const urlRoot =
+      config.authentication?.OAuthLibConfig?.redirectUri ??
+      this.getDefaultRedirectUri();
+
     if (
       addBaseSiteToRedirectUri === true ||
       (addBaseSiteToRedirectUri === 'auto' && this.baseSiteInUrl())
     ) {
-      const urlRoot =
-        config.authentication?.OAuthLibConfig?.redirectUri ??
-        (!this.isSSR ? this.windowRef.nativeWindow?.location.origin : '');
-
       return `${urlRoot}/${encodeURIComponent(activeBaseSite)}`;
     } else {
-      return config.authentication?.OAuthLibConfig?.redirectUri;
+      return urlRoot;
     }
   }
 
@@ -81,5 +82,9 @@ export class AuthConfigInitializer implements ConfigInitializer {
     return this.siteContextParamsService
       .getUrlEncodingParameters()
       .includes(BASE_SITE_CONTEXT_ID);
+  }
+
+  protected getDefaultRedirectUri() {
+    return !this.isSSR ? this.windowRef.nativeWindow?.location.origin : '';
   }
 }


### PR DESCRIPTION
When AuthConfigInitializer was enabled but inactive, it would not apply the default value to redirectUri, which would result in the value `undefined` being sent to the authorization server.