### PR TITLE
fix: CXSPA-11641 fix error on email change

### DIFF
--- a/core-libs/core/src/auth/user-auth/facade/auth.service.spec.ts
+++ b/core-libs/core/src/auth/user-auth/facade/auth.service.spec.ts
@@ -39,6 +39,7 @@ class MockOAuthLibWrapperService implements Partial<OAuthLibWrapperService> {
   revokeAndLogout() {
     return Promise.resolve();
   }
+  logout() {}
   authorizeWithPasswordFlow() {
     return Promise.resolve({} as TokenResponse);
   }
@@ -417,6 +418,21 @@ describe('AuthService', () => {
       expect(
         (service.logoutInProgress$ as BehaviorSubject<boolean>).value
       ).toBe(false);
+    }));
+
+    it('should logout without revoking tokens when isRevoke is false', fakeAsync(() => {
+      spyOn(userIdService, 'clearUserId').and.callThrough();
+      spyOn(oAuthLibWrapperService, 'revokeAndLogout').and.callThrough();
+      spyOn(oAuthLibWrapperService, 'logout').and.callThrough();
+      spyOn(store, 'dispatch').and.callThrough();
+
+      service.coreLogout(false);
+      tick();
+
+      expect(userIdService.clearUserId).toHaveBeenCalled();
+      expect(oAuthLibWrapperService.logout).toHaveBeenCalled();
+      expect(oAuthLibWrapperService.revokeAndLogout).not.toHaveBeenCalled();
+      expect(store.dispatch).toHaveBeenCalledWith(new AuthActions.Logout());
     }));
 
     describe('when propagateLogoutToAllTabs is enabled', () => {

--- a/core-libs/core/src/auth/user-auth/facade/auth.service.ts
+++ b/core-libs/core/src/auth/user-auth/facade/auth.service.ts
@@ -195,8 +195,14 @@ export class AuthService {
   /**
    * Revokes tokens and clears state for logged user (tokens, userId).
    * To perform logout it is best to use `logout` method. Use this method with caution.
+   *
+   * @param isRevoke When `true` (default), the access token is revoked on the
+   * authorization server before clearing the local session. Set to `false` to
+   * skip revocation and only clear the local tokens, e.g. when the current
+   * token is already known to be invalid server-side and the revoke call would
+   * fail.
    */
-  coreLogout(): Promise<void> {
+  coreLogout(isRevoke = true): Promise<void> {
     this.setLogoutProgress(true);
     this.userIdService.clearUserId();
     if (this.featureToggles.propagateLogoutToAllTabs) {
@@ -204,8 +210,11 @@ export class AuthService {
         AuthNotificationType.LOGOUT
       );
     }
+    const logout = isRevoke
+      ? this.oAuthLibWrapperService.revokeAndLogout()
+      : Promise.resolve(this.oAuthLibWrapperService.logout());
     return new Promise((resolve) => {
-      this.oAuthLibWrapperService.revokeAndLogout().finally(() => {
+      logout.finally(() => {
         this.store.dispatch(new AuthActions.Logout());
         this.setLogoutProgress(false);
         resolve();

--- a/feature-libs/asm/root/services/asm-auth.service.spec.ts
+++ b/feature-libs/asm/root/services/asm-auth.service.spec.ts
@@ -58,6 +58,7 @@ class MockUserIdService {
 
 class MockOAuthLibWrapperService {
   revokeAndLogout = jasmine.createSpy().and.returnValue(Promise.resolve());
+  logout = jasmine.createSpy();
   initLoginFlow = jasmine.createSpy();
   tryLogin = jasmine
     .createSpy()
@@ -229,6 +230,14 @@ describe('AsmAuthService', () => {
 
       expect(userIdService.clearUserId).toHaveBeenCalled();
       expect(oAuthLibWrapperService.revokeAndLogout).toHaveBeenCalled();
+    });
+
+    it('should forward isRevoke=false to super, skipping revocation when user not emulated', async () => {
+      await service.coreLogout(false);
+
+      expect(userIdService.clearUserId).toHaveBeenCalled();
+      expect(oAuthLibWrapperService.logout).toHaveBeenCalled();
+      expect(oAuthLibWrapperService.revokeAndLogout).not.toHaveBeenCalled();
     });
 
     it('should logout when emulating user', async () => {

--- a/feature-libs/asm/root/services/asm-auth.service.ts
+++ b/feature-libs/asm/root/services/asm-auth.service.ts
@@ -176,8 +176,14 @@ export class AsmAuthService extends AuthService {
   /**
    * Revokes tokens and clears state for logged user (tokens, userId).
    * To perform logout it is best to use `logout` method. Use this method with caution.
+   *
+   * @param isRevoke When `true` (default), the access token is revoked on the
+   * authorization server before clearing the local session. Set to `false` to
+   * skip revocation and only clear the local tokens, e.g. when the current
+   * token is already known to be invalid server-side and the revoke call would
+   * fail. Ignored for emulated sessions, which never revoke.
    */
-  coreLogout(): Promise<any> {
+  coreLogout(isRevoke = true): Promise<any> {
     return lastValueFrom(
       this.userIdService.isEmulated().pipe(
         take(1),
@@ -188,7 +194,7 @@ export class AsmAuthService extends AuthService {
             this.store.dispatch(new AuthActions.Logout());
             return of(true);
           } else {
-            return from(super.coreLogout());
+            return from(super.coreLogout(isRevoke));
           }
         })
       )

--- a/feature-libs/user/profile/components/update-email/update-email-component.service.spec.ts
+++ b/feature-libs/user/profile/components/update-email/update-email-component.service.spec.ts
@@ -9,6 +9,7 @@ import {
   RoutingService,
 } from '@spartacus/core';
 import { FormErrorsModule } from '@spartacus/storefront';
+// eslint-disable-next-line @nx/workspace-no-self-public-api-import -- ESLint is misfiring here: core and root are not the same library — they're separate entry points
 import { UserEmailFacade } from '@spartacus/user/profile/root';
 import { of } from 'rxjs';
 import { UpdateEmailComponentService } from './update-email-component.service';
@@ -25,6 +26,7 @@ class MockRoutingService {
 }
 class MockGlobalMessageService {
   add = createSpy().and.stub();
+  remove = createSpy().and.stub();
 }
 
 class MockAuthRedirectService implements Partial<AuthRedirectService> {
@@ -167,6 +169,15 @@ describe('UpdateEmailComponentService', () => {
         authService.coreLogout().then(() => {
           expect(authRedirectService.setRedirectUrl).toHaveBeenCalledBefore(
             routingService.go
+          );
+        });
+      }));
+
+      it('should clear any error message caused by token revocation during logout', waitForAsync(() => {
+        service.save();
+        authService.coreLogout().then(() => {
+          expect(globalMessageService.remove).toHaveBeenCalledWith(
+            GlobalMessageType.MSG_TYPE_ERROR
           );
         });
       }));

--- a/feature-libs/user/profile/components/update-email/update-email-component.service.spec.ts
+++ b/feature-libs/user/profile/components/update-email/update-email-component.service.spec.ts
@@ -26,7 +26,6 @@ class MockRoutingService {
 }
 class MockGlobalMessageService {
   add = createSpy().and.stub();
-  remove = createSpy().and.stub();
 }
 
 class MockAuthRedirectService implements Partial<AuthRedirectService> {
@@ -173,14 +172,10 @@ describe('UpdateEmailComponentService', () => {
         });
       }));
 
-      it('should clear any error message caused by token revocation during logout', waitForAsync(() => {
+      it('should log out without revoking the token, as the email change invalidates it', () => {
         service.save();
-        authService.coreLogout().then(() => {
-          expect(globalMessageService.remove).toHaveBeenCalledWith(
-            GlobalMessageType.MSG_TYPE_ERROR
-          );
-        });
-      }));
+        expect(authService.coreLogout).toHaveBeenCalledWith(false);
+      });
     });
 
     describe('error', () => {

--- a/feature-libs/user/profile/components/update-email/update-email-component.service.ts
+++ b/feature-libs/user/profile/components/update-email/update-email-component.service.ts
@@ -18,6 +18,7 @@ import {
   RoutingService,
 } from '@spartacus/core';
 import { CustomFormValidators } from '@spartacus/storefront';
+// eslint-disable-next-line @nx/workspace-no-self-public-api-import -- ESLint is misfiring here: core and root are not the same library — they're separate entry points
 import { UserEmailFacade } from '@spartacus/user/profile/root';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -92,6 +93,12 @@ export class UpdateEmailComponentService {
     );
     // TODO(#9638): Use logout route when it will support passing redirect url
     this.authService.coreLogout().then(() => {
+      // The email change invalidates the current token, so the token revocation
+      // during logout can fail (e.g. HTTP 500). AuthService.coreLogout() still
+      // resolves and logs the user out regardless (via its `.finally`), so we
+      // only need to clear the error banner the HTTP interceptor produced for
+      // that 500.
+      this.globalMessageService.remove(GlobalMessageType.MSG_TYPE_ERROR);
       this.routingService.go(
         { cxRoute: 'login' },
         {

--- a/feature-libs/user/profile/components/update-email/update-email-component.service.ts
+++ b/feature-libs/user/profile/components/update-email/update-email-component.service.ts
@@ -92,13 +92,10 @@ export class UpdateEmailComponentService {
       this.routingService.getUrl({ cxRoute: 'home' })
     );
     // TODO(#9638): Use logout route when it will support passing redirect url
-    this.authService.coreLogout().then(() => {
-      // The email change invalidates the current token, so the token revocation
-      // during logout can fail (e.g. HTTP 500). AuthService.coreLogout() still
-      // resolves and logs the user out regardless (via its `.finally`), so we
-      // only need to clear the error banner the HTTP interceptor produced for
-      // that 500.
-      this.globalMessageService.remove(GlobalMessageType.MSG_TYPE_ERROR);
+    // Changing the email changes the account's login id, which invalidates the
+    // current token server-side. Revoking that already-invalid token would fail
+    // (HTTP 500), so we skip revocation and only clear the local session.
+    this.authService.coreLogout(false).then(() => {
       this.routingService.go(
         { cxRoute: 'login' },
         {


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-11641

### Actual Cause
After a successful email change, the user is logged out, which POSTs to /oauth/revoke. But at this point in time, the user's ID has been changed so the backend is responding with 500 HTTP error. 

Therefore, on successful email update, we only logout the user without revoking the access token on the authorization server