### PR TITLE
fix: CXSPA-14114 address submit broken safari

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -673,6 +673,15 @@ export interface FeatureTogglesInterface {
   a11yAddressFormInitialFocus?: boolean;
 
   /**
+   * When enabled, the payment form focuses the first invalid field after a
+   * failed submit, so keyboard and screen reader users land directly on the
+   * control that needs attention.
+   *
+   * Affects: `CheckoutPaymentFormComponent`
+   */
+  a11yPaymentFormFocus?: boolean;
+
+  /**
    * When enabled, after navigating to a `CategoryPage` (e.g. a Product Listing Page)
    * via a header navigation link, keyboard focus moves to the first anchor inside
    * `cx-breadcrumb` (resolved via `StorefrontComponent.categoryPageFocusSelector`)
@@ -783,6 +792,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yFocusIndicatorContrast: false,
   a11yDisabledButtonContrast: false,
   a11yAddressFormInitialFocus: false,
+  a11yPaymentFormFocus: false,
   a11yFocusBreadcrumbOnNavigation: false,
   a11yNavigationChevronContrast: false,
 };

--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -673,15 +673,6 @@ export interface FeatureTogglesInterface {
   a11yAddressFormInitialFocus?: boolean;
 
   /**
-   * When enabled, the payment form focuses the first invalid field after a
-   * failed submit, so keyboard and screen reader users land directly on the
-   * control that needs attention.
-   *
-   * Affects: `CheckoutPaymentFormComponent`
-   */
-  a11yPaymentFormFocus?: boolean;
-
-  /**
    * When enabled, after navigating to a `CategoryPage` (e.g. a Product Listing Page)
    * via a header navigation link, keyboard focus moves to the first anchor inside
    * `cx-breadcrumb` (resolved via `StorefrontComponent.categoryPageFocusSelector`)
@@ -792,7 +783,6 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yFocusIndicatorContrast: false,
   a11yDisabledButtonContrast: false,
   a11yAddressFormInitialFocus: false,
-  a11yPaymentFormFocus: false,
   a11yFocusBreadcrumbOnNavigation: false,
   a11yNavigationChevronContrast: false,
 };

--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -666,11 +666,11 @@ export interface FeatureTogglesInterface {
 
   /**
    * When enabled, the address form applies the `cxFocus` directive with autofocus
-   * to manage initial keyboard focus.
+   * to manage initial keyboard focus and uses new directive cxFocusFirstInvalidField.
    *
    * Affects: `AddressFormComponent`
    */
-  a11yAddressFormInitialFocus?: boolean;
+  a11yImproveAddressFormFocus?: boolean;
 
   /**
    * When enabled, after navigating to a `CategoryPage` (e.g. a Product Listing Page)
@@ -782,7 +782,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   a11yFormErrorIconContrast: false,
   a11yFocusIndicatorContrast: false,
   a11yDisabledButtonContrast: false,
-  a11yAddressFormInitialFocus: false,
+  a11yImproveAddressFormFocus: false,
   a11yFocusBreadcrumbOnNavigation: false,
   a11yNavigationChevronContrast: false,
 };

--- a/core-libs/storefront/layout/a11y/focus-first-invalid-field/focus-first-invalid-field.directive.spec.ts
+++ b/core-libs/storefront/layout/a11y/focus-first-invalid-field/focus-first-invalid-field.directive.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FocusFirstInvalidFieldDirective } from './focus-first-invalid-field.directive';
+
+@Component({
+  selector: 'cx-host',
+  template: `
+    <form cxFocusFirstInvalidField>
+      <ng-select class="valid-select"><input /></ng-select>
+      <ng-select class="invalid-select ng-invalid"><input /></ng-select>
+      <input class="text-input ng-invalid" />
+    </form>
+  `,
+  imports: [FocusFirstInvalidFieldDirective],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+class HostComponent {}
+
+describe('FocusFirstInvalidFieldDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let directive: FocusFirstInvalidFieldDirective;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HostComponent],
+    });
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    directive = fixture.debugElement
+      .query(By.directive(FocusFirstInvalidFieldDirective))
+      .injector.get(FocusFirstInvalidFieldDirective);
+  });
+
+  it('should focus the inner input of the first invalid ng-select', fakeAsync(() => {
+    const invalidSelectInput: HTMLElement = fixture.debugElement.query(
+      By.css('.invalid-select input')
+    ).nativeElement;
+    spyOn(invalidSelectInput, 'focus');
+
+    directive.focusFirstInvalidField();
+    tick(); // flush the deferred macrotask
+
+    expect(invalidSelectInput.focus).toHaveBeenCalled();
+  }));
+
+  it('should focus a plain invalid input directly', fakeAsync(() => {
+    // Remove the invalid ng-select so the plain input is the first invalid field.
+    // eslint-disable-next-line no-restricted-syntax -- test DOM teardown; Renderer2 has no node-removal equivalent
+    fixture.debugElement
+      .query(By.css('.invalid-select'))
+      .nativeElement.remove();
+
+    const textInput: HTMLElement = fixture.debugElement.query(
+      By.css('.text-input')
+    ).nativeElement;
+    spyOn(textInput, 'focus');
+
+    directive.focusFirstInvalidField();
+    tick();
+
+    expect(textInput.focus).toHaveBeenCalled();
+  }));
+
+  it('should do nothing when there is no invalid field', fakeAsync(() => {
+    // eslint-disable-next-line no-restricted-syntax -- test DOM teardown; Renderer2 has no node-removal equivalent
+    fixture.debugElement
+      .query(By.css('.invalid-select'))
+      .nativeElement.remove();
+    // eslint-disable-next-line no-restricted-syntax -- test DOM teardown; Renderer2 has no node-removal equivalent
+    fixture.debugElement.query(By.css('.text-input')).nativeElement.remove();
+
+    const validSelectInput: HTMLElement = fixture.debugElement.query(
+      By.css('.valid-select input')
+    ).nativeElement;
+    spyOn(validSelectInput, 'focus');
+
+    directive.focusFirstInvalidField();
+    tick();
+
+    expect(validSelectInput.focus).not.toHaveBeenCalled();
+  }));
+});

--- a/core-libs/storefront/layout/a11y/focus-first-invalid-field/focus-first-invalid-field.directive.ts
+++ b/core-libs/storefront/layout/a11y/focus-first-invalid-field/focus-first-invalid-field.directive.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Directive, ElementRef, inject } from '@angular/core';
+
+/**
+ * Focuses the first invalid form control within the host element.
+ *
+ * Meant to run after a failed submit, once the controls have been marked as
+ * touched (so the `ng-invalid` class is present). Unlike the data-driven
+ * autofocus (`cxFocus`), which always targets the first focusable field, a
+ * failed submit must land on the *specific* invalid one — hence the direct DOM
+ * query.
+ *
+ * This is useful when the host is wrapped in a `cxFocus` autofocus host with
+ * `tabindex="-1"`: in Safari a `<button>` doesn't receive focus on click, so
+ * focus falls to that host and its autofocus redirects to the first focusable
+ * field, regardless of which field is actually invalid. Deferring to a
+ * macrotask lets this run after that autofocus and land the user on the real
+ * error.
+ *
+ * @example
+ * ```html
+ * <form cxFocusFirstInvalidField>...</form>
+ * ```
+ */
+@Directive({
+  selector: '[cxFocusFirstInvalidField]',
+  standalone: true,
+})
+export class FocusFirstInvalidFieldDirective {
+  protected elementRef = inject(ElementRef);
+
+  focusFirstInvalidField(): void {
+    setTimeout(() => {
+      const host = this.elementRef.nativeElement as HTMLElement;
+      const firstInvalid = host.querySelector<HTMLElement>(
+        'input.ng-invalid, select.ng-invalid, textarea.ng-invalid, ng-select.ng-invalid'
+      );
+      if (!firstInvalid) {
+        return;
+      }
+      // `ng-select` isn't focusable itself; focus its inner input. Plain
+      // inputs/selects/textareas have no nested input, so we focus them directly.
+      const focusable =
+        firstInvalid.querySelector<HTMLElement>('input') ?? firstInvalid;
+      focusable.focus();
+    });
+  }
+}

--- a/core-libs/storefront/layout/a11y/focus-first-invalid-field/index.ts
+++ b/core-libs/storefront/layout/a11y/focus-first-invalid-field/index.ts
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './focus-first-invalid-field.directive';

--- a/core-libs/storefront/layout/a11y/index.ts
+++ b/core-libs/storefront/layout/a11y/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from './btn-like-link';
+export * from './focus-first-invalid-field';
 export * from './keyboard-focus/index';
 export * from './native-select-space';
 export * from './on-dom-change';

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.html
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.html
@@ -8,7 +8,7 @@
     novalidate
   >
     <ng-container *cxFeature="'a11yImproveCheckoutFocus'">
-      <div [cxFocus]="{ autofocus: true }">
+      <div [cxFocus]="focusConfig">
         <ng-container *ngTemplateOutlet="formBody" />
       </div>
     </ng-container>

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.html
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.html
@@ -1,259 +1,282 @@
 <!-- FORM -->
 <ng-container *ngIf="!loading; else spinner">
   <cx-form-required-legend />
-  <form (ngSubmit)="next()" [formGroup]="paymentForm">
-    <div class="row">
-      <div class="col-md-12 col-xl-10">
-        <div class="form-group" formGroupName="cardType">
-          <ng-container *ngIf="cardTypes$ | async as cardTypes">
-            <div *ngIf="cardTypes.length !== 0">
-              <label>
-                <span class="label-content required"
-                  >{{ 'paymentForm.paymentType' | cxTranslate }}
-                  <cx-form-required-asterisks />
-                </span>
-                <ng-select
-                  [inputAttrs]="{ required: 'true' }"
-                  [searchable]="true"
-                  [clearable]="false"
-                  [items]="cardTypes"
-                  bindLabel="name"
-                  bindValue="code"
-                  placeholder="{{ 'paymentForm.selectOne' | cxTranslate }}"
-                  formControlName="code"
-                  id="card-type-select"
-                  ariaLabelDropdown="{{
-                    'common.ngSelectDropdownOptionsList' | cxTranslate
-                  }}"
-                  [cxNgSelectA11y]="{
-                    ariaLabel: 'paymentForm.paymentType' | cxTranslate,
-                  }"
-                >
-                </ng-select>
+  <form
+    (ngSubmit)="next()"
+    [formGroup]="paymentForm"
+    cxFocusFirstInvalidField
+    novalidate
+  >
+    <ng-container *cxFeature="'a11yImproveCheckoutFocus'">
+      <div [cxFocus]="{ autofocus: true }">
+        <ng-container *ngTemplateOutlet="formBody" />
+      </div>
+    </ng-container>
+    <ng-container *cxFeature="'!a11yImproveCheckoutFocus'">
+      <ng-container *ngTemplateOutlet="formBody" />
+    </ng-container>
 
-                <cx-form-errors
-                  [translationParams]="{
-                    label: 'paymentForm.paymentType' | cxTranslate,
-                  }"
-                  [control]="paymentForm.get('cardType.code')"
-                ></cx-form-errors>
-              </label>
-            </div>
-          </ng-container>
-        </div>
+    <!--
+      Buttons are rendered outside the `cxFocus` autofocus host on purpose:
+      in Safari a `<button>` doesn't take focus on click, so if it lived inside
+      the host, focus would fall to the host and its autofocus would redirect to
+      the first field (card type select). Keeping them outside prevents that jump.
+    -->
+    <ng-container *ngTemplateOutlet="formButtons" />
 
-        <div class="form-group">
-          <label>
-            <span class="label-content"
-              >{{ 'paymentForm.accountHolderName.label' | cxTranslate }}
-              <cx-form-required-asterisks />
-            </span>
-            <input
-              required="true"
-              class="form-control"
-              type="text"
-              placeholder="{{
-                'paymentForm.accountHolderName.placeholder' | cxTranslate
-              }}"
-              formControlName="accountHolderName"
-              [attr.aria-invalid]="
-                paymentForm.get('accountHolderName')?.touched &&
-                paymentForm.get('accountHolderName')?.invalid
-              "
-              [attr.aria-errormessage]="'accountHolderNameError'"
-            />
+    <ng-template #formBody>
+      <div class="row">
+        <div class="col-md-12 col-xl-10">
+          <div class="form-group" formGroupName="cardType">
+            <ng-container *ngIf="cardTypes$ | async as cardTypes">
+              <div *ngIf="cardTypes.length !== 0">
+                <label>
+                  <span class="label-content required"
+                    >{{ 'paymentForm.paymentType' | cxTranslate }}
+                    <cx-form-required-asterisks />
+                  </span>
+                  <ng-select
+                    [inputAttrs]="{ required: 'true' }"
+                    [searchable]="true"
+                    [clearable]="false"
+                    [items]="cardTypes"
+                    bindLabel="name"
+                    bindValue="code"
+                    placeholder="{{ 'paymentForm.selectOne' | cxTranslate }}"
+                    formControlName="code"
+                    id="card-type-select"
+                    ariaLabelDropdown="{{
+                      'common.ngSelectDropdownOptionsList' | cxTranslate
+                    }}"
+                    [cxNgSelectA11y]="{
+                      ariaLabel: 'paymentForm.paymentType' | cxTranslate,
+                    }"
+                  />
 
-            <cx-form-errors
-              id="accountHolderNameError"
-              [translationParams]="{
-                label: 'paymentForm.accountHolderName.label' | cxTranslate,
-              }"
-              [control]="paymentForm.get('accountHolderName')"
-            ></cx-form-errors>
-          </label>
-        </div>
-
-        <div class="form-group">
-          <label>
-            <span class="label-content"
-              >{{ 'paymentForm.cardNumber' | cxTranslate }}
-              <cx-form-required-asterisks />
-            </span>
-            <input
-              required="true"
-              type="text"
-              class="form-control"
-              formControlName="cardNumber"
-              [attr.aria-invalid]="
-                paymentForm.get('cardNumber')?.touched &&
-                paymentForm.get('cardNumber')?.invalid
-              "
-              [attr.aria-errormessage]="'cardNumberError'"
-            />
-
-            <cx-form-errors
-              id="cardNumberError"
-              [translationParams]="{
-                label: 'paymentForm.cardNumber' | cxTranslate,
-              }"
-              [control]="paymentForm.get('cardNumber')"
-            ></cx-form-errors>
-          </label>
-        </div>
-
-        <div class="row">
-          <div class="form-group col-md-8">
-            <fieldset class="cx-payment-form-exp-date">
-              <legend class="label-content">
-                {{ 'paymentForm.expirationDate' | cxTranslate }}
-                <cx-form-required-asterisks />
-              </legend>
-              <label class="cx-payment-form-exp-date-wrapper">
-                <ng-select
-                  [inputAttrs]="{ required: 'true' }"
-                  [searchable]="true"
-                  [clearable]="false"
-                  [items]="months"
-                  placeholder="{{ 'paymentForm.monthMask' | cxTranslate }}"
-                  formControlName="expiryMonth"
-                  id="month-select"
-                  ariaLabelDropdown="{{
-                    'common.ngSelectDropdownOptionsList' | cxTranslate
-                  }}"
-                  [cxNgSelectA11y]="{
-                    ariaLabel:
-                      'paymentForm.expirationMonth'
-                      | cxTranslate
-                        : { selected: paymentForm.get('expiryMonth')?.value },
-                  }"
-                >
-                </ng-select>
-
-                <cx-form-errors
-                  [translationParams]="{
-                    label: 'paymentForm.expirationDate' | cxTranslate,
-                  }"
-                  [control]="paymentForm.get('expiryMonth')"
-                ></cx-form-errors>
-              </label>
-              <label class="cx-payment-form-exp-date-wrapper">
-                <ng-select
-                  [inputAttrs]="{ required: 'true' }"
-                  [searchable]="true"
-                  [clearable]="false"
-                  [items]="years"
-                  placeholder="{{ 'paymentForm.yearMask' | cxTranslate }}"
-                  id="year-select"
-                  ariaLabelDropdown="{{
-                    'common.ngSelectDropdownOptionsList' | cxTranslate
-                  }}"
-                  [cxNgSelectA11y]="{
-                    ariaLabel:
-                      'paymentForm.expirationYear'
-                      | cxTranslate
-                        : { selected: paymentForm.get('expiryYear')?.value },
-                  }"
-                  formControlName="expiryYear"
-                >
-                </ng-select>
-
-                <cx-form-errors
-                  [translationParams]="{
-                    label: 'paymentForm.expirationDate' | cxTranslate,
-                  }"
-                  [control]="paymentForm.get('expiryYear')"
-                ></cx-form-errors>
-              </label>
-            </fieldset>
+                  <cx-form-errors
+                    [translationParams]="{
+                      label: 'paymentForm.paymentType' | cxTranslate,
+                    }"
+                    [control]="paymentForm.get('cardType.code')"
+                  />
+                </label>
+              </div>
+            </ng-container>
           </div>
 
-          <div class="form-group col-md-4">
+          <div class="form-group">
             <label>
-              <span class="label-content">
-                {{ 'paymentForm.securityCode' | cxTranslate }}
+              <span class="label-content"
+                >{{ 'paymentForm.accountHolderName.label' | cxTranslate }}
                 <cx-form-required-asterisks />
-                <cx-icon
-                  [type]="iconTypes.INFO"
-                  class="cx-payment-form-tooltip"
-                  placement="right"
-                  title="{{ 'paymentForm.securityCodeTitle' | cxTranslate }}"
-                  alt=""
-                  [attr.aria-label]="
-                    'paymentForm.securityCodeTitle' | cxTranslate
-                  "
-                ></cx-icon>
+              </span>
+              <input
+                required="true"
+                class="form-control"
+                type="text"
+                placeholder="{{
+                  'paymentForm.accountHolderName.placeholder' | cxTranslate
+                }}"
+                formControlName="accountHolderName"
+                [attr.aria-invalid]="
+                  paymentForm.get('accountHolderName')?.touched &&
+                  paymentForm.get('accountHolderName')?.invalid
+                "
+                [attr.aria-errormessage]="'accountHolderNameError'"
+              />
+
+              <cx-form-errors
+                id="accountHolderNameError"
+                [translationParams]="{
+                  label: 'paymentForm.accountHolderName.label' | cxTranslate,
+                }"
+                [control]="paymentForm.get('accountHolderName')"
+              />
+            </label>
+          </div>
+
+          <div class="form-group">
+            <label>
+              <span class="label-content"
+                >{{ 'paymentForm.cardNumber' | cxTranslate }}
+                <cx-form-required-asterisks />
               </span>
               <input
                 required="true"
                 type="text"
                 class="form-control"
-                id="cVVNumber"
-                formControlName="cvn"
+                formControlName="cardNumber"
                 [attr.aria-invalid]="
-                  paymentForm.get('cvn')?.touched &&
-                  paymentForm.get('cvn')?.invalid
+                  paymentForm.get('cardNumber')?.touched &&
+                  paymentForm.get('cardNumber')?.invalid
                 "
-                [attr.aria-errormessage]="'cvnError'"
+                [attr.aria-errormessage]="'cardNumberError'"
               />
 
               <cx-form-errors
-                id="cvnError"
+                id="cardNumberError"
                 [translationParams]="{
-                  label: 'paymentForm.securityCode' | cxTranslate,
+                  label: 'paymentForm.cardNumber' | cxTranslate,
                 }"
-                [control]="paymentForm.get('cvn')"
-              ></cx-form-errors>
-            </label>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="setAsDefaultField">
-          <div class="form-check">
-            <label>
-              <input
-                type="checkbox"
-                class="form-check-input"
-                (change)="toggleDefaultPaymentMethod()"
+                [control]="paymentForm.get('cardNumber')"
               />
-              <span class="form-check-label">{{
-                'paymentForm.setAsDefault' | cxTranslate
-              }}</span>
             </label>
           </div>
+
+          <div class="row">
+            <div class="form-group col-md-8">
+              <fieldset class="cx-payment-form-exp-date">
+                <legend class="label-content">
+                  {{ 'paymentForm.expirationDate' | cxTranslate }}
+                  <cx-form-required-asterisks />
+                </legend>
+                <label class="cx-payment-form-exp-date-wrapper">
+                  <ng-select
+                    [inputAttrs]="{ required: 'true' }"
+                    [searchable]="true"
+                    [clearable]="false"
+                    [items]="months"
+                    placeholder="{{ 'paymentForm.monthMask' | cxTranslate }}"
+                    formControlName="expiryMonth"
+                    id="month-select"
+                    ariaLabelDropdown="{{
+                      'common.ngSelectDropdownOptionsList' | cxTranslate
+                    }}"
+                    [cxNgSelectA11y]="{
+                      ariaLabel:
+                        'paymentForm.expirationMonth'
+                        | cxTranslate
+                          : { selected: paymentForm.get('expiryMonth')?.value },
+                    }"
+                  />
+
+                  <cx-form-errors
+                    [translationParams]="{
+                      label: 'paymentForm.expirationDate' | cxTranslate,
+                    }"
+                    [control]="paymentForm.get('expiryMonth')"
+                  />
+                </label>
+                <label class="cx-payment-form-exp-date-wrapper">
+                  <ng-select
+                    [inputAttrs]="{ required: 'true' }"
+                    [searchable]="true"
+                    [clearable]="false"
+                    [items]="years"
+                    placeholder="{{ 'paymentForm.yearMask' | cxTranslate }}"
+                    id="year-select"
+                    ariaLabelDropdown="{{
+                      'common.ngSelectDropdownOptionsList' | cxTranslate
+                    }}"
+                    [cxNgSelectA11y]="{
+                      ariaLabel:
+                        'paymentForm.expirationYear'
+                        | cxTranslate
+                          : { selected: paymentForm.get('expiryYear')?.value },
+                    }"
+                    formControlName="expiryYear"
+                  />
+
+                  <cx-form-errors
+                    [translationParams]="{
+                      label: 'paymentForm.expirationDate' | cxTranslate,
+                    }"
+                    [control]="paymentForm.get('expiryYear')"
+                  />
+                </label>
+              </fieldset>
+            </div>
+
+            <div class="form-group col-md-4">
+              <label>
+                <span class="label-content">
+                  {{ 'paymentForm.securityCode' | cxTranslate }}
+                  <cx-form-required-asterisks />
+                  <cx-icon
+                    [type]="iconTypes.INFO"
+                    class="cx-payment-form-tooltip"
+                    placement="right"
+                    title="{{ 'paymentForm.securityCodeTitle' | cxTranslate }}"
+                    alt=""
+                    [attr.aria-label]="
+                      'paymentForm.securityCodeTitle' | cxTranslate
+                    "
+                  />
+                </span>
+                <input
+                  required="true"
+                  type="text"
+                  class="form-control"
+                  id="cVVNumber"
+                  formControlName="cvn"
+                  [attr.aria-invalid]="
+                    paymentForm.get('cvn')?.touched &&
+                    paymentForm.get('cvn')?.invalid
+                  "
+                  [attr.aria-errormessage]="'cvnError'"
+                />
+
+                <cx-form-errors
+                  id="cvnError"
+                  [translationParams]="{
+                    label: 'paymentForm.securityCode' | cxTranslate,
+                  }"
+                  [control]="paymentForm.get('cvn')"
+                />
+              </label>
+            </div>
+          </div>
+
+          <div class="form-group" *ngIf="setAsDefaultField">
+            <div class="form-check">
+              <label>
+                <input
+                  type="checkbox"
+                  class="form-check-input"
+                  (change)="toggleDefaultPaymentMethod()"
+                />
+                <span class="form-check-label">{{
+                  'paymentForm.setAsDefault' | cxTranslate
+                }}</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- BILLING -->
+          <cx-checkout-billing-address-form />
         </div>
+      </div>
+    </ng-template>
 
-        <!-- BILLING -->
-        <cx-checkout-billing-address-form></cx-checkout-billing-address-form>
+    <ng-template #formButtons>
+      <!-- BUTTON SECTION -->
+      <div class="cx-checkout-btns row">
+        <div class="col-md-12 col-lg-6">
+          <button
+            *ngIf="paymentMethodsCount === 0"
+            class="btn btn-block btn-secondary"
+            (click)="back()"
+          >
+            {{ 'common.back' | cxTranslate }}
+          </button>
+          <button
+            *ngIf="paymentMethodsCount > 0"
+            class="btn btn-block btn-secondary"
+            (click)="close()"
+          >
+            {{ 'paymentForm.changePayment' | cxTranslate }}
+          </button>
+        </div>
+        <div class="col-md-12 col-lg-6">
+          <button class="btn btn-block btn-primary" type="submit">
+            {{ 'common.continue' | cxTranslate }}
+          </button>
+        </div>
       </div>
-    </div>
-
-    <!-- BUTTON SECTION -->
-    <div class="cx-checkout-btns row">
-      <div class="col-md-12 col-lg-6">
-        <button
-          *ngIf="paymentMethodsCount === 0"
-          class="btn btn-block btn-secondary"
-          (click)="back()"
-        >
-          {{ 'common.back' | cxTranslate }}
-        </button>
-        <button
-          *ngIf="paymentMethodsCount > 0"
-          class="btn btn-block btn-secondary"
-          (click)="close()"
-        >
-          {{ 'paymentForm.changePayment' | cxTranslate }}
-        </button>
-      </div>
-      <div class="col-md-12 col-lg-6">
-        <button class="btn btn-block btn-primary" type="submit">
-          {{ 'common.continue' | cxTranslate }}
-        </button>
-      </div>
-    </div>
+    </ng-template>
   </form>
 </ng-container>
 
 <ng-template #spinner>
-  <cx-spinner></cx-spinner>
+  <cx-spinner />
 </ng-template>

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
@@ -258,7 +258,7 @@ describe('CheckoutPaymentFormComponent', () => {
           provide: CheckoutBillingAddressFormService,
           useClass: MockCheckoutBillingAddressFormService,
         },
-        provideMockFeatureToggles({ a11yPaymentFormFocus: true }),
+        provideMockFeatureToggles({ a11yImproveCheckoutFocus: true }),
       ],
     })
       .overrideComponent(CheckoutPaymentFormComponent, {
@@ -361,7 +361,7 @@ describe('CheckoutPaymentFormComponent', () => {
     expect(component.closeForm.emit).toHaveBeenCalled();
   });
 
-  describe('a11yPaymentFormFocus', () => {
+  describe('a11yImproveCheckoutFocus', () => {
     let featureTogglesController: MockFeatureTogglesController;
 
     const getFocusFirstInvalidFieldDirective =
@@ -376,7 +376,7 @@ describe('CheckoutPaymentFormComponent', () => {
     });
 
     it('should focus the first invalid field on invalid submit when toggle is on', () => {
-      featureTogglesController.set('a11yPaymentFormFocus', true);
+      featureTogglesController.set('a11yImproveCheckoutFocus', true);
       const directive = getFocusFirstInvalidFieldDirective();
       spyOn(directive, 'focusFirstInvalidField');
 
@@ -386,7 +386,7 @@ describe('CheckoutPaymentFormComponent', () => {
     });
 
     it('should not focus the first invalid field on invalid submit when toggle is off', () => {
-      featureTogglesController.set('a11yPaymentFormFocus', false);
+      featureTogglesController.set('a11yImproveCheckoutFocus', false);
       const directive = getFocusFirstInvalidFieldDirective();
       spyOn(directive, 'focusFirstInvalidField');
 

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
@@ -1,5 +1,16 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  Input,
+} from '@angular/core';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+  waitForAsync,
+} from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NgSelectModule } from '@ng-select/ng-select';
@@ -13,7 +24,6 @@ import {
   CardType,
   Country,
   CxDatePipe,
-  FeatureDirective,
   GlobalMessageService,
   I18nTestingModule,
   MockDatePipe,
@@ -25,6 +35,7 @@ import {
 } from '@spartacus/core';
 import {
   CardComponent,
+  FocusDirective,
   FocusFirstInvalidFieldDirective,
   FormErrorsModule,
   ICON_TYPE,
@@ -37,7 +48,6 @@ import {
   MockFeatureTogglesController,
   provideMockFeatureToggles,
 } from 'core-libs/core/src/features-config/feature-toggles/testing';
-import { MockFeatureDirective } from 'core-libs/storefront/shared/test/mock-feature-directive';
 import { EMPTY, Observable, of } from 'rxjs';
 import {
   CheckoutBillingAddressFormComponent,
@@ -270,7 +280,6 @@ describe('CheckoutPaymentFormComponent', () => {
             CheckoutBillingAddressFormComponent,
             IconComponent,
             SpinnerComponent,
-            FeatureDirective,
           ],
         },
         add: {
@@ -282,7 +291,6 @@ describe('CheckoutPaymentFormComponent', () => {
             MockBillingAddressFormComponent,
             MockCxIconComponent,
             MockSpinnerComponent,
-            MockFeatureDirective,
           ],
         },
       })
@@ -364,6 +372,9 @@ describe('CheckoutPaymentFormComponent', () => {
   describe('a11yImproveCheckoutFocus', () => {
     let featureTogglesController: MockFeatureTogglesController;
 
+    const getFocusForm = (): DebugElement =>
+      fixture.debugElement.query(By.directive(FocusDirective));
+
     const getFocusFirstInvalidFieldDirective =
       (): FocusFirstInvalidFieldDirective =>
         fixture.debugElement
@@ -372,11 +383,48 @@ describe('CheckoutPaymentFormComponent', () => {
 
     beforeEach(() => {
       featureTogglesController = TestBed.inject(MockFeatureTogglesController);
+    });
+
+    it('should apply cxFocus to the form when a11yImproveCheckoutFocus is true', () => {
+      featureTogglesController.set('a11yImproveCheckoutFocus', true);
       fixture.detectChanges();
+
+      expect(getFocusForm()).toBeTruthy();
+    });
+
+    it('should not apply cxFocus to the form when a11yImproveCheckoutFocus is false', () => {
+      featureTogglesController.set('a11yImproveCheckoutFocus', false);
+      fixture.detectChanges();
+
+      expect(getFocusForm()).toBeNull();
+    });
+
+    it('should render the action buttons outside the cxFocus host', () => {
+      featureTogglesController.set('a11yImproveCheckoutFocus', true);
+      mockCheckoutPaymentService.getPaymentCardTypes =
+        createSpy().and.returnValue(of(mockCardTypes));
+      component.paymentMethodsCount = 0;
+      fixture.detectChanges();
+
+      const focusHost: HTMLElement = getFocusForm().nativeElement;
+      const submitBtn = fixture.debugElement.query(
+        By.css('.btn-primary')
+      )?.nativeElement;
+      const backBtn = fixture.debugElement.query(
+        By.css('.btn-secondary')
+      )?.nativeElement;
+
+      expect(submitBtn).toBeTruthy();
+      expect(backBtn).toBeTruthy();
+      // In Safari a `<button>` doesn't take focus on click; keeping the buttons
+      // out of the autofocus host prevents focus from jumping to the first field.
+      expect(focusHost.contains(submitBtn)).toBe(false);
+      expect(focusHost.contains(backBtn)).toBe(false);
     });
 
     it('should focus the first invalid field on invalid submit when toggle is on', () => {
       featureTogglesController.set('a11yImproveCheckoutFocus', true);
+      fixture.detectChanges();
       const directive = getFocusFirstInvalidFieldDirective();
       spyOn(directive, 'focusFirstInvalidField');
 
@@ -387,6 +435,7 @@ describe('CheckoutPaymentFormComponent', () => {
 
     it('should not focus the first invalid field on invalid submit when toggle is off', () => {
       featureTogglesController.set('a11yImproveCheckoutFocus', false);
+      fixture.detectChanges();
       const directive = getFocusFirstInvalidFieldDirective();
       spyOn(directive, 'focusFirstInvalidField');
 
@@ -394,6 +443,67 @@ describe('CheckoutPaymentFormComponent', () => {
 
       expect(directive.focusFirstInvalidField).not.toHaveBeenCalled();
     });
+
+    it('should start with autofocus disabled', () => {
+      expect(component.focusConfig).toEqual({ autofocus: false });
+    });
+
+    it('should enable autofocus once the card type data has loaded', fakeAsync(() => {
+      featureTogglesController.set('a11yImproveCheckoutFocus', true);
+      mockCheckoutPaymentService.getPaymentCardTypes =
+        createSpy().and.returnValue(of(mockCardTypes));
+
+      component.ngOnInit();
+      tick(); // flush the deferred macrotask
+
+      expect(component.focusConfig.autofocus).toBe(true);
+      // a `refreshFocus` token is set to re-trigger the directive's focus logic
+      expect(component.focusConfig.refreshFocus).toBeTruthy();
+    }));
+
+    it('should not steal focus when the user has already focused a form field', fakeAsync(() => {
+      featureTogglesController.set('a11yImproveCheckoutFocus', true);
+      mockCheckoutPaymentService.getPaymentCardTypes =
+        createSpy().and.returnValue(of(mockCardTypes));
+
+      // Simulate the user having engaged with the form before the (deferred)
+      // card type data arrives — the focus refresh must not yank focus back.
+      const host: HTMLElement = fixture.nativeElement;
+      const input = document.createElement('input');
+      host.appendChild(input);
+      document.body.appendChild(host);
+      input.focus();
+      expect(document.activeElement).toBe(input);
+
+      component.ngOnInit();
+      tick();
+
+      expect(component.focusConfig).toEqual({ autofocus: false });
+
+      document.body.removeChild(host);
+    }));
+
+    it('should not enable autofocus while the card type list is empty', fakeAsync(() => {
+      featureTogglesController.set('a11yImproveCheckoutFocus', true);
+      mockCheckoutPaymentService.getPaymentCardTypes =
+        createSpy().and.returnValue(of([]));
+
+      component.ngOnInit();
+      tick();
+
+      expect(component.focusConfig).toEqual({ autofocus: false });
+    }));
+
+    it('should not enable autofocus when the toggle is off', fakeAsync(() => {
+      featureTogglesController.set('a11yImproveCheckoutFocus', false);
+      mockCheckoutPaymentService.getPaymentCardTypes =
+        createSpy().and.returnValue(of(mockCardTypes));
+
+      component.ngOnInit();
+      tick();
+
+      expect(component.focusConfig).toEqual({ autofocus: false });
+    }));
   });
 
   describe('UI continue button', () => {

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NgSelectModule } from '@ng-select/ng-select';
+
 import {
   CheckoutDeliveryAddressFacade,
   CheckoutPaymentFacade,
@@ -24,6 +25,7 @@ import {
 } from '@spartacus/core';
 import {
   CardComponent,
+  FocusFirstInvalidFieldDirective,
   FormErrorsModule,
   ICON_TYPE,
   IconComponent,
@@ -31,6 +33,10 @@ import {
   NgSelectA11yModule,
   SpinnerComponent,
 } from '@spartacus/storefront';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { MockFeatureDirective } from 'core-libs/storefront/shared/test/mock-feature-directive';
 import { EMPTY, Observable, of } from 'rxjs';
 import {
@@ -252,6 +258,7 @@ describe('CheckoutPaymentFormComponent', () => {
           provide: CheckoutBillingAddressFormService,
           useClass: MockCheckoutBillingAddressFormService,
         },
+        provideMockFeatureToggles({ a11yPaymentFormFocus: true }),
       ],
     })
       .overrideComponent(CheckoutPaymentFormComponent, {
@@ -354,6 +361,41 @@ describe('CheckoutPaymentFormComponent', () => {
     expect(component.closeForm.emit).toHaveBeenCalled();
   });
 
+  describe('a11yPaymentFormFocus', () => {
+    let featureTogglesController: MockFeatureTogglesController;
+
+    const getFocusFirstInvalidFieldDirective =
+      (): FocusFirstInvalidFieldDirective =>
+        fixture.debugElement
+          .query(By.directive(FocusFirstInvalidFieldDirective))
+          .injector.get(FocusFirstInvalidFieldDirective);
+
+    beforeEach(() => {
+      featureTogglesController = TestBed.inject(MockFeatureTogglesController);
+      fixture.detectChanges();
+    });
+
+    it('should focus the first invalid field on invalid submit when toggle is on', () => {
+      featureTogglesController.set('a11yPaymentFormFocus', true);
+      const directive = getFocusFirstInvalidFieldDirective();
+      spyOn(directive, 'focusFirstInvalidField');
+
+      component.next(); // form is invalid by default
+
+      expect(directive.focusFirstInvalidField).toHaveBeenCalled();
+    });
+
+    it('should not focus the first invalid field on invalid submit when toggle is off', () => {
+      featureTogglesController.set('a11yPaymentFormFocus', false);
+      const directive = getFocusFirstInvalidFieldDirective();
+      spyOn(directive, 'focusFirstInvalidField');
+
+      component.next(); // form is invalid by default
+
+      expect(directive.focusFirstInvalidField).not.toHaveBeenCalled();
+    });
+  });
+
   describe('UI continue button', () => {
     const getContinueBtn = () =>
       fixture.debugElement.query(By.css('.btn-primary'));
@@ -396,9 +438,7 @@ describe('CheckoutPaymentFormComponent', () => {
       // set values for payment form
       controls.payment['accountHolderName'].setValue('test accountHolderName');
       controls.payment['cardNumber'].setValue('test cardNumber');
-      controls.payment.cardType['controls'].code.setValue(
-        'test card type code'
-      );
+      controls.payment.cardType.get('code')?.setValue('test card type code');
       controls.payment['expiryMonth'].setValue('test expiryMonth');
       controls.payment['expiryYear'].setValue('test expiryYear');
       controls.payment['cvn'].setValue('test cvn');

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
@@ -214,7 +214,7 @@ export class CheckoutPaymentFormComponent implements OnInit {
         this.billingAddressService.markAllAsTouched();
       }
 
-      if (this.featureToggles.a11yPaymentFormFocus) {
+      if (this.featureToggles.a11yImproveCheckoutFocus) {
         this.firstInvalidFieldFocus?.focusFirstInvalidField();
       }
     }

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AsyncPipe, NgIf } from '@angular/common';
+import { AsyncPipe, NgIf, NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -12,6 +12,7 @@ import {
   Input,
   OnInit,
   Output,
+  ViewChild,
   inject,
 } from '@angular/core';
 import {
@@ -28,6 +29,8 @@ import {
 } from '@spartacus/checkout/base/root';
 import {
   CardType,
+  FeatureDirective,
+  FeatureToggles,
   GlobalMessageService,
   GlobalMessageType,
   PaymentDetails,
@@ -37,6 +40,8 @@ import {
   UserPaymentService,
 } from '@spartacus/core';
 import {
+  FocusDirective,
+  FocusFirstInvalidFieldDirective,
   FormErrorsComponent,
   FormRequiredAsterisksComponent,
   FormRequiredLegendComponent,
@@ -56,12 +61,16 @@ import { CheckoutBillingAddressFormComponent } from '../../checkout-billing-addr
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     NgIf,
+    NgTemplateOutlet,
+    FeatureDirective,
+    FocusDirective,
     FormRequiredLegendComponent,
     FormsModule,
     ReactiveFormsModule,
     FormRequiredAsterisksComponent,
     NgSelectComponent,
     NgSelectA11yDirective,
+    FocusFirstInvalidFieldDirective,
     FormErrorsComponent,
     IconComponent,
     CheckoutBillingAddressFormComponent,
@@ -99,6 +108,9 @@ export class CheckoutPaymentFormComponent implements OnInit {
   @Output()
   setPaymentDetails = new EventEmitter<any>();
 
+  @ViewChild(FocusFirstInvalidFieldDirective)
+  protected firstInvalidFieldFocus?: FocusFirstInvalidFieldDirective;
+
   paymentForm: UntypedFormGroup = this.fb.group({
     cardType: this.fb.group({
       code: [null, Validators.required],
@@ -112,6 +124,7 @@ export class CheckoutPaymentFormComponent implements OnInit {
   });
 
   protected billingAddressService = inject(CheckoutBillingAddressFormService);
+  private featureToggles = inject(FeatureToggles);
   constructor(
     protected checkoutPaymentFacade: CheckoutPaymentFacade,
     protected checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
@@ -199,6 +212,10 @@ export class CheckoutPaymentFormComponent implements OnInit {
 
       if (!sameAsDeliveryAddress) {
         this.billingAddressService.markAllAsTouched();
+      }
+
+      if (this.featureToggles.a11yPaymentFormFocus) {
+        this.firstInvalidFieldFocus?.focusFirstInvalidField();
       }
     }
   }

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.ts
@@ -7,9 +7,12 @@
 import { AsyncPipe, NgIf, NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
   Input,
+  OnDestroy,
   OnInit,
   Output,
   ViewChild,
@@ -40,6 +43,7 @@ import {
   UserPaymentService,
 } from '@spartacus/core';
 import {
+  FocusConfig,
   FocusDirective,
   FocusFirstInvalidFieldDirective,
   FormErrorsComponent,
@@ -51,7 +55,8 @@ import {
   NgSelectA11yDirective,
   SpinnerComponent,
 } from '@spartacus/storefront';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
+import { filter, take } from 'rxjs/operators';
 import { CheckoutBillingAddressFormService } from '../../checkout-billing-address';
 import { CheckoutBillingAddressFormComponent } from '../../checkout-billing-address/checkout-billing-address-form.component';
 
@@ -79,8 +84,21 @@ import { CheckoutBillingAddressFormComponent } from '../../checkout-billing-addr
     TranslatePipe,
   ],
 })
-export class CheckoutPaymentFormComponent implements OnInit {
+export class CheckoutPaymentFormComponent implements OnInit, OnDestroy {
   iconTypes = ICON_TYPE;
+
+  /**
+   * Drives the `cxFocus` autofocus host wrapping the form body. Autofocus starts
+   * disabled and is enabled (with a `refreshFocus` token to re-trigger the
+   * directive) only once the card type data has loaded, so focus lands on the
+   * card type select rather than whichever field wins the async render race.
+   *
+   * Keeping the host inside the template (rather than on the component element)
+   * also lets the action buttons render outside it: in Safari a `<button>`
+   * doesn't take focus on click, so if it lived inside the host, focus would
+   * fall to the host and its autofocus would redirect to the first field.
+   */
+  focusConfig: FocusConfig = { autofocus: false };
 
   months: string[] = [];
   years: number[] = [];
@@ -125,6 +143,9 @@ export class CheckoutPaymentFormComponent implements OnInit {
 
   protected billingAddressService = inject(CheckoutBillingAddressFormService);
   private featureToggles = inject(FeatureToggles);
+  protected cdr = inject(ChangeDetectorRef);
+  protected elementRef = inject(ElementRef);
+  protected subscription = new Subscription();
   constructor(
     protected checkoutPaymentFacade: CheckoutPaymentFacade,
     protected checkoutDeliveryAddressFacade: CheckoutDeliveryAddressFacade,
@@ -148,6 +169,42 @@ export class CheckoutPaymentFormComponent implements OnInit {
     this.expMonthAndYear();
 
     this.cardTypes$ = this.checkoutPaymentFacade.getPaymentCardTypes();
+
+    // Initial focus (form load): enable autofocus only once the card type data
+    // has loaded, so the `cxFocus` host focuses the card type select instead of
+    // whichever field wins the async render race. This is intentionally
+    // data-driven rather than DOM-driven; the post-submit counterpart,
+    // `focusFirstInvalidField()`, has to query the DOM instead because it needs
+    // the *specific* invalid field, not just the first.
+    if (this.featureToggles.a11yImproveCheckoutFocus) {
+      this.subscription.add(
+        this.cardTypes$
+          .pipe(
+            filter((cardTypes) => !!cardTypes?.length),
+            take(1)
+          )
+          .subscribe(() => {
+            // The emission and the change detection that renders the card type
+            // select happen in the same tick; defer to a macrotask so the
+            // select exists in the DOM before `refreshFocus` re-triggers the
+            // directive's focus logic and picks the first focusable field.
+            setTimeout(() => {
+              // Don't steal focus if the user has already engaged with the form.
+              const active = document.activeElement;
+              const host = this.elementRef.nativeElement as HTMLElement;
+              if (active && active !== document.body && host.contains(active)) {
+                return;
+              }
+              this.focusConfig = { autofocus: true, refreshFocus: {} };
+              this.cdr.markForCheck();
+            });
+          })
+      );
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 
   expMonthAndYear(): void {

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.html
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-method.component.html
@@ -85,18 +85,6 @@
 
     <ng-template #newPaymentForm>
       <cx-payment-form
-        *cxFeature="'a11yImproveCheckoutFocus'"
-        [cxFocus]="{ autofocus: true }"
-        (setPaymentDetails)="setPaymentDetails($event)"
-        (closeForm)="hideNewPaymentForm()"
-        (goBack)="back()"
-        [paymentMethodsCount]="cards?.length || 0"
-        [setAsDefaultField]="!isGuestCheckout && !!cards?.length"
-        [loading]="(isUpdating$ | async) ?? false"
-        [paymentDetails]="paymentDetails"
-      />
-      <cx-payment-form
-        *cxFeature="'!a11yImproveCheckoutFocus'"
         (setPaymentDetails)="setPaymentDetails($event)"
         (closeForm)="hideNewPaymentForm()"
         (goBack)="back()"

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
@@ -5,12 +5,12 @@
   cxFocusFirstInvalidField
   novalidate
 >
-  <ng-container *cxFeature="'a11yAddressFormInitialFocus'">
+  <ng-container *cxFeature="'a11yImproveAddressFormFocus'">
     <div [cxFocus]="focusConfig">
       <ng-container *ngTemplateOutlet="formBody" />
     </div>
   </ng-container>
-  <ng-container *cxFeature="'!a11yAddressFormInitialFocus'">
+  <ng-container *cxFeature="'!a11yImproveAddressFormFocus'">
     <ng-container *ngTemplateOutlet="formBody" />
   </ng-container>
 

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
@@ -1,7 +1,7 @@
 <cx-form-required-legend />
 <form (ngSubmit)="verifyAddress()" [formGroup]="addressForm" novalidate>
   <ng-container *cxFeature="'a11yAddressFormInitialFocus'">
-    <div [cxFocus]="{ autofocus: true }">
+    <div [cxFocus]="focusConfig">
       <ng-container *ngTemplateOutlet="formBody" />
     </div>
   </ng-container>

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
@@ -9,6 +9,14 @@
     <ng-container *ngTemplateOutlet="formBody" />
   </ng-container>
 
+  <!--
+    Buttons are rendered outside the `cxFocus` autofocus host on purpose:
+    in Safari a `<button>` doesn't take focus on click, so if it lived inside
+    the host, focus would fall to the host and its autofocus would redirect to
+    the first field (country select). Keeping them outside prevents that jump.
+  -->
+  <ng-container *ngTemplateOutlet="formButtons" />
+
   <ng-template #formBody>
     <div class="form-group" formGroupName="country">
       <ng-container *ngIf="countries$ | async as countries">
@@ -449,6 +457,9 @@
         </label>
       </div>
     </div>
+  </ng-template>
+
+  <ng-template #formButtons>
     <div class="cx-address-form-btns">
       <div class="row">
         <div class="col-md-13 col-lg-6" *ngIf="showCancelBtn">

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
@@ -1,5 +1,5 @@
 <cx-form-required-legend />
-<form (ngSubmit)="verifyAddress()" [formGroup]="addressForm">
+<form (ngSubmit)="verifyAddress()" [formGroup]="addressForm" novalidate>
   <ng-container *cxFeature="'a11yAddressFormInitialFocus'">
     <div [cxFocus]="{ autofocus: true }">
       <ng-container *ngTemplateOutlet="formBody" />

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.html
@@ -1,5 +1,10 @@
 <cx-form-required-legend />
-<form (ngSubmit)="verifyAddress()" [formGroup]="addressForm" novalidate>
+<form
+  (ngSubmit)="verifyAddress()"
+  [formGroup]="addressForm"
+  cxFocusFirstInvalidField
+  novalidate
+>
   <ng-container *cxFeature="'a11yAddressFormInitialFocus'">
     <div [cxFocus]="focusConfig">
       <ng-container *ngTemplateOutlet="formBody" />

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
@@ -670,5 +670,87 @@ describe('AddressFormComponent', () => {
 
       expect(getFocusForm()).toBeNull();
     });
+
+    it('should render the action buttons outside the cxFocus host', () => {
+      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      fixture.detectChanges();
+
+      const focusHost: HTMLElement = getFocusForm().nativeElement;
+      const submitBtn = fixture.debugElement.query(
+        By.css('.btn-primary')
+      )?.nativeElement;
+      const backBtn = fixture.debugElement.query(
+        By.css('.btn-secondary')
+      )?.nativeElement;
+
+      expect(submitBtn).toBeTruthy();
+      expect(backBtn).toBeTruthy();
+      // In Safari a `<button>` doesn't take focus on click; keeping the buttons
+      // out of the autofocus host prevents focus from jumping to the first field.
+      expect(focusHost.contains(submitBtn)).toBe(false);
+      expect(focusHost.contains(backBtn)).toBe(false);
+    });
+
+    it('should focus the first invalid field on invalid submit when toggle is on', () => {
+      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      spyOn(component as any, 'focusFirstInvalidField');
+
+      component.verifyAddress(); // form is invalid by default
+
+      expect(component['focusFirstInvalidField']).toHaveBeenCalled();
+    });
+
+    it('should not focus the first invalid field on invalid submit when toggle is off', () => {
+      featureTogglesController.set('a11yAddressFormInitialFocus', false);
+      spyOn(component as any, 'focusFirstInvalidField');
+
+      component.verifyAddress(); // form is invalid by default
+
+      expect(component['focusFirstInvalidField']).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('focusFirstInvalidField', () => {
+    beforeEach(() => {
+      spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(
+        of(mockCountries)
+      );
+      spyOn(userProfileFacade, 'getTitles').and.returnValue(of([]));
+      spyOn(userAddressService, 'getRegions').and.returnValue(of([]));
+      component.ngOnInit();
+      fixture.detectChanges();
+    });
+
+    it('should focus the inner input of the invalid country ng-select', (done) => {
+      const countryInput: HTMLElement = fixture.debugElement.query(
+        By.css('ng-select.country-select input')
+      ).nativeElement;
+      spyOn(countryInput, 'focus');
+
+      component['focusFirstInvalidField']();
+
+      // the method defers focus to a macrotask, so assert after it runs
+      setTimeout(() => {
+        expect(countryInput.focus).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('should focus the first invalid text input when preceding selects are valid', (done) => {
+      (controls.country as UntypedFormGroup).controls['isocode'].setValue('AD');
+      fixture.detectChanges();
+
+      const firstNameInput: HTMLElement = fixture.debugElement.query(
+        By.css('[formcontrolname=firstName]')
+      ).nativeElement;
+      spyOn(firstNameInput, 'focus');
+
+      component['focusFirstInvalidField']();
+
+      setTimeout(() => {
+        expect(firstNameInput.focus).toHaveBeenCalled();
+        done();
+      });
+    });
   });
 });

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
@@ -29,6 +29,7 @@ import {
 } from '@spartacus/core';
 import {
   FocusDirective,
+  FocusFirstInvalidFieldDirective,
   FormErrorsModule,
   LaunchDialogService,
 } from '@spartacus/storefront';
@@ -697,22 +698,32 @@ describe('AddressFormComponent', () => {
       expect(focusHost.contains(backBtn)).toBe(false);
     });
 
+    const getFocusFirstInvalidFieldDirective =
+      (): FocusFirstInvalidFieldDirective =>
+        fixture.debugElement
+          .query(By.directive(FocusFirstInvalidFieldDirective))
+          .injector.get(FocusFirstInvalidFieldDirective);
+
     it('should focus the first invalid field on invalid submit when toggle is on', () => {
       featureTogglesController.set('a11yAddressFormInitialFocus', true);
-      spyOn(component as any, 'focusFirstInvalidField');
+      fixture.detectChanges();
+      const directive = getFocusFirstInvalidFieldDirective();
+      spyOn(directive, 'focusFirstInvalidField');
 
       component.verifyAddress(); // form is invalid by default
 
-      expect(component['focusFirstInvalidField']).toHaveBeenCalled();
+      expect(directive.focusFirstInvalidField).toHaveBeenCalled();
     });
 
     it('should not focus the first invalid field on invalid submit when toggle is off', () => {
       featureTogglesController.set('a11yAddressFormInitialFocus', false);
-      spyOn(component as any, 'focusFirstInvalidField');
+      fixture.detectChanges();
+      const directive = getFocusFirstInvalidFieldDirective();
+      spyOn(directive, 'focusFirstInvalidField');
 
       component.verifyAddress(); // form is invalid by default
 
-      expect(component['focusFirstInvalidField']).not.toHaveBeenCalled();
+      expect(directive.focusFirstInvalidField).not.toHaveBeenCalled();
     });
 
     it('should start with autofocus disabled', () => {
@@ -780,6 +791,8 @@ describe('AddressFormComponent', () => {
   });
 
   describe('focusFirstInvalidField', () => {
+    let focusFirstInvalidFieldDirective: FocusFirstInvalidFieldDirective;
+
     beforeEach(() => {
       spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(
         of(mockCountries)
@@ -788,6 +801,9 @@ describe('AddressFormComponent', () => {
       spyOn(userAddressService, 'getRegions').and.returnValue(of([]));
       component.ngOnInit();
       fixture.detectChanges();
+      focusFirstInvalidFieldDirective = fixture.debugElement
+        .query(By.directive(FocusFirstInvalidFieldDirective))
+        .injector.get(FocusFirstInvalidFieldDirective);
     });
 
     it('should focus the inner input of the invalid country ng-select', (done) => {
@@ -796,9 +812,9 @@ describe('AddressFormComponent', () => {
       ).nativeElement;
       spyOn(countryInput, 'focus');
 
-      component['focusFirstInvalidField']();
+      focusFirstInvalidFieldDirective.focusFirstInvalidField();
 
-      // the method defers focus to a macrotask, so assert after it runs
+      // the directive defers focus to a macrotask, so assert after it runs
       setTimeout(() => {
         expect(countryInput.focus).toHaveBeenCalled();
         done();
@@ -814,7 +830,7 @@ describe('AddressFormComponent', () => {
       ).nativeElement;
       spyOn(firstNameInput, 'focus');
 
-      component['focusFirstInvalidField']();
+      focusFirstInvalidFieldDirective.focusFirstInvalidField();
 
       setTimeout(() => {
         expect(firstNameInput.focus).toHaveBeenCalled();

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
@@ -4,7 +4,13 @@ import {
   Directive,
   Input,
 } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+  waitForAsync,
+} from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NgSelectModule } from '@ng-select/ng-select';
@@ -708,6 +714,69 @@ describe('AddressFormComponent', () => {
 
       expect(component['focusFirstInvalidField']).not.toHaveBeenCalled();
     });
+
+    it('should start with autofocus disabled', () => {
+      expect(component.focusConfig).toEqual({ autofocus: false });
+    });
+
+    it('should enable autofocus once the country data has loaded', fakeAsync(() => {
+      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(
+        of(mockCountries)
+      );
+
+      component.ngOnInit();
+      tick(); // flush the deferred macrotask
+
+      expect(component.focusConfig.autofocus).toBe(true);
+      // a `refreshFocus` token is set to re-trigger the directive's focus logic
+      expect(component.focusConfig.refreshFocus).toBeTruthy();
+    }));
+
+    it('should not steal focus when the user has already focused a form field', fakeAsync(() => {
+      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(
+        of(mockCountries)
+      );
+
+      // Simulate the user having engaged with the form before the (deferred)
+      // country data arrives — the focus refresh must not yank focus back.
+      const host: HTMLElement = fixture.nativeElement;
+      const input = document.createElement('input');
+      host.appendChild(input);
+      document.body.appendChild(host);
+      input.focus();
+      expect(document.activeElement).toBe(input);
+
+      component.ngOnInit();
+      tick();
+
+      expect(component.focusConfig).toEqual({ autofocus: false });
+
+      document.body.removeChild(host);
+    }));
+
+    it('should not enable autofocus while the country list is empty', fakeAsync(() => {
+      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(of([]));
+
+      component.ngOnInit();
+      tick();
+
+      expect(component.focusConfig).toEqual({ autofocus: false });
+    }));
+
+    it('should not enable autofocus when the toggle is off', fakeAsync(() => {
+      featureTogglesController.set('a11yAddressFormInitialFocus', false);
+      spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(
+        of(mockCountries)
+      );
+
+      component.ngOnInit();
+      tick();
+
+      expect(component.focusConfig).toEqual({ autofocus: false });
+    }));
   });
 
   describe('focusFirstInvalidField', () => {

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.spec.ts
@@ -654,7 +654,7 @@ describe('AddressFormComponent', () => {
     });
   });
 
-  describe('a11yAddressFormInitialFocus', () => {
+  describe('a11yImproveAddressFormFocus', () => {
     let featureTogglesController: MockFeatureTogglesController;
 
     const getFocusForm = (): DebugElement =>
@@ -664,22 +664,22 @@ describe('AddressFormComponent', () => {
       featureTogglesController = TestBed.inject(MockFeatureTogglesController);
     });
 
-    it('should apply cxFocus to the form when a11yAddressFormInitialFocus is true', () => {
-      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+    it('should apply cxFocus to the form when a11yImproveAddressFormFocus is true', () => {
+      featureTogglesController.set('a11yImproveAddressFormFocus', true);
       fixture.detectChanges();
 
       expect(getFocusForm()).toBeTruthy();
     });
 
-    it('should not apply cxFocus to the form when a11yAddressFormInitialFocus is false', () => {
-      featureTogglesController.set('a11yAddressFormInitialFocus', false);
+    it('should not apply cxFocus to the form when a11yImproveAddressFormFocus is false', () => {
+      featureTogglesController.set('a11yImproveAddressFormFocus', false);
       fixture.detectChanges();
 
       expect(getFocusForm()).toBeNull();
     });
 
     it('should render the action buttons outside the cxFocus host', () => {
-      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      featureTogglesController.set('a11yImproveAddressFormFocus', true);
       fixture.detectChanges();
 
       const focusHost: HTMLElement = getFocusForm().nativeElement;
@@ -705,7 +705,7 @@ describe('AddressFormComponent', () => {
           .injector.get(FocusFirstInvalidFieldDirective);
 
     it('should focus the first invalid field on invalid submit when toggle is on', () => {
-      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      featureTogglesController.set('a11yImproveAddressFormFocus', true);
       fixture.detectChanges();
       const directive = getFocusFirstInvalidFieldDirective();
       spyOn(directive, 'focusFirstInvalidField');
@@ -716,7 +716,7 @@ describe('AddressFormComponent', () => {
     });
 
     it('should not focus the first invalid field on invalid submit when toggle is off', () => {
-      featureTogglesController.set('a11yAddressFormInitialFocus', false);
+      featureTogglesController.set('a11yImproveAddressFormFocus', false);
       fixture.detectChanges();
       const directive = getFocusFirstInvalidFieldDirective();
       spyOn(directive, 'focusFirstInvalidField');
@@ -731,7 +731,7 @@ describe('AddressFormComponent', () => {
     });
 
     it('should enable autofocus once the country data has loaded', fakeAsync(() => {
-      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      featureTogglesController.set('a11yImproveAddressFormFocus', true);
       spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(
         of(mockCountries)
       );
@@ -745,7 +745,7 @@ describe('AddressFormComponent', () => {
     }));
 
     it('should not steal focus when the user has already focused a form field', fakeAsync(() => {
-      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      featureTogglesController.set('a11yImproveAddressFormFocus', true);
       spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(
         of(mockCountries)
       );
@@ -768,7 +768,7 @@ describe('AddressFormComponent', () => {
     }));
 
     it('should not enable autofocus while the country list is empty', fakeAsync(() => {
-      featureTogglesController.set('a11yAddressFormInitialFocus', true);
+      featureTogglesController.set('a11yImproveAddressFormFocus', true);
       spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(of([]));
 
       component.ngOnInit();
@@ -778,7 +778,7 @@ describe('AddressFormComponent', () => {
     }));
 
     it('should not enable autofocus when the toggle is off', fakeAsync(() => {
-      featureTogglesController.set('a11yAddressFormInitialFocus', false);
+      featureTogglesController.set('a11yImproveAddressFormFocus', false);
       spyOn(userAddressService, 'getDeliveryCountries').and.returnValue(
         of(mockCountries)
       );

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
@@ -207,7 +207,7 @@ export class AddressFormComponent implements OnInit, OnDestroy {
     // `titles$`. This is intentionally data-driven rather than DOM-driven; the
     // post-submit counterpart, `focusFirstInvalidField()`, has to query the DOM
     // instead because it needs the *specific* invalid field, not just the first.
-    if (this.featureToggles.a11yAddressFormInitialFocus) {
+    if (this.featureToggles.a11yImproveAddressFormFocus) {
       this.subscription.add(
         this.countries$
           .pipe(
@@ -504,7 +504,7 @@ export class AddressFormComponent implements OnInit, OnDestroy {
         { key: 'formErrors.globalMessage' },
         GlobalMessageType.MSG_TYPE_ASSISTIVE
       );
-      if (this.featureToggles.a11yAddressFormInitialFocus) {
+      if (this.featureToggles.a11yImproveAddressFormFocus) {
         this.firstInvalidFieldFocus?.focusFirstInvalidField();
       }
     }

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
@@ -46,6 +46,7 @@ import {
   UserAddressService,
 } from '@spartacus/core';
 import {
+  FocusConfig,
   FocusDirective,
   FormErrorsComponent,
   FormRequiredAsterisksComponent,
@@ -55,6 +56,7 @@ import {
   NgSelectA11yDirective,
   sortTitles,
 } from '@spartacus/storefront';
+// eslint-disable-next-line @nx/workspace-no-self-public-api-import -- ESLint is misfiring here: core and root are not the same library — they're separate entry points
 import { UserProfileFacade } from '@spartacus/user/profile/root';
 import {
   BehaviorSubject,
@@ -63,7 +65,15 @@ import {
   of,
   Subscription,
 } from 'rxjs';
-import { filter, map, skip, switchMap, take, tap } from 'rxjs/operators';
+import {
+  filter,
+  map,
+  shareReplay,
+  skip,
+  switchMap,
+  take,
+  tap,
+} from 'rxjs/operators';
 
 @Component({
   selector: 'cx-address-form',
@@ -102,6 +112,14 @@ export class AddressFormComponent implements OnInit, OnDestroy {
   cities: City[] = [];
   districts: CityDistrict[] = [];
   addresses$: Observable<Address[]>;
+
+  /**
+   * Drives the `cxFocus` autofocus host. Autofocus starts disabled and is
+   * enabled (with a `refreshFocus` token to re-trigger the directive) only once
+   * the country data has loaded, so focus lands on the country select rather
+   * than whichever field wins the async render race.
+   */
+  focusConfig: FocusConfig = { autofocus: false };
 
   @Input()
   addressData: Address;
@@ -164,8 +182,10 @@ export class AddressFormComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    // Fetching countries if no data stream was provided
-    this.countries$ =
+    // Fetching countries if no data stream was provided.
+    // `shareReplay` so the template's async pipe and the autofocus subscription
+    // below share a single execution (no duplicate `loadDeliveryCountries()`).
+    this.countries$ = (
       this.countries ||
       this.userAddressService.getDeliveryCountries().pipe(
         tap((countries: Country[]) => {
@@ -173,7 +193,43 @@ export class AddressFormComponent implements OnInit, OnDestroy {
             this.userAddressService.loadDeliveryCountries();
           }
         })
+      )
+    ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
+    // Initial focus (form load): enable autofocus only once the country data
+    // has loaded, so the `cxFocus` host focuses the country select instead of
+    // whichever field wins the async render race between `countries$` and
+    // `titles$`. This is intentionally data-driven rather than DOM-driven; the
+    // post-submit counterpart, `focusFirstInvalidField()`, has to query the DOM
+    // instead because it needs the *specific* invalid field, not just the first.
+    if (this.featureToggles.a11yAddressFormInitialFocus) {
+      this.subscription.add(
+        this.countries$
+          .pipe(
+            filter((countries) => !!countries?.length),
+            take(1)
+          )
+          .subscribe(() => {
+            // The `countries$` emission and the change detection that renders
+            // the country select happen in the same tick; defer to a macrotask
+            // so the select exists in the DOM before `refreshFocus` re-triggers
+            // the directive's focus logic and picks the first focusable field.
+            setTimeout(() => {
+              // Don't steal focus if the user has already engaged with the
+              // form — this matters when country data loads slowly or a custom
+              // template renders a different (non-country) first field, where
+              // the deferred refresh would otherwise yank focus back to the top.
+              const active = document.activeElement;
+              const host = this.elementRef.nativeElement as HTMLElement;
+              if (active && active !== document.body && host.contains(active)) {
+                return;
+              }
+              this.focusConfig = { autofocus: true, refreshFocus: {} };
+              this.cdr.markForCheck();
+            });
+          })
       );
+    }
 
     // Fetching titles
     this.titles$ = this.getTitles();
@@ -451,6 +507,11 @@ export class AddressFormComponent implements OnInit, OnDestroy {
 
   /**
    * Moves focus to the first invalid form control after a failed submit.
+   *
+   * Counterpart to the data-driven initial focus set up in `ngOnInit`: unlike
+   * that case, we can't rely on `cxFocus` here because it always targets the
+   * first focusable field, whereas a failed submit must land on the *specific*
+   * invalid one — hence the direct DOM query.
    *
    * This is needed for the `a11yAddressFormInitialFocus` feature: the form is
    * wrapped in a `cxFocus` autofocus host with `tabindex="-1"`. In Safari a

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
@@ -48,6 +48,7 @@ import {
 import {
   FocusConfig,
   FocusDirective,
+  FocusFirstInvalidFieldDirective,
   FormErrorsComponent,
   FormRequiredAsterisksComponent,
   FormRequiredLegendComponent,
@@ -92,6 +93,7 @@ import {
     AsyncPipe,
     FeatureDirective,
     FocusDirective,
+    FocusFirstInvalidFieldDirective,
     TranslatePipe,
   ],
 })
@@ -149,6 +151,9 @@ export class AddressFormComponent implements OnInit, OnDestroy {
   backToAddress = new EventEmitter<any>();
 
   @ViewChild('submit') element: ElementRef;
+
+  @ViewChild(FocusFirstInvalidFieldDirective)
+  protected firstInvalidFieldFocus?: FocusFirstInvalidFieldDirective;
 
   subscription: Subscription = new Subscription();
 
@@ -500,41 +505,9 @@ export class AddressFormComponent implements OnInit, OnDestroy {
         GlobalMessageType.MSG_TYPE_ASSISTIVE
       );
       if (this.featureToggles.a11yAddressFormInitialFocus) {
-        this.focusFirstInvalidField();
+        this.firstInvalidFieldFocus?.focusFirstInvalidField();
       }
     }
-  }
-
-  /**
-   * Moves focus to the first invalid form control after a failed submit.
-   *
-   * Counterpart to the data-driven initial focus set up in `ngOnInit`: unlike
-   * that case, we can't rely on `cxFocus` here because it always targets the
-   * first focusable field, whereas a failed submit must land on the *specific*
-   * invalid one — hence the direct DOM query.
-   *
-   * This is needed for the `a11yAddressFormInitialFocus` feature: the form is
-   * wrapped in a `cxFocus` autofocus host with `tabindex="-1"`. In Safari a
-   * `<button>` doesn't receive focus on click, so focus falls to that host and
-   * its autofocus redirects to the first focusable field (the country select),
-   * regardless of which field is actually invalid. We defer to a macrotask so
-   * this runs after that autofocus and lands the user on the real error.
-   */
-  protected focusFirstInvalidField(): void {
-    setTimeout(() => {
-      const host = this.elementRef.nativeElement as HTMLElement;
-      const firstInvalid = host.querySelector<HTMLElement>(
-        'input.ng-invalid, select.ng-invalid, textarea.ng-invalid, ng-select.ng-invalid'
-      );
-      if (!firstInvalid) {
-        return;
-      }
-      // `ng-select` isn't focusable itself; focus its inner input. Plain
-      // inputs/selects/textareas have no nested input, so we focus them directly.
-      const focusable =
-        firstInvalid.querySelector<HTMLElement>('input') ?? firstInvalid;
-      focusable.focus();
-    });
   }
 
   openSuggestedAddress(results: AddressValidation): void {

--- a/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
+++ b/feature-libs/user/profile/components/address-book/address-form/address-form.component.ts
@@ -90,6 +90,7 @@ export class AddressFormComponent implements OnInit, OnDestroy {
   protected cdr = inject(ChangeDetectorRef);
   private featureToggles = inject(FeatureToggles);
   protected hierarchicalAddressConfig = inject(HierarchicalAddressConfig);
+  protected elementRef = inject(ElementRef);
 
   countries$: Observable<Country[]>;
   titles$: Observable<Title[]>;
@@ -442,7 +443,37 @@ export class AddressFormComponent implements OnInit, OnDestroy {
         { key: 'formErrors.globalMessage' },
         GlobalMessageType.MSG_TYPE_ASSISTIVE
       );
+      if (this.featureToggles.a11yAddressFormInitialFocus) {
+        this.focusFirstInvalidField();
+      }
     }
+  }
+
+  /**
+   * Moves focus to the first invalid form control after a failed submit.
+   *
+   * This is needed for the `a11yAddressFormInitialFocus` feature: the form is
+   * wrapped in a `cxFocus` autofocus host with `tabindex="-1"`. In Safari a
+   * `<button>` doesn't receive focus on click, so focus falls to that host and
+   * its autofocus redirects to the first focusable field (the country select),
+   * regardless of which field is actually invalid. We defer to a macrotask so
+   * this runs after that autofocus and lands the user on the real error.
+   */
+  protected focusFirstInvalidField(): void {
+    setTimeout(() => {
+      const host = this.elementRef.nativeElement as HTMLElement;
+      const firstInvalid = host.querySelector<HTMLElement>(
+        'input.ng-invalid, select.ng-invalid, textarea.ng-invalid, ng-select.ng-invalid'
+      );
+      if (!firstInvalid) {
+        return;
+      }
+      // `ng-select` isn't focusable itself; focus its inner input. Plain
+      // inputs/selects/textareas have no nested input, so we focus them directly.
+      const focusable =
+        firstInvalid.querySelector<HTMLElement>('input') ?? firstInvalid;
+      focusable.focus();
+    });
   }
 
   openSuggestedAddress(results: AddressValidation): void {

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -380,7 +380,6 @@ if (environment.cpq) {
         a11yFocusIndicatorContrast: true,
         a11yDisabledButtonContrast: true,
         a11yAddressFormInitialFocus: true,
-        a11yPaymentFormFocus: true,
         a11yFocusBreadcrumbOnNavigation: true,
         a11yNavigationChevronContrast: true,
       };

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -379,7 +379,7 @@ if (environment.cpq) {
         a11yFormErrorIconContrast: true,
         a11yFocusIndicatorContrast: true,
         a11yDisabledButtonContrast: true,
-        a11yAddressFormInitialFocus: true,
+        a11yImproveAddressFormFocus: true,
         a11yFocusBreadcrumbOnNavigation: true,
         a11yNavigationChevronContrast: true,
       };

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -380,6 +380,7 @@ if (environment.cpq) {
         a11yFocusIndicatorContrast: true,
         a11yDisabledButtonContrast: true,
         a11yAddressFormInitialFocus: true,
+        a11yPaymentFormFocus: true,
         a11yFocusBreadcrumbOnNavigation: true,
         a11yNavigationChevronContrast: true,
       };


### PR DESCRIPTION
## What

- Fix the Continue button not submitting the address form on Safari (address-form component).
- Fix Safari-only issues on the checkout payment form and the address form, and improve invalid-submit focus.

## Change (most of these are made to both checkout-payment-method and address-form components)

- Added `novalidate` to the form.
- Move the action buttons (**Back**/**Continue**) outside the `cxFocus` autofocus host. In Safari a `<button>` doesn't take focus on click, so focus fell to the `tabindex="-1"` host and got redirected to the country select / payment type. Rendering them outside prevents that jump.
- On invalid submit (guarded by the two new toggles), move focus to the first invalid field instead of the country select / payment type. Handles `ng-select` by focusing its inner input.
- Improve cxFocus configuration to handle aysnc loading of countries and the Country ng-select input
- Introduce new directive to autofocus top most invalid input of a form when it is submitted and invalid. 

The country `<ng-select>` sets a native `required` attribute on its internal input, but ng-select never populates that input's value. On submit, Safari ran native HTML5 constraint validation, saw an "empty required" field, cancelled the submit, and refocused country-select. Validation is already handled by Angular reactive-form validators in `verifyAddress()`, so native validation was redundant and was blocking submission. `novalidate` disables it while keeping all Angular validation and error messages intact. Chrome was unaffected because it doesn't apply native validation to ng-select's custom-widget input the same way.

## Testing

- Verify in Safari that Continue submits successfully.
- Verify invalid submissions still show field errors and the global assistive message.
- Verify invalid submissions jump to top most invalid field


## Notes
Safari-only behavior — needs manual verification in Safari. Not reproducible in Chrome.

