### PR TITLE
fix: improve incorrect handling of results in searchBox

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -93,6 +93,24 @@ export interface FeatureTogglesInterface {
   searchBoxRecentSearchesRemoval?: boolean;
 
   /**
+   * Controls the empty-query results panel in `SearchBoxComponent`.
+   *
+   * Before (disabled):
+   * - With `searchBoxRecentSearchesRemoval` enabled, an empty query closes the
+   *   results panel on desktop. Clearing the query closes the panel.
+   * - Without that toggle, desktop can show the results panel with an empty query.
+   *
+   * After (enabled):
+   * - On desktop, an empty query opens the results panel only when trending or
+   *   recent searches are available; otherwise the panel stays closed.
+   * - Clearing the query does not keep leftover OCC suggestions, products, or a
+   *   no-match message in the panel.
+   * - On mobile, the search box stays open for an empty query so the input is
+   *   not collapsed. The search panel Close button is hidden; Clear remains.
+   */
+  searchBoxEmptyQueryResultsPanel?: boolean;
+
+  /**
    * Corrects `BottomHeaderSlot` layout when CDS registers `MerchandisingCarouselComponent`
    * beside `BreadcrumbComponent` (e.g. on search results pages in sample data).
    *
@@ -710,6 +728,7 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   removeDuplicatedOrderHistoryHeader: true,
   a11yCardNotificationMessage: true,
   searchBoxRecentSearchesRemoval: false,
+  searchBoxEmptyQueryResultsPanel: false,
   cdsBottomHeaderSlotAdjustPosition: false,
   enableB2BUnitSearch: false,
   enableB2BCostCenterSearch: false,

--- a/core-libs/storefront/cms-components/navigation/search-box/search-box-component.service.spec.ts
+++ b/core-libs/storefront/cms-components/navigation/search-box/search-box-component.service.spec.ts
@@ -12,6 +12,10 @@ import {
   TranslationService,
   WindowRef,
 } from '@spartacus/core';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { EMPTY, Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
@@ -93,6 +97,7 @@ describe('SearchBoxComponentService', () => {
   let service: SearchBoxComponentService;
   let searchBoxService: SearchboxService;
   let eventService: EventService;
+  let featureToggles: MockFeatureTogglesController;
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [I18nTestingModule],
@@ -110,6 +115,10 @@ describe('SearchBoxComponentService', () => {
           useClass: MockSearchBoxService,
         },
         { provide: TranslationService, useClass: MockTranslationService },
+        provideMockFeatureToggles({
+          searchBoxRecentSearchesRemoval: false,
+          searchBoxEmptyQueryResultsPanel: false,
+        }),
         SearchBoxComponentService,
         WindowRef,
       ],
@@ -117,6 +126,11 @@ describe('SearchBoxComponentService', () => {
     service = TestBed.inject(SearchBoxComponentService);
     searchBoxService = TestBed.inject(SearchboxService);
     eventService = TestBed.inject(EventService);
+    featureToggles = TestBed.inject(MockFeatureTogglesController);
+  });
+
+  afterEach(() => {
+    document.body.classList.remove('has-searchbox-results');
   });
 
   it('should be created', () => {
@@ -243,6 +257,53 @@ describe('SearchBoxComponentService', () => {
       expect(result.message).toBeTruthy();
 
       expect(result.message).toEqual('searchBox.help.noMatch');
+    });
+
+    it('should not mark the body as having searchbox results for leftover OCC data when the query is empty', () => {
+      featureToggles.set('searchBoxEmptyQueryResultsPanel', true);
+      spyOn(searchBoxService, 'getResults').and.returnValue(
+        of({ products: [] })
+      );
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(of([]));
+
+      service.getResults(searchBoxConfig).subscribe();
+
+      expect(
+        document.body.classList.contains('has-searchbox-results')
+      ).toBeFalse();
+    });
+
+    it('should mark the body as having searchbox results when trending searches are enabled with an empty query', () => {
+      featureToggles.set('searchBoxEmptyQueryResultsPanel', true);
+      spyOn(searchBoxService, 'getResults').and.returnValue(of({}));
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(of([]));
+
+      service.getResults(searchBoxConfig).subscribe();
+      service.setTrendingSearches(true);
+
+      expect(
+        document.body.classList.contains('has-searchbox-results')
+      ).toBeTrue();
+
+      service.setTrendingSearches(false);
+    });
+
+    it('should mark the body as having searchbox results for OCC data when the query is not empty', () => {
+      featureToggles.set('searchBoxEmptyQueryResultsPanel', true);
+      spyOn(searchBoxService, 'getResults').and.returnValue(
+        of(mockSearchResults)
+      );
+      spyOn(searchBoxService, 'getSuggestionResults').and.returnValue(of([]));
+
+      service.search('ab', {
+        ...searchBoxConfig,
+        minCharactersBeforeRequest: 3,
+      });
+      service.getResults(searchBoxConfig).subscribe();
+
+      expect(
+        document.body.classList.contains('has-searchbox-results')
+      ).toBeTrue();
     });
 
     it('should not get a message when there are products ', () => {

--- a/core-libs/storefront/cms-components/navigation/search-box/search-box-component.service.ts
+++ b/core-libs/storefront/cms-components/navigation/search-box/search-box-component.service.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import {
   EventService,
+  FeatureToggles,
   isNotUndefined,
   ProductSearchPage,
   RoutingService,
@@ -21,6 +22,7 @@ import {
   Observable,
   of,
   ReplaySubject,
+  Subject,
 } from 'rxjs';
 import { map, switchMap, tap, filter, take } from 'rxjs/operators';
 import {
@@ -38,6 +40,15 @@ export class SearchBoxComponentService {
   chosenWord = new ReplaySubject<string>();
   sharedEvent = new ReplaySubject<KeyboardEvent>();
   searchCompleted = new BehaviorSubject<boolean>(false);
+  /**
+   * Emits when trending and recent searches both become empty while the
+   * search box was showing those lists. Used by `SearchBoxComponent` when
+   * `searchBoxEmptyQueryResultsPanel` is enabled.
+   */
+  emptyOuterResults$ = new Subject<void>();
+
+  // DELIBERATELY PRIVATE PROPERTY, to remove easily in the future
+  private featureToggles = inject(FeatureToggles);
 
   protected enableRecentSearches: boolean = false;
   protected enableTrendingSearches: boolean = false;
@@ -160,6 +171,10 @@ export class SearchBoxComponentService {
    */
   clearResults() {
     this.searchService.clearResults();
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      this.enableTrendingSearches = false;
+      this.enableRecentSearches = false;
+    }
     this.toggleBodyClass(HAS_SEARCH_RESULT_CLASS, false);
 
     // Reset search completion state
@@ -220,15 +235,35 @@ export class SearchBoxComponentService {
    * * the is any search suggestion OR
    * * there is a message.
    *
+   * When `searchBoxEmptyQueryResultsPanel` is enabled, an empty query only
+   * counts as having results when trending or recent searches are available.
+   * Leftover OCC products or a no-match message from a previous search must
+   * not keep the panel open.
+   *
    * Otherwise it returns false.
    */
   protected hasResults(results: SearchResults): boolean {
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      if (this.currentQueryLength === 0) {
+        return this.hasOuterSearches();
+      }
+      return this.hasOccResults(results) || this.hasOuterSearches();
+    } else {
+      return this.hasOccResults(results);
+    }
+  }
+
+  protected hasOccResults(results: SearchResults): boolean {
     return (
-      (!!results.products && results.products.length > 0) ||
-      (!!results.suggestions && results.suggestions.length > 0) ||
+      !!results.products?.length ||
+      !!results.suggestions?.length ||
       !!results.message ||
       !!results.recentSearches
     );
+  }
+
+  protected hasOuterSearches(): boolean {
+    return this.enableTrendingSearches || this.enableRecentSearches;
   }
 
   /**
@@ -354,10 +389,41 @@ export class SearchBoxComponentService {
   }
 
   setTrendingSearches(enabled: boolean = false) {
+    const hadTrendingSearches = this.enableTrendingSearches;
     this.enableTrendingSearches = enabled;
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      this.syncOuterResultsClass();
+      if (hadTrendingSearches && !enabled && !this.enableRecentSearches) {
+        this.emptyOuterResults$.next();
+      }
+    }
   }
 
   setRecentSearches(enabled: boolean = false) {
+    const hadRecentSearches = this.enableRecentSearches;
     this.enableRecentSearches = enabled;
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      this.syncOuterResultsClass();
+      if (hadRecentSearches && !enabled && !this.enableTrendingSearches) {
+        this.emptyOuterResults$.next();
+      }
+    }
+  }
+
+  protected syncOuterResultsClass(): void {
+    if (this.enableTrendingSearches || this.enableRecentSearches) {
+      this.toggleBodyClass(HAS_SEARCH_RESULT_CLASS, true);
+    } else if (this.currentQueryLength === 0) {
+      this.toggleBodyClass(HAS_SEARCH_RESULT_CLASS, false);
+    }
+  }
+
+  /**
+   * Toggles the `has-searchbox-results` body class. Used by `SearchBoxComponent`
+   * when `searchBoxEmptyQueryResultsPanel` is enabled to sync the overlay with
+   * trending and recent search lists in the DOM.
+   */
+  setSearchResultsShown(shown: boolean): void {
+    this.toggleBodyClass(HAS_SEARCH_RESULT_CLASS, shown);
   }
 }

--- a/core-libs/storefront/cms-components/navigation/search-box/search-box.component.html
+++ b/core-libs/storefront/cms-components/navigation/search-box/search-box.component.html
@@ -161,7 +161,7 @@
       ></ng-template>
     </ng-container>
     <!--RESULT  PRODUCTS-->
-    <div class="products">
+    <div class="products" *cxFeature="'!searchBoxEmptyQueryResultsPanel'">
       <h3 *ngIf="result.products?.length">
         {{ 'searchBox.products' | cxTranslate }}
       </h3>
@@ -216,6 +216,63 @@
         </ng-template>
       </ng-container>
     </div>
+    <ng-container *cxFeature="'searchBoxEmptyQueryResultsPanel'">
+      <div class="products" *ngIf="hasQuery">
+        <h3 *ngIf="result.products?.length">
+          {{ 'searchBox.products' | cxTranslate }}
+        </h3>
+        <ng-container *ngIf="items$ | async as items">
+          <cx-carousel
+            role="region"
+            [attr.aria-label]="'searchBox.ariaLabelProducts' | cxTranslate"
+            [items]="items"
+            [template]="carouselItemFeature"
+            itemWidth="160px"
+            (keybordEvent)="carouselEventPropagator($event)"
+          >
+          </cx-carousel>
+
+          <ng-template #carouselItemFeature let-product="item">
+            <a
+              tabindex="0"
+              [routerLink]="
+                {
+                  cxRoute: 'product',
+                  params: product,
+                } | cxUrl
+              "
+              [class.has-media]="config.displayProductImages"
+              (keydown.enter)="close(true)"
+              (keydown.escape)="close(true)"
+              (keydown.arrowleft)="carouselEventPropagator($any($event))"
+              (keydown.arrowright)="carouselEventPropagator($any($event))"
+              (keydown.arrowup)="carouselEventPropagator($any($event))"
+              (mousedown)="preventDefault($event)"
+              (click)="
+                dispatchProductEvent({
+                  freeText: searchInputEl?.nativeElement?.value,
+                  productCode: product.code,
+                })
+              "
+            >
+              <cx-media
+                tabindex="0"
+                [container]="product.images?.PRIMARY"
+                format="product"
+                [alt]="product.name ?? ''"
+              ></cx-media>
+              <h3 class="cx-product-name" [innerHtml]="product.nameHtml"></h3>
+              <div class="price">
+                {{ product.price?.formattedValue }}
+              </div>
+            </a>
+            <div class="actions">
+              <ng-container cxInnerComponentsHost></ng-container>
+            </div>
+          </ng-template>
+        </ng-container>
+      </div>
+    </ng-container>
 
     <div
       class="search-panel-header"

--- a/core-libs/storefront/cms-components/navigation/search-box/search-box.component.spec.ts
+++ b/core-libs/storefront/cms-components/navigation/search-box/search-box.component.spec.ts
@@ -11,6 +11,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import {
   CmsSearchBoxComponent,
+  FeatureConfigService,
   MockTranslatePipe,
   PageType,
   ProductSearchService,
@@ -26,6 +27,7 @@ import {
   Observable,
   of,
   ReplaySubject,
+  Subject,
 } from 'rxjs';
 import { CmsComponentData } from '../../../cms-structure/page/model/cms-component-data';
 import { CarouselComponent } from '../../../shared/components/carousel/carousel.component';
@@ -132,6 +134,7 @@ describe('SearchBoxComponent', () => {
   {
     chosenWord = new ReplaySubject<string>();
     sharedEvent = new ReplaySubject<KeyboardEvent>();
+    emptyOuterResults$ = new Subject<void>();
 
     launchSearchPage = jasmine.createSpy('launchSearchPage');
     getResults = jasmine.createSpy('search').and.callFake(() => {
@@ -155,6 +158,7 @@ describe('SearchBoxComponent', () => {
     search() {}
     toggleBodyClass() {}
     clearResults() {}
+    setSearchResultsShown(_shown: boolean) {}
   }
 
   beforeEach(waitForAsync(() => {
@@ -180,6 +184,12 @@ describe('SearchBoxComponent', () => {
         {
           provide: RoutingService,
           useClass: MockRoutingService,
+        },
+        {
+          provide: FeatureConfigService,
+          useValue: {
+            isEnabled: (feature: string) => feature.startsWith('!'),
+          },
         },
       ],
     })
@@ -370,6 +380,26 @@ describe('SearchBoxComponent', () => {
 
         expect(fixture.debugElement.query(By.css('.results'))).toBeTruthy();
       }));
+
+      it('should remove has-outer-results when the feature is enabled and there are no outer results', () => {
+        fixture.componentRef.setInput('queryText', 'test input');
+        fixture.detectChanges();
+
+        const results = fixture.debugElement.query(
+          By.css('.results')
+        ).nativeElement;
+        (searchBoxComponent as any).featureToggles = {
+          searchBoxEmptyQueryResultsPanel: true,
+        };
+        spyOn(searchBoxComponent['renderer'], 'removeClass');
+
+        searchBoxComponent['checkOuterResults']();
+
+        expect(searchBoxComponent['renderer'].removeClass).toHaveBeenCalledWith(
+          results,
+          'has-outer-results'
+        );
+      });
 
       it('should contain a message after search', () => {
         fixture.componentRef.setInput(

--- a/core-libs/storefront/cms-components/navigation/search-box/search-box.component.ts
+++ b/core-libs/storefront/cms-components/navigation/search-box/search-box.component.ts
@@ -160,26 +160,33 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
 
   /**
    * Tracks whether the search box currently has a non-empty query.
-   * Used with searchBoxRecentSearchesRemoval to decide if results should be rendered.
+   * Used with searchBoxRecentSearchesRemoval and
+   * searchBoxEmptyQueryResultsPanel to decide if results should be rendered.
    */
   protected hasQuery = false;
 
   /**
    * Whether the results panel should be visible for the current state.
-   * When searchBoxRecentSearchesRemoval is disabled, matches develop behavior.
+   * When both related toggles are disabled, matches develop behavior.
    */
   isResultsPanelVisible(): boolean {
-    if (!this.searchBoxRecentSearchesRemovalEnabled) {
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      return this.hasQuery || this.searchBoxActive;
+    } else if (this.featureToggles.searchBoxRecentSearchesRemoval) {
+      return this.hasQuery;
+    } else {
       return true;
     }
-    return this.hasQuery;
   }
 
   protected getAriaControls(): string | null {
-    if (!this.searchBoxRecentSearchesRemovalEnabled) {
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      return this.isResultsPanelVisible() ? 'results' : null;
+    } else if (this.featureToggles.searchBoxRecentSearchesRemoval) {
+      return this.hasQuery ? 'results' : null;
+    } else {
       return 'results';
     }
-    return this.hasQuery ? 'results' : null;
   }
 
   /**
@@ -188,16 +195,21 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
    */
   protected isMobileState: boolean | null = null;
 
-  private readonly searchBoxRecentSearchesRemovalEnabled =
-    this.featureToggles.searchBoxRecentSearchesRemoval;
-
   /**
    * Returns true when the current results represent a \"no results\" state.
-   * Used to hide recent searches when there are no suggestions or products.
+   * Used to hide recent searches when a typed query has no suggestions or products.
+   * When `searchBoxEmptyQueryResultsPanel` is enabled, an empty query is not a
+   * no-results state, so recent searches can still render.
    */
   isNoResults(result: SearchResults | null | undefined): boolean {
     if (!result) {
       return false;
+    }
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      const query = this.searchInputEl?.nativeElement?.value ?? '';
+      if (!query.trim()) {
+        return false;
+      }
     }
     const hasSuggestions = (result.suggestions?.length ?? 0) > 0;
     const hasProducts = (result.products?.length ?? 0) > 0;
@@ -221,6 +233,7 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
     protected routingService: RoutingService
   ) {
     useFeatureStyles('searchBoxRecentSearchesRemoval');
+    useFeatureStyles('searchBoxEmptyQueryResultsPanel');
     useFeatureStyles('a11yFixSearchBoxDoubleFocus');
   }
 
@@ -260,17 +273,17 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
   );
 
   ngOnInit(): void {
-    if (this.searchBoxRecentSearchesRemovalEnabled) {
-      const configSubscription = this.config$.subscribe();
-      this.subscriptions.add(configSubscription);
-
-      const isMobile$ = this.isMobile;
-      if (isMobile$) {
-        const isMobileSubscription = isMobile$.subscribe(
-          (isMobile) => (this.isMobileState = isMobile ?? false)
-        );
-        this.subscriptions.add(isMobileSubscription);
-      }
+    let subscribeToMobileViewport = false;
+    if (this.featureToggles.searchBoxRecentSearchesRemoval) {
+      this.subscribeToRecentSearchesRemoval();
+      subscribeToMobileViewport = true;
+    }
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      this.subscribeToEmptyOuterResults();
+      subscribeToMobileViewport = true;
+    }
+    if (subscribeToMobileViewport) {
+      this.subscribeToMobileViewport();
     }
 
     const routeStateSubscription = this.routingService
@@ -307,6 +320,47 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Subscribes to search box config.
+   */
+  protected subscribeToRecentSearchesRemoval(): void {
+    const configSubscription = this.config$.subscribe();
+    this.subscriptions.add(configSubscription);
+  }
+
+  /**
+   * Subscribes to viewport size so desktop and mobile search box behaviour can differ.
+   */
+  protected subscribeToMobileViewport(): void {
+    const isMobile$ = this.isMobile;
+    if (isMobile$) {
+      const isMobileSubscription = isMobile$.subscribe(
+        (isMobile) => (this.isMobileState = isMobile ?? false)
+      );
+      this.subscriptions.add(isMobileSubscription);
+    }
+  }
+
+  /**
+   * Closes the desktop search box when trending and recent searches become empty.
+   */
+  protected subscribeToEmptyOuterResults(): void {
+    const emptyOuterResultsSubscription =
+      this.searchBoxComponentService.emptyOuterResults$.subscribe(() => {
+        const emptyQuery = !(
+          this.searchInputEl?.nativeElement?.value ?? ''
+        ).trim();
+        if (
+          this.searchBoxActive &&
+          emptyQuery &&
+          this.isMobileState === false
+        ) {
+          this.close(true);
+        }
+      });
+    this.subscriptions.add(emptyOuterResultsSubscription);
+  }
+
+  /**
    * The Searchbox should not be focusable while not visible.
    */
   getTabIndex(isMobile: boolean | null): number {
@@ -320,48 +374,102 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
    * Closes the searchBox and opens the search result page.
    */
   search(query: string): void {
-    if (this.searchBoxRecentSearchesRemovalEnabled) {
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      const trimmedQuery = query?.trim() ?? '';
+
+      if (!trimmedQuery) {
+        this.hasQuery = false;
+        this.searchBoxComponentService.clearResults();
+        this.open();
+        this.checkOuterResults();
+      } else {
+        this.hasQuery = true;
+        this.searchBoxComponentService.search(trimmedQuery, this.config);
+        this.checkOuterResults();
+        this.open();
+      }
+    } else if (this.featureToggles.searchBoxRecentSearchesRemoval) {
       const trimmedQuery = query?.trim() ?? '';
 
       if (!trimmedQuery) {
         this.hasQuery = false;
         this.searchBoxComponentService.clearResults();
         this.close(true);
-        return;
+      } else {
+        this.hasQuery = true;
+        this.searchBoxComponentService.search(trimmedQuery, this.config);
+        this.checkOuterResults();
+        this.open();
       }
-
-      this.hasQuery = true;
-      this.searchBoxComponentService.search(trimmedQuery, this.config);
+    } else {
+      this.searchBoxComponentService.search(query, this.config);
       this.checkOuterResults();
       this.open();
-      return;
     }
-
-    this.searchBoxComponentService.search(query, this.config);
-    this.checkOuterResults();
-    this.open();
   }
 
   /**
    * Opens the type-ahead searchBox
    */
   open(): void {
-    if (!this.searchBoxActive) {
-      if (this.searchBoxRecentSearchesRemovalEnabled) {
-        const inputValue = this.searchInputEl?.nativeElement?.value ?? '';
-        const trimmed = inputValue.trim();
-
-        // On desktop, do not open results when there is no query.
-        // On mobile, always allow opening to show the panel.
-        if (this.isMobileState === false && !trimmed) {
-          return;
-        }
-      }
-
-      this.searchBoxComponentService.toggleBodyClass(SEARCHBOX_IS_ACTIVE, true);
-      this.searchBoxActive = true;
-      this.searchInputEl?.nativeElement.focus();
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      this.clearLeftoverResultsForEmptyQuery();
     }
+
+    if (!this.searchBoxActive) {
+      this.activateSearchBox();
+    }
+
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      this.checkOuterResults();
+    }
+  }
+
+  /**
+   * Clears leftover OCC results when the input is empty.
+   */
+  protected clearLeftoverResultsForEmptyQuery(): void {
+    const emptyQuery = !(this.searchInputEl?.nativeElement?.value ?? '').trim();
+    if (emptyQuery) {
+      this.hasQuery = false;
+      this.searchBoxComponentService.clearResults();
+    }
+  }
+
+  /**
+   * Activates the search box UI. Override to change how the panel is opened.
+   */
+  protected activateSearchBox(): void {
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      this.setSearchBoxActive();
+      this.changeDetectorRef.detectChanges();
+    } else if (this.featureToggles.searchBoxRecentSearchesRemoval) {
+      if (this.shouldSkipDesktopEmptyOpen()) {
+        return;
+      }
+      this.setSearchBoxActive();
+    } else {
+      this.setSearchBoxActive();
+    }
+  }
+
+  /**
+   * On desktop with recent-searches removal, do not open results when there
+   * is no query. On mobile, always allow opening to show the panel.
+   */
+  protected shouldSkipDesktopEmptyOpen(): boolean {
+    const inputValue = this.searchInputEl?.nativeElement?.value ?? '';
+    const trimmed = inputValue.trim();
+    if (this.isMobileState === false && !trimmed) {
+      return true;
+    }
+    return false;
+  }
+
+  protected setSearchBoxActive(): void {
+    this.searchBoxComponentService.toggleBodyClass(SEARCHBOX_IS_ACTIVE, true);
+    this.searchBoxActive = true;
+    this.searchInputEl?.nativeElement.focus();
   }
 
   /**
@@ -387,7 +495,7 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
    * Uses feature-specific logic when searchBoxRecentSearchesRemoval is enabled.
    */
   onSearchBlur(event: FocusEvent): void {
-    if (this.searchBoxRecentSearchesRemovalEnabled) {
+    if (this.featureToggles.searchBoxRecentSearchesRemoval) {
       this.handleInputBlur(event);
     } else {
       this.close();
@@ -454,8 +562,22 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
       'cx-trending-searches .trending-searches'
     );
     const results = this.elementRef.nativeElement.querySelector('.results');
-    if (recentSearches || trendingSearches) {
-      this.renderer.addClass(results, 'has-outer-results');
+    const hasOuterResults = !!(recentSearches || trendingSearches);
+    if (results) {
+      if (hasOuterResults) {
+        this.renderer.addClass(results, 'has-outer-results');
+      } else if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+        this.renderer.removeClass(results, 'has-outer-results');
+      }
+    }
+
+    if (this.featureToggles.searchBoxEmptyQueryResultsPanel) {
+      const emptyQuery = !(
+        this.searchInputEl?.nativeElement?.value ?? ''
+      ).trim();
+      if (emptyQuery) {
+        this.searchBoxComponentService.setSearchResultsShown(hasOuterResults);
+      }
     }
   }
 
@@ -546,7 +668,18 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
   }
 
   protected propagateEvent(event: KeyboardEvent) {
-    if (!this.searchBoxRecentSearchesRemovalEnabled) {
+    if (this.featureToggles.searchBoxRecentSearchesRemoval) {
+      if (event.type === 'blur') {
+        this.close();
+        return;
+      }
+
+      if (!event.code) {
+        return;
+      }
+
+      this.handleKeyboardEvent(event);
+    } else {
       if (event.code) {
         this.handleKeyboardEvent(event);
         return;
@@ -554,19 +687,7 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
       if (event.type === 'blur') {
         this.close();
       }
-      return;
     }
-
-    if (event.type === 'blur') {
-      this.close();
-      return;
-    }
-
-    if (!event.code) {
-      return;
-    }
-
-    this.handleKeyboardEvent(event);
   }
 
   protected handleKeyboardEvent(event: KeyboardEvent): void {
@@ -809,9 +930,7 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
   clear(el: HTMLInputElement): void {
     this.disableClose();
     el.value = '';
-    if (this.searchBoxRecentSearchesRemovalEnabled) {
-      this.hasQuery = false;
-    }
+    this.hasQuery = false;
     this.searchBoxComponentService.clearResults();
 
     // Use Timeout to run after blur event to prevent the searchbox from closing on mobile

--- a/core-libs/styles/scss/components/product/search/_searchbox.scss
+++ b/core-libs/styles/scss/components/product/search/_searchbox.scss
@@ -424,6 +424,9 @@
         display: block;
         right: 12px;
         top: 20px;
+        @include forFeature('searchBoxEmptyQueryResultsPanel') {
+          display: none;
+        }
       }
     }
     @include forFeature('searchBoxRecentSearchesRemoval') {
@@ -451,6 +454,13 @@
       margin-top: 14px;
       overflow: hidden;
       flex-wrap: wrap;
+
+      @include forFeature('searchBoxEmptyQueryResultsPanel') {
+        &:not(:has(.products)) {
+          height: auto;
+          align-content: flex-start;
+        }
+      }
 
       .search-panel-header {
         width: 100%;
@@ -652,6 +662,9 @@
       }
 
       cx-recent-searches {
+        @include forFeature('searchBoxEmptyQueryResultsPanel') {
+          display: block;
+        }
         flex-wrap: wrap;
         list-style: none;
         padding-inline-start: 0;
@@ -691,6 +704,11 @@
       }
       .trending-searches-container {
         display: none;
+        @include forFeature('searchBoxEmptyQueryResultsPanel') {
+          &.d-block:not(:has(.trending-searches)) {
+            display: none !important;
+          }
+        }
         &:has(.trending-searches) {
           width: 20%;
           @include media-breakpoint-down(sm) {

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -326,6 +326,7 @@ if (environment.cpq) {
         removeDuplicatedOrderHistoryHeader: true,
         a11yCardNotificationMessage: true,
         searchBoxRecentSearchesRemoval: true,
+        searchBoxEmptyQueryResultsPanel: true,
         cdsBottomHeaderSlotAdjustPosition: true,
         enableB2BUnitSearch: true,
         enableB2BCostCenterSearch: true,


### PR DESCRIPTION
## Summary
- Cherry-pick of https://github.com/SAP/spartacus/pull/21891 onto `release/221121.18.x`
- Fixes incorrect handling of results in the search box (empty query / trending searches)

## Test plan
- [ ] Search box still shows expected results for a typed query
- [ ] Empty query / trending searches behave correctly with `searchBoxEmptyQueryResultsPanel` enabled
- [ ] Empty query / trending searches behave correctly with the toggle disabled
- [ ] No visual regressions in the search box dropdown
