### PR TITLE
refactor: add accesscode in getActiveConfigurations call

### DIFF
--- a/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.spec.ts
+++ b/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.spec.ts
@@ -17,6 +17,7 @@ import { TestBed } from '@angular/core/testing';
 import { ConverterService, LoggerService } from '@spartacus/core';
 import { OpfEndpointsService } from '@spartacus/opf/base/core';
 import {
+  OPF_CC_ACCESS_CODE_HEADER,
   OPF_CC_PUBLIC_KEY_HEADER,
   OpfActiveConfiguration,
   OpfActiveConfigurationsPagination,
@@ -25,8 +26,13 @@ import {
   OpfMetadataStatePersistanceService,
   OpfPaymentProviderType,
 } from '@spartacus/opf/base/root';
-import { map } from 'rxjs';
+import { map, of } from 'rxjs';
 import { OpfApiBaseAdapter } from './opf-api-base.adapter';
+import {
+  ActiveCartFacade,
+  CartAccessCodeFacade,
+} from '@spartacus/cart/base/root';
+import { UserIdService } from '@spartacus/core';
 
 const mockActiveConfigurationsPagination: OpfActiveConfigurationsPagination = {
   totalPages: 1,
@@ -112,6 +118,15 @@ describe('OpfApiBaseAdapter', () => {
           useClass: MockOpfMetadataStatePersistanceService,
         },
         { provide: OpfConfig, useValue: mockOpfConfig },
+        { provide: UserIdService, useValue: { takeUserId: () => of('') } },
+        {
+          provide: ActiveCartFacade,
+          useValue: { takeActiveCartId: () => of('') },
+        },
+        {
+          provide: CartAccessCodeFacade,
+          useValue: { getCartAccessCode: () => of(null) },
+        },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
       ],
@@ -163,5 +178,101 @@ describe('OpfApiBaseAdapter', () => {
 
     const req = httpMock.expectOne('test-url/getActiveConfigurations');
     req.flush(mockErrorResponse, { status: 404, statusText: 'Not Found' });
+  });
+});
+
+describe('OpfApiBaseAdapter - enableActiveConfigurationAccessCodeHeader', () => {
+  let service: OpfApiBaseAdapter;
+  let httpMock: HttpTestingController;
+  let converter: ConverterService;
+  let userIdServiceMock: jasmine.SpyObj<UserIdService>;
+  let activeCartFacadeMock: jasmine.SpyObj<ActiveCartFacade>;
+  let cartAccessCodeFacadeMock: jasmine.SpyObj<CartAccessCodeFacade>;
+
+  beforeEach(() => {
+    userIdServiceMock = jasmine.createSpyObj('UserIdService', ['takeUserId']);
+    activeCartFacadeMock = jasmine.createSpyObj('ActiveCartFacade', [
+      'takeActiveCartId',
+    ]);
+    cartAccessCodeFacadeMock = jasmine.createSpyObj('CartAccessCodeFacade', [
+      'getCartAccessCode',
+    ]);
+    userIdServiceMock.takeUserId.and.returnValue(of('user1'));
+    activeCartFacadeMock.takeActiveCartId.and.returnValue(of('cart1'));
+    cartAccessCodeFacadeMock.getCartAccessCode.and.returnValue(
+      of({ accessCode: 'test-access-code' })
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        OpfApiBaseAdapter,
+        ConverterService,
+        { provide: LoggerService, useClass: MockLoggerService },
+        { provide: OpfEndpointsService, useClass: MockOpfEndpointsService },
+        {
+          provide: OpfMetadataStatePersistanceService,
+          useClass: MockOpfMetadataStatePersistanceService,
+        },
+        {
+          provide: OpfConfig,
+          useValue: {
+            opf: {
+              commerceCloudPublicKey: 'test-public-key',
+              enableActiveConfigurationAccessCodeHeader: true,
+            },
+          },
+        },
+        { provide: UserIdService, useValue: userIdServiceMock },
+        { provide: ActiveCartFacade, useValue: activeCartFacadeMock },
+        { provide: CartAccessCodeFacade, useValue: cartAccessCodeFacadeMock },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(OpfApiBaseAdapter);
+    httpMock = TestBed.inject(HttpTestingController);
+    converter = TestBed.inject(ConverterService);
+    spyOn(converter, 'pipeable').and.returnValue(
+      map(() => mockActiveConfigurationsResponse)
+    );
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should include access code header', () => {
+    service.getActiveConfigurations().subscribe();
+
+    const req = httpMock.expectOne('test-url/getActiveConfigurations');
+    expect(req.request.headers.get(OPF_CC_PUBLIC_KEY_HEADER)).toBe(
+      'test-public-key'
+    );
+    expect(req.request.headers.get(OPF_CC_ACCESS_CODE_HEADER)).toBe(
+      'test-access-code'
+    );
+    req.flush(mockActiveConfigurations);
+  });
+
+  it('should call getCartAccessCode with userId and cartId', () => {
+    service.getActiveConfigurations().subscribe();
+
+    httpMock.expectOne('test-url/getActiveConfigurations').flush([]);
+
+    expect(cartAccessCodeFacadeMock.getCartAccessCode).toHaveBeenCalledWith(
+      'user1',
+      'cart1'
+    );
+  });
+
+  it('should send empty string when getCartAccessCode returns null', () => {
+    cartAccessCodeFacadeMock.getCartAccessCode.and.returnValue(of(null));
+
+    service.getActiveConfigurations().subscribe();
+
+    const req = httpMock.expectOne('test-url/getActiveConfigurations');
+    expect(req.request.headers.get(OPF_CC_ACCESS_CODE_HEADER)).toBe('');
+    req.flush([]);
   });
 });

--- a/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.spec.ts
+++ b/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.spec.ts
@@ -181,7 +181,7 @@ describe('OpfApiBaseAdapter', () => {
   });
 });
 
-describe('OpfApiBaseAdapter - enableActiveConfigurationAccessCodeHeader', () => {
+describe('OpfApiBaseAdapter - enableGetActiveConfigurationsAccessCodeHeader', () => {
   let service: OpfApiBaseAdapter;
   let httpMock: HttpTestingController;
   let converter: ConverterService;
@@ -218,7 +218,7 @@ describe('OpfApiBaseAdapter - enableActiveConfigurationAccessCodeHeader', () => 
           useValue: {
             opf: {
               commerceCloudPublicKey: 'test-public-key',
-              enableActiveConfigurationAccessCodeHeader: true,
+              enableGetActiveConfigurationsAccessCodeHeader: true,
             },
           },
         },

--- a/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
+++ b/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
@@ -93,13 +93,13 @@ export class OpfApiBaseAdapter implements OpfBaseAdapter {
       this.config.opf?.commerceCloudPublicKey || ''
     );
 
-    if (this.config.opf?.enableActiveConfigurationAccessCodeHeader !== true) {
-      return of(headers);
+    if (this.config.opf?.enableActiveConfigurationAccessCodeHeader) {
+      return this.getAccessCode().pipe(
+        map((accessCode) => headers.set(OPF_CC_ACCESS_CODE_HEADER, accessCode))
+      );
     }
 
-    return this.getAccessCode().pipe(
-      map((accessCode) => headers.set(OPF_CC_ACCESS_CODE_HEADER, accessCode))
-    );
+    return of(headers);
   }
 
   protected getAccessCode(): Observable<string> {

--- a/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
+++ b/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
@@ -7,8 +7,13 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import {
+  ActiveCartFacade,
+  CartAccessCodeFacade,
+} from '@spartacus/cart/base/root';
+import {
   ConverterService,
   LoggerService,
+  UserIdService,
   tryNormalizeHttpError,
 } from '@spartacus/core';
 import {
@@ -17,14 +22,15 @@ import {
   OpfEndpointsService,
 } from '@spartacus/opf/base/core';
 import {
+  OPF_CC_ACCESS_CODE_HEADER,
   OPF_CC_PUBLIC_KEY_HEADER,
   OpfActiveConfigurationsQuery,
   OpfActiveConfigurationsResponse,
   OpfConfig,
   OpfMetadataStatePersistanceService,
 } from '@spartacus/opf/base/root';
-import { Observable } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
 
 @Injectable()
 export class OpfApiBaseAdapter implements OpfBaseAdapter {
@@ -36,6 +42,9 @@ export class OpfApiBaseAdapter implements OpfBaseAdapter {
     OpfMetadataStatePersistanceService
   );
   protected logger = inject(LoggerService);
+  protected userIdService = inject(UserIdService);
+  protected activeCartFacade = inject(ActiveCartFacade);
+  protected cartAccessCodeFacade = inject(CartAccessCodeFacade);
 
   protected headerWithNoLanguage: { [name: string]: string } = {
     accept: 'application/json',
@@ -56,24 +65,18 @@ export class OpfApiBaseAdapter implements OpfBaseAdapter {
   getActiveConfigurations(
     query?: OpfActiveConfigurationsQuery
   ): Observable<OpfActiveConfigurationsResponse> {
-    const headers = new HttpHeaders(this.header).set(
-      OPF_CC_PUBLIC_KEY_HEADER,
-      this.config.opf?.commerceCloudPublicKey || ''
+    return this.getHeaders().pipe(
+      switchMap((headers) =>
+        this.http.get<OpfActiveConfigurationsResponse>(
+          this.getActiveConfigurationsEndpoint(query),
+          { headers }
+        )
+      ),
+      catchError((error) => {
+        throw tryNormalizeHttpError(error, this.logger);
+      }),
+      this.converter.pipeable(OPF_ACTIVE_CONFIGURATIONS_NORMALIZER)
     );
-
-    return this.http
-      .get<OpfActiveConfigurationsResponse>(
-        this.getActiveConfigurationsEndpoint(query),
-        {
-          headers,
-        }
-      )
-      .pipe(
-        catchError((error) => {
-          throw tryNormalizeHttpError(error, this.logger);
-        }),
-        this.converter.pipeable(OPF_ACTIVE_CONFIGURATIONS_NORMALIZER)
-      );
   }
 
   protected getActiveConfigurationsEndpoint(
@@ -82,5 +85,35 @@ export class OpfApiBaseAdapter implements OpfBaseAdapter {
     return this.opfEndpointsService.buildUrl('getActiveConfigurations', {
       queryParams: query,
     });
+  }
+
+  protected getHeaders(): Observable<HttpHeaders> {
+    const headers = new HttpHeaders(this.header).set(
+      OPF_CC_PUBLIC_KEY_HEADER,
+      this.config.opf?.commerceCloudPublicKey || ''
+    );
+
+    if (this.config.opf?.enableActiveConfigurationAccessCodeHeader !== true) {
+      return of(headers);
+    }
+
+    return this.getAccessCode().pipe(
+      map((accessCode) => headers.set(OPF_CC_ACCESS_CODE_HEADER, accessCode))
+    );
+  }
+
+  protected getAccessCode(): Observable<string> {
+    return this.userIdService.takeUserId().pipe(
+      switchMap((userId) =>
+        this.activeCartFacade
+          .takeActiveCartId()
+          .pipe(
+            switchMap((cartId) =>
+              this.cartAccessCodeFacade.getCartAccessCode(userId, cartId)
+            )
+          )
+      ),
+      map((response) => response?.accessCode ?? '')
+    );
   }
 }

--- a/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
+++ b/integration-libs/opf/base/opf-api/adapters/opf-api-base.adapter.ts
@@ -93,7 +93,7 @@ export class OpfApiBaseAdapter implements OpfBaseAdapter {
       this.config.opf?.commerceCloudPublicKey || ''
     );
 
-    if (this.config.opf?.enableActiveConfigurationAccessCodeHeader) {
+    if (this.config.opf?.enableGetActiveConfigurationsAccessCodeHeader) {
       return this.getAccessCode().pipe(
         map((accessCode) => headers.set(OPF_CC_ACCESS_CODE_HEADER, accessCode))
       );

--- a/integration-libs/opf/base/root/config/opf-config.ts
+++ b/integration-libs/opf/base/root/config/opf-config.ts
@@ -84,7 +84,7 @@ export abstract class OpfConfig {
      * When enabled, a cart access code is generated and sent as the
      * `sap-commerce-cloud-access-code` header on the `getActiveConfigurations` request.
      */
-    enableActiveConfigurationAccessCodeHeader?: boolean;
+    enableGetActiveConfigurationsAccessCodeHeader?: boolean;
   };
 }
 

--- a/integration-libs/opf/base/root/config/opf-config.ts
+++ b/integration-libs/opf/base/root/config/opf-config.ts
@@ -80,6 +80,11 @@ export abstract class OpfConfig {
         cssFiles: string[];
       }
     >;
+    /**
+     * When enabled, a cart access code is generated and sent as the
+     * `sap-commerce-cloud-access-code` header on the `getActiveConfigurations` request.
+     */
+    enableActiveConfigurationAccessCodeHeader?: boolean;
   };
 }
 

--- a/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
@@ -188,7 +188,7 @@ if (!environment.b2b && environment.opf) {
         opfBaseUrl:
           'https://opf-iss-d0.opf.commerce.stage.context.cloud.sap/commerce-cloud-adapter/storefront',
         commerceCloudPublicKey: 'ADD_COMMERCE_CLOUD_PUBLIC_KEY_HERE',
-        enableActiveConfigurationAccessCodeHeader: true,
+        enableGetActiveConfigurationsAccessCodeHeader: true,
       },
     }),
     ...extensionProviders,

--- a/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
@@ -187,7 +187,8 @@ if (!environment.b2b && environment.opf) {
       opf: {
         opfBaseUrl:
           'https://opf-iss-d0.opf.commerce.stage.context.cloud.sap/commerce-cloud-adapter/storefront',
-        commerceCloudPublicKey: 'ADD_COMMERCE_CLOUD_PUBLIC_KEY_HERE',
+        commerceCloudPublicKey: 'ab4RhYGZ+w5B0SALMPOPlepWk/kmDQjTy2FU5hrQoFg=',
+        enableActiveConfigurationAccessCodeHeader: false,
       },
     }),
     ...extensionProviders,

--- a/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
@@ -188,7 +188,7 @@ if (!environment.b2b && environment.opf) {
         opfBaseUrl:
           'https://opf-iss-d0.opf.commerce.stage.context.cloud.sap/commerce-cloud-adapter/storefront',
         commerceCloudPublicKey: 'ADD_COMMERCE_CLOUD_PUBLIC_KEY_HERE',
-        enableActiveConfigurationAccessCodeHeader: false,
+        enableActiveConfigurationAccessCodeHeader: true,
       },
     }),
     ...extensionProviders,

--- a/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/features/opf/opf-feature.module.ts
@@ -187,7 +187,7 @@ if (!environment.b2b && environment.opf) {
       opf: {
         opfBaseUrl:
           'https://opf-iss-d0.opf.commerce.stage.context.cloud.sap/commerce-cloud-adapter/storefront',
-        commerceCloudPublicKey: 'ab4RhYGZ+w5B0SALMPOPlepWk/kmDQjTy2FU5hrQoFg=',
+        commerceCloudPublicKey: 'ADD_COMMERCE_CLOUD_PUBLIC_KEY_HERE',
         enableActiveConfigurationAccessCodeHeader: false,
       },
     }),


### PR DESCRIPTION
To support Account Group filtering as a part of the Intellligent Routing Feature, we need the access code to get the Cart/Order DTO details for rule based filtering. 

The current GET /configurations flow does not include the access code in the request. 

The requirement is that Spartacus sends the access code as an optional header with the GET /configurations request so that the commerce-cloud adapter can fetch the details and then send them to the opf-plus service to enable filtering of Payment Integrations. 

https://jira.tools.sap/browse/CXSPA-14007
