### PR TITLE
chore: allow node imports vitest config

### DIFF
--- a/tools/config/manage-dependencies.ts
+++ b/tools/config/manage-dependencies.ts
@@ -401,8 +401,12 @@ function filterNativeNodeAPIs(
               // Don't allow to use node api outside of schematics files
               if (imp.usageIn.spec || imp.usageIn.lib) {
                 imp.files.forEach((file) => {
-                  // Allow to use Node APIs in SSR
-                  if (!file.includes('ssr')) {
+                  // Allow to use Node APIs in SSR and in build-time config files
+                  // (e.g. vitest.config.ts), which are never shipped to the browser
+                  if (
+                    !file.includes('ssr') &&
+                    !file.endsWith('vitest.config.ts')
+                  ) {
                     errorsFound = true;
                     error(
                       file,


### PR DESCRIPTION
A vitest.config.ts is a build-time Node script — it runs in Node during test setup and is never bundled into the browser output. Using path here is correct and necessary, so we can exclude from Node.js API import check