### PR TITLE
feat: Open large CPQ cart bundles in configuration overview (CXSPA-13473)

### DIFF
--- a/feature-libs/product-configurator/common/assets/translations/en/configurator.json
+++ b/feature-libs/product-configurator/common/assets/translations/en/configurator.json
@@ -101,6 +101,7 @@
       "buttonUpdateCart": "Done",
       "buttonDisplayOnly": "Done",
       "buttonClose": "Close",
+      "buttonBackToCart": "Back to Cart",
       "confirmation": "Configuration has been added to the cart",
       "confirmationUpdate": "Cart has been updated with configuration",
       "confirmationQuoteUpdate": "Quote has been updated with configuration",

--- a/feature-libs/product-configurator/common/components/common-configurator-components.module.ts
+++ b/feature-libs/product-configurator/common/components/common-configurator-components.module.ts
@@ -5,6 +5,8 @@
  */
 
 import { NgModule } from '@angular/core';
+import { provideDefaultConfig } from '@spartacus/core';
+import { defaultCommonConfiguratorUISettingsConfig } from './config/default-common-configurator-ui-settings.config';
 import { ConfiguratorCartEntryInfoModule } from './configurator-cart-entry-info/configurator-cart-entry-info.module';
 import { ConfiguratorIssuesNotificationModule } from './configurator-issues-notification/configurator-issues-notification.module';
 import { ConfigureCartEntryModule } from './configure-cart-entry/configure-cart-entry.module';
@@ -19,5 +21,6 @@ import { ConfiguratorCartEntryBundleInfoModule } from './configurator-cart-entry
     ConfigureCartEntryModule,
     ConfigureProductModule,
   ],
+  providers: [provideDefaultConfig(defaultCommonConfiguratorUISettingsConfig)],
 })
 export class CommonConfiguratorComponentsModule {}

--- a/feature-libs/product-configurator/common/components/config/common-configurator-ui-settings.config.ts
+++ b/feature-libs/product-configurator/common/components/config/common-configurator-ui-settings.config.ts
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable } from '@angular/core';
+import { Config } from '@spartacus/core';
+
+export interface CommonProductConfiguratorUISettingsConfig {
+  /**
+   * Maximum number of CPQ bundle line items that are expanded inline on a cart entry.
+   * If the entry has more items, the 'show' link navigates to the read-only
+   * configuration overview instead.
+   */
+  cpqProductCartEntriesThreshold?: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+  useExisting: Config,
+})
+export abstract class CommonConfiguratorUISettingsConfig {
+  productConfigurator?: CommonProductConfiguratorUISettingsConfig;
+}
+
+declare module '../../core/model/product-configurator.config' {
+  interface ProductConfiguratorConfig
+    extends CommonProductConfiguratorUISettingsConfig {}
+}

--- a/feature-libs/product-configurator/common/components/config/common-configurator-ui-settings.config.ts
+++ b/feature-libs/product-configurator/common/components/config/common-configurator-ui-settings.config.ts
@@ -9,11 +9,11 @@ import { Config } from '@spartacus/core';
 
 export interface CommonProductConfiguratorUISettingsConfig {
   /**
-   * Maximum number of CPQ bundle line items that are expanded inline on a cart entry.
+   * Maximum number of bundle line items that are expanded inline on a cart entry.
    * If the entry has more items, the 'show' link navigates to the read-only
    * configuration overview instead.
    */
-  cpqProductCartEntriesThreshold?: number;
+  cartEntryBundleLineItemsThreshold?: number;
 }
 
 @Injectable({

--- a/feature-libs/product-configurator/common/components/config/default-common-configurator-ui-settings.config.ts
+++ b/feature-libs/product-configurator/common/components/config/default-common-configurator-ui-settings.config.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommonConfiguratorUISettingsConfig } from './common-configurator-ui-settings.config';
+
+export const defaultCommonConfiguratorUISettingsConfig: CommonConfiguratorUISettingsConfig =
+  {
+    productConfigurator: {
+      cpqProductCartEntriesThreshold: 10,
+    },
+  };

--- a/feature-libs/product-configurator/common/components/config/default-common-configurator-ui-settings.config.ts
+++ b/feature-libs/product-configurator/common/components/config/default-common-configurator-ui-settings.config.ts
@@ -9,6 +9,6 @@ import { CommonConfiguratorUISettingsConfig } from './common-configurator-ui-set
 export const defaultCommonConfiguratorUISettingsConfig: CommonConfiguratorUISettingsConfig =
   {
     productConfigurator: {
-      cpqProductCartEntriesThreshold: 10,
+      cartEntryBundleLineItemsThreshold: 10,
     },
   };

--- a/feature-libs/product-configurator/common/components/config/index.ts
+++ b/feature-libs/product-configurator/common/components/config/index.ts
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2026 SAP Spartacus team <spartacus-team@sap.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { CommonConfiguratorUISettingsConfig } from './common-configurator-ui-settings.config';

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
@@ -6,15 +6,36 @@
           'configurator.header.items' | cxTranslate: { count: numberOfItems }
         }}
       </div>
-      <button
-        (click)="toggleItems()"
-        [attr.aria-expanded]="!this.hideItems"
-        [attr.aria-label]="getItemsMsg(numberOfItems)"
-      >
+      <ng-container *ngIf="navigateToOverview$ | async; else toggleItemsButton">
+        <span
+          id="{{ getItemsLinkMsgId(orderEntry) }}"
+          class="cx-visually-hidden"
+        >
+          {{ getItemsLinkMsg(numberOfItems) }}
+        </span>
         <div class="cx-toggle-hide-items">
-          {{ getButtonText() }}
+          <cx-configure-cart-entry
+            [cartEntry]="orderEntry"
+            [readOnly]="true"
+            [msgBanner]="false"
+            [disabled]="false"
+            [isBundleOverviewLink]="true"
+            [a11yDescriptionId]="getItemsLinkMsgId(orderEntry)"
+          ></cx-configure-cart-entry>
         </div>
-      </button>
+      </ng-container>
+
+      <ng-template #toggleItemsButton>
+        <button
+          (click)="toggleItems()"
+          [attr.aria-expanded]="!this.hideItems"
+          [attr.aria-label]="getItemsMsg(numberOfItems)"
+        >
+          <div class="cx-toggle-hide-items">
+            {{ getButtonText() }}
+          </div>
+        </button>
+      </ng-template>
 
       <div class="cx-item-infos" [class.open]="!hideItems">
         <div

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
@@ -35,40 +35,40 @@
             {{ getButtonText() }}
           </div>
         </button>
-      </ng-template>
 
-      <div class="cx-item-infos" [class.open]="!hideItems">
-        <div
-          *ngFor="let lineItem of lineItems$ | async; let i = index"
-          class="cx-item-info"
-          attr.aria-describedby="{{ getHiddenItemInfoId(i) }}"
-        >
-          <span id="{{ getHiddenItemInfoId(i) }}" class="cx-visually-hidden">
-            {{ getHiddenItemInfo(lineItem) }}
-          </span>
-          <div class="cx-item-name" aria-hidden="true">
-            {{ lineItem?.name }}
-          </div>
-          <div class="cx-item-quantity" aria-hidden="true">
-            <ng-container *ngIf="lineItem?.formattedQuantity">
-              <span class="cx-identifier">{{
-                'configurator.attribute.quantity' | cxTranslate
-              }}</span>
-              <span class="cx-item">{{
-                lineItem?.formattedQuantity | cxNumeric
-              }}</span>
-            </ng-container>
-          </div>
-          <div class="cx-item-price" aria-hidden="true">
-            <ng-container *ngIf="lineItem?.formattedPrice">
-              <span class="cx-identifier">{{
-                'configurator.overviewForm.itemPrice' | cxTranslate
-              }}</span>
-              <span class="cx-item">{{ lineItem?.formattedPrice }}</span>
-            </ng-container>
+        <div class="cx-item-infos" [class.open]="!hideItems">
+          <div
+            *ngFor="let lineItem of lineItems$ | async; let i = index"
+            class="cx-item-info"
+            attr.aria-describedby="{{ getHiddenItemInfoId(i) }}"
+          >
+            <span id="{{ getHiddenItemInfoId(i) }}" class="cx-visually-hidden">
+              {{ getHiddenItemInfo(lineItem) }}
+            </span>
+            <div class="cx-item-name" aria-hidden="true">
+              {{ lineItem?.name }}
+            </div>
+            <div class="cx-item-quantity" aria-hidden="true">
+              <ng-container *ngIf="lineItem?.formattedQuantity">
+                <span class="cx-identifier">{{
+                  'configurator.attribute.quantity' | cxTranslate
+                }}</span>
+                <span class="cx-item">{{
+                  lineItem?.formattedQuantity | cxNumeric
+                }}</span>
+              </ng-container>
+            </div>
+            <div class="cx-item-price" aria-hidden="true">
+              <ng-container *ngIf="lineItem?.formattedPrice">
+                <span class="cx-identifier">{{
+                  'configurator.overviewForm.itemPrice' | cxTranslate
+                }}</span>
+                <span class="cx-item">{{ lineItem?.formattedPrice }}</span>
+              </ng-container>
+            </div>
           </div>
         </div>
-      </div>
+      </ng-template>
     </ng-container>
     <ng-container *ngIf="quantityControl$ | async as quantityControl">
       <cx-configure-cart-entry

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
@@ -23,6 +23,10 @@ import {
   TranslatePipe,
 } from '@spartacus/core';
 import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
+import {
   CommonConfiguratorUtilsService,
   ConfigurationInfo,
   ConfiguratorCartEntryBundleInfoService,
@@ -34,6 +38,7 @@ import { BreakpointService } from '@spartacus/storefront';
 import { BehaviorSubject, EMPTY, of, ReplaySubject } from 'rxjs';
 import { take, toArray } from 'rxjs/operators';
 import { CommonConfiguratorTestUtilsService } from '../../testing/common-configurator-test-utils.service';
+import { CommonConfiguratorUISettingsConfig } from '../config/common-configurator-ui-settings.config';
 import { ConfiguratorCartEntryBundleInfoComponent } from './configurator-cart-entry-bundle-info.component';
 
 @Pipe({ name: 'cxNumeric' })
@@ -52,6 +57,8 @@ class MockConfigureCartEntryComponent {
   @Input() readOnly: boolean;
   @Input() msgBanner: boolean;
   @Input() disabled: boolean;
+  @Input() isBundleOverviewLink = false;
+  @Input() a11yDescriptionId?: string;
 }
 
 class MockCartItemContext implements Partial<CartItemContext> {
@@ -116,6 +123,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
         {
           provide: ControlContainer,
         },
+        provideMockFeatureToggles({ productConfiguratorCPQContainer: false }),
       ],
     })
       .overrideComponent(ConfiguratorCartEntryBundleInfoComponent, {
@@ -714,7 +722,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
         expect(
           component
             .getItemsMsg(numberOfItems)
-            .indexOf('configurator.a11y.cartEntryBundleInfo items:1')
+            .indexOf('configurator.a11y.cartEntryBundleInfo count:1 items:1')
         ).toBe(0);
       });
 
@@ -723,7 +731,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
         expect(
           component
             .getItemsMsg(numberOfItems)
-            .indexOf('configurator.a11y.cartEntryBundleInfo items:4')
+            .indexOf('configurator.a11y.cartEntryBundleInfo count:4 items:4')
         ).toBe(0);
       });
     });
@@ -822,7 +830,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
           undefined,
           undefined,
           'aria-label',
-          'configurator.a11y.cartEntryBundleInfo items:1configurator.header.hide'
+          'configurator.a11y.cartEntryBundleInfo count:1 items:1configurator.header.hide'
         );
 
         CommonConfiguratorTestUtilsService.expectElementContainsA11y(
@@ -922,6 +930,158 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
           undefined,
           undefined,
           '5'
+        );
+      });
+    });
+
+    describe('navigation to the configuration overview', () => {
+      const TOGGLE_LINK = '.cx-toggle-hide-items cx-configure-cart-entry';
+
+      let featureToggles: MockFeatureTogglesController;
+
+      function emitCartEntry(location: PromotionLocation) {
+        mockCartItemContext.item$.next({
+          entryNumber: 3,
+          statusSummaryList: undefined,
+          configurationInfos: configurationInfos,
+          product: {
+            configurable: true,
+          },
+        });
+        mockCartItemContext.location$.next(location);
+        mockCartItemContext.readonly$.next(false);
+        mockCartItemContext.quantityControl$.next(new UntypedFormControl());
+        fixture.detectChanges();
+      }
+
+      beforeEach(() => {
+        featureToggles = TestBed.inject(MockFeatureTogglesController);
+        featureToggles.set('productConfiguratorCPQContainer', true);
+        spyOn(component, 'getCpqProductCartEntriesThreshold').and.returnValue(
+          2
+        );
+      });
+
+      it('should render a link to the overview instead of the toggle button if the threshold is exceeded', () => {
+        emitCartEntry(PromotionLocation.ActiveCart);
+
+        CommonConfiguratorTestUtilsService.expectElementPresent(
+          expect,
+          htmlElem,
+          TOGGLE_LINK
+        );
+        CommonConfiguratorTestUtilsService.expectElementNotPresent(
+          expect,
+          htmlElem,
+          'button'
+        );
+      });
+
+      it('should render the link in read only mode with the show text', () => {
+        emitCartEntry(PromotionLocation.ActiveCart);
+
+        const linkComponent = fixture.debugElement.query(
+          By.css(TOGGLE_LINK)
+        ).componentInstance;
+
+        expect(linkComponent.readOnly).toBe(true);
+        expect(linkComponent.msgBanner).toBe(false);
+        expect(linkComponent.disabled).toBe(false);
+        expect(linkComponent.isBundleOverviewLink).toBe(true);
+        expect(linkComponent.a11yDescriptionId).toBe('cx-item-list-info-3');
+      });
+
+      it('should render the toggle button if the threshold is not exceeded', () => {
+        (
+          component.getCpqProductCartEntriesThreshold as jasmine.Spy
+        ).and.returnValue(3);
+        emitCartEntry(PromotionLocation.ActiveCart);
+
+        CommonConfiguratorTestUtilsService.expectElementNotPresent(
+          expect,
+          htmlElem,
+          TOGGLE_LINK
+        );
+        CommonConfiguratorTestUtilsService.expectElementPresent(
+          expect,
+          htmlElem,
+          'button'
+        );
+      });
+
+      it('should render the toggle button if the feature toggle is not active', () => {
+        featureToggles.set('productConfiguratorCPQContainer', false);
+        emitCartEntry(PromotionLocation.ActiveCart);
+
+        CommonConfiguratorTestUtilsService.expectElementNotPresent(
+          expect,
+          htmlElem,
+          TOGGLE_LINK
+        );
+        CommonConfiguratorTestUtilsService.expectElementPresent(
+          expect,
+          htmlElem,
+          'button'
+        );
+      });
+
+      it('should render the toggle button for a saved cart, as no navigation to the overview is possible there', () => {
+        emitCartEntry(PromotionLocation.SavedCart);
+
+        CommonConfiguratorTestUtilsService.expectElementNotPresent(
+          expect,
+          htmlElem,
+          TOGGLE_LINK
+        );
+        CommonConfiguratorTestUtilsService.expectElementPresent(
+          expect,
+          htmlElem,
+          'button'
+        );
+      });
+
+      it('should render the toggle button for save for later, as no navigation to the overview is possible there', () => {
+        emitCartEntry(PromotionLocation.SaveForLater);
+
+        CommonConfiguratorTestUtilsService.expectElementNotPresent(
+          expect,
+          htmlElem,
+          TOGGLE_LINK
+        );
+        CommonConfiguratorTestUtilsService.expectElementPresent(
+          expect,
+          htmlElem,
+          'button'
+        );
+      });
+    });
+
+    describe('getCpqProductCartEntriesThreshold', () => {
+      it('should return the default threshold if nothing is configured', () => {
+        expect(component.getCpqProductCartEntriesThreshold()).toBe(10);
+      });
+
+      it('should return the configured threshold', () => {
+        TestBed.inject(CommonConfiguratorUISettingsConfig).productConfigurator =
+          {
+            cpqProductCartEntriesThreshold: 25,
+          };
+        expect(component.getCpqProductCartEntriesThreshold()).toBe(25);
+      });
+    });
+
+    describe('getItemsLinkMsg', () => {
+      it("should return 'configurator.a11y.cartEntryBundleInfo' with the number of items", () => {
+        expect(component.getItemsLinkMsg(4)).toBe(
+          'configurator.a11y.cartEntryBundleInfo count:4 items:4'
+        );
+      });
+    });
+
+    describe('getItemsLinkMsgId', () => {
+      it('should return an ID that is unique per cart entry', () => {
+        expect(component.getItemsLinkMsgId({ entryNumber: 4 })).toBe(
+          'cx-item-list-info-4'
         );
       });
     });

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
@@ -975,6 +975,11 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
           htmlElem,
           'button'
         );
+        CommonConfiguratorTestUtilsService.expectElementNotPresent(
+          expect,
+          htmlElem,
+          '.cx-item-infos'
+        );
       });
 
       it('should render the link in read only mode with the show text', () => {
@@ -1006,6 +1011,11 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
           expect,
           htmlElem,
           'button'
+        );
+        CommonConfiguratorTestUtilsService.expectElementPresent(
+          expect,
+          htmlElem,
+          '.cx-item-infos'
         );
       });
 

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
@@ -957,9 +957,10 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
       beforeEach(() => {
         featureToggles = TestBed.inject(MockFeatureTogglesController);
         featureToggles.set('productConfiguratorCPQContainer', true);
-        spyOn(component, 'getCartEntryBundleLineItemsThreshold').and.returnValue(
-          2
-        );
+        spyOn(
+          component as any,
+          'getCartEntryBundleLineItemsThreshold'
+        ).and.returnValue(2);
       });
 
       it('should render a link to the overview instead of the toggle button if the threshold is exceeded', () => {
@@ -998,7 +999,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
 
       it('should render the toggle button if the threshold is not exceeded', () => {
         (
-          component.getCartEntryBundleLineItemsThreshold as jasmine.Spy
+          component['getCartEntryBundleLineItemsThreshold'] as jasmine.Spy
         ).and.returnValue(3);
         emitCartEntry(PromotionLocation.ActiveCart);
 
@@ -1068,7 +1069,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
 
     describe('getCartEntryBundleLineItemsThreshold', () => {
       it('should return the default threshold if nothing is configured', () => {
-        expect(component.getCartEntryBundleLineItemsThreshold()).toBe(10);
+        expect(component['getCartEntryBundleLineItemsThreshold']()).toBe(10);
       });
 
       it('should return the configured threshold', () => {
@@ -1076,7 +1077,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
           {
             cartEntryBundleLineItemsThreshold: 25,
           };
-        expect(component.getCartEntryBundleLineItemsThreshold()).toBe(25);
+        expect(component['getCartEntryBundleLineItemsThreshold']()).toBe(25);
       });
     });
 

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.spec.ts
@@ -957,7 +957,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
       beforeEach(() => {
         featureToggles = TestBed.inject(MockFeatureTogglesController);
         featureToggles.set('productConfiguratorCPQContainer', true);
-        spyOn(component, 'getCpqProductCartEntriesThreshold').and.returnValue(
+        spyOn(component, 'getCartEntryBundleLineItemsThreshold').and.returnValue(
           2
         );
       });
@@ -998,7 +998,7 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
 
       it('should render the toggle button if the threshold is not exceeded', () => {
         (
-          component.getCpqProductCartEntriesThreshold as jasmine.Spy
+          component.getCartEntryBundleLineItemsThreshold as jasmine.Spy
         ).and.returnValue(3);
         emitCartEntry(PromotionLocation.ActiveCart);
 
@@ -1066,17 +1066,17 @@ describe('ConfiguratorCartEntryBundleInfoComponent', () => {
       });
     });
 
-    describe('getCpqProductCartEntriesThreshold', () => {
+    describe('getCartEntryBundleLineItemsThreshold', () => {
       it('should return the default threshold if nothing is configured', () => {
-        expect(component.getCpqProductCartEntriesThreshold()).toBe(10);
+        expect(component.getCartEntryBundleLineItemsThreshold()).toBe(10);
       });
 
       it('should return the configured threshold', () => {
         TestBed.inject(CommonConfiguratorUISettingsConfig).productConfigurator =
           {
-            cpqProductCartEntriesThreshold: 25,
+            cartEntryBundleLineItemsThreshold: 25,
           };
-        expect(component.getCpqProductCartEntriesThreshold()).toBe(25);
+        expect(component.getCartEntryBundleLineItemsThreshold()).toBe(25);
       });
     });
 

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
@@ -5,18 +5,21 @@
  */
 
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
-import { Component, Optional } from '@angular/core';
+import { Component, Optional, inject } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { CartItemContext, OrderEntry } from '@spartacus/cart/base/root';
 import {
   CxNumericPipe,
+  FeatureToggles,
   TranslatePipe,
   TranslationService,
+  useFeatureStyles,
 } from '@spartacus/core';
 import { BreakpointService } from '@spartacus/storefront';
-import { EMPTY, Observable } from 'rxjs';
+import { EMPTY, Observable, combineLatest } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { CommonConfiguratorUtilsService } from '../../shared/utils/common-configurator-utils.service';
+import { CommonConfiguratorUISettingsConfig } from '../config/common-configurator-ui-settings.config';
 import { ConfigureCartEntryComponent } from '../configure-cart-entry/configure-cart-entry.component';
 import { LineItem } from './configurator-cart-entry-bundle-info.model';
 import { ConfiguratorCartEntryBundleInfoService } from './configurator-cart-entry-bundle-info.service';
@@ -38,13 +41,18 @@ import { ConfiguratorCartEntryBundleInfoService } from './configurator-cart-entr
   ],
 })
 export class ConfiguratorCartEntryBundleInfoComponent {
+  protected config = inject(CommonConfiguratorUISettingsConfig);
+  private featureToggles = inject(FeatureToggles);
+
   constructor(
     protected commonConfigUtilsService: CommonConfiguratorUtilsService,
     protected configCartEntryBundleInfoService: ConfiguratorCartEntryBundleInfoService,
     protected breakpointService: BreakpointService,
     protected translation: TranslationService,
     @Optional() protected cartItemContext?: CartItemContext
-  ) {}
+  ) {
+    useFeatureStyles('productConfiguratorCPQContainer');
+  }
 
   readonly orderEntry$: Observable<OrderEntry> =
     this.cartItemContext?.item$ ?? EMPTY;
@@ -93,6 +101,58 @@ export class ConfiguratorCartEntryBundleInfoComponent {
   readonly shouldShowButton$: Observable<boolean> =
     this.commonConfigUtilsService.isActiveCartContext(this.cartItemContext);
 
+  /**
+   * Emits 'true' if the number of line items exceeds the configured threshold and
+   * a navigation to the configuration overview is possible. In that case the items
+   * are not expanded in place, but the user is taken to the overview page instead.
+   */
+  readonly navigateToOverview$: Observable<boolean> = combineLatest([
+    this.numberOfLineItems$,
+    this.shouldShowButton$,
+  ]).pipe(
+    map(
+      ([numberOfLineItems, shouldShowButton]) =>
+        !!this.featureToggles.productConfiguratorCPQContainer &&
+        shouldShowButton &&
+        numberOfLineItems > this.getCpqProductCartEntriesThreshold()
+    )
+  );
+
+  /**
+   * Retrieves the maximum number of line items that are expanded within the cart entry.
+   *
+   * @returns {number} - the configured threshold
+   */
+  getCpqProductCartEntriesThreshold(): number {
+    return (
+      this.config.productConfigurator?.cpqProductCartEntriesThreshold ?? 10
+    );
+  }
+
+  /**
+   * Compiles the accessibility description of the link that navigates to the
+   * configuration overview.
+   *
+   * @param {number} items - number of line items
+   * @returns {string} - accessibility description
+   */
+  getItemsLinkMsg(items: number): string {
+    let translatedText = '';
+    this.translation
+      .translate('configurator.a11y.cartEntryBundleInfo', {
+        count: items,
+        items: items,
+      })
+      .pipe(take(1))
+      .subscribe((text) => (translatedText = text));
+
+    return translatedText;
+  }
+
+  getItemsLinkMsgId(entry: OrderEntry): string {
+    return 'cx-item-list-info-' + entry.entryNumber;
+  }
+
   getButtonText(translatedText?: string): string {
     if (!translatedText) {
       translatedText = '';
@@ -115,7 +175,10 @@ export class ConfiguratorCartEntryBundleInfoComponent {
   getItemsMsg(items: number): string {
     let translatedText = '';
     this.translation
-      .translate('configurator.a11y.cartEntryBundleInfo', { items: items })
+      .translate('configurator.a11y.cartEntryBundleInfo', {
+        count: items,
+        items: items,
+      })
       .pipe(take(1))
       .subscribe((text) => (translatedText = text));
 

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
@@ -114,7 +114,7 @@ export class ConfiguratorCartEntryBundleInfoComponent {
       ([numberOfLineItems, shouldShowButton]) =>
         !!this.featureToggles.productConfiguratorCPQContainer &&
         shouldShowButton &&
-        numberOfLineItems > this.getCpqProductCartEntriesThreshold()
+        numberOfLineItems > this.getCartEntryBundleLineItemsThreshold()
     )
   );
 
@@ -123,9 +123,9 @@ export class ConfiguratorCartEntryBundleInfoComponent {
    *
    * @returns {number} - the configured threshold
    */
-  getCpqProductCartEntriesThreshold(): number {
+  getCartEntryBundleLineItemsThreshold(): number {
     return (
-      this.config.productConfigurator?.cpqProductCartEntriesThreshold ?? 10
+      this.config.productConfigurator?.cartEntryBundleLineItemsThreshold ?? 10
     );
   }
 

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.ts
@@ -123,7 +123,7 @@ export class ConfiguratorCartEntryBundleInfoComponent {
    *
    * @returns {number} - the configured threshold
    */
-  getCartEntryBundleLineItemsThreshold(): number {
+  protected getCartEntryBundleLineItemsThreshold(): number {
     return (
       this.config.productConfigurator?.cartEntryBundleLineItemsThreshold ?? 10
     );

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.html
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.html
@@ -26,17 +26,6 @@
   </ng-container>
 
   <ng-template #configureText>
-    <ng-container *ngIf="getDisplayOnly()">
-      {{
-        'configurator.header.displayConfiguration' | cxTranslate
-      }}</ng-container
-    >
-    <ng-container *ngIf="!getDisplayOnly() && !msgBanner">
-      {{ 'configurator.header.editConfiguration' | cxTranslate }}
-    </ng-container>
-
-    <ng-container *ngIf="!getDisplayOnly() && msgBanner">
-      {{ 'configurator.header.resolveIssues' | cxTranslate }}
-    </ng-container>
+    {{ getLinkTextResourceKey() | cxTranslate }}
   </ng-template>
 </ng-container>

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.spec.ts
@@ -499,6 +499,26 @@ describe('ConfigureCartEntryComponent', () => {
           });
       });
 
+      it('should set "navigateToCart" for a bundle overview link', (done) => {
+        component.isBundleOverviewLink = true;
+        component.queryParams$
+          .pipe(take(1), delay(0))
+          .subscribe((queryParams) => {
+            expect(queryParams.navigateToCart).toBe(true);
+            done();
+          });
+      });
+
+      it('should not set "navigateToCart" for a regular configuration link', (done) => {
+        component.isBundleOverviewLink = false;
+        component.queryParams$
+          .pipe(take(1), delay(0))
+          .subscribe((queryParams) => {
+            expect(queryParams.navigateToCart).toBe(false);
+            done();
+          });
+      });
+
       it('should contain "productCode" parameter in case product code is relevant', (done) => {
         component.cartEntry = {
           entryNumber: 0,

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.spec.ts
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.spec.ts
@@ -387,6 +387,22 @@ describe('ConfigureCartEntryComponent', () => {
           'configurator.header.resolveIssues'
         );
       });
+
+      it("should be 'Show' for a bundle overview link", () => {
+        component.readOnly = true;
+        component.isBundleOverviewLink = true;
+        component.cartEntry = {
+          entryNumber: 0,
+          product: { configuratorType: configuratorType },
+        };
+        fixture.detectChanges();
+        CommonConfiguratorTestUtilsService.expectElementToContainText(
+          expect,
+          htmlElem,
+          'a',
+          'configurator.header.show'
+        );
+      });
     });
 
     describe('a', () => {
@@ -454,6 +470,20 @@ describe('ConfigureCartEntryComponent', () => {
         fixture.detectChanges();
         expect(component.getResolveIssuesA11yDescription()).toEqual(
           'cx-error-msg-0'
+        );
+      });
+
+      it('should return the provided a11yDescriptionId with precedence', () => {
+        component.readOnly = true;
+        component.msgBanner = false;
+        component.a11yDescriptionId = 'cx-item-list-info-3';
+        component.cartEntry = {
+          entryNumber: 0,
+          product: { configuratorType: configuratorType },
+        };
+        fixture.detectChanges();
+        expect(component.getResolveIssuesA11yDescription()).toEqual(
+          'cx-item-list-info-3'
         );
       });
     });

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.ts
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.ts
@@ -61,12 +61,14 @@ export class ConfigureCartEntryComponent {
     forceReload: boolean;
     resolveIssues: boolean;
     navigateToCheckout: boolean;
+    navigateToCart: boolean;
     productCode: string | undefined;
   }> = this.isInCheckout().pipe(
     map((isInCheckout) => ({
       forceReload: true,
       resolveIssues: this.msgBanner && this.hasIssues(),
       navigateToCheckout: isInCheckout,
+      navigateToCart: this.isBundleOverviewLink,
       productCode: this.cartEntry.product?.code,
     }))
   );

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.ts
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.ts
@@ -40,6 +40,15 @@ export class ConfigureCartEntryComponent {
   @Input() readOnly: boolean;
   @Input() msgBanner: boolean;
   @Input() disabled: boolean;
+  /**
+   * Indicates whether the link navigates from bundle information to the
+   * configuration overview.
+   */
+  @Input() isBundleOverviewLink = false;
+  /**
+   * ID of an element that provides an additional description for the link.
+   */
+  @Input() a11yDescriptionId?: string;
   abstractOrderContext = inject(AbstractOrderContext, { optional: true });
 
   // we default to active cart as owner in case no context is provided
@@ -141,6 +150,23 @@ export class ConfigureCartEntryComponent {
   }
 
   /**
+   * Retrieves the resource key for the link text.
+   *
+   * @returns - The resource key that controls the link text
+   */
+  getLinkTextResourceKey(): string {
+    if (this.isBundleOverviewLink) {
+      return 'configurator.header.show';
+    } else if (this.getDisplayOnly()) {
+      return 'configurator.header.displayConfiguration';
+    } else if (this.msgBanner) {
+      return 'configurator.header.resolveIssues';
+    } else {
+      return 'configurator.header.editConfiguration';
+    }
+  }
+
+  /**
    * Verifies whether the link to the configuration is disabled.
    *
    *  @returns - 'true' if the the configuration is not read only, otherwise 'false'
@@ -155,6 +181,9 @@ export class ConfigureCartEntryComponent {
    * @returns - If there is a 'resolve issues' link, the ID to the element with additional description will be returned.
    */
   getResolveIssuesA11yDescription(): string | undefined {
+    if (this.a11yDescriptionId) {
+      return this.a11yDescriptionId;
+    }
     const errorMsgId = 'cx-error-msg-' + this.cartEntry.entryNumber;
     return !this.getDisplayOnly() && this.msgBanner ? errorMsgId : undefined;
   }

--- a/feature-libs/product-configurator/common/components/index.ts
+++ b/feature-libs/product-configurator/common/components/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from './common-configurator-components.module';
+export * from './config/index';
 export * from './configurator-cart-entry-bundle-info/index';
 export * from './configurator-cart-entry-info/index';
 export * from './configurator-issues-notification/index';

--- a/feature-libs/product-configurator/common/components/service/configurator-router-data.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-data.ts
@@ -23,6 +23,7 @@ export namespace ConfiguratorRouter {
     displayRestartDialog?: boolean;
     navigationId?: number;
     navigateToCheckout?: boolean;
+    navigateToCart?: boolean;
     productCode?: string;
   }
 }

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.spec.ts
@@ -315,6 +315,30 @@ describe('ConfigRouterExtractorService', () => {
         .unsubscribe();
     });
 
+    it('should tell from the URL if the navigation to the cart is relevant', () => {
+      mockRouterState.state.queryParams = { navigateToCart: 'true' };
+      let routerData: ConfiguratorRouter.Data;
+      serviceUnderTest
+        .extractRouterData()
+        .subscribe((data) => {
+          routerData = data;
+          expect(routerData.navigateToCart).toBe(true);
+        })
+        .unsubscribe();
+    });
+
+    it('should tell from the URL if the navigation to the cart is not relevant', () => {
+      mockRouterState.state.queryParams = { navigateToCart: 'false' };
+      let routerData: ConfiguratorRouter.Data;
+      serviceUnderTest
+        .extractRouterData()
+        .subscribe((data) => {
+          routerData = data;
+          expect(routerData.navigateToCart).toBe(false);
+        })
+        .unsubscribe();
+    });
+
     it('should tell from the URL that a product code has been passed', () => {
       mockRouterState.state.queryParams = {
         productCode: PRODUCT_CODE,

--- a/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
+++ b/feature-libs/product-configurator/common/components/service/configurator-router-extractor.service.ts
@@ -57,6 +57,8 @@ export class ConfiguratorRouterExtractorService {
               : ConfiguratorRouter.PageType.CONFIGURATION,
           navigateToCheckout:
             routingData.state.queryParams?.navigateToCheckout === 'true',
+          navigateToCart:
+            routingData.state.queryParams?.navigateToCart === 'true',
           productCode: routingData.state.queryParams?.productCode,
         };
 

--- a/feature-libs/product-configurator/common/styles/_configurator-cart-entry-bundle-info.scss
+++ b/feature-libs/product-configurator/common/styles/_configurator-cart-entry-bundle-info.scss
@@ -15,6 +15,18 @@
     }
   }
 
+  @include forFeature('productConfiguratorCPQContainer') {
+    // The 'show' control is rendered as a link to the configuration overview
+    // once the line item threshold is exceeded, so it is not nested in a button.
+    .cx-toggle-hide-items {
+      .cx-action-link {
+        font-size: inherit;
+        font-weight: bold;
+        inline-size: max-content;
+      }
+    }
+  }
+
   .cx-item-infos {
     inline-size: 100%;
     max-block-size: 0;

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.html
@@ -69,7 +69,9 @@
         class="cx-btn btn btn-block btn-secondary cx-display-only-btn"
         (click)="leaveConfigurationOverview()"
       >
-        {{ 'configurator.addToCart.buttonClose' | cxTranslate }}
+        {{
+          getDisplayOnlyButtonResourceKey(container.routerData) | cxTranslate
+        }}
       </button>
     </div>
   </ng-template>

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.spec.ts
@@ -1078,12 +1078,14 @@ describe('ConfiguratorAddToCartButtonComponent', () => {
     let featureToggles: MockFeatureTogglesController;
 
     function createRouterData(
-      ownerType: CommonConfigurator.OwnerType
+      ownerType: CommonConfigurator.OwnerType,
+      navigateToCart = false
     ): ConfiguratorRouter.Data {
       return {
         pageType: ConfiguratorRouter.PageType.OVERVIEW,
         displayOnly: true,
         owner: { ...mockOwner, type: ownerType },
+        navigateToCart,
       };
     }
 
@@ -1095,7 +1097,7 @@ describe('ConfiguratorAddToCartButtonComponent', () => {
       featureToggles.set('productConfiguratorCPQContainer', true);
       expect(
         component.getDisplayOnlyButtonResourceKey(
-          createRouterData(CommonConfigurator.OwnerType.CART_ENTRY)
+          createRouterData(CommonConfigurator.OwnerType.CART_ENTRY, true)
         )
       ).toBe('configurator.addToCart.buttonBackToCart');
     });
@@ -1104,7 +1106,16 @@ describe('ConfiguratorAddToCartButtonComponent', () => {
       featureToggles.set('productConfiguratorCPQContainer', true);
       expect(
         component.getDisplayOnlyButtonResourceKey(
-          createRouterData(CommonConfigurator.OwnerType.ORDER_ENTRY)
+          createRouterData(CommonConfigurator.OwnerType.ORDER_ENTRY, true)
+        )
+      ).toBe('configurator.addToCart.buttonClose');
+    });
+
+    it('should return `configurator.addToCart.buttonClose` for a regular cart entry overview', () => {
+      featureToggles.set('productConfiguratorCPQContainer', true);
+      expect(
+        component.getDisplayOnlyButtonResourceKey(
+          createRouterData(CommonConfigurator.OwnerType.CART_ENTRY)
         )
       ).toBe('configurator.addToCart.buttonClose');
     });
@@ -1113,7 +1124,7 @@ describe('ConfiguratorAddToCartButtonComponent', () => {
       featureToggles.set('productConfiguratorCPQContainer', false);
       expect(
         component.getDisplayOnlyButtonResourceKey(
-          createRouterData(CommonConfigurator.OwnerType.CART_ENTRY)
+          createRouterData(CommonConfigurator.OwnerType.CART_ENTRY, true)
         )
       ).toBe('configurator.addToCart.buttonClose');
     });
@@ -1121,6 +1132,7 @@ describe('ConfiguratorAddToCartButtonComponent', () => {
     it('should render `Back to Cart` on the display only button of a cart entry', () => {
       featureToggles.set('productConfiguratorCPQContainer', true);
       setRouterTestDataReadOnlyCart();
+      mockRouterData.navigateToCart = true;
       initialize();
 
       CommonConfiguratorTestUtilsService.expectElementToContainText(

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.spec.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.spec.ts
@@ -35,6 +35,10 @@ import {
   ItemCounterComponent,
   KeyboardFocusService,
 } from '@spartacus/storefront';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { MockFeatureLevelDirective } from 'core-libs/storefront/shared/test/mock-feature-level-directive';
 import { Observable, of } from 'rxjs';
 import { delay, take } from 'rxjs/operators';
@@ -504,6 +508,7 @@ describe('ConfiguratorAddToCartButtonComponent', () => {
           useClass: MockMultiCartFacade,
         },
         { provide: ActiveCartFacade, useClass: MockActiveCartFacade },
+        provideMockFeatureToggles({ productConfiguratorCPQContainer: false }),
       ],
     })
       .overrideComponent(ConfiguratorAddToCartButtonComponent, {
@@ -1065,6 +1070,64 @@ describe('ConfiguratorAddToCartButtonComponent', () => {
 
       expect(component.getButtonResourceKey(routerData, config)).toBe(
         'configurator.addToCart.button'
+      );
+    });
+  });
+
+  describe('getDisplayOnlyButtonResourceKey', () => {
+    let featureToggles: MockFeatureTogglesController;
+
+    function createRouterData(
+      ownerType: CommonConfigurator.OwnerType
+    ): ConfiguratorRouter.Data {
+      return {
+        pageType: ConfiguratorRouter.PageType.OVERVIEW,
+        displayOnly: true,
+        owner: { ...mockOwner, type: ownerType },
+      };
+    }
+
+    beforeEach(() => {
+      featureToggles = TestBed.inject(MockFeatureTogglesController);
+    });
+
+    it('should return `configurator.addToCart.buttonBackToCart` for a cart entry', () => {
+      featureToggles.set('productConfiguratorCPQContainer', true);
+      expect(
+        component.getDisplayOnlyButtonResourceKey(
+          createRouterData(CommonConfigurator.OwnerType.CART_ENTRY)
+        )
+      ).toBe('configurator.addToCart.buttonBackToCart');
+    });
+
+    it('should return `configurator.addToCart.buttonClose` for an order entry', () => {
+      featureToggles.set('productConfiguratorCPQContainer', true);
+      expect(
+        component.getDisplayOnlyButtonResourceKey(
+          createRouterData(CommonConfigurator.OwnerType.ORDER_ENTRY)
+        )
+      ).toBe('configurator.addToCart.buttonClose');
+    });
+
+    it('should return `configurator.addToCart.buttonClose` for a cart entry if the feature toggle is not active', () => {
+      featureToggles.set('productConfiguratorCPQContainer', false);
+      expect(
+        component.getDisplayOnlyButtonResourceKey(
+          createRouterData(CommonConfigurator.OwnerType.CART_ENTRY)
+        )
+      ).toBe('configurator.addToCart.buttonClose');
+    });
+
+    it('should render `Back to Cart` on the display only button of a cart entry', () => {
+      featureToggles.set('productConfiguratorCPQContainer', true);
+      setRouterTestDataReadOnlyCart();
+      initialize();
+
+      CommonConfiguratorTestUtilsService.expectElementToContainText(
+        expect,
+        htmlElem,
+        'button.btn-secondary.cx-display-only-btn',
+        'configurator.addToCart.buttonBackToCart'
       );
     });
   });

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
@@ -287,14 +287,16 @@ export class ConfiguratorAddToCartButtonComponent implements OnInit, OnDestroy {
 
   /**
    * Decides on the resource key for the button that is rendered in display only mode.
-   * For a cart entry the user returns to the cart, which is reflected in the button description.
+   * For a cart entry overview opened from the bundle information, the user returns
+   * to the cart, which is reflected in the button description.
    *
    * @param routerData - Reflects the current router state
    * @returns - The resource key that controls the button description
    */
   getDisplayOnlyButtonResourceKey(routerData: ConfiguratorRouter.Data): string {
     return this.featureToggles.productConfiguratorCPQContainer &&
-      routerData.owner.type === CommonConfigurator.OwnerType.CART_ENTRY
+      routerData.owner.type === CommonConfigurator.OwnerType.CART_ENTRY &&
+      routerData.navigateToCart
       ? 'configurator.addToCart.buttonBackToCart'
       : 'configurator.addToCart.buttonClose';
   }

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.ts
@@ -15,6 +15,7 @@ import {
 import { UntypedFormControl } from '@angular/forms';
 import { ActiveCartFacade, MultiCartFacade } from '@spartacus/cart/base/root';
 import {
+  FeatureToggles,
   GlobalMessageService,
   GlobalMessageType,
   RoutingService,
@@ -71,6 +72,7 @@ export class ConfiguratorAddToCartButtonComponent implements OnInit, OnDestroy {
   protected multiCartFacade = inject(MultiCartFacade);
   protected focusService = inject(KeyboardFocusService);
   protected activeCartFacade = inject(ActiveCartFacade);
+  private featureToggles = inject(FeatureToggles);
   quantityControl = new UntypedFormControl(1);
   iconType = ICON_TYPE;
   addToCartButtonDisabled = false;
@@ -281,6 +283,20 @@ export class ConfiguratorAddToCartButtonComponent implements OnInit, OnDestroy {
     } else {
       return 'configurator.addToCart.button';
     }
+  }
+
+  /**
+   * Decides on the resource key for the button that is rendered in display only mode.
+   * For a cart entry the user returns to the cart, which is reflected in the button description.
+   *
+   * @param routerData - Reflects the current router state
+   * @returns - The resource key that controls the button description
+   */
+  getDisplayOnlyButtonResourceKey(routerData: ConfiguratorRouter.Data): string {
+    return this.featureToggles.productConfiguratorCPQContainer &&
+      routerData.owner.type === CommonConfigurator.OwnerType.CART_ENTRY
+      ? 'configurator.addToCart.buttonBackToCart'
+      : 'configurator.addToCart.buttonClose';
   }
 
   /**

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { clickAllowAllFromBanner } from '../../../helpers/anonymous-consents';
+import * as common from '../../../helpers/common';
 import * as configuration from '../../../helpers/product-configurator';
+import * as configurationCart from '../../../helpers/product-configurator-cart';
+import * as configurationCartCpq from '../../../helpers/product-configurator-cart-cpq';
 import * as configurationCpq from '../../../helpers/product-configurator-cpq';
 import * as configurationCpqContainer from '../../../helpers/product-configurator-cpq-container';
 import * as configurationOverview from '../../../helpers/product-configurator-overview';
 import * as configurationOverviewCpq from '../../../helpers/product-configurator-overview-cpq';
-import * as configurationCart from '../../../helpers/product-configurator-cart';
-import * as configurationCartCpq from '../../../helpers/product-configurator-cart-cpq';
-import * as common from '../../../helpers/common';
-import { clickAllowAllFromBanner } from '../../../helpers/anonymous-consents';
 
 const POWERTOOLS = 'powertools-spa';
 const EMAIL = 'gi.sun@pronto-hw.com';
@@ -593,6 +593,37 @@ testConfig.forEach((config) => {
             'Canon EOS 80D',
             0
           );
+        });
+      });
+
+      it('should navigate to the read-only overview when the bundle item threshold is exceeded', () => {
+        cy.cxConfig({
+          productConfigurator: {
+            cpqProductCartEntriesThreshold: 2,
+          },
+        });
+        common.goToPDPage(POWERTOOLS, PROD_CODE_CAM);
+        common.clickOnAddToCartBtnOnPD();
+        common.clickOnViewCartBtnOnPD();
+
+        cy.get('cx-mini-cart .count').then((elem) => {
+          const cartEntryIndex = Number(elem.text()) - 1;
+
+          configurationCartCpq.checkBundleOverviewLink(cartEntryIndex, 3);
+          configurationCartCpq.clickOnBundleOverviewLink(cartEntryIndex);
+
+          cy.wait('@readConfig');
+          cy.location('pathname')
+            .should('contain', '/configure-overview/cpq/cartEntry/entityKey/')
+            .and('contain', '/displayOnly/true');
+          cy.location('search').should('contain', 'navigateToCart=true');
+          configurationOverview.checkConfigOverviewPageDisplayed();
+          cy.get('cx-configurator-add-to-cart-button .cx-display-only-btn')
+            .should('be.visible')
+            .and('contain', 'Back to Cart');
+          cy.get(
+            'cx-configurator-add-to-cart-button .cx-add-to-cart-btn'
+          ).should('not.exist');
         });
       });
     });

--- a/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/e2e/vendor/cpq/cpq-configuration.core-e2e.cy.ts
@@ -599,7 +599,7 @@ testConfig.forEach((config) => {
       it('should navigate to the read-only overview when the bundle item threshold is exceeded', () => {
         cy.cxConfig({
           productConfigurator: {
-            cpqProductCartEntriesThreshold: 2,
+            cartEntryBundleLineItemsThreshold: 2,
           },
         });
         common.goToPDPage(POWERTOOLS, PROD_CODE_CAM);

--- a/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart-cpq.ts
+++ b/projects/storefrontapp-e2e-cypress/cypress/helpers/product-configurator-cart-cpq.ts
@@ -442,6 +442,39 @@ export function checkAmountOfBundleItems(
 }
 
 /**
+ * Verifies that bundle items are represented by an overview link instead of
+ * being rendered inline.
+ *
+ * @param {number} cartItemIndex - Index of cart item
+ * @param {number} itemsAmount - Expected amount of bundle items
+ */
+export function checkBundleOverviewLink(
+  cartItemIndex: number,
+  itemsAmount: number
+): void {
+  findBundleItem(cartItemIndex).within(() => {
+    cy.get('.cx-number-items').should('contain', itemsAmount);
+    cy.get('button').should('not.exist');
+    cy.get('.cx-item-infos').should('not.exist');
+    cy.get('.cx-item-info').should('not.exist');
+    cy.get('.cx-toggle-hide-items a')
+      .should('contain', 'show')
+      .and('be.visible');
+  });
+}
+
+/**
+ * Navigates from a cart bundle to its read-only configuration overview.
+ *
+ * @param {number} cartItemIndex - Index of cart item
+ */
+export function clickOnBundleOverviewLink(cartItemIndex: number): void {
+  findBundleItem(cartItemIndex).within(() => {
+    cy.get('.cx-toggle-hide-items a').contains('show').click();
+  });
+}
+
+/**
  * Verifies the amount of cart entries.
  *
  * @param {number} expectedCount - Expected amount of cart entries


### PR DESCRIPTION
## Issue

CPQ-configured products can contain a large number of bundle items. Previously, all items were rendered and expanded directly within the cart entry.

## Solution

- Add the configurable `cpqProductCartEntriesThreshold` setting with a default value of `10`.
- Keep bundle items expandable directly in the cart when the threshold is not exceeded.
- Navigate to the read-only configuration overview when the threshold is exceeded.
- Display “Back to Cart” on the overview opened from the cart bundle information.
- Do not instantiate the bundle item list in the DOM when navigation to the overview is used.
- Keep inline expansion for saved carts and Save for Later, where overview navigation is unavailable.
- Gate the new behavior behind the `productConfiguratorCPQContainer` feature toggle.
- Correct the pluralization of the bundle item accessibility text.
- Add an optional `navigateToCart` query parameter to identify configuration overviews opened from CPQ bundle information.
- Show “Back to Cart” only for these overviews instead of applying the label to all display-only cart entry overviews.
- Preserve “Close” for existing display-only flows, including checkout, order, quote, and saved-cart overviews.
- Keep existing URLs backward compatible by treating a missing parameter as `false`.

## Testing

- Added unit tests for threshold boundaries and feature-toggle behavior.
- Added coverage for active cart, saved cart, and Save for Later contexts.
- Added coverage for overview link text, routing inputs, and accessibility descriptions.
- Verified that bundle items are not rendered when the threshold is exceeded.
- Verified existing configure-cart-entry behavior.

### E2E coverage
Added a CPQ cart E2E test for bundle entries exceeding the configured inline-display threshold.
The test:
- overrides `cpqProductCartEntriesThreshold` to `2`,
- verifies that 3 bundle items are not rendered inline,
- verifies that the “show” overview link is displayed,
- navigates to the read-only configuration overview,
- verifies the “Back to Cart” action.