### PR TITLE
refactor(CXSPA-11236): adopt Angular self-closing tags syntax

### DIFF
--- a/core-libs/schematics/src/add-spartacus/__snapshots__/index_spec.ts.snap
+++ b/core-libs/schematics/src/add-spartacus/__snapshots__/index_spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`add-spartacus on Angular app without routing app.component.html should match snapshot 1`] = `
-"<cx-storefront></cx-storefront>
+"<cx-storefront/>
 "
 `;
 

--- a/core-libs/schematics/src/add-spartacus/index.ts
+++ b/core-libs/schematics/src/add-spartacus/index.ts
@@ -205,7 +205,7 @@ function updateMainComponent(
     }
 
     const htmlContent = buffer.toString();
-    const insertion = `<cx-storefront></cx-storefront>\n`;
+    const insertion = `<cx-storefront/>\n`;
 
     if (htmlContent.includes(insertion)) {
       return;

--- a/core-libs/schematics/src/add-spartacus/index_spec.ts
+++ b/core-libs/schematics/src/add-spartacus/index_spec.ts
@@ -458,7 +458,7 @@ describe('add-spartacus', () => {
       .readContent('/projects/schematics-test/src/app/app.component.html')
       .replace(newLineRegEx, '');
 
-    expect(appComponentTemplate).toEqual(`<cx-storefront></cx-storefront>`);
+    expect(appComponentTemplate).toEqual(`<cx-storefront/>`);
   });
 
   it('Add cx-storefront component to your app.component', async () => {
@@ -471,7 +471,7 @@ describe('add-spartacus', () => {
     const appComponentTemplate = tree.readContent(
       '/projects/schematics-test/src/app/app.component.html'
     );
-    const cxTemplate = `<cx-storefront></cx-storefront>`;
+    const cxTemplate = `<cx-storefront/>`;
     expect(appComponentTemplate.includes(cxTemplate)).toBe(true);
     expect(appComponentTemplate.length).toBeGreaterThan(cxTemplate.length);
   });

--- a/core-libs/schematics/src/migrations/mechanism/component-deprecations/component-deprecations_spec.ts
+++ b/core-libs/schematics/src/migrations/mechanism/component-deprecations/component-deprecations_spec.ts
@@ -12,21 +12,21 @@ import { runMigration, writeFile } from '../../../shared/utils/test-utils';
 const MIGRATION_SCRIPT_NAME = 'migration-v2-component-deprecations-05';
 
 const SINGLE_USAGE_EXAMPLE = `<div>test</div>
-<cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>
+<cx-consent-management-form isLevel13="xxx" />
 <div *ngIf="isAnonymousConsentsEnabled">Using a removed property</div>`;
 const SINGLE_USAGE_EXAMPLE_EXPECTED = `<div>test</div>
 <!-- ${TODO_SPARTACUS} 'isLevel13' property has been removed. -->
-<cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>
+<cx-consent-management-form isLevel13="xxx" />
 <!-- ${TODO_SPARTACUS} 'isAnonymousConsentsEnabled' property has been removed. -->
 <div *ngIf="isAnonymousConsentsEnabled">Using a removed property</div>`;
-const MULTI_USAGE_EXAMPLE = `<cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>
+const MULTI_USAGE_EXAMPLE = `<cx-consent-management-form isLevel13="xxx" />
 <div>test</div>
-<cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>`;
+<cx-consent-management-form isLevel13="xxx" />`;
 const MULTI_USAGE_EXAMPLE_EXPECTED = `<!-- ${TODO_SPARTACUS} 'isLevel13' property has been removed. -->
-<cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>
+<cx-consent-management-form isLevel13="xxx" />
 <div>test</div>
 <!-- ${TODO_SPARTACUS} 'isLevel13' property has been removed. -->
-<cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>`;
+<cx-consent-management-form isLevel13="xxx" />`;
 
 const PRODUCT_IMAGES_SINGLE_USAGE_EXAMPLE = `<div *ngIf="isThumbsEmpty">test</div>`;
 const PRODUCT_IMAGES_SINGLE_USAGE_EXAMPLE_EXPECTED = `<!-- ${TODO_SPARTACUS} 'isThumbsEmpty' property has been removed. -->
@@ -147,7 +147,7 @@ const HTML_EXTEND_COMPONENT_BECAUSE_OF_TEMPLATE = `
         [type]="
           isFacetCollapsed(facet.name) ? iconTypes.EXPAND : iconTypes.COLLAPSE
         "
-      ></cx-icon>
+      />
     </a>
     <form class="collapse" [ngClass]="{ in: !isFacetCollapsed(facet.name) }">
       <li *ngFor="let value of getVisibleFacetValues(facet)">
@@ -180,7 +180,7 @@ const HTML_EXTEND_COMPONENT_BECAUSE_OF_TEMPLATE = `
         [type]="
           isFacetCollapsed(facet.name) ? iconTypes.EXPAND : iconTypes.COLLAPSE
         "
-      ></cx-icon>
+      />
     </a>
 
     <div [ngClass]="{ in: !isFacetCollapsed(facet.name) }">
@@ -231,7 +231,7 @@ const HTML_EXTEND_COMPONENT_BECAUSE_OF_TEMPLATE_EXPECTED = `
         [type]="
           isFacetCollapsed(facet.name) ? iconTypes.EXPAND : iconTypes.COLLAPSE
         "
-      ></cx-icon>
+      />
     </a>
 <!-- ${TODO_SPARTACUS} 'isFacetCollapsed' method has been removed. Please refer to the migration guide on how to handle this change. -->
     <form class="collapse" [ngClass]="{ in: !isFacetCollapsed(facet.name) }">
@@ -277,7 +277,7 @@ const HTML_EXTEND_COMPONENT_BECAUSE_OF_TEMPLATE_EXPECTED = `
         [type]="
           isFacetCollapsed(facet.name) ? iconTypes.EXPAND : iconTypes.COLLAPSE
         "
-      ></cx-icon>
+      />
     </a>
 
 <!-- ${TODO_SPARTACUS} 'isFacetCollapsed' method has been removed. Please refer to the migration guide on how to handle this change. -->

--- a/core-libs/schematics/src/shared/utils/file-utils_spec.ts
+++ b/core-libs/schematics/src/shared/utils/file-utils_spec.ts
@@ -247,12 +247,12 @@ export class AppModule {}
 const INHERITANCE_VALID_TEST_CLASS = `
 export class Test extends UserAddressService {}
 `;
-const HTML_EXAMPLE = `<cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>
+const HTML_EXAMPLE = `<cx-consent-management-form isLevel13="xxx" />
 <div>test</div>
-<cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>`;
-const HTML_EXAMPLE_EXPECTED = `<!-- ${TODO_SPARTACUS} 'isLevel13' property has been removed. --><cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>
+<cx-consent-management-form isLevel13="xxx" />`;
+const HTML_EXAMPLE_EXPECTED = `<!-- ${TODO_SPARTACUS} 'isLevel13' property has been removed. --><cx-consent-management-form isLevel13="xxx" />
 <div>test</div>
-<!-- ${TODO_SPARTACUS} 'isLevel13' property has been removed. --><cx-consent-management-form isLevel13="xxx"></cx-consent-management-form>`;
+<!-- ${TODO_SPARTACUS} 'isLevel13' property has been removed. --><cx-consent-management-form isLevel13="xxx" />`;
 const HTML_EXAMPLE_NGIF = `<div *ngIf="isThumbsEmpty">test</div>`;
 const HTML_EXAMPLE_NGIF_EXPECTED = `<!-- ${TODO_SPARTACUS} 'isThumbsEmpty' property has been removed. -->
 <div *ngIf="isThumbsEmpty">test</div>`;

--- a/core-libs/setup/ssr/engine/cx-common-engine.spec.ts
+++ b/core-libs/setup/ssr/engine/cx-common-engine.spec.ts
@@ -85,7 +85,7 @@ describe('CxCommonEngine', () => {
 
     const html = await engine.render({
       url: 'http://localhost:4200',
-      document: '<cx-mock></cx-mock>',
+      document: '<cx-mock/>',
     });
 
     // Cannot use `.toMatchInlineSnapshot()` due to bug in jest:
@@ -101,7 +101,7 @@ describe('CxCommonEngine', () => {
 
     const html = await engine.render({
       url: 'http://localhost:4200',
-      document: '<cx-token></cx-token>',
+      document: '<cx-token/>',
       providers: [{ provide: SOME_TOKEN, useValue: 'test' }],
     });
 
@@ -121,7 +121,7 @@ describe('CxCommonEngine', () => {
     await expect(
       engine.render({
         url: 'http://localhost:4200',
-        document: '<cx-token></cx-token>',
+        document: '<cx-token/>',
       })
     ).rejects.toThrowErrorMatchingSnapshot();
   });
@@ -137,7 +137,7 @@ describe('CxCommonEngine', () => {
     await expect(
       engine.render({
         url: 'http://localhost:4200',
-        document: '<cx-response></cx-response>',
+        document: '<cx-response/>',
       })
     ).rejects.toThrowErrorMatchingSnapshot();
   });

--- a/core-libs/setup/ssr/engine/ng-express-engine.spec.ts
+++ b/core-libs/setup/ssr/engine/ng-express-engine.spec.ts
@@ -278,7 +278,7 @@ describe('ngExpressEngine', () => {
         req: getTestRequest({
           res: { statusCode: someStatusCode },
         }),
-        document: '<cx-response></cx-response>',
+        document: '<cx-response/>',
       },
       (err, html) => {
         if (err) {
@@ -300,7 +300,7 @@ describe('ngExpressEngine', () => {
       null as any as string,
       {
         req: getTestRequest(),
-        document: '<cx-token></cx-token>',
+        document: '<cx-token/>',
       },
       (err, html) => {
         if (err) {

--- a/core-libs/storefront/cms-components/content/banner-carousel/banner-carousel.component.html
+++ b/core-libs/storefront/cms-components/content/banner-carousel/banner-carousel.component.html
@@ -4,7 +4,7 @@
   [template]="template"
   itemWidth="100%"
   class="inline-navigation"
-></cx-carousel>
+/>
 
 <ng-template #template let-item="item">
   <ng-container
@@ -13,6 +13,5 @@
       typeCode: item.typeCode,
       uid: item?.uid,
     }"
-  >
-  </ng-container>
+  />
 </ng-template>

--- a/core-libs/storefront/cms-components/content/banner/banner.component.html
+++ b/core-libs/storefront/cms-components/content/banner/banner.component.html
@@ -6,14 +6,13 @@
         [target]="getTarget(data)"
         [ariaLabel]="getLinkAriaLabel(data)"
         [attr.title]="!data.headline ? getImageAltText(data) : null"
-      >
-      </cx-generic-link>
+      />
       <p class="headline" *ngIf="data.headline" [innerHTML]="data.headline"></p>
       <cx-media
         [container]="getImage(data)"
         [elementType]="'picture'"
         [fetchPriority]="lcpContext.fetchPriority$ | async"
-      ></cx-media>
+      />
       <p class="content" *ngIf="data.content" [innerHTML]="data.content"></p>
     </ng-container>
 
@@ -28,7 +27,7 @@
           [container]="getImage(data)"
           [elementType]="'picture'"
           [fetchPriority]="lcpContext.fetchPriority$ | async"
-        ></cx-media>
+        />
         <p class="content" *ngIf="data.content" [innerHTML]="data.content"></p>
       </div>
     </ng-container>

--- a/core-libs/storefront/cms-components/content/pdf/pdf.component.html
+++ b/core-libs/storefront/cms-components/content/pdf/pdf.component.html
@@ -9,7 +9,7 @@
         )
       }}</span>
       <span aria-hidden="true">
-        <cx-icon [type]="'PDF_FILE'"></cx-icon>
+        <cx-icon [type]="'PDF_FILE'" />
       </span>
     </a>
   </div>

--- a/core-libs/storefront/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.html
+++ b/core-libs/storefront/cms-components/content/tab-paragraph-container/tab-paragraph-container.component.html
@@ -8,7 +8,7 @@
       <ng-container
         [cxComponentWrapper]="component"
         (cxComponentRef)="tabCompLoaded($event, component.uid)"
-      ></ng-container>
+      />
     </ng-template>
   </cx-tab>
 </ng-container>

--- a/core-libs/storefront/cms-components/content/tab/panel/tab-panel.component.html
+++ b/core-libs/storefront/cms-components/content/tab/panel/tab-panel.component.html
@@ -8,8 +8,5 @@
   class="active"
   [cxFocus]="{ focusOnEscape: !tab.disableBorderFocus }"
 >
-  <ng-container
-    *ngIf="tab.content"
-    [ngTemplateOutlet]="tab.content"
-  ></ng-container>
+  <ng-container *ngIf="tab.content" [ngTemplateOutlet]="tab.content" />
 </div>

--- a/core-libs/storefront/cms-components/content/tab/tab.component.html
+++ b/core-libs/storefront/cms-components/content/tab/tab.component.html
@@ -41,7 +41,7 @@
         *ngIf="mode === TAB_MODE.ACCORDIAN"
         [ngTemplateOutlet]="tabPanel"
         [ngTemplateOutletContext]="{ tabNum: i }"
-      ></ng-container>
+      />
     </ng-container>
   </div>
 
@@ -51,16 +51,11 @@
       *ngFor="let tab of tabs; let i = index"
       [ngTemplateOutlet]="tabPanel"
       [ngTemplateOutletContext]="{ tabNum: i }"
-    >
-    </ng-container>
+    />
   </ng-container>
 
   <!-- Tab Panel shows the content of the given tab -->
   <ng-template #tabPanel let-tabNum="tabNum">
-    <cx-tab-panel
-      [tab]="tabs[tabNum]"
-      [mode]="mode"
-      *ngIf="isOpen(tabNum)"
-    ></cx-tab-panel>
+    <cx-tab-panel [tab]="tabs[tabNum]" [mode]="mode" *ngIf="isOpen(tabNum)" />
   </ng-template>
 </ng-container>

--- a/core-libs/storefront/cms-components/content/video/video.component.html
+++ b/core-libs/storefront/cms-components/content/video/video.component.html
@@ -20,5 +20,5 @@
 </div>
 
 <ng-template #loading>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/core-libs/storefront/cms-components/misc/global-message/global-message.component.html
+++ b/core-libs/storefront/cms-components/misc/global-message/global-message.component.html
@@ -30,7 +30,7 @@
     "
   >
     <span class="alert-icon">
-      <cx-icon [type]="iconTypes.SUCCESS"></cx-icon>
+      <cx-icon [type]="iconTypes.SUCCESS" />
     </span>
     <span>{{ confMsg | cxTranslate }}</span>
     <button
@@ -38,7 +38,7 @@
       title="{{ 'common.close' | cxTranslate }}"
       (click)="clear(messageType.MSG_TYPE_CONFIRMATION, i)"
     >
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </button>
   </div>
   <div
@@ -46,7 +46,7 @@
     *ngFor="let infoMsg of messages[messageType.MSG_TYPE_INFO]; let i = index"
   >
     <span class="alert-icon">
-      <cx-icon [type]="iconTypes.INFO"></cx-icon>
+      <cx-icon [type]="iconTypes.INFO" />
     </span>
     <span>{{ infoMsg | cxTranslate }}</span>
     <button
@@ -54,7 +54,7 @@
       title="{{ 'common.close' | cxTranslate }}"
       (click)="clear(messageType.MSG_TYPE_INFO, i)"
     >
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </button>
   </div>
   <div
@@ -65,7 +65,7 @@
     "
   >
     <span class="alert-icon">
-      <cx-icon [type]="iconTypes.WARNING"></cx-icon>
+      <cx-icon [type]="iconTypes.WARNING" />
     </span>
     <span>{{ infoMsg | cxTranslate }}</span>
     <button
@@ -73,7 +73,7 @@
       title="{{ 'common.close' | cxTranslate }}"
       (click)="clear(messageType.MSG_TYPE_WARNING, i)"
     >
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </button>
   </div>
   <div
@@ -81,7 +81,7 @@
     *ngFor="let errorMsg of messages[messageType.MSG_TYPE_ERROR]; let i = index"
   >
     <span class="alert-icon">
-      <cx-icon [type]="iconTypes.ERROR"></cx-icon>
+      <cx-icon [type]="iconTypes.ERROR" />
     </span>
     <span>{{ errorMsg | cxTranslate }}</span>
     <button
@@ -89,7 +89,7 @@
       title="{{ 'common.close' | cxTranslate }}"
       (click)="clear(messageType.MSG_TYPE_ERROR, i)"
     >
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </button>
   </div>
 </div>

--- a/core-libs/storefront/cms-components/misc/icon/icon.component.html
+++ b/core-libs/storefront/cms-components/misc/icon/icon.component.html
@@ -1,4 +1,4 @@
 <ng-container *ngIf="icon">
   <i [outerHTML]="icon"></i>
 </ng-container>
-<ng-content></ng-content>
+<ng-content />

--- a/core-libs/storefront/cms-components/misc/message/message.component.html
+++ b/core-libs/storefront/cms-components/misc/message/message.component.html
@@ -7,7 +7,7 @@
   <div class="cx-message-content">
     <div role="presentation" class="cx-message-header">
       <span role="presentation" class="cx-message-icon">
-        <cx-icon role="presentation" [type]="getIconType"></cx-icon>
+        <cx-icon role="presentation" [type]="getIconType" />
       </span>
 
       <span class="cx-message-text">
@@ -26,7 +26,7 @@
         <cx-icon
           [type]="showBody ? 'CARET_UP' : 'CARET_DOWN'"
           class="cx-message-accordion-icon"
-        ></cx-icon>
+        />
       </button>
 
       <button
@@ -48,12 +48,12 @@
         class="close"
         type="button"
       >
-        <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+        <cx-icon [type]="iconTypes.CLOSE" />
       </button>
     </div>
 
     <div *ngIf="showBody || !accordionText" class="cx-message-body">
-      <ng-content></ng-content>
+      <ng-content />
     </div>
   </div>
 </div>

--- a/core-libs/storefront/cms-components/misc/site-context-selector/site-context-selector.component.html
+++ b/core-libs/storefront/cms-components/misc/site-context-selector/site-context-selector.component.html
@@ -11,11 +11,7 @@
         {{ item.label }}
       </option>
     </select>
-    <cx-icon
-      aria-hidden="true"
-      [type]="iconTypes.CARET_DOWN"
-      class="small"
-    ></cx-icon>
+    <cx-icon aria-hidden="true" [type]="iconTypes.CARET_DOWN" class="small" />
   </div>
   <ng-container *cxFeature="'!a11ySiteContextCaretClick'">
     <select cxNativeSelectSpace (change)="active = $any($event).target.value">
@@ -28,10 +24,6 @@
         {{ item.label }}
       </option>
     </select>
-    <cx-icon
-      aria-hidden="true"
-      [type]="iconTypes.CARET_DOWN"
-      class="small"
-    ></cx-icon>
+    <cx-icon aria-hidden="true" [type]="iconTypes.CARET_DOWN" class="small" />
   </ng-container>
 </label>

--- a/core-libs/storefront/cms-components/myaccount/consent-management/components/consent-form/consent-management-form.component.html
+++ b/core-libs/storefront/cms-components/myaccount/consent-management/components/consent-form/consent-management-form.component.html
@@ -21,7 +21,7 @@
   </label>
   <span class="form-check-label">
     {{ consentTemplate?.description }}
-    <ng-template [ngTemplateOutlet]="requiredAsterisk"></ng-template>
+    <ng-template [ngTemplateOutlet]="requiredAsterisk" />
   </span>
 </div>
 

--- a/core-libs/storefront/cms-components/myaccount/consent-management/components/consent-management.component.html
+++ b/core-libs/storefront/cms-components/myaccount/consent-management/components/consent-management.component.html
@@ -70,7 +70,7 @@
               [requiredConsents]="requiredConsents"
               [disabled]="!!data.loading"
               (consentChanged)="onConsentChange($event)"
-            ></cx-consent-management-form>
+            />
           </div>
         </div>
       </fieldset>

--- a/core-libs/storefront/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/my-account-v2-consent-management.component.html
+++ b/core-libs/storefront/cms-components/myaccount/my-account-v2/my-account-v2-consent-management/components/my-account-v2-consent-management.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="loading$ | async; else consentManagementForm">
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </div>
 <ng-template #consentManagementForm>
@@ -31,7 +31,7 @@
           [consentTemplate]="consentTemplate"
           [requiredConsents]="requiredConsents"
           (consentChanged)="onConsentChange($event)"
-        ></cx-my-account-v2-consent-management-form>
+        />
       </div>
     </div>
   </ng-container>

--- a/core-libs/storefront/cms-components/myaccount/my-account-v2/my-account-v2-navigation/my-account-v2-navigation.component.html
+++ b/core-libs/storefront/cms-components/myaccount/my-account-v2/my-account-v2-navigation/my-account-v2-navigation.component.html
@@ -5,4 +5,4 @@
   [ngClass]="(styleClass$ | async) ?? ''"
   [navAriaLabel]="name$ | async"
   [focusableNodeTitles]="true"
-></cx-navigation-ui>
+/>

--- a/core-libs/storefront/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/my-account-v2-notification-preference.component.html
+++ b/core-libs/storefront/cms-components/myaccount/my-account-v2/my-account-v2-notification-preference/my-account-v2-notification-preference.component.html
@@ -41,7 +41,7 @@
 
   <ng-template #loading>
     <div class="cx-spinner">
-      <cx-spinner></cx-spinner>
+      <cx-spinner />
     </div>
   </ng-template>
 </ng-container>

--- a/core-libs/storefront/cms-components/myaccount/my-coupons/claim-dialog/claim-dialog.component.html
+++ b/core-libs/storefront/cms-components/myaccount/my-coupons/claim-dialog/claim-dialog.component.html
@@ -20,7 +20,7 @@
         (click)="close('Cross click')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -52,7 +52,7 @@
               label: 'myCoupons.claimCouponCode.label' | cxTranslate,
             }"
             [control]="form.get('couponCode')"
-          ></cx-form-errors>
+          />
         </label>
         <div class="cx-dialog-row">
           <div class="col-md-6 cx-dialog-row--reset-button">

--- a/core-libs/storefront/cms-components/myaccount/my-coupons/coupon-card/coupon-dialog/coupon-dialog.component.html
+++ b/core-libs/storefront/cms-components/myaccount/my-coupons/coupon-card/coupon-dialog/coupon-dialog.component.html
@@ -20,7 +20,7 @@
         (click)="close('Cross click')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>

--- a/core-libs/storefront/cms-components/myaccount/my-coupons/my-coupons.component.html
+++ b/core-libs/storefront/cms-components/myaccount/my-coupons/my-coupons.component.html
@@ -26,15 +26,14 @@
               [selectedOption]="sort"
               [ariaLabel]="'myCoupons.sortCoupons' | cxTranslate"
               ariaControls="coupon-deck"
-            >
-            </cx-sorting>
+            />
           </label>
           <div class="cx-my-coupons-pagination cx-mycoupon-thead-mobile">
             <cx-pagination
               [pagination]="pagination"
               (viewPageEvent)="pageChange($event)"
               paginationID="pagination-top"
-            ></cx-pagination>
+            />
           </div>
         </div>
 
@@ -47,7 +46,7 @@
               [coupon]="coupon"
               [couponSubscriptionLoading$]="couponSubscriptionLoading$"
               (notificationChanged)="notificationChange($event)"
-            ></cx-coupon-card>
+            />
           </div>
         </div>
 
@@ -69,20 +68,19 @@
               placeholder="{{ 'myCoupons.sortBy' | cxTranslate }}"
               [ariaLabel]="'myCoupons.sortCoupons' | cxTranslate"
               ariaControls="coupon-deck"
-            >
-            </cx-sorting>
+            />
           </label>
           <div class="cx-my-coupons-pagination">
             <cx-pagination
               [pagination]="pagination"
               (viewPageEvent)="pageChange($event)"
               paginationID="pagination-bottom"
-            ></cx-pagination>
+            />
           </div>
         </div>
         <div class="cx-my-coupons-notes">
           <span>
-            <cx-icon [type]="iconTypes.INFO"></cx-icon>
+            <cx-icon [type]="iconTypes.INFO" />
             {{ 'myCoupons.notesPreffix' | cxTranslate
             }}<a [routerLink]="['/my-account/notification-preference']">{{
               'myCoupons.notesLink' | cxTranslate
@@ -104,7 +102,7 @@
 
   <ng-template #loading>
     <div class="col-md-12 cx-coupon-spinner">
-      <cx-spinner></cx-spinner>
+      <cx-spinner />
     </div>
   </ng-template>
 </div>

--- a/core-libs/storefront/cms-components/myaccount/my-interests/my-interests.component.html
+++ b/core-libs/storefront/cms-components/myaccount/my-interests/my-interests.component.html
@@ -26,8 +26,7 @@
             placeholder="{{ 'myInterests.sortBy' | cxTranslate }}"
             [ariaLabel]="'myInterests.sortInterests' | cxTranslate"
             ariaControls="product-interests-table"
-          >
-          </cx-sorting>
+          />
         </label>
         <div
           class="cx-product-interests-pagination cx-product-interests-thead-mobile"
@@ -36,7 +35,7 @@
             [pagination]="pagination"
             (viewPageEvent)="pageChange($event)"
             paginationID="pagination-top"
-          ></cx-pagination>
+          />
         </div>
       </div>
 
@@ -87,7 +86,7 @@
                       <cx-media
                         [container]="product.images?.PRIMARY"
                         format="thumbnail"
-                      ></cx-media>
+                      />
                     </a>
                   </div>
 
@@ -216,15 +215,14 @@
             placeholder="{{ 'myInterests.sortBy' | cxTranslate }}"
             [ariaLabel]="'myInterests.sortInterests' | cxTranslate"
             ariaControls="product-interests-table"
-          >
-          </cx-sorting>
+          />
         </label>
         <div class="cx-product-interests-pagination">
           <cx-pagination
             [pagination]="pagination"
             (viewPageEvent)="pageChange($event)"
             paginationID="pagination-bottom"
-          ></cx-pagination>
+          />
         </div>
       </div>
     </ng-container>
@@ -237,6 +235,6 @@
 </ng-template>
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/core-libs/storefront/cms-components/myaccount/notification-preference/notification-preference.component.html
+++ b/core-libs/storefront/cms-components/myaccount/notification-preference/notification-preference.component.html
@@ -37,7 +37,7 @@
 
   <ng-template #loading>
     <div class="cx-spinner">
-      <cx-spinner></cx-spinner>
+      <cx-spinner />
     </div>
   </ng-template>
 </ng-container>

--- a/core-libs/storefront/cms-components/myaccount/payment-methods/payment-methods.component.html
+++ b/core-libs/storefront/cms-components/myaccount/payment-methods/payment-methods.component.html
@@ -13,7 +13,7 @@
           'paymentMethods.newPaymentMethodsAreAddedDuringCheckout' | cxTranslate
         }}
       </div>
-      <div *ngIf="loading$ | async; else cards"><cx-spinner></cx-spinner></div>
+      <div *ngIf="loading$ | async; else cards"><cx-spinner /></div>
       <ng-template #cards>
         <div class="cx-existing row">
           <div
@@ -31,7 +31,7 @@
                 (editCard)="setEdit(paymentMethod)"
                 [editMode]="editCard === paymentMethod.id"
                 (cancelCard)="cancelCard()"
-              ></cx-card>
+              />
             </div>
           </div>
         </div>

--- a/core-libs/storefront/cms-components/navigation/category-navigation/category-navigation.component.html
+++ b/core-libs/storefront/cms-components/navigation/category-navigation/category-navigation.component.html
@@ -5,4 +5,4 @@
   [wrapAfter]="+(data.wrapAfter ?? '')"
   [resetMenuOnClose]="data.resetMenuOnClose"
   [navAriaLabel]="'navigation.categoryNavLabel' | cxTranslate"
-></cx-navigation-ui>
+/>

--- a/core-libs/storefront/cms-components/navigation/footer-navigation/footer-navigation.component.html
+++ b/core-libs/storefront/cms-components/navigation/footer-navigation/footer-navigation.component.html
@@ -4,4 +4,4 @@
   [flyout]="false"
   [ngClass]="(styleClass$ | async) ?? ''"
   [navAriaLabel]="'navigation.footerNavLabel' | cxTranslate"
-></cx-navigation-ui>
+/>

--- a/core-libs/storefront/cms-components/navigation/navigation/navigation-ui.component.html
+++ b/core-libs/storefront/cms-components/navigation/navigation/navigation-ui.component.html
@@ -9,14 +9,15 @@
       class="back is-open"
     >
       <button (click)="back()">
-        <cx-icon [type]="iconType.CARET_LEFT"></cx-icon>
+        <cx-icon [type]="iconType.CARET_LEFT" />
         {{ 'common.back' | cxTranslate }}
       </button>
     </li>
 
     <ng-container *ngFor="let child of node?.children">
-      <ng-container *ngTemplateOutlet="nav; context: { node: child, depth: 0 }">
-      </ng-container>
+      <ng-container
+        *ngTemplateOutlet="nav; context: { node: child, depth: 0 }"
+      />
     </ng-container>
   </ul>
 </nav>
@@ -98,7 +99,7 @@
             <ng-container *ngIf="!node.url">
               {{ node.title }}
             </ng-container>
-            <cx-icon [type]="iconType.CARET_DOWN"></cx-icon>
+            <cx-icon [type]="iconType.CARET_DOWN" />
           </button>
         </ng-template>
       </ng-container>
@@ -138,8 +139,7 @@
                 position: i + 1,
               }
             "
-          >
-          </ng-container>
+          />
         </ng-container>
       </ul>
     </div>

--- a/core-libs/storefront/cms-components/navigation/navigation/navigation.component.html
+++ b/core-libs/storefront/cms-components/navigation/navigation/navigation.component.html
@@ -2,5 +2,4 @@
   [node]="node$ | async"
   [ngClass]="(styleClass$ | async) ?? ''"
   [navAriaLabel]="name$ | async"
->
-</cx-navigation-ui>
+/>

--- a/core-libs/storefront/cms-components/navigation/scroll-to-top/scroll-to-top.component.html
+++ b/core-libs/storefront/cms-components/navigation/scroll-to-top/scroll-to-top.component.html
@@ -8,6 +8,6 @@
   (keydown.Tab)="onTab($event)"
 >
   <span aria-hidden="true">
-    <cx-icon class="caret-up-icon" [type]="iconTypes.CARET_UP"></cx-icon>
+    <cx-icon class="caret-up-icon" [type]="iconTypes.CARET_UP" />
   </span>
 </button>

--- a/core-libs/storefront/cms-components/navigation/search-box/search-box.component.html
+++ b/core-libs/storefront/cms-components/navigation/search-box/search-box.component.html
@@ -30,7 +30,7 @@
         (click)="clear(searchInput)"
         class="reset"
       >
-        <cx-icon [type]="iconTypes.RESET"></cx-icon>
+        <cx-icon [type]="iconTypes.RESET" />
       </button>
 
       <div
@@ -38,7 +38,7 @@
         class="search-icon"
         [title]="'common.productSearchDescription' | cxTranslate"
       >
-        <cx-icon [type]="iconTypes.SEARCH"></cx-icon>
+        <cx-icon [type]="iconTypes.SEARCH" />
       </div>
     </div>
     <button
@@ -48,7 +48,7 @@
       class="search"
       (click)="open()"
     >
-      <cx-icon [type]="iconTypes.SEARCH"></cx-icon>
+      <cx-icon [type]="iconTypes.SEARCH" />
     </button>
   </label>
 </div>
@@ -133,7 +133,7 @@
         [cxOutletContext]="{
           maxTrendingSearches: config.maxTrendingSearches,
         }"
-      ></ng-template>
+      />
     </div>
 
     <!--  RECENT SEARCHES-->
@@ -146,7 +146,7 @@
           searchBoxActive: searchBoxActive,
           maxRecentSearches: config.maxRecentSearches,
         }"
-      ></ng-template>
+      />
     </ng-container>
 
     <ng-container *cxFeature="'!searchBoxRecentSearchesRemoval'">
@@ -158,7 +158,7 @@
           searchBoxActive: searchBoxActive,
           maxRecentSearches: config.maxRecentSearches,
         }"
-      ></ng-template>
+      />
     </ng-container>
     <!--RESULT  PRODUCTS-->
     <div class="products" *cxFeature="'!searchBoxEmptyQueryResultsPanel'">
@@ -173,8 +173,7 @@
           [template]="carouselItem"
           itemWidth="160px"
           (keybordEvent)="carouselEventPropagator($event)"
-        >
-        </cx-carousel>
+        />
 
         <ng-template #carouselItem let-product="item">
           <a
@@ -204,14 +203,14 @@
               [container]="product.images?.PRIMARY"
               format="product"
               [alt]="product.name ?? ''"
-            ></cx-media>
+            />
             <h3 class="cx-product-name" [innerHtml]="product.nameHtml"></h3>
             <div class="price">
               {{ product.price?.formattedValue }}
             </div>
           </a>
           <div class="actions">
-            <ng-container cxInnerComponentsHost></ng-container>
+            <ng-container cxInnerComponentsHost />
           </div>
         </ng-template>
       </ng-container>
@@ -229,8 +228,7 @@
             [template]="carouselItemFeature"
             itemWidth="160px"
             (keybordEvent)="carouselEventPropagator($event)"
-          >
-          </cx-carousel>
+          />
 
           <ng-template #carouselItemFeature let-product="item">
             <a
@@ -260,14 +258,14 @@
                 [container]="product.images?.PRIMARY"
                 format="product"
                 [alt]="product.name ?? ''"
-              ></cx-media>
+              />
               <h3 class="cx-product-name" [innerHtml]="product.nameHtml"></h3>
               <div class="price">
                 {{ product.price?.formattedValue }}
               </div>
             </a>
             <div class="actions">
-              <ng-container cxInnerComponentsHost></ng-container>
+              <ng-container cxInnerComponentsHost />
             </div>
           </ng-template>
         </ng-container>
@@ -294,8 +292,7 @@
           {{ 'searchBox.trendingSearches' | cxTranslate }}
         </h3>
         <ng-container *cxFeature="'searchBoxRecentSearchesRemoval'">
-          <ng-template [cxOutlet]="searchBoxOutlets.RECENT_SEARCHES_HEADER">
-          </ng-template>
+          <ng-template [cxOutlet]="searchBoxOutlets.RECENT_SEARCHES_HEADER" />
         </ng-container>
         <h3
           *cxFeature="'!searchBoxRecentSearchesRemoval'"

--- a/core-libs/storefront/cms-components/product/carousel/product-carousel-item/product-carousel-item.component.html
+++ b/core-libs/storefront/cms-components/product/carousel/product-carousel-item/product-carousel-item.component.html
@@ -7,7 +7,7 @@
       [fetchPriority]="
         itemIndex === 0 ? (lcpContext.fetchPriority$ | async) : undefined
       "
-    ></cx-media>
+    />
   </ng-container>
   <h3 class="cx-product-name">
     {{ item.name }}
@@ -17,5 +17,5 @@
   </div>
 </a>
 <div class="actions">
-  <ng-container cxInnerComponentsHost></ng-container>
+  <ng-container cxInnerComponentsHost />
 </div>

--- a/core-libs/storefront/cms-components/product/carousel/product-carousel/product-carousel.component.html
+++ b/core-libs/storefront/cms-components/product/carousel/product-carousel/product-carousel.component.html
@@ -8,12 +8,8 @@
   [title]="title$ | async"
   [template]="carouselItem"
   [trackByFn]="trackByFn"
->
-</cx-carousel-scrolling>
+/>
 
 <ng-template #carouselItem let-item="item" let-itemIndex="itemIndex">
-  <cx-product-carousel-item
-    [item]="item"
-    [itemIndex]="itemIndex"
-  ></cx-product-carousel-item>
+  <cx-product-carousel-item [item]="item" [itemIndex]="itemIndex" />
 </ng-template>

--- a/core-libs/storefront/cms-components/product/carousel/product-references/product-references.component.html
+++ b/core-libs/storefront/cms-components/product/carousel/product-references/product-references.component.html
@@ -5,13 +5,12 @@
     [items]="items"
     [template]="carouselItem"
     [trackByFn]="trackByFn"
-  >
-  </cx-carousel-scrolling>
+  />
 </ng-container>
 
 <ng-template #carouselItem let-item="item">
   <a tabindex="0" [routerLink]="{ cxRoute: 'product', params: item } | cxUrl">
-    <cx-media [container]="item.images?.PRIMARY" format="product"></cx-media>
+    <cx-media [container]="item.images?.PRIMARY" format="product" />
     <h4>{{ item.name }}</h4>
     <div class="price">{{ item.price?.formattedValue }}</div>
   </a>

--- a/core-libs/storefront/cms-components/product/product-images/product-images.component.html
+++ b/core-libs/storefront/cms-components/product/product-images/product-images.component.html
@@ -3,7 +3,7 @@
     [container]="main"
     *cxLcpContext="let lcpContext"
     [fetchPriority]="lcpContext.fetchPriority$ | async"
-  ></cx-media>
+  />
 </ng-container>
 
 <ng-container *ngIf="thumbs$ | async as thumbs">
@@ -13,7 +13,7 @@
     [items]="thumbs"
     [template]="thumb"
     [trackByFn]="trackByFn"
-  ></cx-carousel-scrolling>
+  />
 </ng-container>
 
 <ng-template #thumb let-item="item">
@@ -23,6 +23,5 @@
     (focus)="openImage(item.container)"
     [class.is-active]="isActive(item.container) | async"
     format="product"
-  >
-  </cx-media>
+  />
 </ng-template>

--- a/core-libs/storefront/cms-components/product/product-intro/product-intro.component.html
+++ b/core-libs/storefront/cms-components/product/product-intro/product-intro.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="product$ | async as product">
   <div class="rating" *ngIf="product?.averageRating">
-    <cx-star-rating [rating]="product?.averageRating ?? 0"></cx-star-rating>
+    <cx-star-rating [rating]="product?.averageRating ?? 0" />
 
     <div class="count">({{ product?.numberOfReviews }})</div>
     <!-- TODO: (CXSPA-7603) - Remove feature flag next major release. -->

--- a/core-libs/storefront/cms-components/product/product-list/container/product-list.component.html
+++ b/core-libs/storefront/cms-components/product/product-list/container/product-list.component.html
@@ -20,7 +20,7 @@
                   [ariaLabel]="'productList.sortResults' | cxTranslate"
                   ariaControls="product-results-list"
                   placeholder="{{ 'productList.sortBy' | cxTranslate }}"
-                ></cx-sorting>
+                />
               </label>
               <div *ngIf="!isInfiniteScroll" class="col-auto">
                 <div
@@ -34,14 +34,14 @@
                     queryParam="currentPage"
                     [defaultPage]="0"
                     paginationID="pagination-top"
-                  ></cx-pagination>
+                  />
                 </div>
               </div>
               <div class="col-auto ml-auto ml-lg-0">
                 <cx-product-view
                   (modeChange)="setViewMode($event)"
                   [mode]="viewMode"
-                ></cx-product-view>
+                />
               </div>
             </div>
           </div>
@@ -55,7 +55,7 @@
                     [product]="product"
                     [itemIndex]="i"
                     class="col-12 col-sm-6 col-md-4"
-                  ></cx-product-grid-item>
+                  />
                 </div>
               </ng-container>
 
@@ -65,7 +65,7 @@
                   [product]="product"
                   [itemIndex]="i"
                   class="cx-product-search-list"
-                ></cx-product-list-item>
+                />
               </ng-container>
             </ng-container>
 
@@ -75,7 +75,7 @@
                 [scrollConfig]="scrollConfig"
                 [model]="model"
                 [inputViewMode]="viewMode"
-              ></cx-product-scroll>
+              />
             </ng-template>
           </div>
           <div class="cx-sorting bottom">
@@ -91,7 +91,7 @@
                   [ariaLabel]="'productList.sortResults' | cxTranslate"
                   ariaControls="product-results-list"
                   placeholder="{{ 'productList.sortBy' | cxTranslate }}"
-                ></cx-sorting>
+                />
               </label>
               <div
                 *ngIf="!isInfiniteScroll"
@@ -106,14 +106,14 @@
                     queryParam="currentPage"
                     [defaultPage]="0"
                     paginationID="pagination-bottom"
-                  ></cx-pagination>
+                  />
                 </div>
               </div>
               <div class="col-auto ml-auto ml-lg-0">
                 <cx-product-view
                   (modeChange)="setViewMode($event)"
                   [mode]="viewMode"
-                ></cx-product-view>
+                />
               </div>
             </div>
           </div>

--- a/core-libs/storefront/cms-components/product/product-list/container/product-scroll/product-scroll.component.html
+++ b/core-libs/storefront/cms-components/product/product-list/container/product-scroll/product-scroll.component.html
@@ -12,7 +12,7 @@
         [product]="product"
         [itemIndex]="i"
         class="col-12 col-sm-6 col-md-4"
-      ></cx-product-grid-item>
+      />
     </div>
     <div
       [className]="
@@ -40,7 +40,7 @@
       </div>
     </div>
     <div *ngIf="appendProducts" class="cx-spinner">
-      <cx-spinner></cx-spinner>
+      <cx-spinner />
     </div>
   </div>
 </ng-container>
@@ -58,7 +58,7 @@
       [product]="product"
       [itemIndex]="i"
       class="cx-product-search-list"
-    ></cx-product-list-item>
+    />
     <div
       [className]="
         !isLastPage && (model?.pagination?.currentPage ?? 0) > 0
@@ -85,7 +85,7 @@
       </div>
     </div>
     <div *ngIf="appendProducts" class="cx-spinner">
-      <cx-spinner></cx-spinner>
+      <cx-spinner />
     </div>
   </div>
 </ng-container>

--- a/core-libs/storefront/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.html
+++ b/core-libs/storefront/cms-components/product/product-list/product-facet-navigation/active-facets/active-facets.component.html
@@ -28,7 +28,7 @@
       "
     >
       <span>{{ facet.facetValueName }}</span>
-      <cx-icon aria-hidden="true" [type]="closeIcon"></cx-icon>
+      <cx-icon aria-hidden="true" [type]="closeIcon" />
     </a>
     <a
       *cxFeature="'!a11yFilteredFacetAnnouncement'"
@@ -47,7 +47,7 @@
       "
     >
       <span>{{ facet.facetValueName }}</span>
-      <cx-icon aria-hidden="true" [type]="closeIcon"></cx-icon>
+      <cx-icon aria-hidden="true" [type]="closeIcon" />
     </a>
   </ng-container>
 </ng-container>

--- a/core-libs/storefront/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.html
+++ b/core-libs/storefront/cms-components/product/product-list/product-facet-navigation/facet-list/facet-list.component.html
@@ -16,7 +16,7 @@
       [attr.aria-label]="'common.close' | cxTranslate"
       (click)="close()"
     >
-      <cx-icon aria-hidden="true" [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon aria-hidden="true" [type]="iconTypes.CLOSE" />
     </button>
   </div>
 
@@ -24,7 +24,7 @@
       Here we'd like to introduce configurable facet components,
       either by using specific configuration or generic sproutlets
   -->
-  <cx-tab [tabs$]="tabs$" [config]="tabConfig"></cx-tab>
+  <cx-tab [tabs$]="tabs$" [config]="tabConfig" />
 
   <ng-template #facetsRef *ngFor="let facet of facets">
     <cx-facet
@@ -38,7 +38,7 @@
                 count: facet?.values?.length,
               }
       }}"
-    ></cx-facet>
+    />
   </ng-template>
 
   <div *ngIf="isDialog" class="cx-facet-list-footer">

--- a/core-libs/storefront/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.html
+++ b/core-libs/storefront/cms-components/product/product-list/product-facet-navigation/product-facet-navigation.component.html
@@ -3,11 +3,11 @@
   class="btn btn-secondary btn-block dialog-trigger"
   (click)="launch()"
 >
-  <cx-icon [type]="iconTypes.FILTER"></cx-icon>
+  <cx-icon [type]="iconTypes.FILTER" />
   {{ 'productList.filterBy.label' | cxTranslate }}
 </button>
 
-<cx-active-facets></cx-active-facets>
+<cx-active-facets />
 
 <cx-facet-list
   *ngIf="isOpen$ | async"
@@ -15,4 +15,4 @@
   (closeList)="close()"
   [class.active]="isActive$ | async"
   [class.dialog]="hasTrigger"
-></cx-facet-list>
+/>

--- a/core-libs/storefront/cms-components/product/product-list/product-grid-item/product-grid-item.component.html
+++ b/core-libs/storefront/cms-components/product/product-list/product-grid-item/product-grid-item.component.html
@@ -12,7 +12,7 @@
     [fetchPriority]="
       itemIndex === 0 ? (lcpContext.fetchPriority$ | async) : undefined
     "
-  ></cx-media>
+  />
 </a>
 <a
   [routerLink]="{ cxRoute: 'product', params: product } | cxUrl"
@@ -25,7 +25,7 @@
     <cx-star-rating
       *ngIf="product.averageRating"
       [rating]="product?.averageRating"
-    ></cx-star-rating>
+    />
     <div *ngIf="!product.averageRating">
       {{ 'productDetails.noReviews' | cxTranslate }}
     </div>
@@ -42,6 +42,6 @@
 
 <ng-template [cxOutlet]="ProductListOutlets.ITEM_ACTIONS">
   <ng-container *ngIf="!hideAddToCartButton">
-    <ng-container cxInnerComponentsHost></ng-container>
+    <ng-container cxInnerComponentsHost />
   </ng-container>
 </ng-template>

--- a/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.html
+++ b/core-libs/storefront/cms-components/product/product-list/product-list-item/product-list-item.component.html
@@ -19,7 +19,7 @@
         [fetchPriority]="
           itemIndex === 0 ? (lcpContext.fetchPriority$ | async) : undefined
         "
-      ></cx-media>
+      />
     </a>
   </div>
   <div class="col-12 col-md-8">
@@ -34,7 +34,7 @@
       <cx-star-rating
         *ngIf="product.averageRating"
         [rating]="product?.averageRating"
-      ></cx-star-rating>
+      />
       <div *ngIf="!product.averageRating" class="cx-product-no-review">
         {{ 'productDetails.noReviews' | cxTranslate }}
       </div>
@@ -59,13 +59,13 @@
             class="text"
             [text]="product.summary"
             [maxLength]="summaryMaxLength"
-          ></cx-read-more>
+          />
         </ng-container>
       </div>
       <div class="col-12 col-md-5 col-xl-5">
         <ng-template [cxOutlet]="ProductListOutlets.ITEM_ACTIONS">
           <ng-container *ngIf="!hideAddToCartButton">
-            <ng-container cxInnerComponentsHost></ng-container>
+            <ng-container cxInnerComponentsHost />
           </ng-container>
         </ng-template>
       </div>

--- a/core-libs/storefront/cms-components/product/product-list/product-view/product-view.component.html
+++ b/core-libs/storefront/cms-components/product/product-list/product-view/product-view.component.html
@@ -18,12 +18,6 @@
         : null
   }}"
 >
-  <cx-icon
-    *ngIf="viewMode === iconTypes.GRID"
-    [type]="iconTypes.GRID"
-  ></cx-icon>
-  <cx-icon
-    *ngIf="viewMode === iconTypes.LIST"
-    [type]="iconTypes.LIST"
-  ></cx-icon>
+  <cx-icon *ngIf="viewMode === iconTypes.GRID" [type]="iconTypes.GRID" />
+  <cx-icon *ngIf="viewMode === iconTypes.LIST" [type]="iconTypes.LIST" />
 </button>

--- a/core-libs/storefront/cms-components/product/product-summary/product-summary.component.html
+++ b/core-libs/storefront/cms-components/product/product-summary/product-summary.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="product$ | async as product">
   <ng-container *ngIf="product.potentialPromotions">
-    <cx-promotions [promotions]="product.potentialPromotions"></cx-promotions>
+    <cx-promotions [promotions]="product.potentialPromotions" />
   </ng-container>
 
   <ng-template

--- a/core-libs/storefront/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.html
+++ b/core-libs/storefront/cms-components/product/product-tabs/product-details-tab/product-details-tab.component.html
@@ -6,7 +6,7 @@
     <ng-container *ngIf="child">
       <ng-template [cxOutlet]="child.flexType" [cxOutletContext]="{}">
         <div class="container">
-          <ng-container [cxComponentWrapper]="child"></ng-container>
+          <ng-container [cxComponentWrapper]="child" />
         </div>
       </ng-template>
     </ng-container>

--- a/core-libs/storefront/cms-components/product/product-tabs/product-reviews/product-reviews.component.html
+++ b/core-libs/storefront/cms-components/product/product-tabs/product-reviews/product-reviews.component.html
@@ -16,7 +16,7 @@
         *ngIf="product.averageRating"
         class="rating"
         [rating]="product.averageRating"
-      ></cx-star-rating>
+      />
       <div class="rating" *ngIf="!product.averageRating">
         {{ 'productDetails.noReviews' | cxTranslate }}
       </div>
@@ -37,7 +37,7 @@
             (keydown.arrowup)="focusPreviousReview($event, i)"
           >
             <div class="title">{{ review.headline }}</div>
-            <cx-star-rating [rating]="review.rating ?? 0"></cx-star-rating>
+            <cx-star-rating [rating]="review.rating ?? 0" />
             <div class="name">
               {{ review.alias ? review.alias : review.principal?.name }}
             </div>
@@ -52,7 +52,7 @@
             *ngFor="let review of reviews | slice: 0 : maxListItems"
           >
             <div class="title">{{ review.headline }}</div>
-            <cx-star-rating [rating]="review.rating ?? 0"></cx-star-rating>
+            <cx-star-rating [rating]="review.rating ?? 0" />
             <div class="name">
               {{ review.alias ? review.alias : review.principal?.name }}
             </div>
@@ -168,7 +168,7 @@
             aria-labelledby="starRatingLabel"
             (change)="setRating($event)"
             [disabled]="false"
-          ></cx-star-rating>
+          />
 
           <cx-form-errors
             id="ratingError"
@@ -176,7 +176,7 @@
               label: 'productReview.rating' | cxTranslate,
             }"
             [control]="reviewForm.get('rating')"
-          ></cx-form-errors>
+          />
         </label>
       </div>
       <div class="form-group">

--- a/core-libs/storefront/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.html
+++ b/core-libs/storefront/cms-components/product/stock-notification/stock-notification-dialog/stock-notification-dialog.component.html
@@ -108,7 +108,7 @@
       </p>
       <div class="cx-dialog-row">
         <div class="col-sm-12">
-          <cx-spinner></cx-spinner>
+          <cx-spinner />
         </div>
       </div>
     </div>

--- a/core-libs/storefront/cms-components/product/stock-notification/stock-notification.component.html
+++ b/core-libs/storefront/cms-components/product/stock-notification/stock-notification.component.html
@@ -65,7 +65,7 @@
   <div class="cx-dialog-body modal-body">
     <div class="cx-dialog-row">
       <div class="col-sm-12">
-        <cx-spinner></cx-spinner>
+        <cx-spinner />
       </div>
     </div>
   </div>

--- a/core-libs/storefront/cms-structure/page/page-layout/page-layout.component.html
+++ b/core-libs/storefront/cms-structure/page/page-layout/page-layout.component.html
@@ -8,11 +8,11 @@
     section$: section$,
   }"
 >
-  <ng-content></ng-content>
+  <ng-content />
 
   <cx-page-slot
     *ngFor="let slot of slots$ | async"
     [position]="slot"
     [isPageFold]="slot === (pageFoldSlot$ | async)"
-  ></cx-page-slot>
+  />
 </ng-template>

--- a/core-libs/storefront/cms-structure/page/slot/page-slot.component.html
+++ b/core-libs/storefront/cms-structure/page/slot/page-slot.component.html
@@ -11,7 +11,7 @@
       [cxOutletDefer]="getComponentDeferOptions(component.flexType)"
       (loaded)="isLoaded($event)"
     >
-      <ng-container [cxComponentWrapper]="component"></ng-container>
+      <ng-container [cxComponentWrapper]="component" />
     </ng-template>
   </ng-container>
 </ng-template>

--- a/core-libs/storefront/cms-structure/pwa/components/add-to-home-screen-btn/add-to-home-screen-btn.component.html
+++ b/core-libs/storefront/cms-structure/pwa/components/add-to-home-screen-btn/add-to-home-screen-btn.component.html
@@ -1,3 +1,3 @@
 <span (click)="prompt()">
-  <ng-content *ngIf="canPrompt$ | async"></ng-content>
+  <ng-content *ngIf="canPrompt$ | async" />
 </span>

--- a/core-libs/storefront/layout/main/storefront.component.html
+++ b/core-libs/storefront/layout/main/storefront.component.html
@@ -8,30 +8,21 @@
       (keydown.escape)="collapseMenu()"
       (click)="collapseMenuIfClickOutside($event)"
     >
-      <cx-page-layout
-        section="header"
-        [cxSkipFocus]="skipFocusConfig"
-      ></cx-page-layout>
+      <cx-page-layout section="header" [cxSkipFocus]="skipFocusConfig" />
 
-      <cx-page-layout section="navigation"></cx-page-layout>
+      <cx-page-layout section="navigation" />
     </header>
-    <cx-page-slot
-      position="BottomHeaderSlot"
-      class="cx-bottom-header-slot"
-    ></cx-page-slot>
-    <cx-global-message
-      aria-atomic="true"
-      aria-live="assertive"
-    ></cx-global-message>
+    <cx-page-slot position="BottomHeaderSlot" class="cx-bottom-header-slot" />
+    <cx-global-message aria-atomic="true" aria-live="assertive" />
   </ng-template>
 
   <main cxSkipLink="cx-main" [cxFocus]="{ disableMouseFocus: true }">
-    <router-outlet></router-outlet>
+    <router-outlet />
   </main>
 
   <ng-template cxOutlet="cx-footer">
     <footer cxSkipLink="cx-footer" [cxFocus]="{ disableMouseFocus: true }">
-      <cx-page-layout section="footer"></cx-page-layout>
+      <cx-page-layout section="footer" />
     </footer>
   </ng-template>
 </ng-template>

--- a/core-libs/storefront/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.html
+++ b/core-libs/storefront/shared/components/anonymous-consents-dialog/anonymous-consent-dialog.component.html
@@ -7,7 +7,7 @@
 >
   <div class="modal-content cx-dialog-content">
     <div *ngIf="loading$ | async; else dialogBody">
-      <cx-spinner></cx-spinner>
+      <cx-spinner />
     </div>
     <ng-template #dialogBody>
       <div class="modal-header cx-dialog-header">
@@ -22,7 +22,7 @@
           (click)="close('Cross click')"
         >
           <span aria-hidden="true">
-            <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+            <cx-icon [type]="iconTypes.CLOSE" />
           </span>
         </button>
       </div>
@@ -41,7 +41,7 @@
           [type]="message.type"
           [isVisibleCloseButton]="true"
           (closeMessage)="closeMessage()"
-        ></cx-message>
+        />
       </div>
       <!-- Actions -->
       <div class="cx-dialog-buttons">
@@ -67,7 +67,7 @@
               [requiredConsents]="requiredConsents"
               [consent]="getCorrespondingConsent(template, consents)"
               (consentChanged)="onConsentChange($event)"
-            ></cx-consent-management-form>
+            />
           </div>
         </ng-container>
       </div>

--- a/core-libs/storefront/shared/components/card/card.component.html
+++ b/core-libs/storefront/shared/components/card/card.component.html
@@ -49,8 +49,7 @@
                 text: line,
               }
             "
-          >
-          </ng-container>
+          />
         </div>
         <div
           class="cx-card-paragraph"
@@ -69,11 +68,10 @@
                   text: text,
                 }
               "
-            >
-            </ng-container>
+            />
           </div>
         </div>
-        <ng-content select="[label_container_bottom]"></ng-content>
+        <ng-content select="[label_container_bottom]" />
       </div>
       <!-- Image -->
       <div
@@ -85,7 +83,7 @@
         role="img"
         [attr.title]="content.imgLabel ?? 'paymentCard.credit' | cxTranslate"
       >
-        <cx-icon [type]="content.img"></cx-icon>
+        <cx-icon [type]="content.img" />
       </div>
     </div>
     <!-- Edit Mode Actions -->
@@ -182,5 +180,5 @@
     [charactersLimit]="charactersLimit"
     [content]="text"
     [customClass]="content.customClass || class"
-  ></cx-truncate-text-popover>
+  />
 </ng-template>

--- a/core-libs/storefront/shared/components/carousel-scrolling/carousel-scrolling.component.html
+++ b/core-libs/storefront/shared/components/carousel-scrolling/carousel-scrolling.component.html
@@ -24,7 +24,7 @@
         cxHorizontalScrollingPosition.isScrollNeeded$ | async
       "
     >
-      <cx-icon [type]="previousIcon"></cx-icon>
+      <cx-icon [type]="previousIcon" />
     </button>
     <div class="carousel-items" #scrollingArea>
       <span #scrollingAreaStart class="carousel-items-start"></span>
@@ -40,7 +40,7 @@
         >
           <ng-container
             *ngTemplateOutlet="template; context: { item: data, itemIndex: i }"
-          ></ng-container>
+          />
         </div>
       </ng-container>
 
@@ -59,7 +59,7 @@
         cxHorizontalScrollingPosition.isScrollNeeded$ | async
       "
     >
-      <cx-icon [type]="nextIcon"></cx-icon>
+      <cx-icon [type]="nextIcon" />
     </button>
   </div>
 </ng-container>

--- a/core-libs/storefront/shared/components/carousel/carousel.component.html
+++ b/core-libs/storefront/shared/components/carousel/carousel.component.html
@@ -16,7 +16,7 @@
         (keydown.arrowup)="shareEvent($any($event))"
         (keydown.arrowdown)="shareEvent($any($event))"
       >
-        <cx-icon [type]="previousIcon"></cx-icon>
+        <cx-icon [type]="previousIcon" />
       </button>
       <button
         *cxFeature="'!a11yCarouselPreventNavigationFocus'"
@@ -33,7 +33,7 @@
         (keydown.arrowup)="shareEvent($any($event))"
         (keydown.arrowdown)="shareEvent($any($event))"
       >
-        <cx-icon [type]="previousIcon"></cx-icon>
+        <cx-icon [type]="previousIcon" />
       </button>
     </ng-container>
     <div class="slides">
@@ -64,7 +64,7 @@
                     itemIndex: i + j,
                   }
                 "
-              ></ng-container>
+              />
             </div>
           </ng-container>
         </div>
@@ -85,7 +85,7 @@
         (keydown.arrowup)="shareEvent($any($event))"
         (keydown.arrowdown)="shareEvent($any($event))"
       >
-        <cx-icon [type]="nextIcon"></cx-icon>
+        <cx-icon [type]="nextIcon" />
       </button>
       <button
         *cxFeature="'!a11yCarouselPreventNavigationFocus'"
@@ -104,7 +104,7 @@
         (keydown.arrowup)="shareEvent($any($event))"
         (keydown.arrowdown)="shareEvent($any($event))"
       >
-        <cx-icon [type]="nextIcon"></cx-icon>
+        <cx-icon [type]="nextIcon" />
       </button>
     </ng-container>
   </div>
@@ -133,7 +133,7 @@
                 }
         "
       >
-        <cx-icon [type]="indicatorIcon" aria-hidden="true"></cx-icon>
+        <cx-icon [type]="indicatorIcon" aria-hidden="true" />
       </button>
     </ng-container>
   </div>

--- a/core-libs/storefront/shared/components/chat-messaging/avatar/avatar.component.html
+++ b/core-libs/storefront/shared/components/chat-messaging/avatar/avatar.component.html
@@ -10,7 +10,7 @@
   <cx-icon
     *ngIf="!message.rightAlign && !message?.author"
     [type]="iconTypes.USER"
-  ></cx-icon>
+  />
 
-  <cx-icon *ngIf="message.rightAlign" [type]="iconTypes.HEADSET"></cx-icon>
+  <cx-icon *ngIf="message.rightAlign" [type]="iconTypes.HEADSET" />
 </div>

--- a/core-libs/storefront/shared/components/chat-messaging/messaging/messaging.component.html
+++ b/core-libs/storefront/shared/components/chat-messaging/messaging/messaging.component.html
@@ -137,7 +137,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <cx-icon [type]="iconTypes.ATTACHMENT"></cx-icon>
+              <cx-icon [type]="iconTypes.ATTACHMENT" />
               {{ attachment.filename }}
             </a>
           </div>
@@ -211,7 +211,7 @@
           *ngIf="messagingConfigs?.enableFileUploadOption"
         >
           <ng-template>
-            <cx-icon [type]="iconTypes.UPLOAD"></cx-icon>
+            <cx-icon [type]="iconTypes.UPLOAD" />
             <span class="cx-message-footer-text"
               >{{ 'chatMessaging.uploadFile' | cxTranslate }}
             </span>
@@ -225,10 +225,7 @@
           }}
         </p>
       </div>
-      <cx-form-errors
-        [control]="form.get('file')"
-        prefix="formErrors.file"
-      ></cx-form-errors>
+      <cx-form-errors [control]="form.get('file')" prefix="formErrors.file" />
     </div>
   </div>
 </ng-container>

--- a/core-libs/storefront/shared/components/form/date-picker/date-picker.component.html
+++ b/core-libs/storefront/shared/components/form/date-picker/date-picker.component.html
@@ -22,4 +22,4 @@
     max: getDate(max) | cxDate,
     min: getDate(min) | cxDate,
   }"
-></cx-form-errors>
+/>

--- a/core-libs/storefront/shared/components/form/file-upload/file-upload.component.html
+++ b/core-libs/storefront/shared/components/form/file-upload/file-upload.component.html
@@ -13,7 +13,7 @@
   type="button"
   (click)="fileInput.click()"
 >
-  <ng-content></ng-content>
+  <ng-content />
 </button>
 <!-- TODO(Brian-Parth): CXEC-17196 -->
 <button
@@ -21,7 +21,7 @@
   *ngIf="customButton"
   (click)="fileInput.click()"
 >
-  <ng-container *ngTemplateOutlet="customButton"> </ng-container>
+  <ng-container *ngTemplateOutlet="customButton" />
 </button>
 <p *ngFor="let file of selectedFiles">
   {{ file?.name }}

--- a/core-libs/storefront/shared/components/form/password-visibility-toggle/password-visibility-toggle.component.html
+++ b/core-libs/storefront/shared/components/form/password-visibility-toggle/password-visibility-toggle.component.html
@@ -7,7 +7,7 @@
   [attr.aria-pressed]="state.inputType === showState.inputType"
 >
   <span aria-hidden="true">
-    <cx-icon [type]="state.icon"></cx-icon>
+    <cx-icon [type]="state.icon" />
   </span>
 </button>
 <button
@@ -19,6 +19,6 @@
   [attr.aria-pressed]="state.inputType === showState.inputType"
 >
   <span aria-hidden="true">
-    <cx-icon [type]="state.icon"></cx-icon>
+    <cx-icon [type]="state.icon" />
   </span>
 </button>

--- a/core-libs/storefront/shared/components/generic-link/generic-link.component.html
+++ b/core-libs/storefront/shared/components/generic-link/generic-link.component.html
@@ -12,7 +12,7 @@
     [attr.aria-label]="ariaLabel ? ariaLabel : null"
     [tabindex]="tabindex"
   >
-    <ng-container *ngTemplateOutlet="content"></ng-container>
+    <ng-container *ngTemplateOutlet="content" />
   </a>
 </ng-container>
 
@@ -29,10 +29,10 @@
     [attr.aria-label]="ariaLabel ? ariaLabel : null"
     [tabindex]="tabindex"
   >
-    <ng-container *ngTemplateOutlet="content"></ng-container>
+    <ng-container *ngTemplateOutlet="content" />
   </a>
 </ng-template>
 
 <ng-template #content>
-  <ng-content></ng-content>
+  <ng-content />
 </ng-template>

--- a/core-libs/storefront/shared/components/popover/popover.component.html
+++ b/core-libs/storefront/shared/components/popover/popover.component.html
@@ -11,11 +11,11 @@
       (keydown.space)="close($event)"
       (click)="close($event)"
     >
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </button>
   </div>
   <ng-container *ngIf="isTemplate(content)">
-    <ng-container *ngTemplateOutlet="content"></ng-container>
+    <ng-container *ngTemplateOutlet="content" />
   </ng-container>
   <span *ngIf="isString(content)">{{ content }}</span>
 </div>

--- a/core-libs/storefront/shared/components/progress-button/progress-button.component.html
+++ b/core-libs/storefront/shared/components/progress-button/progress-button.component.html
@@ -9,6 +9,6 @@
     <div *ngIf="loading" class="loader-container">
       <div class="loader">{{ 'spinner.loading' | cxTranslate }}</div>
     </div>
-    <ng-content></ng-content>
+    <ng-content />
   </div>
 </button>

--- a/core-libs/storefront/shared/components/split-view/split/split-view.component.html
+++ b/core-libs/storefront/shared/components/split-view/split/split-view.component.html
@@ -1,1 +1,1 @@
-<ng-content></ng-content>
+<ng-content />

--- a/core-libs/storefront/shared/components/split-view/view/view.component.html
+++ b/core-libs/storefront/shared/components/split-view/view/view.component.html
@@ -1,1 +1,1 @@
-<ng-content></ng-content>
+<ng-content />

--- a/core-libs/storefront/shared/components/star-rating/star-rating.component.html
+++ b/core-libs/storefront/shared/components/star-rating/star-rating.component.html
@@ -8,7 +8,7 @@
     'productReview.ratedOutOf' | cxTranslate: { rating: rating.toFixed(1) }
   "
 >
-  <ng-container *ngTemplateOutlet="starRating"></ng-container>
+  <ng-container *ngTemplateOutlet="starRating" />
 </div>
 
 <ng-template #starRating>
@@ -26,5 +26,5 @@
       !disabled ? ('productReview.addRate' | cxTranslate: { count: i }) : null
     "
     [attr.aria-hidden]="disabled"
-  ></cx-icon>
+  />
 </ng-template>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,16 +27,14 @@ export default defineConfig(
   },
   {
     files: ['**/*.ts'],
-    extends: [
-      ...angular.configs.tsRecommended,
-    ],
+    extends: [...angular.configs.tsRecommended],
     processor: angular.processInlineTemplates,
     plugins: {
       '@typescript-eslint': tseslint.plugin,
       '@nx': nxPlugin,
       '@stylistic/ts': stylisticTs,
-      'import': importPlugin,
-      'jsdoc': jsdocPlugin,
+      import: importPlugin,
+      jsdoc: jsdocPlugin,
       'prefer-arrow': preferArrowPlugin,
     },
     languageOptions: {
@@ -154,9 +152,9 @@ export default defineConfig(
           ],
         },
       ],
-      'complexity': 'off',
+      complexity: 'off',
       'constructor-super': 'error',
-      'eqeqeq': ['error', 'smart'],
+      eqeqeq: ['error', 'smart'],
       'guard-for-in': 'error',
       'id-blacklist': 'off',
       'id-match': 'off',
@@ -188,8 +186,7 @@ export default defineConfig(
         {
           selector:
             'PropertyDefinition[accessibility="private"][value.type="CallExpression"][value.callee.name="inject"]:not([value.arguments.0.name="FeatureConfigService"]):not([value.arguments.0.name="FeatureToggles"])',
-          message:
-            `[Spartacus] Injected dependencies should use "protected" instead of "private" to allow customers to extend the class.
+          message: `[Spartacus] Injected dependencies should use "protected" instead of "private" to allow customers to extend the class.
             (Exceptions: FeatureConfigService, FeatureToggles — those MUST be private; see @nx/workspace-feature-config-service-must-be-private and @nx/workspace-feature-toggles-must-be-private.)`,
         },
       ],
@@ -203,13 +200,13 @@ export default defineConfig(
       'object-shorthand': 'off',
       'one-var': ['error', 'never'],
       'prefer-const': 'off',
-      'radix': 'error',
+      radix: 'error',
       'use-isnan': 'error',
       'valid-typeof': 'off',
       'arrow-body-style': 'off',
       'arrow-parens': 'off',
       'comma-dangle': 'off',
-      'curly': 'error',
+      curly: 'error',
       'eol-last': 'error',
       'linebreak-style': ['error', 'unix'],
       'max-len': 'off',
@@ -217,20 +214,18 @@ export default defineConfig(
       'no-multiple-empty-lines': 'off',
       'no-trailing-spaces': 'error',
       'quote-props': ['error', 'as-needed'],
-      'quotes': 'off',
+      quotes: 'off',
       'space-before-function-paren': 'off',
     },
   },
   {
     files: ['**/*.html'],
-    extends: [
-      ...angular.configs.templateRecommended,
-    ],
+    extends: [...angular.configs.templateRecommended],
     rules: {
       '@angular-eslint/template/no-negated-async': 'off',
       '@angular-eslint/template/eqeqeq': 'error',
       '@angular-eslint/template/prefer-control-flow': 'off',
-      '@angular-eslint/template/prefer-self-closing-tags': 'warn',
+      '@angular-eslint/template/prefer-self-closing-tags': 'error',
     },
   },
   {
@@ -261,5 +256,5 @@ export default defineConfig(
       '@nx/workspace-feature-toggles-must-be-private': 'error',
       '@nx/workspace-no-self-public-api-import': 'warn',
     },
-  },
+  }
 );

--- a/feature-libs/asm/components/asm-bind-cart/asm-bind-cart.component.html
+++ b/feature-libs/asm/components/asm-bind-cart/asm-bind-cart.component.html
@@ -30,7 +30,7 @@
     <cx-dot-spinner
       [attr.aria-hidden]="!(loading$ | async)"
       [attr.aria-label]="'common.loading' | cxTranslate"
-    ></cx-dot-spinner>
+    />
   </button>
 
   <button
@@ -48,6 +48,6 @@
     <cx-dot-spinner
       [attr.aria-hidden]="!(loading$ | async)"
       [attr.aria-label]="'common.loading' | cxTranslate"
-    ></cx-dot-spinner>
+    />
   </button>
 </form>

--- a/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.component.html
+++ b/feature-libs/asm/components/asm-create-customer-form/asm-create-customer-form.component.html
@@ -22,8 +22,7 @@
               [text]="'asm.createCustomerForm.createAccountAlert' | cxTranslate"
               [type]="globalMessageType.MSG_TYPE_INFO"
               (closeMessage)="closeDialogInfoAlert()"
-            >
-            </cx-message>
+            />
             <ng-container
               *ngFor="let errorMessage of backendErrorMessages; let i = index"
             >
@@ -32,8 +31,7 @@
                 [text]="errorMessage"
                 [type]="globalMessageType.MSG_TYPE_ERROR"
                 (closeMessage)="closeDialogBackendErroAlert(i)"
-              >
-              </cx-message>
+              />
             </ng-container>
           </div>
 
@@ -62,7 +60,7 @@
                 <cx-form-errors
                   id="firstNameError"
                   [control]="registerForm.get('firstName')"
-                ></cx-form-errors>
+                />
               </label>
             </div>
 
@@ -89,7 +87,7 @@
                 <cx-form-errors
                   id="lastNameError"
                   [control]="registerForm.get('lastName')"
-                ></cx-form-errors>
+                />
               </label>
             </div>
 
@@ -119,7 +117,7 @@
                 <cx-form-errors
                   id="emailError"
                   [control]="registerForm.get('email')"
-                ></cx-form-errors>
+                />
               </label>
             </div>
           </div>
@@ -146,5 +144,5 @@
 </div>
 
 <ng-template #loading>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/feature-libs/asm/components/asm-main-ui/asm-main-ui.component.html
+++ b/feature-libs/asm/components/asm-main-ui/asm-main-ui.component.html
@@ -21,7 +21,7 @@
         rel="noopener noreferrer"
         role="button"
       >
-        <cx-icon [type]="iconTypes.HELP"></cx-icon>
+        <cx-icon [type]="iconTypes.HELP" />
         <span>{{ 'asm.helpPortalUrl' | cxTranslate }}</span></a
       >
     </div>
@@ -37,20 +37,16 @@
         class="cx-asm-customer-list-link"
         (click)="showCustomList()"
       >
-        <cx-icon [type]="iconTypes.USER_FRIENDS"></cx-icon>
+        <cx-icon [type]="iconTypes.USER_FRIENDS" />
         <span>{{ 'asm.customers' | cxTranslate }}</span></a
       >
     </div>
 
     <ng-container *cxFeature="'!authorizationCodeFlowByDefault'">
-      <cx-asm-toggle-ui
-        *ngIf="customerSupportAgentLoggedIn$ | async"
-      ></cx-asm-toggle-ui>
+      <cx-asm-toggle-ui *ngIf="customerSupportAgentLoggedIn$ | async" />
     </ng-container>
 
-    <cx-asm-session-timer
-      *ngIf="customerSupportAgentLoggedIn$ | async"
-    ></cx-asm-session-timer>
+    <cx-asm-session-timer *ngIf="customerSupportAgentLoggedIn$ | async" />
 
     <ng-container *cxFeature="'authorizationCodeFlowByDefault'">
       <div
@@ -89,34 +85,31 @@
     *ngIf="customerSupportAgentLoggedIn$ | async; else showLoginForm"
   >
     <ng-container *ngIf="customer$ | async; else showCustomerSelection">
-      <cx-customer-emulation *ngIf="notCollapsed"></cx-customer-emulation>
+      <cx-customer-emulation *ngIf="notCollapsed" />
       <cx-message
         *ngIf="notCollapsed && showCreateCustomerSuccessfullyAlert"
         [text]="'asm.createCustomerSuccessfullyAlert' | cxTranslate"
         [type]="globalMessageType.MSG_TYPE_CONFIRMATION"
         (closeMessage)="closeDialogConfirmationAlert()"
-      >
-      </cx-message>
+      />
       <cx-message
         *ngIf="showDeeplinkCartInfoAlert$ | async"
         [text]="deeplinkCartAlertKey | cxTranslate"
         [type]="globalMessageType.MSG_TYPE_INFO"
         (closeMessage)="closeDeeplinkCartInfoAlert()"
-      >
-      </cx-message>
+      />
       <cx-message
         *ngIf="notCollapsed && showCustomerEmulationInfoAlert"
         [text]="'asm.startCustomerEmulationAlertInfo' | cxTranslate"
         [type]="globalMessageType.MSG_TYPE_INFO"
         (closeMessage)="closeCustomerEmulationInfoAlert()"
-      >
-      </cx-message>
+      />
     </ng-container>
     <ng-template #showCustomerSelection>
       <cx-customer-selection
         *ngIf="notCollapsed"
         (submitEvent)="startCustomerEmulationSession($event, $event.parameters)"
-      ></cx-customer-selection>
+      />
     </ng-template>
   </ng-container>
 
@@ -126,7 +119,7 @@
         *ngIf="notCollapsed"
         (submitEvent)="loginCustomerSupportAgent($event)"
         [csAgentTokenLoading]="csAgentTokenLoading$ | async"
-      ></cx-csagent-login-form>
+      />
     </ng-container>
   </ng-template>
 </ng-container>

--- a/feature-libs/asm/components/asm-save-cart-dialog/asm-save-cart-dialog.component.html
+++ b/feature-libs/asm/components/asm-save-cart-dialog/asm-save-cart-dialog.component.html
@@ -22,8 +22,7 @@
             [text]="'asm.saveCart.dialog.saveInfo' | cxTranslate"
             [type]="globalMessageType.MSG_TYPE_INFO"
             (closeMessage)="closeDialogAlert()"
-          >
-          </cx-message>
+          />
         </div>
       </ng-container>
       <ng-template #showSaveCartWarning>
@@ -33,8 +32,7 @@
             [text]="'asm.saveCart.dialog.disableInfo' | cxTranslate"
             [type]="globalMessageType.MSG_TYPE_WARNING"
             (closeMessage)="closeDialogAlert()"
-          >
-          </cx-message>
+          />
         </div>
       </ng-template>
 

--- a/feature-libs/asm/components/asm-switch-customer-dialog/asm-switch-customer-dialog.component.html
+++ b/feature-libs/asm/components/asm-switch-customer-dialog/asm-switch-customer-dialog.component.html
@@ -10,7 +10,7 @@
     <div class="cx-dialog-header modal-header">
       <div>
         <span>
-          <cx-icon type="WARNING"></cx-icon>
+          <cx-icon type="WARNING" />
         </span>
         <span id="asm-switch-customer-dialog-title" class="title modal-title">
           {{ 'asm.switchCustomer.dialog.title' | cxTranslate }}

--- a/feature-libs/asm/components/csagent-login-form/csagent-login-form.component.html
+++ b/feature-libs/asm/components/csagent-login-form/csagent-login-form.component.html
@@ -25,7 +25,7 @@
         label: 'asm.loginForm.userId.label' | cxTranslate,
       }"
       [control]="csAgentLoginForm.get('userId')"
-    ></cx-form-errors>
+    />
   </label>
 
   <span class="label-content">
@@ -51,7 +51,7 @@
         label: 'asm.loginForm.password.label' | cxTranslate,
       }"
       [control]="csAgentLoginForm.get('password')"
-    ></cx-form-errors>
+    />
   </label>
   <button type="submit">
     {{ 'asm.loginForm.submit' | cxTranslate }}
@@ -62,4 +62,4 @@
   *ngIf="csAgentTokenLoading"
   aria-hidden="false"
   [attr.aria-label]="'common.loading' | cxTranslate"
-></cx-dot-spinner>
+/>

--- a/feature-libs/asm/components/customer-emulation/customer-emulation.component.html
+++ b/feature-libs/asm/components/customer-emulation/customer-emulation.component.html
@@ -3,7 +3,7 @@
     <label class="cx-asm-name">{{ customer?.name }}</label>
     <label class="cx-asm-uid">{{ customer?.uid }}</label>
   </div>
-  <cx-asm-bind-cart></cx-asm-bind-cart>
+  <cx-asm-bind-cart />
   <button
     *ngIf="isAsmCustomer360Configured && customer"
     #asmCustomer360Launcher

--- a/feature-libs/asm/components/customer-list/customer-list.component.html
+++ b/feature-libs/asm/components/customer-list/customer-list.component.html
@@ -15,7 +15,7 @@
         <div id="asm-customer-list-desc" class="cx-visually-hidden">
           {{ 'asm.customerList.description' | cxTranslate }}
         </div>
-        <ng-template *ngTemplateOutlet="createCustomerButton"></ng-template>
+        <ng-template *ngTemplateOutlet="createCustomerButton" />
       </div>
       <div
         class="cx-dialog-sub-header modal-header"
@@ -31,7 +31,7 @@
               groupSelector;
               context: { customerListsPage: customerListsPage }
             "
-          ></ng-template>
+          />
           <ng-template
             *ngTemplateOutlet="
               total;
@@ -39,16 +39,15 @@
                 customerSearchPage: customerSearchPage$ | async,
               }
             "
-          >
-          </ng-template>
+          />
         </div>
 
         <div
           class="cx-header-actions"
           [class.mobile]="(breakpoint$ | async) === BREAKPOINT.xs"
         >
-          <ng-template *ngTemplateOutlet="sort"></ng-template>
-          <ng-template *ngTemplateOutlet="search"></ng-template>
+          <ng-template *ngTemplateOutlet="sort" />
+          <ng-template *ngTemplateOutlet="search" />
         </div>
       </div>
       <!-- Modal Body -->
@@ -64,7 +63,7 @@
             <div *ngIf="customerSearchError$ | async" class="cx-error-state">
               {{ 'generalErrors.pageFailure' | cxTranslate }}
             </div>
-            <cx-spinner *ngIf="customerSearchLoading$ | async"></cx-spinner>
+            <cx-spinner *ngIf="customerSearchLoading$ | async" />
             <div *ngIf="customerSearchPage$ | async as customerSearchPage">
               <table
                 id="asm-cusomer-list-table"
@@ -146,7 +145,7 @@
                               showHeader: false,
                             }
                           "
-                        ></ng-template>
+                        />
                       </td>
                     </ng-container>
                     <!-- two column if tablet -->
@@ -170,7 +169,7 @@
                                   showHeader: true,
                                 }
                               "
-                            ></ng-template>
+                            />
                           </ng-container>
                         </ng-container>
                       </td>
@@ -191,7 +190,7 @@
                                   showHeader: true,
                                 }
                               "
-                            ></ng-template>
+                            />
                           </ng-container>
                         </ng-container>
                       </td>
@@ -214,7 +213,7 @@
                               showHeader: true,
                             }
                           "
-                        ></ng-template>
+                        />
                       </ng-container>
                     </td>
                   </tr>
@@ -244,7 +243,7 @@
             <cx-pagination
               [pagination]="customerSearchPage.pagination"
               (viewPageEvent)="changePage($event)"
-            ></cx-pagination>
+            />
           </div>
         </div>
       </div>
@@ -281,7 +280,7 @@
           cellContent;
           context: { column: column, customerEntry: customerEntry }
         "
-      ></ng-container>
+      />
     </ng-container>
 
     <div
@@ -331,7 +330,7 @@
           cellContent;
           context: { column: column, customerEntry: customerEntry }
         "
-      ></ng-container>
+      />
     </button>
   </div>
 </ng-template>
@@ -358,7 +357,7 @@
             | cxTranslate)
           : undefined
       "
-    ></cx-icon>
+    />
   </div>
 </ng-template>
 
@@ -378,7 +377,7 @@
       [title]="'storeFinder.searchNearestStores' | cxTranslate"
       class="search"
       (click)="searchCustomers()"
-    ></cx-icon>
+    />
   </div>
 </ng-template>
 
@@ -410,7 +409,7 @@
       placeholder="{{ 'asm.customerList.tableSort.sortBy' | cxTranslate }}"
       [ariaLabel]="sortCode"
       ariaControls="asm-cusomer-list-table"
-    ></cx-sorting>
+    />
   </label>
 </ng-template>
 
@@ -427,8 +426,9 @@
       class="btn btn-link cx-action-link cx-btn-previous"
       [disabled]="currentPage === 0 || !loaded"
     >
-      <cx-icon class="previous" [type]="iconTypes.CARET_LEFT"></cx-icon
-      ><span>{{ 'asm.customerList.page.previous' | cxTranslate }}</span>
+      <cx-icon class="previous" [type]="iconTypes.CARET_LEFT" /><span>{{
+        'asm.customerList.page.previous' | cxTranslate
+      }}</span>
     </button>
     <button
       *ngIf="maxPage > 0"
@@ -437,7 +437,7 @@
       [disabled]="currentPage === maxPage || !loaded"
     >
       <span>{{ 'asm.customerList.page.next' | cxTranslate }}</span
-      ><cx-icon class="next" [type]="iconTypes.CARET_RIGHT"></cx-icon>
+      ><cx-icon class="next" [type]="iconTypes.CARET_RIGHT" />
     </button>
   </div>
 </ng-template>
@@ -464,8 +464,7 @@
         ariaLabel: 'asm.customerList.title' | cxTranslate,
         ariaControls: 'asm-cusomer-list-table',
       }"
-    >
-    </ng-select>
+    />
   </label>
 </ng-template>
 
@@ -478,7 +477,7 @@
     title="{{ 'common.close' | cxTranslate }}"
   >
     <span aria-hidden="true">
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </span>
   </button>
 </ng-template>
@@ -490,7 +489,7 @@
     class="btn cx-asm-create-customer-btn"
     (click)="createCustomer()"
   >
-    <cx-icon [type]="iconTypes.USER_PLUS"></cx-icon>
+    <cx-icon [type]="iconTypes.USER_PLUS" />
     <span>{{ 'asm.customerList.createCustomer' | cxTranslate }}</span>
   </button>
 </ng-template>

--- a/feature-libs/asm/components/customer-selection/customer-selection.component.html
+++ b/feature-libs/asm/components/customer-selection/customer-selection.component.html
@@ -31,7 +31,7 @@
               <cx-icon
                 class="cx-icon fas fa-info-circle"
                 ng-reflect-type="INFO"
-              ></cx-icon>
+              />
             </span>
             <span class="cx-message-text"
               >{{ 'asm.customerSearch.noCustomerMatchResult' | cxTranslate }}
@@ -79,7 +79,7 @@
       <cx-dot-spinner
         aria-hidden="false"
         [attr.aria-label]="'common.loading' | cxTranslate"
-      ></cx-dot-spinner>
+      />
     </div>
   </label>
   <span class="searchLabel">{{
@@ -110,7 +110,7 @@
               <cx-icon
                 class="cx-icon fas fa-info-circle"
                 ng-reflect-type="INFO"
-              ></cx-icon>
+              />
             </span>
             <span class="cx-message-text">
               {{ 'asm.customerSearch.noOrderMatchResult' | cxTranslate }}
@@ -150,7 +150,7 @@
       <cx-dot-spinner
         aria-hidden="false"
         [attr.aria-label]="'common.loading' | cxTranslate"
-      ></cx-dot-spinner>
+      />
     </div>
   </label>
 

--- a/feature-libs/asm/customer-360/components/asm-customer-360-product-item/asm-customer-360-product-item.component.html
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-product-item/asm-customer-360-product-item.component.html
@@ -7,7 +7,7 @@
     [container]="product?.images?.PRIMARY"
     format="product"
     [alt]="product?.name ?? ''"
-  ></cx-media>
+  />
 </button>
 <div class="cx-asm-customer-360-product-item-content">
   <button

--- a/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/asm-customer-360-product-listing.component.html
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/asm-customer-360-product-listing.component.html
@@ -15,7 +15,7 @@
       {{ headerText }}
     </button>
     <ng-container *ngIf="headerTemplate">
-      <ng-container *ngTemplateOutlet="headerTemplate"></ng-container>
+      <ng-container *ngTemplateOutlet="headerTemplate" />
     </ng-container>
   </div>
   <ng-container *ngIf="numberofColumns$ | async as numberofColumns">
@@ -30,7 +30,7 @@
           [product]="product"
           [quantity]="product?.quantity"
           (selectProduct)="selectProduct.emit($event)"
-        ></cx-asm-customer-360-product-item>
+        />
       </ng-container>
     </div>
     <ng-container *ngIf="products.length > numberofColumns">

--- a/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/asm-customer-360-product-listing.component.spec.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-product-listing/asm-customer-360-product-listing.component.spec.ts
@@ -50,8 +50,7 @@ describe('AsmCustomer360ProductListingComponent', () => {
         [headerText]="headerText"
         (clickHeader)="clickHeaderSpy.push(undefined)"
         (selectProduct)="selectProductSpy.push($event)"
-      >
-      </cx-asm-customer-360-product-listing>
+      />
 
       <ng-template #headerTemplate>
         <div id="product-listing-header-template"></div>

--- a/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.component.html
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.component.html
@@ -3,20 +3,20 @@
     {{ headerText }}
   </h4>
 </div>
-<ng-content></ng-content>
+<ng-content />
 <div class="message-container">
   <cx-message
     *ngIf="showAlert"
     [text]="'asmCustomer360.alertErrorMessage' | cxTranslate"
     [type]="globalMessageType.MSG_TYPE_ERROR"
     (closeMessage)="removeAlert.emit()"
-  ></cx-message>
+  />
   <cx-message
     *ngIf="showAlertForApplyAction"
     [text]="'asmCustomer360.applyActionAlter' | cxTranslate"
     [type]="globalMessageType.MSG_TYPE_ERROR"
     (closeMessage)="removeAlertForApplyAction.emit()"
-  ></cx-message>
+  />
 </div>
 <table class="cx-asm-customer-360-promotion-listing">
   <caption class="cx-visually-hidden">
@@ -65,7 +65,7 @@
           <tr class="cx-asm-customer-360-promotion-listing-action">
             <ng-container *ngIf="!isCustomerCoupon">
               <td>
-                <cx-icon class="success" type="SUCCESS"></cx-icon>
+                <cx-icon class="success" type="SUCCESS" />
               </td>
               <td class="cx-asm-customer-360-promotion-listing-applied">
                 {{ applied }}

--- a/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.component.spec.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-promotion-listing/asm-customer-360-promotion-listing.component.spec.ts
@@ -81,8 +81,7 @@ describe('AsmCustomer360PromotionListingComponent', () => {
         [removeButtonText]="removeButtonText"
         [showRemoveButton]="true"
         [showApplyButton]="true"
-      >
-      </cx-asm-customer-360-promotion-listing>
+      />
     `,
     imports: [AsmCustomer360PromotionListingComponent],
   })

--- a/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.component.html
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.component.html
@@ -101,7 +101,7 @@
         >
           <ng-container
             *ngIf="column.navigatable; then linkTemplate; else starRating"
-          ></ng-container>
+          />
 
           <ng-template #linkTemplate>
             <button
@@ -126,7 +126,7 @@
               tabindex="-1"
               *ngIf="column.renderAsStarRating; else dateCell"
               [rating]="entry[column.property]"
-            ></cx-star-rating>
+            />
           </ng-template>
 
           <ng-template #dateCell>

--- a/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.component.spec.ts
+++ b/feature-libs/asm/customer-360/components/asm-customer-360-table/asm-customer-360-table.component.spec.ts
@@ -215,7 +215,7 @@ describe('AsmCustomer360TableComponent', () => {
         [pageSize]="pageSize"
         [sortProperty]="sortProperty"
         (selectItem)="itemSelected($event)"
-      ></cx-asm-customer-360-table>
+      />
     `,
     imports: [AsmCustomer360TableComponent],
   })

--- a/feature-libs/asm/customer-360/components/asm-customer-360/asm-customer-360.component.html
+++ b/feature-libs/asm/customer-360/components/asm-customer-360/asm-customer-360.component.html
@@ -18,15 +18,14 @@
               | cxTranslate: { name: customer.firstName }
           }}
         </div>
-        <ng-template *ngTemplateOutlet="closeButton"></ng-template>
+        <ng-template *ngTemplateOutlet="closeButton" />
       </div>
       <cx-message
         *ngIf="errorAlert$ | async"
         [text]="'asmCustomer360.alertErrorMessage' | cxTranslate"
         [type]="globalMessageType.MSG_TYPE_ERROR"
         (closeMessage)="closeErrorAlert()"
-      >
-      </cx-message>
+      />
       <div
         class="header-content"
         *ngIf="customerOverview$ | async as customerOverview"
@@ -40,7 +39,7 @@
               "
             >
               <div class="cx-avatar-image">
-                <cx-media [container]="avatarImage"></cx-media>
+                <cx-media [container]="avatarImage" />
               </div>
             </ng-container>
 
@@ -88,7 +87,7 @@
             class="header-account-details-active-cart"
             *ngIf="customerOverview?.cartCode"
           >
-            <cx-icon class="account-icon" [type]="cartIcon"></cx-icon>
+            <cx-icon class="account-icon" [type]="cartIcon" />
             {{
               'asmCustomer360.header.activeCartLabel'
                 | cxTranslate: { cartSize: customerOverview?.cartSize }
@@ -108,7 +107,7 @@
             class="header-account-details-recent-order"
             *ngIf="customerOverview?.latestOrderCode"
           >
-            <cx-icon class="account-icon" [type]="orderIcon"></cx-icon>
+            <cx-icon class="account-icon" [type]="orderIcon" />
             {{
               'asmCustomer360.header.recentOrderLabel'
                 | cxTranslate: { price: customerOverview?.latestOrderTotal }
@@ -137,7 +136,7 @@
             class="header-account-details-recent-ticket"
             *ngIf="customerOverview?.latestOpenedTicketId"
           >
-            <cx-icon class="account-icon" [type]="ticketIcon"></cx-icon>
+            <cx-icon class="account-icon" [type]="ticketIcon" />
             {{ 'asmCustomer360.header.recentTicketLabel' | cxTranslate }}
             <button
               [attr.aria-label]="
@@ -202,7 +201,7 @@
               [config]="config.config"
               [data]="asmCustomer360Tabs?.[i]"
               (navigate)="navigateTo($event)"
-            ></cx-asm-customer-360-section>
+            />
           </ng-container>
         </ng-template>
       </div>
@@ -218,6 +217,6 @@
     attr.title="{{ 'common.close' | cxTranslate }}"
     (click)="closeModal('Cross click')"
   >
-    <cx-icon [type]="closeIcon"></cx-icon>
+    <cx-icon [type]="closeIcon" />
   </button>
 </ng-template>

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-active-cart/asm-customer-360-active-cart.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-active-cart/asm-customer-360-active-cart.component.html
@@ -10,8 +10,7 @@
   (selectProduct)="
     sectionContext.navigate$.next({ cxRoute: 'product', params: $event })
   "
->
-</cx-asm-customer-360-product-listing>
+/>
 
 <ng-template #headerTemplate>
   <ng-container *ngIf="activeCart$ | async as activeCart">

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-activity/asm-customer-360-activity.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-activity/asm-customer-360-activity.component.html
@@ -6,4 +6,4 @@
   [entries]="entries$ | async"
   [pageSize]="(context.config$ | async)?.pageSize"
   (selectItem)="itemSelected($event)"
-></cx-asm-customer-360-table>
+/>

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-coupon/asm-customer-360-coupon.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-coupon/asm-customer-360-coupon.component.html
@@ -13,5 +13,4 @@
   [removeButtonText]="'asmCustomer360.coupons.removeButtonText' | cxTranslate"
   [showRemoveButton]="true"
   [showApplyButton]="true"
->
-</cx-asm-customer-360-promotion-listing>
+/>

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-customer-coupon/asm-customer-360-customer-coupon.component.html
@@ -57,14 +57,14 @@
         role="button"
         title="{{ 'common.close' | cxTranslate }}"
         (click)="searchBox.value = ''"
-      ></cx-icon>
+      />
       <cx-icon
         class="cx-asm-customer-360-promotion-listing-search-icon-search"
         [type]="iconTypes.SEARCH"
         role="button"
         title="{{ 'common.search' | cxTranslate }}"
         (click)="this.searchCustomerCoupon(searchBox.value)"
-      ></cx-icon>
+      />
     </div>
   </ng-container>
 </cx-asm-customer-360-promotion-listing>

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-interests/asm-customer-360-product-interests.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-interests/asm-customer-360-product-interests.component.html
@@ -9,5 +9,4 @@
   (selectProduct)="
     sectionContext.navigate$.next({ cxRoute: 'product', params: $event })
   "
->
-</cx-asm-customer-360-product-listing>
+/>

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-reviews/asm-customer-360-product-reviews.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-product-reviews/asm-customer-360-product-reviews.component.html
@@ -8,4 +8,4 @@
   [entries]="reviewEntries$ | async"
   [pageSize]="(context.config$ | async)?.pageSize"
   (selectItem)="navigateTo($event)"
-></cx-asm-customer-360-table>
+/>

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-profile/asm-customer-360-profile.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-profile/asm-customer-360-profile.component.html
@@ -19,7 +19,7 @@
                 address;
                 context: { address: customerProfileData?.billingAddress }
               "
-            ></ng-container>
+            />
           </div>
         </div>
         <div class="col">
@@ -32,7 +32,7 @@
                 address;
                 context: { address: customerProfileData?.deliveryAddress }
               "
-            ></ng-container>
+            />
           </div>
         </div>
         <div class="w-100 d-lg-none"></div>
@@ -70,7 +70,7 @@
           [border]="true"
           [fitToContainer]="true"
           [content]="getCardContent(paymentInfoList) | async"
-        ></cx-card>
+        />
       </div>
     </div>
   </ng-container>

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-promotion/asm-customer-360-promotion.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-promotion/asm-customer-360-promotion.component.html
@@ -6,5 +6,4 @@
   [applied]="'asmCustomer360.promotions.applied' | cxTranslate"
   [showRemoveButton]="false"
   [showApplyButton]="false"
->
-</cx-asm-customer-360-promotion-listing>
+/>

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-saved-cart/asm-customer-360-saved-cart.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-saved-cart/asm-customer-360-saved-cart.component.html
@@ -10,8 +10,7 @@
   (selectProduct)="
     sectionContext.navigate$.next({ cxRoute: 'product', params: $event })
   "
->
-</cx-asm-customer-360-product-listing>
+/>
 
 <ng-template #headerTemplate>
   <ng-container *ngIf="savedCart$ | async as savedCart">

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-section/asm-customer-360-section.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-section/asm-customer-360-section.component.html
@@ -1,1 +1,1 @@
-<ng-container *ngComponentOutlet="component"></ng-container>
+<ng-container *ngComponentOutlet="component" />

--- a/feature-libs/asm/customer-360/components/sections/asm-customer-360-support-tickets/asm-customer-360-support-tickets.component.html
+++ b/feature-libs/asm/customer-360/components/sections/asm-customer-360-support-tickets/asm-customer-360-support-tickets.component.html
@@ -8,4 +8,4 @@
   [entries]="supportTicketsEntries$ | async"
   [pageSize]="(context.config$ | async)?.pageSize"
   (selectItem)="navigateTo($event)"
-></cx-asm-customer-360-table>
+/>

--- a/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.html
+++ b/feature-libs/cart/base/components/add-to-cart/add-to-cart.component.html
@@ -7,7 +7,7 @@
         [max]="maxQuantity"
         [control]="addToCartForm.get('quantity')"
         [ariaDescribedById]="'add-to-card-stock-info'"
-      ></cx-item-counter>
+      />
 
       <span class="info" id="add-to-card-stock-info">
         <span *ngIf="showInventory$ | async">{{ getInventory() }}</span>
@@ -25,7 +25,7 @@
       [cxOutlet]="CartOutlets.ADD_TO_CART_PICKUP_OPTION"
       [(cxComponentRef)]="pickupOptionCompRef"
       (cxComponentRefChange)="onPickupOptionsCompLoaded()"
-    ></ng-template>
+    />
   </ng-container>
 
   <button
@@ -52,8 +52,8 @@
         !unavailable
       "
       class="repeat-icon"
-      ><cx-icon [type]="iconTypes.REPEAT"></cx-icon
-    ></span>
+      ><cx-icon [type]="iconTypes.REPEAT"
+    /></span>
     <span
       [ngClass]="
         options?.addToCartString === ('addToCart.buyItAgain' | cxTranslate)

--- a/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.html
+++ b/feature-libs/cart/base/components/added-to-cart-dialog/added-to-cart-dialog.component.html
@@ -31,7 +31,7 @@
         (click)="dismissModal('Cross click')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -46,7 +46,7 @@
               [compact]="true"
               [quantityControl]="getQuantityControl() | async"
               [promotionLocation]="promotionLocation"
-            ></cx-cart-item>
+            />
             <div class="cx-dialog-pickup-store" *ngIf="pickupStoreName">
               {{ 'pickupOptionDialog.modalHeader' | cxTranslate }}:
               <span class="cx-dialog-pickup-store-name">{{
@@ -82,7 +82,7 @@
                     cart.potentialOrderPromotions || []
                   )
                 "
-              ></cx-promotions>
+              />
             </div>
 
             <!-- Actions -->
@@ -114,7 +114,7 @@
     <div class="cx-dialog-body modal-body">
       <div class="cx-dialog-row">
         <div class="col-sm-12">
-          <cx-spinner aria-hidden="true"></cx-spinner>
+          <cx-spinner aria-hidden="true" />
         </div>
       </div>
     </div>

--- a/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.html
+++ b/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.html
@@ -33,7 +33,7 @@
             [class.disabled]="cartIsLoading"
           >
             <span aria-hidden="true">
-              <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+              <cx-icon [type]="iconTypes.CLOSE" />
             </span>
           </button>
         </div>

--- a/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.spec.ts
+++ b/feature-libs/cart/base/components/cart-coupon/applied-coupons/applied-coupons.component.spec.ts
@@ -31,8 +31,7 @@ class MockCxIconComponent {
       [vouchers]="coupons"
       [cartIsLoading]="cartIsLoading"
       [isReadOnly]="isReadOnly"
-    >
-    </cx-applied-coupons>
+    />
   `,
   imports: [I18nTestingModule, AppliedCouponsComponent],
 })

--- a/feature-libs/cart/base/components/cart-coupon/cart-coupon.component.html
+++ b/feature-libs/cart/base/components/cart-coupon/cart-coupon.component.html
@@ -31,8 +31,7 @@
     [vouchers]="cart.appliedVouchers"
     [cartIsLoading]="cartIsLoading$ | async"
     [isReadOnly]="false"
-  >
-  </cx-applied-coupons>
+  />
 
   <ng-container *ngIf="applicableCoupons && applicableCoupons.length > 0">
     <div class="cx-available-coupon">

--- a/feature-libs/cart/base/components/cart-details/cart-details.component.html
+++ b/feature-libs/cart/base/components/cart-details/cart-details.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="cart$ | async as cart">
   <ng-container *ngIf="entries$ | async as entries">
     <div *ngIf="cart.totalItems > 0" class="cart-details-wrapper">
-      <cx-cart-validation-warnings></cx-cart-validation-warnings>
+      <cx-cart-validation-warnings />
 
       <h2 class="cx-total">
         {{ 'cartDetails.cartName' | cxTranslate: { code: cart.code } }}
@@ -25,7 +25,7 @@
             cart.potentialOrderPromotions || []
           )
         "
-      ></cx-promotions>
+      />
 
       <cx-cart-item-list
         [items]="entries"
@@ -35,7 +35,7 @@
           isSaveForLater: false,
           optionalBtn: saveForLaterBtn,
         }"
-      ></cx-cart-item-list>
+      />
     </div>
   </ng-container>
 </ng-container>

--- a/feature-libs/cart/base/components/cart-details/cart-details.component.html
+++ b/feature-libs/cart/base/components/cart-details/cart-details.component.html
@@ -14,7 +14,7 @@
           role="status"
           aria-live="polite"
         >
-          <cx-spinner aria-hidden="true"></cx-spinner>
+          <cx-spinner aria-hidden="true" />
           <span>{{ 'cartDetails.updating' | cxTranslate }}</span>
         </div>
       </ng-container>

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.html
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list-row/cart-item-list-row.component.html
@@ -1,12 +1,8 @@
 <!-- Item Start Outlet -->
 <ng-template [cxOutlet]="CartOutlets.LIST_ITEM">
   <td role="cell">
-    <ng-template
-      [cxOutlet]="CartOutlets.ITEM_CONFIGURATOR_ISSUES"
-    ></ng-template>
-    <cx-cart-item-validation-warning
-      [code]="item.product?.code"
-    ></cx-cart-item-validation-warning>
+    <ng-template [cxOutlet]="CartOutlets.ITEM_CONFIGURATOR_ISSUES" />
+    <cx-cart-item-validation-warning [code]="item.product?.code" />
     <div class="cx-table-item-container">
       <!-- Item Image -->
       <a
@@ -17,13 +13,13 @@
         <cx-media
           [container]="item.product?.images?.PRIMARY"
           format="cartIcon"
-        ></cx-media>
+        />
       </a>
       <cx-media
         *ngIf="options.disableItemLink"
         [container]="item.product?.images?.PRIMARY"
         format="cartIcon"
-      ></cx-media>
+      />
       <div class="cx-info">
         <div *ngIf="item.product?.name" class="cx-name">
           <a
@@ -50,25 +46,25 @@
           [cxOutletContext]="{
             items: item,
           }"
-        ></ng-template>
+        />
       </div>
     </div>
     <div class="cx-cart-addons">
       <!-- Item Details Outlet -->
-      <ng-template [cxOutlet]="CartOutlets.ITEM_DETAILS"> </ng-template>
+      <ng-template [cxOutlet]="CartOutlets.ITEM_DETAILS" />
 
       <!-- Item Bundle Details Outlet -->
-      <ng-template [cxOutlet]="CartOutlets.ITEM_BUNDLE_DETAILS"> </ng-template>
+      <ng-template [cxOutlet]="CartOutlets.ITEM_BUNDLE_DETAILS" />
 
       <!-- Promotion -->
-      <cx-promotions [promotions]="item.promotions"></cx-promotions>
+      <cx-promotions [promotions]="item.promotions" />
 
       <!-- Item Delivery Details Outlet -->
       <ng-template
         *ngIf="!readonly"
         [cxOutlet]="CartOutlets.ITEM_DELIVERY_DETAILS"
         [cxOutletContext]="{ item, cartType: options.cartType }"
-      ></ng-template>
+      />
     </div>
 
     <!-- Variants -->
@@ -105,8 +101,7 @@
       item,
       parent: 'cart',
     }"
-  >
-  </ng-template>
+  />
 
   <!-- item price with discount -->
   <ng-template
@@ -114,7 +109,7 @@
     [cxOutletContext]="{
       items: item,
     }"
-  ></ng-template>
+  />
 
   <!-- Item Quantity -->
   <td role="cell" class="cx-quantity">
@@ -134,12 +129,9 @@
         [ariaDescribedById]="
           item.product?.code ? 'cx-qty-hint-' + item.product?.code : ''
         "
-      >
-      </cx-item-counter>
+      />
     </div>
-    <ng-template
-      [cxOutlet]="CartOutlets.ITEM_VALIDATION_QUANTITY_HINT"
-    ></ng-template>
+    <ng-template [cxOutlet]="CartOutlets.ITEM_VALIDATION_QUANTITY_HINT" />
   </td>
   <!-- Total -->
   <ng-container *ngIf="options.isSaveForLater; else total">
@@ -181,7 +173,7 @@
             },
           }
         "
-      ></ng-container>
+      />
     </ng-container>
 
     <!-- Availability -->

--- a/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.html
+++ b/feature-libs/cart/base/components/cart-shared/cart-item-list/cart-item-list.component.html
@@ -16,12 +16,12 @@
           items,
           parent: 'cart',
         }"
-      ></ng-template>
+      />
 
       <ng-template
         [cxOutlet]="CartOutlets.CPQ_QUOTE_HEADING"
         [cxOutletContext]="items"
-      ></ng-template>
+      />
       <th role="columnheader" scope="col" class="cx-item-list-qty">
         {{ 'cartItems.quantityFull' | cxTranslate }}
       </th>

--- a/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.html
+++ b/feature-libs/cart/base/components/cart-shared/cart-item/cart-item.component.html
@@ -1,9 +1,7 @@
 <!-- Item Start Outlet -->
 <ng-template [cxOutlet]="CartOutlets.ITEM">
-  <ng-template [cxOutlet]="CartOutlets.ITEM_CONFIGURATOR_ISSUES"></ng-template>
-  <cx-cart-item-validation-warning
-    [code]="item.product?.code"
-  ></cx-cart-item-validation-warning>
+  <ng-template [cxOutlet]="CartOutlets.ITEM_CONFIGURATOR_ISSUES" />
+  <cx-cart-item-validation-warning [code]="item.product?.code" />
   <div [ngClass]="compact ? 'cx-compact row' : 'row'">
     <!-- Item Image -->
     <div class="col-2 cx-image-container">
@@ -14,7 +12,7 @@
         <cx-media
           [container]="item.product?.images?.PRIMARY"
           format="cartIcon"
-        ></cx-media>
+        />
       </a>
     </div>
     <!-- Item Information -->
@@ -36,7 +34,7 @@
           </div>
 
           <!-- Item Details Outlet -->
-          <ng-template [cxOutlet]="CartOutlets.ITEM_DETAILS"> </ng-template>
+          <ng-template [cxOutlet]="CartOutlets.ITEM_DETAILS" />
 
           <!-- Variants -->
           <ng-container *ngIf="item.product?.baseOptions?.length">
@@ -64,8 +62,7 @@
               item: item,
               parent: 'minicart',
             }"
-          >
-          </ng-template>
+          />
         </div>
         <!-- Item Price -->
         <div
@@ -101,8 +98,7 @@
               "
               [max]="item.product?.stock?.stockLevel"
               [allowZero]="true"
-            >
-            </cx-item-counter>
+            />
           </div>
         </div>
         <!-- Total -->
@@ -142,11 +138,11 @@
       </div>
 
       <!-- Item Bundle Details Outlet -->
-      <ng-template [cxOutlet]="CartOutlets.ITEM_BUNDLE_DETAILS"> </ng-template>
+      <ng-template [cxOutlet]="CartOutlets.ITEM_BUNDLE_DETAILS" />
 
       <!-- Promotion -->
 
-      <cx-promotions [promotions]="item.promotions"></cx-promotions>
+      <cx-promotions [promotions]="item.promotions" />
 
       <!-- Actions -->
       <div
@@ -161,7 +157,7 @@
                 $implicit: { loading: quantityControl.disabled, item: item },
               }
             "
-          ></ng-container>
+          />
         </ng-container>
 
         <div class="col-md-3 cx-remove-btn">

--- a/feature-libs/cart/base/components/cart-shared/order-summary/order-summary.component.html
+++ b/feature-libs/cart/base/components/cart-shared/order-summary/order-summary.component.html
@@ -60,7 +60,4 @@
   </ng-template>
 </div>
 
-<cx-applied-coupons
-  [vouchers]="cart.appliedVouchers"
-  [isReadOnly]="true"
-></cx-applied-coupons>
+<cx-applied-coupons [vouchers]="cart.appliedVouchers" [isReadOnly]="true" />

--- a/feature-libs/cart/base/components/cart-totals/cart-totals.component.html
+++ b/feature-libs/cart/base/components/cart-totals/cart-totals.component.html
@@ -1,3 +1,3 @@
 <ng-container *ngIf="cart$ | async as cart">
-  <cx-order-summary [cart]="cart"></cx-order-summary>
+  <cx-order-summary [cart]="cart" />
 </ng-container>

--- a/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog.component.html
+++ b/feature-libs/cart/base/components/clear-cart/clear-cart-dialog/clear-cart-dialog.component.html
@@ -21,7 +21,7 @@
           title="{{ 'common.close' | cxTranslate }}"
         >
           <span aria-hidden="true">
-            <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+            <cx-icon [type]="iconTypes.CLOSE" />
           </span>
         </button>
       </div>
@@ -60,6 +60,6 @@
     </h2>
   </div>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/cart/base/components/mini-cart/mini-cart.component.html
+++ b/feature-libs/cart/base/components/mini-cart/mini-cart.component.html
@@ -5,7 +5,7 @@
   [class.is-updating]="data.updating"
   [routerLink]="{ cxRoute: 'cart' } | cxUrl"
 >
-  <cx-icon [type]="iconTypes.CART"></cx-icon>
+  <cx-icon [type]="iconTypes.CART" />
 
   <ng-container *cxFeature="'enableCartSlowNetworkResilience'">
     <span

--- a/feature-libs/cart/base/components/save-for-later/save-for-later.component.html
+++ b/feature-libs/cart/base/components/save-for-later/save-for-later.component.html
@@ -24,7 +24,7 @@
           isSaveForLater: true,
           optionalBtn: moveToCartBtn,
         }"
-      ></cx-cart-item-list>
+      />
     </div>
   </ng-container>
 </ng-container>

--- a/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.component.html
+++ b/feature-libs/cart/base/components/validation/cart-item-warning/cart-item-validation-warning.component.html
@@ -32,7 +32,7 @@
       title="{{ 'common.close' | cxTranslate }}"
       (click)="isVisible = !isVisible"
     >
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </button>
   </div>
 </ng-container>

--- a/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.component.html
+++ b/feature-libs/cart/base/components/validation/cart-warnings/cart-validation-warnings.component.html
@@ -4,7 +4,7 @@
     *ngIf="visibleWarnings[cartModification.entry.product.code]"
   >
     <span class="alert-icon">
-      <cx-icon [type]="iconTypes.ERROR"></cx-icon>
+      <cx-icon [type]="iconTypes.ERROR" />
     </span>
     <span>
       <a
@@ -24,7 +24,7 @@
       [attr.aria-label]="'common.close' | cxTranslate"
       (click)="removeMessage(cartModification)"
     >
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </button>
   </div>
 </ng-container>

--- a/feature-libs/cart/import-export/components/import-export/import-export-order-entries.component.html
+++ b/feature-libs/cart/import-export/components/import-export/import-export-order-entries.component.html
@@ -1,6 +1,2 @@
-<cx-import-order-entries
-  *ngIf="shouldDisplayImport$ | async"
-></cx-import-order-entries>
-<cx-export-order-entries
-  *ngIf="shouldDisplayExport$ | async"
-></cx-export-order-entries>
+<cx-import-order-entries *ngIf="shouldDisplayImport$ | async" />
+<cx-export-order-entries *ngIf="shouldDisplayExport$ | async" />

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-dialog.component.html
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-dialog.component.html
@@ -23,7 +23,7 @@
         [disabled]="(summary$ | async)?.loading"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -36,13 +36,13 @@
           *ngIf="isNewCartForm(context); else reducedForm"
           [type]="context.type"
           (submitEvent)="importProducts(context, $event)"
-        ></cx-import-to-new-saved-cart-form>
+        />
         <ng-template #reducedForm>
           <cx-import-entries-form
             class="modal-body"
             [type]="context.type"
             (submitEvent)="importProducts(context, $event)"
-          ></cx-import-entries-form>
+          />
         </ng-template>
       </ng-container>
 
@@ -52,7 +52,7 @@
           [summary]="summary$ | async"
           [type]="context.type"
           (closeEvent)="close('Close Import Products Dialog')"
-        ></cx-import-entries-summary>
+        />
       </ng-template>
     </ng-container>
   </div>

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-form/import-entries-form.component.html
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-form/import-entries-form.component.html
@@ -10,7 +10,7 @@
       [type]="globalMessageType.MSG_TYPE_CONFIRMATION"
       [isVisibleCloseButton]="false"
       [cxFocus]="{ autofocus: '.cx-message' }"
-    ></cx-message>
+    />
   </div>
   <p class="cx-import-entries-subtitle">
     {{ 'importEntriesDialog.importProductsSubtitle' | cxTranslate }}
@@ -22,10 +22,7 @@
     <cx-file-upload [formControl]="form.get('file')" [accept]="allowedTypes">
       {{ 'importEntriesDialog.selectFile' | cxTranslate }}
     </cx-file-upload>
-    <cx-form-errors
-      [control]="form.get('file')"
-      prefix="formErrors.file"
-    ></cx-form-errors>
+    <cx-form-errors [control]="form.get('file')" prefix="formErrors.file" />
   </label>
   <div class="cx-import-entries-footer">
     <button

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-summary/import-entries-summary.component.html
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-entries-summary/import-entries-summary.component.html
@@ -17,7 +17,7 @@
   *ngIf="summary.successesCount > 0"
   class="cx-import-entries-summary-successes"
 >
-  <cx-icon class="success" [type]="iconTypes.SUCCESS"></cx-icon>
+  <cx-icon class="success" [type]="iconTypes.SUCCESS" />
   {{ 'importEntriesDialog.summary.successes' | cxTranslate: summary }}
 </p>
 <div
@@ -25,7 +25,7 @@
   class="cx-import-entries-summary-warnings"
 >
   <p>
-    <cx-icon class="warning" [type]="iconTypes.ERROR"></cx-icon>
+    <cx-icon class="warning" [type]="iconTypes.ERROR" />
     {{
       'importEntriesDialog.summary.warning'
         | cxTranslate: { count: summary.warningMessages.length }
@@ -53,7 +53,7 @@
   class="cx-import-entries-summary-errors"
 >
   <p>
-    <cx-icon class="error" [type]="iconTypes.RESET"></cx-icon>
+    <cx-icon class="error" [type]="iconTypes.RESET" />
     {{
       'importEntriesDialog.summary.error'
         | cxTranslate: { count: summary.errorMessages.length }

--- a/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-to-new-saved-cart-form/import-to-new-saved-cart-form.component.html
+++ b/feature-libs/cart/import-export/components/import-to-cart/import-entries-dialog/import-to-new-saved-cart-form/import-to-new-saved-cart-form.component.html
@@ -10,7 +10,7 @@
       [type]="globalMessageType.MSG_TYPE_CONFIRMATION"
       [isVisibleCloseButton]="false"
       [cxFocus]="{ autofocus: '.cx-message' }"
-    ></cx-message>
+    />
   </div>
   <cx-form-required-legend />
   <p class="cx-import-entries-subtitle">
@@ -28,10 +28,7 @@
     >
       {{ 'importEntriesDialog.selectFile' | cxTranslate }}
     </cx-file-upload>
-    <cx-form-errors
-      [control]="form.get('file')"
-      prefix="formErrors.file"
-    ></cx-form-errors>
+    <cx-form-errors [control]="form.get('file')" prefix="formErrors.file" />
   </label>
   <div class="cx-import-entries-row">
     <label>
@@ -50,10 +47,7 @@
         "
         [attr.aria-errormessage]="'nameError'"
       />
-      <cx-form-errors
-        id="nameError"
-        [control]="form.get('name')"
-      ></cx-form-errors>
+      <cx-form-errors id="nameError" [control]="form.get('name')" />
     </label>
   </div>
 
@@ -78,7 +72,7 @@
       <cx-form-errors
         id="descriptionError"
         [control]="form.get('description')"
-      ></cx-form-errors>
+      />
 
       <p class="cx-import-entries-input-hint">
         {{

--- a/feature-libs/cart/quick-order/components/cart-quick-order-form/cart-quick-order-form.component.html
+++ b/feature-libs/cart/quick-order/components/cart-quick-order-form/cart-quick-order-form.component.html
@@ -46,7 +46,7 @@
             label: 'quickOrderCartForm.productCodeLabel' | cxTranslate,
           }"
           [control]="quickOrderForm.get('productCode')"
-        ></cx-form-errors>
+        />
         <button
           *cxFeature="'a11yCartQuickOrderFormEnableSubmitAndAddValidation'"
           [attr.aria-label]="'quickOrderCartForm.addToCart' | cxTranslate"

--- a/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.html
+++ b/feature-libs/cart/quick-order/components/quick-order/form/quick-order-form.component.html
@@ -33,7 +33,7 @@
       [attr.title]="'common.reset' | cxTranslate"
       class="quick-order-form-reset-icon"
     >
-      <cx-icon [type]="iconTypes.RESET"></cx-icon>
+      <cx-icon [type]="iconTypes.RESET" />
     </button>
 
     <ng-template #searchIcon>
@@ -43,7 +43,7 @@
         [attr.title]="'common.productSearchDescription' | cxTranslate"
         tabindex="-1"
       >
-        <cx-icon [type]="iconTypes.SEARCH"></cx-icon>
+        <cx-icon [type]="iconTypes.SEARCH" />
       </button>
     </ng-template>
 
@@ -88,7 +88,7 @@
             class="media"
             format="thumbnail"
             role="presentation"
-          ></cx-media>
+          />
           <div class="name" [innerHTML]="product.name"></div>
           <span class="id">
             {{

--- a/feature-libs/cart/quick-order/components/quick-order/quick-order.component.html
+++ b/feature-libs/cart/quick-order/components/quick-order/quick-order.component.html
@@ -15,8 +15,7 @@
           [isVisibleCloseButton]="false"
           [type]="globalMessageType.MSG_TYPE_ERROR"
           class="quick-order-list-limit-message"
-        >
-        </cx-message>
+        />
       </ng-container>
     </ng-container>
   </ng-container>
@@ -29,8 +28,7 @@
       "
       [type]="globalMessageType.MSG_TYPE_ERROR"
       class="quick-order-add-to-cart-information-message"
-    >
-    </cx-message>
+    />
   </ng-container>
 
   <ng-container *ngIf="nonPurchasableError$ | async as nonPurchasableError">
@@ -42,8 +40,7 @@
       "
       [type]="globalMessageType.MSG_TYPE_ERROR"
       class="quick-order-non-purchasable-product-error-message"
-    >
-    </cx-message>
+    />
   </ng-container>
 
   <ng-container *ngIf="softDeletedEntries$ | async as deletedEntries">
@@ -62,8 +59,7 @@
       "
       [type]="globalMessageType.MSG_TYPE_CONFIRMATION"
       class="quick-order-deletions-message"
-    >
-    </cx-message>
+    />
   </ng-container>
 
   <ng-container *ngIf="errors$ | async as errors">
@@ -176,15 +172,14 @@
     </div>
 
     <div class="quick-order-form-body">
-      <cx-quick-order-form #quickOrderForm [limit]="quickOrderListLimit">
-      </cx-quick-order-form>
+      <cx-quick-order-form #quickOrderForm [limit]="quickOrderListLimit" />
     </div>
 
     <div class="quick-order-table-body">
       <cx-quick-order-table
         [entries]="entries"
         [loading]="!(isCartStable$ | async)"
-      ></cx-quick-order-table>
+      />
     </div>
 
     <div class="quick-order-footer row">

--- a/feature-libs/cart/quick-order/components/quick-order/table/item/quick-order-item.component.html
+++ b/feature-libs/cart/quick-order/components/quick-order/table/item/quick-order-item.component.html
@@ -12,7 +12,7 @@
         [container]="entry?.product?.images?.PRIMARY"
         [alt]="entry?.product?.name"
         format="cartIcon"
-      ></cx-media>
+      />
     </a>
     <div class="cx-info">
       <div class="cx-name">
@@ -49,7 +49,7 @@
       [control]="quantityControl"
       [max]="entry.product?.stock?.stockLevel"
       [readonly]="loading"
-    ></cx-item-counter>
+    />
   </div>
 </td>
 

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details-items/saved-cart-details-items.component.html
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details-items/saved-cart-details-items.component.html
@@ -15,8 +15,7 @@
             cartType: CartType.SELECTIVE,
           },
         }"
-      >
-      </ng-template>
+      />
     </div>
   </ng-container>
 
@@ -28,13 +27,12 @@
       [options]="ctx.options"
       [pickupStore]="ctx.item.deliveryPointOfService?.name"
       [savedCart]="cart"
-    >
-    </cx-add-to-cart>
+    />
   </ng-template>
 </ng-container>
 
 <ng-template #emptyCartItems>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/cart/saved-cart/components/details/saved-cart-details-overview/saved-cart-details-overview.component.html
+++ b/feature-libs/cart/saved-cart/components/details/saved-cart-details-overview/saved-cart-details-overview.component.html
@@ -3,7 +3,7 @@
     <div class="container">
       <div class="cx-summary-card">
         <div class="cx-edit-container">
-          <cx-card [content]="getCartName(cart?.name) | async"></cx-card>
+          <cx-card [content]="getCartName(cart?.name) | async" />
           <button
             [attr.aria-label]="'savedCartDetails.editSavedCart' | cxTranslate"
             [attr.title]="'savedCartDetails.editSavedCart' | cxTranslate"
@@ -11,7 +11,7 @@
             #element
             (click)="openDialog(cart)"
           >
-            <cx-icon [type]="iconTypes.PENCIL"></cx-icon>
+            <cx-icon [type]="iconTypes.PENCIL" />
           </button>
         </div>
         <div class="cx-card-description">
@@ -19,27 +19,23 @@
             [content]="getCartDescription(cart?.description) | async"
             [truncateText]="true"
             [charactersLimit]="30"
-          ></cx-card>
+          />
         </div>
       </div>
       <div class="cx-summary-card">
-        <cx-card [content]="getCartId(cart?.code) | async"></cx-card>
+        <cx-card [content]="getCartId(cart?.code) | async" />
       </div>
       <div class="cx-summary-card">
-        <cx-card
-          [content]="getDateSaved(cart?.saveTime | cxDate) | async"
-        ></cx-card>
-        <cx-card [content]="getCartItems(cart?.totalItems) | async"></cx-card>
+        <cx-card [content]="getDateSaved(cart?.saveTime | cxDate) | async" />
+        <cx-card [content]="getCartItems(cart?.totalItems) | async" />
       </div>
       <div class="cx-summary-card">
-        <cx-card
-          [content]="getCartQuantity(cart?.totalUnitCount) | async"
-        ></cx-card>
+        <cx-card [content]="getCartQuantity(cart?.totalUnitCount) | async" />
         <cx-card
           [content]="
             getCartTotal(cart?.totalPriceWithTax?.formattedValue) | async
           "
-        ></cx-card>
+        />
       </div>
     </div>
   </div>

--- a/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.html
+++ b/feature-libs/cart/saved-cart/components/list/saved-cart-list.component.html
@@ -145,7 +145,7 @@
 
   <ng-template #loading>
     <div class="cx-spinner">
-      <cx-spinner></cx-spinner>
+      <cx-spinner />
     </div>
   </ng-template>
 </ng-container>

--- a/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.component.html
+++ b/feature-libs/cart/saved-cart/components/saved-cart-form-dialog/saved-cart-form-dialog.component.html
@@ -35,7 +35,7 @@
           [attr.aria-label]="'common.close' | cxTranslate"
         >
           <span aria-hidden="true">
-            <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+            <cx-icon [type]="iconTypes.CLOSE" />
           </span>
         </button>
       </div>
@@ -218,7 +218,7 @@
                     label: 'savedCartDialog.savedCartName' | cxTranslate,
                   }"
                   [control]="form.get('name')"
-                ></cx-form-errors>
+                />
               </label>
             </ng-container>
           </div>
@@ -249,7 +249,7 @@
                   label: 'savedCartDialog.savedCartDescription' | cxTranslate,
                 }"
                 [control]="form.get('description')"
-              ></cx-form-errors>
+              />
 
               <p class="cx-saved-carts-input-hint">
                 {{

--- a/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.html
+++ b/feature-libs/cart/wish-list/components/add-to-wishlist/add-to-wish-list.component.html
@@ -17,7 +17,7 @@
               [disabled]="loading$ | async"
               [cxAtMessage]="'addToWishList.removedFromWishList' | cxTranslate"
             >
-              <cx-icon aria-hidden="true" [type]="iconTypes.HEART"></cx-icon>
+              <cx-icon aria-hidden="true" [type]="iconTypes.HEART" />
               <span class="button-text">{{
                 'addToWishList.remove' | cxTranslate
               }}</span>
@@ -31,10 +31,7 @@
               [disabled]="loading$ | async"
               [cxAtMessage]="'addToWishList.addedToWishList' | cxTranslate"
             >
-              <cx-icon
-                aria-hidden="true"
-                [type]="iconTypes.EMPTY_HEART"
-              ></cx-icon>
+              <cx-icon aria-hidden="true" [type]="iconTypes.EMPTY_HEART" />
               <span class="button-text">{{
                 'addToWishList.add' | cxTranslate
               }}</span>
@@ -54,7 +51,7 @@
               [disabled]="loading$ | async"
               [cxAtMessage]="'addToWishList.removedFromWishList' | cxTranslate"
             >
-              <cx-icon aria-hidden="true" [type]="iconTypes.HEART"></cx-icon>
+              <cx-icon aria-hidden="true" [type]="iconTypes.HEART" />
               <span class="button-text">{{
                 'addToWishList.remove' | cxTranslate
               }}</span>
@@ -67,10 +64,7 @@
               [disabled]="loading$ | async"
               [cxAtMessage]="'addToWishList.addedToWishList' | cxTranslate"
             >
-              <cx-icon
-                aria-hidden="true"
-                [type]="iconTypes.EMPTY_HEART"
-              ></cx-icon>
+              <cx-icon aria-hidden="true" [type]="iconTypes.EMPTY_HEART" />
               <span class="button-text">{{
                 'addToWishList.add' | cxTranslate
               }}</span>
@@ -89,7 +83,7 @@
       [routerLink]="{ cxRoute: 'login' } | cxUrl"
       cxBtnLikeLink
     >
-      <cx-icon aria-hidden="true" [type]="iconTypes.EMPTY_HEART"></cx-icon>
+      <cx-icon aria-hidden="true" [type]="iconTypes.EMPTY_HEART" />
       <span class="button-text">{{
         'addToWishList.anonymous' | cxTranslate
       }}</span>

--- a/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.html
+++ b/feature-libs/cart/wish-list/components/wish-list-item/wish-list-item.component.html
@@ -8,7 +8,7 @@
       <cx-media
         [container]="cartEntry.product?.images?.PRIMARY"
         format="thumbnail"
-      ></cx-media>
+      />
     </a>
     <div class="cx-info">
       <div *ngIf="cartEntry.product?.name" class="cx-name">
@@ -51,10 +51,7 @@
 </td>
 <!-- Action -->
 <td role="cell" class="cx-actions">
-  <ng-container
-    *ngIf="cartEntry.updateable"
-    cxInnerComponentsHost
-  ></ng-container>
+  <ng-container *ngIf="cartEntry.updateable" cxInnerComponentsHost />
   <ng-template #outOfStock>
     <span class="cx-out-of-stock">
       {{ 'addToCart.outOfStock' | cxTranslate }}

--- a/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.html
+++ b/feature-libs/checkout/b2b/components/checkout-delivery-address/checkout-delivery-address.component.html
@@ -10,8 +10,7 @@
         then showExistingAddresses;
         else newAddressForm
       "
-    >
-    </ng-container>
+    />
 
     <ng-template #showExistingAddresses>
       <p class="cx-checkout-text">
@@ -44,7 +43,7 @@
               [content]="card.card"
               (sendCard)="selectAddress(card.address)"
               [role]="'group'"
-            ></cx-card>
+            />
           </div>
         </div>
       </div>
@@ -73,7 +72,7 @@
         [showTitleCode]="true"
         (backToAddress)="hideNewAddressForm(false)"
         (submitAddress)="addAddress($event)"
-      ></cx-address-form>
+      />
       <ng-template #initialAddressForm>
         <cx-address-form
           [showTitleCode]="true"
@@ -81,7 +80,7 @@
           cancelBtnLabel="{{ backBtnText | cxTranslate }}"
           (backToAddress)="hideNewAddressForm(true)"
           (submitAddress)="addAddress($event)"
-        ></cx-address-form>
+        />
       </ng-template>
     </ng-template>
   </ng-container>
@@ -89,6 +88,6 @@
 
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.component.html
+++ b/feature-libs/checkout/b2b/components/checkout-payment-type/checkout-payment-type.component.html
@@ -79,6 +79,6 @@
 
 <ng-template #loading>
   <div class="cx-spinner" *ngIf="!paymentTypesError">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.html
+++ b/feature-libs/checkout/b2b/components/checkout-review-submit/checkout-review-submit.component.html
@@ -10,16 +10,16 @@
         <ng-container *ngFor="let step of paymentSteps(steps)">
           <ng-container [ngSwitch]="step.type[0]">
             <ng-container *ngSwitchCase="checkoutStepTypePaymentType">
-              <ng-container *ngTemplateOutlet="poNumber"></ng-container>
+              <ng-container *ngTemplateOutlet="poNumber" />
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypePaymentType">
-              <ng-container *ngTemplateOutlet="paymentType"></ng-container>
+              <ng-container *ngTemplateOutlet="paymentType" />
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypePaymentDetails">
-              <ng-container *ngTemplateOutlet="paymentMethod"></ng-container>
+              <ng-container *ngTemplateOutlet="paymentMethod" />
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypeDeliveryAddress">
-              <ng-container *ngTemplateOutlet="costCenter"></ng-container>
+              <ng-container *ngTemplateOutlet="costCenter" />
             </ng-container>
           </ng-container>
         </ng-container>
@@ -28,10 +28,10 @@
         <ng-container *ngFor="let step of deliverySteps(steps)">
           <ng-container [ngSwitch]="step.type[0]">
             <ng-container *ngSwitchCase="checkoutStepTypeDeliveryAddress">
-              <ng-container *ngTemplateOutlet="deliveryAddress"></ng-container>
+              <ng-container *ngTemplateOutlet="deliveryAddress" />
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypeDeliveryMode">
-              <ng-container *ngTemplateOutlet="deliveryMode"></ng-container>
+              <ng-container *ngTemplateOutlet="deliveryMode" />
             </ng-container>
           </ng-container>
         </ng-container>
@@ -42,7 +42,7 @@
   <!-- PO NUMBER SECTION -->
   <ng-template #poNumber>
     <div class="cx-review-summary-card">
-      <cx-card [content]="getPoNumberCard(poNumber$ | async) | async"></cx-card>
+      <cx-card [content]="getPoNumberCard(poNumber$ | async) | async" />
       <div class="cx-review-summary-edit-step">
         <a
           [attr.title]="'checkoutReview.editPaymentType' | cxTranslate"
@@ -51,8 +51,8 @@
               cxRoute: getCheckoutStepUrl(checkoutStepTypePaymentType),
             } | cxUrl
           "
-          ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon
-        ></a>
+          ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"
+        /></a>
       </div>
     </div>
   </ng-template>
@@ -63,7 +63,7 @@
       <cx-card
         *ngIf="paymentType$ | async as paymentType"
         [content]="getPaymentTypeCard(paymentType) | async"
-      ></cx-card>
+      />
       <div class="cx-review-summary-edit-step">
         <a
           [attr.title]="'checkoutReview.editPaymentType' | cxTranslate"
@@ -72,8 +72,8 @@
               cxRoute: getCheckoutStepUrl(checkoutStepTypePaymentType),
             } | cxUrl
           "
-          ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon
-        ></a>
+          ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"
+        /></a>
       </div>
     </div>
   </ng-template>
@@ -85,7 +85,7 @@
         <cx-card
           *ngIf="costCenter$ | async as costCenter"
           [content]="getCostCenterCard(costCenter) | async"
-        ></cx-card>
+        />
         <div class="cx-review-summary-edit-step">
           <a
             [attr.title]="
@@ -96,8 +96,8 @@
                 cxRoute: getCheckoutStepUrl(checkoutStepTypeDeliveryAddress),
               } | cxUrl
             "
-            ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon
-          ></a>
+            ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"
+          /></a>
         </div>
       </div>
     </ng-container>
@@ -109,9 +109,7 @@
       *ngIf="deliveryAddress$ | async as deliveryAddress"
       class="cx-review-summary-card cx-review-card-address"
     >
-      <cx-card
-        [content]="getDeliveryAddressCard(deliveryAddress) | async"
-      ></cx-card>
+      <cx-card [content]="getDeliveryAddressCard(deliveryAddress) | async" />
       <div class="cx-review-summary-edit-step">
         <a
           [attr.title]="
@@ -122,8 +120,8 @@
               cxRoute: getCheckoutStepUrl(checkoutStepTypeDeliveryAddress),
             } | cxUrl
           "
-          ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon
-        ></a>
+          ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"
+        /></a>
       </div>
     </div>
   </ng-template>
@@ -135,16 +133,14 @@
         <cx-card
           *ngIf="deliveryMode$ | async as deliveryMode"
           [content]="getDeliveryModeCard(deliveryMode) | async"
-        >
-        </cx-card>
+        />
         <ng-template
           [cxOutlet]="cartOutlets.DELIVERY_MODE"
           [cxOutletContext]="{
             item: cart$ | async,
             readonly: true,
           }"
-        >
-        </ng-template>
+        />
       </div>
 
       <div class="cx-review-summary-edit-step">
@@ -155,7 +151,7 @@
               | cxUrl
           "
         >
-          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>
+          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL" />
         </a>
       </div>
     </div>
@@ -168,7 +164,7 @@
         <cx-card
           *ngIf="paymentDetails$ | async as paymentDetails"
           [content]="getPaymentMethodCard(paymentDetails) | async"
-        ></cx-card>
+        />
       </div>
       <div class="cx-review-summary-edit-step">
         <a
@@ -178,7 +174,7 @@
               | cxUrl
           "
         >
-          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>
+          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL" />
         </a>
       </div>
     </div>
@@ -203,7 +199,7 @@
             cart.potentialOrderPromotions || []
           )
         "
-      ></cx-promotions>
+      />
 
       <ng-template
         [cxOutlet]="cartOutlets.CART_ITEM_LIST"
@@ -212,8 +208,7 @@
           readonly: true,
           promotionLocation: promotionLocation,
         }"
-      >
-      </ng-template>
+      />
     </div>
   </ng-container>
 </div>

--- a/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.component.html
+++ b/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.component.html
@@ -33,7 +33,7 @@
       else billingAddress
     "
   >
-    <cx-card [content]="getAddressCardContent(deliveryAddress)"></cx-card>
+    <cx-card [content]="getAddressCardContent(deliveryAddress)" />
   </ng-container>
 
   <!-- TODO:#future-checkout do we really want this? We can always pass more inputs to the copied address form component to make it more modular -->
@@ -70,12 +70,11 @@
                 [cxNgSelectA11y]="{
                   ariaLabel: 'addressForm.country' | cxTranslate,
                 }"
-              >
-              </ng-select>
+              />
               <cx-form-errors
                 id="isocodeError"
                 [control]="billingAddressForm.get('country.isocode')"
-              ></cx-form-errors>
+              />
             </label>
           </div>
         </ng-container>
@@ -103,7 +102,7 @@
           <cx-form-errors
             id="firstNameError"
             [control]="billingAddressForm.get('firstName')"
-          ></cx-form-errors>
+          />
         </label>
       </div>
       <div class="form-group">
@@ -127,7 +126,7 @@
           <cx-form-errors
             id="lastNameError"
             [control]="billingAddressForm.get('lastName')"
-          ></cx-form-errors>
+          />
         </label>
       </div>
       <div class="form-group">
@@ -151,7 +150,7 @@
           <cx-form-errors
             id="line1Error"
             [control]="billingAddressForm.get('line1')"
-          ></cx-form-errors>
+          />
         </label>
       </div>
       <div class="form-group">
@@ -210,7 +209,7 @@
             <cx-form-errors
               id="townError"
               [control]="billingAddressForm.get('town')"
-            ></cx-form-errors>
+            />
           </label>
         </div>
         <div class="form-group col-md-6">
@@ -236,7 +235,7 @@
             <cx-form-errors
               id="postalCodeError"
               [control]="billingAddressForm.get('postalCode')"
-            ></cx-form-errors>
+            />
           </label>
         </div>
         <ng-container
@@ -271,12 +270,11 @@
                   [cxNgSelectA11y]="{
                     ariaLabel: 'addressForm.state' | cxTranslate,
                   }"
-                >
-                </ng-select>
+                />
                 <cx-form-errors
                   id="isocodeShortError"
                   [control]="billingAddressForm.get('region.isocodeShort')"
-                ></cx-form-errors>
+                />
               </label>
             </div>
           </ng-container>

--- a/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.component.html
+++ b/feature-libs/checkout/base/components/checkout-billing-address/checkout-billing-address-form.component.html
@@ -176,7 +176,7 @@
                 label: 'addressForm.address2' | cxTranslate,
               }"
               [control]="billingAddressForm.get('line2')"
-            ></cx-form-errors>
+            />
           </ng-container>
           <input
             *cxFeature="'!enableFormFieldMaxLength'"

--- a/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.html
+++ b/feature-libs/checkout/base/components/checkout-delivery-address/checkout-delivery-address.component.html
@@ -11,8 +11,7 @@
           then showExistingAddresses;
           else newAddressForm
         "
-      >
-      </ng-container>
+      />
 
       <ng-template #showExistingAddresses>
         <p class="cx-checkout-text">
@@ -44,7 +43,7 @@
                 [content]="card.card"
                 (sendCard)="selectAddress(card.address)"
                 [role]="card.card.role"
-              ></cx-card>
+              />
             </div>
           </div>
         </div>
@@ -82,7 +81,7 @@
           [showTitleCode]="true"
           (backToAddress)="hideNewAddressForm(false)"
           (submitAddress)="addAddress($event)"
-        ></cx-address-form>
+        />
         <ng-template #initialAddressForm>
           <cx-address-form
             [showTitleCode]="true"
@@ -91,7 +90,7 @@
             cancelBtnLabel="{{ backBtnText | cxTranslate }}"
             (backToAddress)="hideNewAddressForm(true)"
             (submitAddress)="addAddress($event)"
-          ></cx-address-form>
+          />
         </ng-template>
       </ng-template>
     </ng-container>
@@ -100,6 +99,6 @@
 
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.html
+++ b/feature-libs/checkout/base/components/checkout-delivery-mode/checkout-delivery-mode.component.html
@@ -56,8 +56,7 @@
           [cxOutletContext]="{
             item: activeCartFacade.getActive() | async,
           }"
-        >
-        </ng-template>
+        />
       </div>
     </ng-container>
   </fieldset>
@@ -114,8 +113,7 @@
           [cxOutletContext]="{
             item: activeCartFacade.getActive() | async,
           }"
-        >
-        </ng-template>
+        />
       </div>
     </ng-container>
   </fieldset>
@@ -131,17 +129,16 @@
         items: activeCartFacade.getDeliveryEntries() | async,
         readonly: true,
       }"
-    >
-    </ng-template>
+    />
   </ng-container>
 
   <ng-template #loading>
     <div class="cx-spinner">
-      <cx-spinner></cx-spinner>
+      <cx-spinner />
     </div>
   </ng-template>
 
-  <ng-container cxInnerComponentsHost></ng-container>
+  <ng-container cxInnerComponentsHost />
 
   <div class="row cx-checkout-btns">
     <div class="col-md-12 col-lg-6">

--- a/feature-libs/checkout/base/components/checkout-login/checkout-login.component.html
+++ b/feature-libs/checkout/base/components/checkout-login/checkout-login.component.html
@@ -28,7 +28,7 @@
           label: 'checkoutLogin.emailAddress.label' | cxTranslate,
         }"
         [control]="checkoutLoginForm.get('email')"
-      ></cx-form-errors>
+      />
     </label>
   </div>
 
@@ -60,7 +60,7 @@
           label: 'checkoutLogin.confirmEmail.label' | cxTranslate,
         }"
         [control]="checkoutLoginForm.get('emailConfirmation')"
-      ></cx-form-errors>
+      />
     </label>
   </div>
 

--- a/feature-libs/checkout/base/components/checkout-order-summary/checkout-order-summary.component.html
+++ b/feature-libs/checkout/base/components/checkout-order-summary/checkout-order-summary.component.html
@@ -1,5 +1,4 @@
 <ng-template
   [cxOutlet]="cartOutlets.ORDER_SUMMARY"
   [cxOutletContext]="cart$ | async"
->
-</ng-template>
+/>

--- a/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.html
+++ b/feature-libs/checkout/base/components/checkout-place-order/checkout-place-order.component.html
@@ -28,7 +28,7 @@
         <cx-form-errors
           id="termsAndConditionsError"
           [control]="checkoutSubmitForm.get('termsAndConditions')"
-        ></cx-form-errors>
+        />
       </span>
     </label>
   </div>

--- a/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.html
+++ b/feature-libs/checkout/base/components/checkout-review-submit/checkout-review-submit.component.html
@@ -10,7 +10,7 @@
         <ng-container *ngFor="let step of paymentSteps(steps)">
           <ng-container [ngSwitch]="step.type[0]">
             <ng-container *ngSwitchCase="checkoutStepTypePaymentDetails">
-              <ng-container *ngTemplateOutlet="paymentMethod"></ng-container>
+              <ng-container *ngTemplateOutlet="paymentMethod" />
             </ng-container>
           </ng-container>
         </ng-container>
@@ -19,10 +19,10 @@
         <ng-container *ngFor="let step of deliverySteps(steps)">
           <ng-container [ngSwitch]="step.type[0]">
             <ng-container *ngSwitchCase="checkoutStepTypeDeliveryAddress">
-              <ng-container *ngTemplateOutlet="deliveryAddress"></ng-container>
+              <ng-container *ngTemplateOutlet="deliveryAddress" />
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypeDeliveryMode">
-              <ng-container *ngTemplateOutlet="deliveryMode"></ng-container>
+              <ng-container *ngTemplateOutlet="deliveryMode" />
             </ng-container>
           </ng-container>
         </ng-container>
@@ -36,9 +36,7 @@
       *ngIf="deliveryAddress$ | async as deliveryAddress"
       class="cx-review-summary-card cx-review-card-address"
     >
-      <cx-card
-        [content]="getDeliveryAddressCard(deliveryAddress) | async"
-      ></cx-card>
+      <cx-card [content]="getDeliveryAddressCard(deliveryAddress) | async" />
       <div class="cx-review-summary-edit-step">
         <a
           [attr.title]="
@@ -49,8 +47,8 @@
               cxRoute: getCheckoutStepUrl(checkoutStepTypeDeliveryAddress),
             } | cxUrl
           "
-          ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon
-        ></a>
+          ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"
+        /></a>
       </div>
     </div>
   </ng-template>
@@ -62,16 +60,14 @@
         <cx-card
           *ngIf="deliveryMode$ | async as deliveryMode"
           [content]="getDeliveryModeCard(deliveryMode) | async"
-        >
-        </cx-card>
+        />
         <ng-template
           [cxOutlet]="cartOutlets.DELIVERY_MODE"
           [cxOutletContext]="{
             item: cart$ | async,
             readonly: true,
           }"
-        >
-        </ng-template>
+        />
       </div>
 
       <div class="cx-review-summary-edit-step">
@@ -82,7 +78,7 @@
               | cxUrl
           "
         >
-          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>
+          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL" />
         </a>
       </div>
     </div>
@@ -95,7 +91,7 @@
         <cx-card
           *ngIf="paymentDetails$ | async as paymentDetails"
           [content]="getPaymentMethodCard(paymentDetails) | async"
-        ></cx-card>
+        />
       </div>
       <div class="cx-review-summary-edit-step">
         <a
@@ -105,7 +101,7 @@
               | cxUrl
           "
         >
-          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>
+          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL" />
         </a>
       </div>
     </div>
@@ -130,7 +126,7 @@
             cart.potentialOrderPromotions || []
           )
         "
-      ></cx-promotions>
+      />
 
       <ng-template
         [cxOutlet]="cartOutlets.CART_ITEM_LIST"
@@ -139,8 +135,7 @@
           readonly: true,
           promotionLocation: promotionLocation,
         }"
-      >
-      </ng-template>
+      />
     </div>
   </ng-container>
 </div>

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-overview/checkout-review-overview.component.html
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-overview/checkout-review-overview.component.html
@@ -9,5 +9,5 @@
         cart.potentialOrderPromotions || []
       )
     "
-  ></cx-promotions>
+  />
 </ng-container>

--- a/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.component.html
+++ b/feature-libs/checkout/base/components/checkout-review/checkout-review-shipping/checkout-review-shipping.component.html
@@ -13,7 +13,7 @@
         >
           <cx-card
             [content]="getDeliveryAddressCard(deliveryAddress) | async"
-          ></cx-card>
+          />
           <div class="cx-review-summary-edit-step">
             <a
               [attr.title]="
@@ -24,8 +24,8 @@
                   cxRoute: deliveryAddressStepRoute,
                 } | cxUrl
               "
-              ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon
-            ></a>
+              ><cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"
+            /></a>
           </div>
         </div>
       </div>
@@ -36,13 +36,13 @@
           <cx-card
             *ngIf="deliveryMode$ | async as deliveryMode"
             [content]="getDeliveryModeCard(deliveryMode) | async"
-          ></cx-card>
+          />
           <div class="cx-review-summary-edit-step">
             <a
               [attr.title]="'checkoutReview.editDeliveryMode' | cxTranslate"
               [routerLink]="{ cxRoute: deliveryModeStepRoute } | cxUrl"
             >
-              <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>
+              <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL" />
             </a>
           </div>
         </div>
@@ -57,8 +57,7 @@
           items: entries,
           readonly: true,
         }"
-      >
-      </ng-template>
+      />
     </div>
   </ng-container>
 </ng-container>

--- a/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.html
+++ b/feature-libs/checkout/scheduled-replenishment/components/checkout-schedule-replenishment-order/checkout-schedule-replenishment-order.component.html
@@ -10,7 +10,7 @@
     >
       {{ 'checkoutScheduledReplenishment.autoReplenishOrder' | cxTranslate }}
     </h3>
-    <cx-icon [type]="iconTypes.CLOCK"></cx-icon>
+    <cx-icon [type]="iconTypes.CLOCK" />
   </div>
   <div
     class="cx-order-type-container form-check"

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close-dialog/customer-ticketing-close-dialog.component.html
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-close/customer-ticketing-close-dialog/customer-ticketing-close-dialog.component.html
@@ -20,7 +20,7 @@
         title="{{ 'common.close' | cxTranslate }}"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -44,10 +44,7 @@
             rows="5"
           ></textarea>
 
-          <cx-form-errors
-            id="messageError"
-            [control]="form.get('message')"
-          ></cx-form-errors>
+          <cx-form-errors id="messageError" [control]="form.get('message')" />
 
           <p class="cx-customer-ticket-input-hint">
             {{
@@ -70,6 +67,6 @@
         </button>
       </div>
     </div>
-    <cx-spinner *ngIf="isDataLoading$ | async" class="overlay"></cx-spinner>
+    <cx-spinner *ngIf="isDataLoading$ | async" class="overlay" />
   </form>
 </div>

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/customer-ticketing-messages.component.html
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-messages/customer-ticketing-messages.component.html
@@ -3,4 +3,4 @@
   [messagingConfigs]="messagingConfigs"
   (send)="onSend($event)"
   (downloadAttachment)="downloadAttachment($event)"
-></cx-messaging>
+/>

--- a/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen-dialog/customer-ticketing-reopen-dialog.component.html
+++ b/feature-libs/customer-ticketing/components/details/customer-ticketing-reopen/customer-ticketing-reopen-dialog/customer-ticketing-reopen-dialog.component.html
@@ -21,7 +21,7 @@
         title="{{ 'common.close' | cxTranslate }}"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -43,10 +43,7 @@
             [attr.aria-errormessage]="'messageError'"
           ></textarea>
 
-          <cx-form-errors
-            id="messageError"
-            [control]="form.get('message')"
-          ></cx-form-errors>
+          <cx-form-errors id="messageError" [control]="form.get('message')" />
 
           <p class="cx-customer-ticket-input-hint">
             {{
@@ -63,7 +60,7 @@
           [accept]="allowedTypes"
         >
           <ng-template>
-            <cx-icon [type]="iconTypes.UPLOAD"></cx-icon>
+            <cx-icon [type]="iconTypes.UPLOAD" />
             <span class="cx-message-footer-text">{{
               'customerTicketing.uploadFile' | cxTranslate
             }}</span>
@@ -79,10 +76,7 @@
           {{ 'customerTicketing.maximumAttachment' | cxTranslate }}
         </p>
 
-        <cx-form-errors
-          [control]="form.get('file')"
-          prefix="formErrors.file"
-        ></cx-form-errors>
+        <cx-form-errors [control]="form.get('file')" prefix="formErrors.file" />
       </div>
 
       <div class="cx-customer-ticket-form-footer">
@@ -98,6 +92,6 @@
         </button>
       </div>
     </div>
-    <cx-spinner *ngIf="isDataLoading$ | async" class="overlay"></cx-spinner>
+    <cx-spinner *ngIf="isDataLoading$ | async" class="overlay" />
   </form>
 </div>

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create-dialog/customer-ticketing-create-dialog.component.html
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-create/customer-ticketing-create-dialog/customer-ticketing-create-dialog.component.html
@@ -21,7 +21,7 @@
         title="{{ 'common.close' | cxTranslate }}"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -46,10 +46,7 @@
             [attr.aria-errormessage]="'subjectError'"
           ></textarea>
 
-          <cx-form-errors
-            id="subjectError"
-            [control]="form.get('subject')"
-          ></cx-form-errors>
+          <cx-form-errors id="subjectError" [control]="form.get('subject')" />
           <p class="cx-customer-ticket-input-hint">
             {{
               'customerTicketing.charactersLeft'
@@ -82,13 +79,12 @@
               form.get('ticketCategory')?.invalid
             "
             [attr.aria-errormessage]="'ticketCategoryError'"
-          >
-          </ng-select>
+          />
 
           <cx-form-errors
             id="ticketCategoryError"
             [control]="form.get('ticketCategory')"
-          ></cx-form-errors>
+          />
         </label>
 
         <ng-container
@@ -142,10 +138,7 @@
             [attr.aria-errormessage]="'messageError'"
           ></textarea>
 
-          <cx-form-errors
-            id="messageError"
-            [control]="form.get('message')"
-          ></cx-form-errors>
+          <cx-form-errors id="messageError" [control]="form.get('message')" />
 
           <p class="cx-customer-ticket-input-hint">
             {{
@@ -161,7 +154,7 @@
             [accept]="allowedTypes"
           >
             <ng-template>
-              <cx-icon [type]="iconTypes.UPLOAD"></cx-icon>
+              <cx-icon [type]="iconTypes.UPLOAD" />
               <span class="cx-message-footer-text">{{
                 'customerTicketing.uploadFile' | cxTranslate
               }}</span>
@@ -181,7 +174,7 @@
           <cx-form-errors
             [control]="form.get('file')"
             prefix="formErrors.file"
-          ></cx-form-errors>
+          />
         </div>
       </div>
 

--- a/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.html
+++ b/feature-libs/customer-ticketing/components/list/customer-ticketing-list/customer-ticketing-list.component.html
@@ -19,9 +19,9 @@
           placeholder="{{ 'customerTicketingList.sortSubtitle' | cxTranslate }}"
           [ariaLabel]="'customerTicketingList.sortOrders' | cxTranslate"
           ariaControls="ticketing-list-table"
-        ></cx-sorting>
+        />
       </label>
-      <cx-customer-ticketing-create></cx-customer-ticketing-create>
+      <cx-customer-ticketing-create />
     </div>
     <table
       id="ticketing-list-table"
@@ -155,12 +155,12 @@
         <cx-pagination
           [pagination]="ticketList.pagination"
           (viewPageEvent)="pageChange($event)"
-        ></cx-pagination>
+        />
       </div>
     </div>
   </ng-container>
   <ng-template #noCustomerTickets>
-    <cx-customer-ticketing-create></cx-customer-ticketing-create>
+    <cx-customer-ticketing-create />
     <ng-container>
       <div class="text-center">
         <h3>{{ 'customerTicketingList.noTickets' | cxTranslate }}</h3>
@@ -170,5 +170,5 @@
 </ng-container>
 
 <ng-template #spinner>
-  <cx-spinner></cx-spinner>
+  <cx-spinner />
 </ng-template>

--- a/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.component.html
+++ b/feature-libs/customer-ticketing/components/my-account-v2/my-account-v2-customer-ticketing.component.html
@@ -80,5 +80,5 @@
 </ng-template>
 
 <ng-template #spinner>
-  <cx-spinner></cx-spinner>
+  <cx-spinner />
 </ng-template>

--- a/feature-libs/order/components/amend-order/amend-order-items/amend-order-items.component.html
+++ b/feature-libs/order/components/amend-order/amend-order-items/amend-order-items.component.html
@@ -56,7 +56,7 @@
             <cx-media
               [container]="item.product.images?.PRIMARY"
               format="thumbnail"
-            ></cx-media>
+            />
 
             <div class="cx-info">
               <div class="cx-name">
@@ -126,7 +126,7 @@
               [min]="0"
               [max]="getMaxAmendQuantity(item)"
               [control]="getControl(form, item)"
-            ></cx-item-counter>
+            />
           </div>
         </td>
 

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.component.html
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order-confirmation/cancel-order-confirmation.component.html
@@ -3,16 +3,15 @@
   [formGroup]="form"
   (ngSubmit)="submit(form)"
 >
-  <ng-container *ngTemplateOutlet="actions"></ng-container>
+  <ng-container *ngTemplateOutlet="actions" />
 
   <cx-amend-order-items
     *ngIf="entries$ | async as entries"
     [entries]="entries"
     [isConfirmation]="true"
-  >
-  </cx-amend-order-items>
+  />
 
-  <ng-container *ngTemplateOutlet="actions"></ng-container>
+  <ng-container *ngTemplateOutlet="actions" />
 
   <ng-template #actions>
     <cx-amend-order-actions
@@ -20,6 +19,6 @@
       [orderCode]="orderCode"
       [amendOrderForm]="form"
       backRoute="orderCancel"
-    ></cx-amend-order-actions>
+    />
   </ng-template>
 </form>

--- a/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.component.html
+++ b/feature-libs/order/components/amend-order/cancellations/cancel-order/cancel-order.component.html
@@ -5,13 +5,14 @@
     [text]="'formErrors.cxNoSelectedItemToCancel' | cxTranslate"
     [isVisibleCloseButton]="false"
     [type]="globalMessageType.MSG_TYPE_ERROR"
-  >
-  </cx-message>
-  <ng-container *ngTemplateOutlet="actions"></ng-container>
-  <cx-amend-order-items *ngIf="entries$ | async as entries" [entries]="entries">
-  </cx-amend-order-items>
+  />
+  <ng-container *ngTemplateOutlet="actions" />
+  <cx-amend-order-items
+    *ngIf="entries$ | async as entries"
+    [entries]="entries"
+  />
 
-  <ng-container *ngTemplateOutlet="actions"></ng-container>
+  <ng-container *ngTemplateOutlet="actions" />
 
   <ng-template #actions>
     <cx-amend-order-actions
@@ -20,6 +21,6 @@
       [amendOrderForm]="form"
       backRoute="orderDetails"
       forwardRoute="orderCancelConfirmation"
-    ></cx-amend-order-actions>
+    />
   </ng-template>
 </ng-container>

--- a/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.component.html
+++ b/feature-libs/order/components/amend-order/returns/return-order-confirmation/return-order-confirmation.component.html
@@ -3,16 +3,15 @@
   [formGroup]="form"
   (ngSubmit)="submit(form)"
 >
-  <ng-container *ngTemplateOutlet="actions"></ng-container>
+  <ng-container *ngTemplateOutlet="actions" />
 
   <cx-amend-order-items
     *ngIf="entries$ | async as entries"
     [entries]="entries"
     [isConfirmation]="true"
-  >
-  </cx-amend-order-items>
+  />
 
-  <ng-container *ngTemplateOutlet="actions"></ng-container>
+  <ng-container *ngTemplateOutlet="actions" />
 
   <ng-template #actions>
     <cx-amend-order-actions
@@ -20,6 +19,6 @@
       [orderCode]="orderCode"
       [amendOrderForm]="form"
       backRoute="orderReturn"
-    ></cx-amend-order-actions>
+    />
   </ng-template>
 </form>

--- a/feature-libs/order/components/amend-order/returns/return-order/return-order.component.html
+++ b/feature-libs/order/components/amend-order/returns/return-order/return-order.component.html
@@ -1,12 +1,14 @@
 <ng-container *ngIf="form$ | async as form">
-  <ng-container *ngTemplateOutlet="actions"></ng-container>
+  <ng-container *ngTemplateOutlet="actions" />
 
-  <cx-amend-order-items *ngIf="entries$ | async as entries" [entries]="entries">
-  </cx-amend-order-items>
+  <cx-amend-order-items
+    *ngIf="entries$ | async as entries"
+    [entries]="entries"
+  />
 
-  <cx-form-errors [control]="form.get('entries')"></cx-form-errors>
+  <cx-form-errors [control]="form.get('entries')" />
 
-  <ng-container *ngTemplateOutlet="actions"></ng-container>
+  <ng-container *ngTemplateOutlet="actions" />
 
   <ng-template #actions>
     <cx-amend-order-actions
@@ -15,6 +17,6 @@
       [amendOrderForm]="form"
       backRoute="orderDetails"
       forwardRoute="orderReturnConfirmation"
-    ></cx-amend-order-actions>
+    />
   </ng-template>
 </ng-container>

--- a/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.html
+++ b/feature-libs/order/components/my-account-v2/my-account-v2-orders.component.html
@@ -66,7 +66,7 @@
                     class="cx-my-account-view-order-img"
                     format="thumbnail"
                     role="presentation"
-                  ></cx-media>
+                  />
                 </div>
                 <div class="cx-my-account-view-order-column-1-details">
                   <div class="cx-my-account-view-order-column-1-details-top">
@@ -172,6 +172,6 @@
 <!-- ORDER HISTORY DATA STILL LOADING -->
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/order/components/order-confirmation/order-confirmation-items/order-confirmation-items.component.html
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-items/order-confirmation-items.component.html
@@ -2,9 +2,7 @@
   <h3 class="cx-order-items-header">
     {{ 'checkoutOrderConfirmation.orderItems' | cxTranslate }}
   </h3>
-  <cx-promotions
-    [promotions]="order.appliedOrderPromotions || []"
-  ></cx-promotions>
+  <cx-promotions [promotions]="order.appliedOrderPromotions || []" />
 
   <ng-template
     [cxAbstractOrderContext]="{
@@ -17,6 +15,5 @@
       readonly: true,
       promotionLocation: promotionLocation,
     }"
-  >
-  </ng-template>
+  />
 </div>

--- a/feature-libs/order/components/order-confirmation/order-confirmation-shipping/order-confirmation-shipping.component.html
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-shipping/order-confirmation-shipping.component.html
@@ -10,7 +10,7 @@
         <div class="cx-review-summary-card cx-review-card-address">
           <cx-card
             [content]="getDeliveryAddressCard(order.deliveryAddress) | async"
-          ></cx-card>
+          />
         </div>
       </div>
 
@@ -19,7 +19,7 @@
         <div class="cx-review-summary-card cx-review-card-address">
           <cx-card
             [content]="getDeliveryModeCard(order.deliveryMode) | async"
-          ></cx-card>
+          />
         </div>
       </div>
     </div>
@@ -36,8 +36,7 @@
           items: entries,
           readonly: true,
         }"
-      >
-      </ng-template>
+      />
     </div>
   </ng-container>
 </div>

--- a/feature-libs/order/components/order-confirmation/order-confirmation-thank-you-message/order-confirmation-thank-you-message.component.html
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-thank-you-message/order-confirmation-thank-you-message.component.html
@@ -20,8 +20,8 @@
     <cx-guest-register-form
       [guid]="orderGuid"
       [email]="order.paymentInfo.billingAddress.email"
-    ></cx-guest-register-form>
+    />
   </div>
 
-  <cx-add-to-home-screen-banner></cx-add-to-home-screen-banner>
+  <cx-add-to-home-screen-banner />
 </ng-container>

--- a/feature-libs/order/components/order-confirmation/order-confirmation-totals/order-confirmation-totals.component.html
+++ b/feature-libs/order/components/order-confirmation/order-confirmation-totals/order-confirmation-totals.component.html
@@ -4,8 +4,7 @@
       <ng-template
         [cxOutlet]="cartOutlets.ORDER_SUMMARY"
         [cxOutletContext]="order"
-      >
-      </ng-template>
+      />
     </div>
   </div>
 </div>

--- a/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.html
+++ b/feature-libs/order/components/order-confirmation/order-guest-register-form/order-guest-register-form.component.html
@@ -38,7 +38,7 @@
               label: 'register.password.label' | cxTranslate,
             }"
             [control]="guestRegisterForm.get('password')"
-          ></cx-form-errors>
+          />
         </label>
       </div>
 
@@ -74,7 +74,7 @@
               label: 'register.confirmPassword.label' | cxTranslate,
             }"
             [control]="guestRegisterForm.get('passwordconf')"
-          ></cx-form-errors>
+          />
         </label>
       </div>
 

--- a/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices.component.html
+++ b/feature-libs/order/components/order-details/my-account-v2/download-invoices/my-account-v2-download-invoices.component.html
@@ -24,13 +24,13 @@
         (click)="close('Close download invoices dialog')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
 
     <div class="cx-dialog-body modal-body">
-      <cx-invoices-list> </cx-invoices-list>
+      <cx-invoices-list />
       <div id="noInvoice" *ngIf="invoiceCount === 0" role="alert">
         {{ 'myAccountV2OrderDetails.noInvoices' | cxTranslate }}
       </div>
@@ -40,7 +40,7 @@
         aria-live="polite"
         role="alert"
       >
-        <cx-spinner></cx-spinner>
+        <cx-spinner />
       </div>
     </div>
   </div>

--- a/feature-libs/order/components/order-details/order-attachments/attachments-dialog/order-attachments-dialog.component.html
+++ b/feature-libs/order/components/order-details/order-attachments/attachments-dialog/order-attachments-dialog.component.html
@@ -24,7 +24,7 @@
         (click)="close('Close dialog')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -37,8 +37,7 @@
         [type]="globalMessageType.MSG_TYPE_ERROR"
         (closeMessage)="closeErrorMessage(errorId)"
         class="cx-dialog-message attachment-error"
-      >
-      </cx-message>
+      />
       <ng-container *ngIf="attachments$ | async as attachments; else loading">
         <ng-container *ngIf="!loadError(); else error">
           <ng-container *ngIf="attachmentsCount(); else empty">
@@ -85,7 +84,7 @@
                         ),
                       }"
                     >
-                      <cx-spinner></cx-spinner>
+                      <cx-spinner />
                     </div>
                   </td>
                   <td>
@@ -115,7 +114,7 @@
                         )
                       "
                     >
-                      <cx-icon [type]="iconTypes.FILE"></cx-icon>
+                      <cx-icon [type]="iconTypes.FILE" />
                     </a>
                   </td>
                 </tr>
@@ -146,8 +145,7 @@
     [type]="globalMessageType.MSG_TYPE_ERROR"
     [isVisibleCloseButton]="false"
     class="cx-dialog-message error-message"
-  >
-  </cx-message>
+  />
 </ng-template>
 <ng-template #empty>
   <cx-message
@@ -155,11 +153,10 @@
     [type]="globalMessageType.MSG_TYPE_INFO"
     [isVisibleCloseButton]="false"
     class="cx-dialog-message info-message"
-  >
-  </cx-message>
+  />
 </ng-template>
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/order/components/order-details/order-detail-billing/order-detail-billing.component.html
+++ b/feature-libs/order/components/order-details/order-detail-billing/order-detail-billing.component.html
@@ -4,23 +4,18 @@
       class="cx-review-summary-card cx-review-summary-payment-card"
       *ngIf="isPaymentInfoCardFull(paymentDetails)"
     >
-      <cx-card
-        [content]="getPaymentMethodCard(paymentDetails) | async"
-      ></cx-card>
+      <cx-card [content]="getPaymentMethodCard(paymentDetails) | async" />
     </div>
     <ng-template
       [cxOutlet]="cartOutlets.ORDER_DETAILS_AFTER_PAYMENT_METHOD"
       [cxOutletContext]="order"
-    >
-    </ng-template>
+    />
 
     <div
       class="cx-review-summary-card cx-review-summary-payment-card"
       *ngIf="paymentDetails?.billingAddress"
     >
-      <cx-card
-        [content]="getBillingAddressCard(paymentDetails) | async"
-      ></cx-card>
+      <cx-card [content]="getBillingAddressCard(paymentDetails) | async" />
     </div>
   </div>
 </div>

--- a/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/tracking-events/tracking-events.component.html
+++ b/feature-libs/order/components/order-details/order-detail-items/consignment-tracking/tracking-events/tracking-events.component.html
@@ -150,7 +150,7 @@
         <div class="body modal-body">
           <div class="row">
             <div class="col-sm-12">
-              <cx-spinner></cx-spinner>
+              <cx-spinner />
             </div>
           </div>
         </div>

--- a/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.component.html
+++ b/feature-libs/order/components/order-details/order-detail-items/order-consigned-entries/order-consigned-entries.component.html
@@ -17,8 +17,7 @@
         [orderCode]="order.code"
         [consignment]="consignment"
         *cxFeature="'consignmentTracking'"
-      >
-      </cx-consignment-tracking>
+      />
     </div>
   </ng-template>
   <div class="cx-list-item col-12">
@@ -38,8 +37,7 @@
           optionalBtn: addToCartBtn,
         },
       }"
-    >
-    </ng-template>
+    />
   </div>
 </div>
 
@@ -51,6 +49,5 @@
     [options]="ctx.options"
     [pickupStore]="ctx.item.deliveryPointOfService?.name"
     class="add-to-cart"
-  >
-  </cx-add-to-cart>
+  />
 </ng-template>

--- a/feature-libs/order/components/order-details/order-detail-items/order-detail-items.component.html
+++ b/feature-libs/order/components/order-details/order-detail-items/order-detail-items.component.html
@@ -7,9 +7,7 @@
         order.replenishmentOrderCode
       "
     >
-      <cx-promotions
-        [promotions]="order.appliedOrderPromotions || []"
-      ></cx-promotions>
+      <cx-promotions [promotions]="order.appliedOrderPromotions || []" />
     </ng-container>
 
     <!-- pickup consigned entries -->
@@ -25,7 +23,7 @@
       [consignments]="pickupConsignments"
       [enableAddToCart]="enableAddToCart$ | async"
       [buyItAgainTranslation]="'addToCart.buyItAgain' | cxTranslate"
-    ></cx-order-consigned-entries>
+    />
 
     <!-- delivery consignment address and delivery mode -->
     <ng-template
@@ -39,8 +37,7 @@
         showItemList: false,
         order: order,
       }"
-    >
-    </ng-template>
+    />
 
     <!-- delivery consigned entries -->
     <cx-order-consigned-entries
@@ -49,7 +46,7 @@
       [consignments]="deliveryConsignments"
       [enableAddToCart]="enableAddToCart$ | async"
       [buyItAgainTranslation]="'addToCart.buyItAgain' | cxTranslate"
-    ></cx-order-consigned-entries>
+    />
 
     <!-- unconsigned entries -->
     <ng-container *ngIf="order?.unconsignedEntries?.length">
@@ -82,8 +79,7 @@
                 optionalBtn: addToCartBtn,
               },
             }"
-          >
-          </ng-template>
+          />
         </div>
       </ng-container>
       <!-- pickup unconsigned entries, b2b does not have pickup items -->
@@ -108,8 +104,7 @@
                 optionalBtn: addToCartBtn,
               },
             }"
-          >
-          </ng-template>
+          />
         </div>
       </ng-container>
     </ng-container>
@@ -141,8 +136,7 @@
                 optionalBtn: addToCartBtn,
               },
             }"
-          >
-          </ng-template>
+          />
         </div>
       </div>
     </ng-container>
@@ -156,7 +150,6 @@
       [options]="ctx.options"
       [pickupStore]="ctx.item.deliveryPointOfService?.name"
       class="add-to-cart"
-    >
-    </cx-add-to-cart>
+    />
   </ng-template>
 </ng-container>

--- a/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.html
+++ b/feature-libs/order/components/order-details/order-detail-reorder/reorder-dialog/reorder-dialog.component.html
@@ -20,7 +20,7 @@
           (click)="close('Close reorder result dialog')"
         >
           <span aria-hidden="true">
-            <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+            <cx-icon [type]="iconTypes.CLOSE" />
           </span>
         </button>
       </div>
@@ -62,10 +62,7 @@
               >
                 <span class="cx-cart-mod-entry-container">
                   <span class="alert-icon">
-                    <cx-icon
-                      class="success"
-                      [type]="iconTypes.SUCCESS"
-                    ></cx-icon>
+                    <cx-icon class="success" [type]="iconTypes.SUCCESS" />
                   </span>
                   {{ 'reorder.dialog.messages.success' | cxTranslate }}
                 </span>
@@ -83,15 +80,12 @@
                     "
                   >
                     <span class="alert-icon">
-                      <cx-icon
-                        class="warning"
-                        [type]="iconTypes.INFO"
-                      ></cx-icon>
+                      <cx-icon class="warning" [type]="iconTypes.INFO" />
                     </span>
                   </ng-container>
                   <ng-template #errorIcon>
                     <span class="alert-icon">
-                      <cx-icon class="error" [type]="iconTypes.ERROR"></cx-icon>
+                      <cx-icon class="error" [type]="iconTypes.ERROR" />
                     </span>
                   </ng-template>
                   <span>
@@ -112,7 +106,7 @@
           </ng-container>
           <ng-template #loading>
             <div class="cx-spinner">
-              <cx-spinner></cx-spinner>
+              <cx-spinner />
             </div>
           </ng-template>
         </ng-template>

--- a/feature-libs/order/components/order-details/order-detail-totals/order-detail-totals.component.html
+++ b/feature-libs/order/components/order-details/order-detail-totals/order-detail-totals.component.html
@@ -4,8 +4,7 @@
       <ng-template
         [cxOutlet]="CartOutlets.ORDER_SUMMARY"
         [cxOutletContext]="order"
-      >
-      </ng-template>
+      />
     </div>
   </div>
 </ng-container>

--- a/feature-libs/order/components/order-history/my-account-v2/consolidated-information/my-account-v2-order-consolidated-information.component.html
+++ b/feature-libs/order/components/order-history/my-account-v2/consolidated-information/my-account-v2-order-consolidated-information.component.html
@@ -23,12 +23,12 @@
               ),
             }
           "
-        ></ng-container>
+        />
       </div>
       <cx-my-account-v2-consignment-entries
         [orderCode]="order.code ?? ''"
         [consignments]="getPickupConsignments(order.consignments ?? [])"
-      ></cx-my-account-v2-consignment-entries>
+      />
     </div>
 
     <!-- delivery consigned entries
@@ -56,12 +56,12 @@
               ),
             }
           "
-        ></ng-container>
+        />
       </div>
       <cx-my-account-v2-consignment-entries
         [orderCode]="order.code ?? ''"
         [consignments]="getDeliveryConsignments(order.consignments ?? [])"
-      ></cx-my-account-v2-consignment-entries>
+      />
     </div>
 
     <!-- unconsigned entries 
@@ -82,7 +82,7 @@
               showManyItems;
               context: { count: getOrderEntriesCount(order.unconsignedEntries) }
             "
-          ></ng-container>
+          />
         </div>
         <ng-template #nonCritical>
           <div class="cx-order-status">
@@ -97,7 +97,7 @@
                   count: getOrderEntriesCount(order.unconsignedEntries),
                 }
               "
-            ></ng-container>
+            />
           </div>
         </ng-template>
       </div>
@@ -125,7 +125,7 @@
               ),
             }
           "
-        ></ng-container>
+        />
       </div>
 
       <!-- pickup unconsigned entries, b2b does not have pickup items
@@ -151,7 +151,7 @@
               ),
             }
           "
-        ></ng-container>
+        />
       </div>
     </div>
 
@@ -197,7 +197,7 @@
           class="cx-order-img"
           format="thumbnail"
           role="presentation"
-        ></cx-media>
+        />
       </ng-container>
     </ng-container>
   </div>

--- a/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.component.html
+++ b/feature-libs/order/components/order-history/my-account-v2/my-account-v2-order-history.component.html
@@ -63,8 +63,7 @@
           </div>
 
           <!--eg: Display consolidated order information-->
-          <cx-my-account-v2-order-consolidated-information [order]="order">
-          </cx-my-account-v2-order-consolidated-information>
+          <cx-my-account-v2-order-consolidated-information [order]="order" />
         </div>
       </ng-container>
 
@@ -79,7 +78,7 @@
         <cx-pagination
           [pagination]="orderHistory.pagination"
           (viewPageEvent)="pageChange($event)"
-        ></cx-pagination>
+        />
       </div>
     </ng-container>
   </div>
@@ -103,6 +102,6 @@
 <!-- ORDER HISTORY DATA STILL LOADING -->
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/order/components/order-history/order-history.component.html
+++ b/feature-libs/order/components/order-history/order-history.component.html
@@ -44,7 +44,7 @@
                 placeholder="{{ 'orderHistory.sortBy' | cxTranslate }}"
                 [ariaLabel]="'orderHistory.sortOrders' | cxTranslate"
                 ariaControls="order-history-table"
-              ></cx-sorting>
+              />
             </label>
             <div
               *ngIf="type.orderHistory.pagination.totalPages > 1"
@@ -54,7 +54,7 @@
                 [pagination]="type.orderHistory.pagination"
                 (viewPageEvent)="pageChange($event)"
                 paginationID="pagination-top"
-              ></cx-pagination>
+              />
             </div>
           </div>
 
@@ -223,7 +223,7 @@
                 [pagination]="type.orderHistory.pagination"
                 (viewPageEvent)="pageChange($event)"
                 paginationID="pagination-bottom"
-              ></cx-pagination>
+              />
             </div>
           </div>
         </ng-container>

--- a/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.html
+++ b/feature-libs/order/components/replenishment-order-cancellation-dialog/replenishment-order-cancellation-dialog.component.html
@@ -18,7 +18,7 @@
         (click)="close('Cross click')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>

--- a/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.html
+++ b/feature-libs/order/components/replenishment-order-history/replenishment-order-history.component.html
@@ -26,7 +26,7 @@
               placeholder="{{ 'orderHistory.sortBy' | cxTranslate }}"
               [ariaLabel]="'orderHistory.sortOrders' | cxTranslate"
               ariaControls="replenishment-order-history-table"
-            ></cx-sorting>
+            />
           </label>
           <div
             class="cx-replenishment-order-history-pagination"
@@ -36,7 +36,7 @@
               [pagination]="replenishmentOrders.pagination"
               (viewPageEvent)="pageChange($event)"
               paginationID="pagination-top"
-            ></cx-pagination>
+            />
           </div>
         </div>
         <!-- TABLE -->
@@ -233,7 +233,7 @@
               (viewPageEvent)="pageChange($event)"
               *ngIf="replenishmentOrders.pagination.totalPages > 1"
               paginationID="pagination-bottom"
-            ></cx-pagination>
+            />
           </div>
         </div>
       </ng-container>

--- a/feature-libs/order/components/return-request-detail/return-request-items/return-request-items.component.html
+++ b/feature-libs/order/components/return-request-detail/return-request-items/return-request-items.component.html
@@ -36,7 +36,7 @@
           <cx-media
             [container]="returnEntry.orderEntry?.product.images?.PRIMARY"
             format="thumbnail"
-          ></cx-media>
+          />
           <!-- Item Description -->
           <div class="cx-info">
             <div *ngIf="returnEntry.orderEntry?.product.name" class="cx-name">

--- a/feature-libs/order/components/return-request-list/order-return-request-list.component.html
+++ b/feature-libs/order/components/return-request-list/order-return-request-list.component.html
@@ -14,14 +14,14 @@
               [selectedOption]="returnRequests.pagination.sort"
               [ariaLabel]="'returnRequestList.sortReturns' | cxTranslate"
               ariaControls="order-return-table"
-            ></cx-sorting>
+            />
           </label>
           <div class="cx-order-history-pagination">
             <cx-pagination
               [pagination]="returnRequests.pagination"
               (viewPageEvent)="pageChange($event)"
               paginationID="pagination-top"
-            ></cx-pagination>
+            />
           </div>
         </div>
         <!-- TABLE -->
@@ -106,14 +106,14 @@
               [selectedOption]="returnRequests.pagination.sort"
               [ariaLabel]="'returnRequestList.sortReturns' | cxTranslate"
               ariaControls="order-return-table"
-            ></cx-sorting>
+            />
           </label>
           <div class="cx-order-history-pagination">
             <cx-pagination
               [pagination]="returnRequests.pagination"
               (viewPageEvent)="pageChange($event)"
               paginationID="pagination-bottom"
-            ></cx-pagination>
+            />
           </div>
         </div>
       </ng-container>

--- a/feature-libs/order/document-flow/components/order-document-flow-dialog/order-document-flow-dialog.component.html
+++ b/feature-libs/order/document-flow/components/order-document-flow-dialog/order-document-flow-dialog.component.html
@@ -16,7 +16,7 @@
               title="{{ 'common.back' | cxTranslate }}"
               (click)="goBack()"
             >
-              <cx-icon [type]="iconTypes.CARET_LEFT"></cx-icon>
+              <cx-icon [type]="iconTypes.CARET_LEFT" />
             </button>
           </span>
           <span *ngIf="selectedDocument$ | async as document">
@@ -35,7 +35,7 @@
         (click)="close('Close dialog')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -48,7 +48,7 @@
         [type]="globalMessageType.MSG_TYPE_ERROR"
         [isVisibleCloseButton]="false"
         class="cx-dialog-message error-message"
-      ></cx-message>
+      />
       <ng-template #content>
         <ng-container *ngIf="displayDocumentEntries(); else documentsView">
           <ng-container
@@ -93,11 +93,10 @@
     [type]="globalMessageType.MSG_TYPE_INFO"
     [isVisibleCloseButton]="false"
     class="cx-dialog-message info-message"
-  >
-  </cx-message>
+  />
 </ng-template>
 <ng-template #spinner>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/order/document-flow/components/order-document-flow-dialog/order-document-flow-list/order-subsequent-document-list.component.html
+++ b/feature-libs/order/document-flow/components/order-document-flow-dialog/order-document-flow-list/order-subsequent-document-list.component.html
@@ -24,7 +24,6 @@
       [documents]="documents"
       [selectedDocument]="selectedDocument"
       (documentSelected)="onDocumentSelection($event)"
-    >
-    </cx-order-subsequent-document-node>
+    />
   </tbody>
 </table>

--- a/feature-libs/order/document-flow/components/order-document-flow-dialog/order-document-flow-list/order-subsequent-document-node.component.html
+++ b/feature-libs/order/document-flow/components/order-document-flow-dialog/order-document-flow-list/order-subsequent-document-node.component.html
@@ -47,7 +47,7 @@
         title="{{ 'documentFlow.dialog.orderItems' | cxTranslate }}"
         (click)="onDocumentSelection(document)"
       >
-        <cx-icon [type]="iconTypes.CARET_RIGHT"></cx-icon>
+        <cx-icon [type]="iconTypes.CARET_RIGHT" />
       </button>
     </td>
   </tr>
@@ -57,6 +57,5 @@
     [selectedDocument]="selectedDocument"
     [depth]="depth + 1"
     (documentSelected)="onDocumentSelection($event)"
-  >
-  </cx-order-subsequent-document-node>
+  />
 </ng-container>

--- a/feature-libs/organization/account-summary/components/details/document/account-summary-document.component.html
+++ b/feature-libs/organization/account-summary/components/details/document/account-summary-document.component.html
@@ -18,8 +18,7 @@
             ? 'cx-account-summary-document-table'
             : undefined
         "
-      >
-      </cx-account-summary-document-filter>
+      />
 
       <ng-container
         *ngIf="
@@ -39,7 +38,7 @@
               placeholder="{{ 'orgAccountSummary.sortBy' | cxTranslate }}"
               [ariaLabel]="'orgAccountSummary.sortDocuments' | cxTranslate"
               ariaControls="cx-account-summary-document-table"
-            ></cx-sorting>
+            />
           </label>
           <div
             class="cx-account-summary-document-pagination"
@@ -53,7 +52,7 @@
               [pagination]="accountSummary.pagination"
               (viewPageEvent)="pageChange($event)"
               paginationID="pagination-top"
-            ></cx-pagination>
+            />
           </div>
         </div>
 
@@ -92,7 +91,7 @@
                   title="{{
                     'orgAccountSummary.document.attachment' | cxTranslate
                   }}"
-                ></cx-icon>
+                />
               </th>
             </tr>
           </thead>
@@ -193,8 +192,7 @@
                       title="{{
                         'orgAccountSummary.document.download' | cxTranslate
                       }}"
-                    >
-                    </cx-icon>
+                    />
                     <span
                       class="cx-account-summary-document-attachment-text"
                       [innerText]="
@@ -223,7 +221,7 @@
               [pagination]="accountSummary.pagination"
               (viewPageEvent)="pageChange($event)"
               paginationID="pagination-bottom"
-            ></cx-pagination>
+            />
           </div>
         </div>
       </ng-container>

--- a/feature-libs/organization/account-summary/components/details/document/filter/account-summary-document-filter.component.html
+++ b/feature-libs/organization/account-summary/components/details/document/filter/account-summary-document-filter.component.html
@@ -6,7 +6,7 @@
         <cx-date-picker
           [control]="formGroup.controls.from"
           label="orgAccountSummary.filter.startRange"
-        ></cx-date-picker>
+        />
       </ng-container>
       <ng-template #inputFrom>
         <input
@@ -25,7 +25,7 @@
             label: 'orgAccountSummary.filter.startRange' | cxTranslate,
           }"
           [control]="formGroup.controls.from"
-        ></cx-form-errors>
+        />
       </ng-template>
     </label>
 
@@ -35,7 +35,7 @@
         <cx-date-picker
           [control]="formGroup.controls.to"
           label="orgAccountSummary.filter.endRange"
-        ></cx-date-picker>
+        />
       </ng-container>
       <ng-template #inputTo>
         <input
@@ -54,12 +54,12 @@
             label: 'orgAccountSummary.filter.endRange' | cxTranslate,
           }"
           [control]="formGroup.controls.to"
-        ></cx-form-errors>
+        />
       </ng-template>
       <cx-form-errors
         [control]="formGroup"
         [prefix]="'orgAccountSummary.filter.errors'"
-      ></cx-form-errors>
+      />
     </label>
   </ng-container>
 </ng-template>
@@ -85,15 +85,14 @@
           ariaLabel: 'orgAccountSummary.filter.status' | cxTranslate,
           ariaControls: cxNgSelectA11yAriaControls,
         }"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{
           label: 'orgAccountSummary.filter.status' | cxTranslate,
         }"
         [control]="filterForm.controls.status"
-      ></cx-form-errors>
+      />
     </label>
 
     <label class="cx-account-summary-document-filter-form-item">
@@ -112,15 +111,14 @@
           ariaLabel: 'orgAccountSummary.filter.filterBy' | cxTranslate,
           ariaControls: cxNgSelectA11yAriaControls,
         }"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{
           label: 'orgAccountSummary.filter.filterBy' | cxTranslate,
         }"
         [control]="filterForm.controls.filterBy"
-      ></cx-form-errors>
+      />
     </label>
 
     <label
@@ -138,15 +136,14 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{
           label: 'orgAccountSummary.filter.documentType' | cxTranslate,
         }"
         [control]="filterForm.controls.documentType"
-      ></cx-form-errors>
+      />
     </label>
 
     <label
@@ -170,7 +167,7 @@
           label: 'orgAccountSummary.filter.documentNumber' | cxTranslate,
         }"
         [control]="filterForm.controls.documentNumber"
-      ></cx-form-errors>
+      />
     </label>
 
     <ng-template [ngIf]="filterBy === FilterByOptions.DOCUMENT_NUMBER_RANGE">
@@ -182,8 +179,7 @@
             type: 'text',
           }
         "
-      >
-      </ng-container>
+      />
     </ng-template>
 
     <ng-template [ngIf]="filterBy === FilterByOptions.DATE_RANGE">
@@ -195,8 +191,7 @@
             type: 'date',
           }
         "
-      >
-      </ng-container>
+      />
     </ng-template>
 
     <ng-template [ngIf]="filterBy === FilterByOptions.DUE_DATE_RANGE">
@@ -205,8 +200,7 @@
           rangeInput;
           context: { formGroup: filterForm.get('dueDateRange'), type: 'date' }
         "
-      >
-      </ng-container>
+      />
     </ng-template>
 
     <ng-template [ngIf]="filterBy === FilterByOptions.AMOUNT_RANGE">
@@ -218,8 +212,7 @@
             type: 'number',
           }
         "
-      >
-      </ng-container>
+      />
     </ng-template>
 
     <ng-template [ngIf]="filterBy === FilterByOptions.OPEN_AMOUNT_RANGE">
@@ -231,8 +224,7 @@
             type: 'number',
           }
         "
-      >
-      </ng-container>
+      />
     </ng-template>
 
     <div class="cx-account-summary-document-filter-form-button-block">

--- a/feature-libs/organization/account-summary/components/details/header/account-summary-header.component.html
+++ b/feature-libs/organization/account-summary/components/details/header/account-summary-header.component.html
@@ -7,13 +7,11 @@
       <div class="cx-summary-card">
         <cx-card
           [content]="getIdCardContent(headerDetails?.orgUnit?.uid) | async"
-        >
-        </cx-card>
+        />
 
         <cx-card
           [content]="getNameCardContent(headerDetails?.orgUnit?.name) | async"
-        >
-        </cx-card>
+        />
       </div>
 
       <!-- Card: Address -->
@@ -22,8 +20,7 @@
           [content]="
             getAddressCardContent(headerDetails?.billingAddress) | async
           "
-        >
-        </cx-card>
+        />
       </div>
     </div>
 
@@ -36,15 +33,13 @@
           [content]="
             getCreditRepCardContent(headerDetails?.accountManagerName) | async
           "
-        >
-        </cx-card>
+        />
 
         <cx-card
           [content]="
             getCreditLineCardContent(headerDetails?.creditLimit) | async
           "
-        >
-        </cx-card>
+        />
       </div>
 
       <!-- Card: Current Balance & Open Balance -->
@@ -55,16 +50,14 @@
               headerDetails?.amountBalance?.currentBalance
             ) | async
           "
-        >
-        </cx-card>
+        />
 
         <cx-card
           [content]="
             getOpenBalanceCardContent(headerDetails?.amountBalance?.openBalance)
               | async
           "
-        >
-        </cx-card>
+        />
       </div>
     </div>
 
@@ -136,8 +129,7 @@
               headerDetails?.amountBalance?.pastDueBalance
             ) | async
           "
-        >
-        </cx-card>
+        />
       </ng-template>
     </div>
   </div>

--- a/feature-libs/organization/account-summary/components/list/account-summary-list.component.spec.ts
+++ b/feature-libs/organization/account-summary/components/list/account-summary-list.component.spec.ts
@@ -14,7 +14,7 @@ import { AccountSummaryListComponent } from './account-summary-list.component';
 
 describe('AccountSummaryListComponent', () => {
   @Component({
-    template: '<ng-content select="[actions]"></ng-content>',
+    template: '<ng-content select="[actions]"/>',
     selector: 'cx-org-list',
   })
   class MockListComponent {

--- a/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.component.html
+++ b/feature-libs/organization/administration/components/budget/cost-centers/budget-cost-center-list.component.html
@@ -1,1 +1,1 @@
-<cx-org-sub-list></cx-org-sub-list>
+<cx-org-sub-list />

--- a/feature-libs/organization/administration/components/budget/details/budget-details.component.html
+++ b/feature-libs/organization/administration/components/budget/details/budget-details.component.html
@@ -12,9 +12,9 @@
     {{ 'organization.edit' | cxTranslate }}
   </a>
 
-  <cx-org-toggle-status actions i18nRoot="orgBudget"></cx-org-toggle-status>
+  <cx-org-toggle-status actions i18nRoot="orgBudget" />
 
-  <cx-org-disable-info info i18nRoot="orgBudget"> </cx-org-disable-info>
+  <cx-org-disable-info info i18nRoot="orgBudget" />
 
   <section main class="details" cxOrgItemExists>
     <div class="property">

--- a/feature-libs/organization/administration/components/budget/form/budget-form.component.html
+++ b/feature-libs/organization/administration/components/budget/form/budget-form.component.html
@@ -25,7 +25,7 @@
           label: 'orgBudget.name' | cxTranslate,
         }"
         [control]="form.get('name')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -51,7 +51,7 @@
           label: 'orgBudget.code' | cxTranslate,
         }"
         [control]="form.get('code')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -65,7 +65,7 @@
         [required]="true"
         (update)="form.get('endDate')?.updateValueAndValidity()"
         label="orgBudget.startDate"
-      ></cx-date-picker>
+      />
     </label>
 
     <label>
@@ -80,7 +80,7 @@
         [required]="true"
         (update)="form.get('startDate')?.updateValueAndValidity()"
         label="orgBudget.endDate"
-      ></cx-date-picker>
+      />
     </label>
 
     <label [formGroup]="$any(form.get('currency'))">
@@ -105,8 +105,7 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         id="isocodeError"
@@ -114,7 +113,7 @@
           label: 'orgBudget.currency' | cxTranslate,
         }"
         [control]="form.get('currency.isocode')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -141,7 +140,7 @@
           label: 'orgBudget.amount' | cxTranslate,
         }"
         [control]="form.get('budget')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label
@@ -170,8 +169,7 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         id="uidError"
@@ -179,7 +177,7 @@
           label: 'orgBudget.businessUnits' | cxTranslate,
         }"
         [control]="form.get('orgUnit.uid')"
-      ></cx-form-errors>
+      />
     </label>
   </ng-container>
 </cx-org-form>

--- a/feature-libs/organization/administration/components/cost-center/details/cost-center-details.component.html
+++ b/feature-libs/organization/administration/components/cost-center/details/cost-center-details.component.html
@@ -12,9 +12,9 @@
     {{ 'organization.edit' | cxTranslate }}
   </a>
 
-  <cx-org-toggle-status actions i18nRoot="orgCostCenter"></cx-org-toggle-status>
+  <cx-org-toggle-status actions i18nRoot="orgCostCenter" />
 
-  <cx-org-disable-info info i18nRoot="orgCostCenter"> </cx-org-disable-info>
+  <cx-org-disable-info info i18nRoot="orgCostCenter" />
 
   <section main class="details" cxOrgItemExists>
     <div class="property">

--- a/feature-libs/organization/administration/components/cost-center/form/cost-center-form.component.html
+++ b/feature-libs/organization/administration/components/cost-center/form/cost-center-form.component.html
@@ -25,7 +25,7 @@
           label: 'orgCostCenter.name' | cxTranslate,
         }"
         [control]="form.get('name')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -50,7 +50,7 @@
           label: 'orgCostCenter.code' | cxTranslate,
         }"
         [control]="form.get('code')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label formGroupName="currency">
@@ -72,15 +72,14 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{
           label: 'orgCostCenter.currency' | cxTranslate,
         }"
         [control]="form.get('currency.isocode')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label [formGroup]="$any(form.get('unit'))">
@@ -101,15 +100,14 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{
           label: 'orgCostCenter.unit' | cxTranslate,
         }"
         [control]="form.get('unit.uid')"
-      ></cx-form-errors>
+      />
     </label>
   </ng-container>
 </cx-org-form>

--- a/feature-libs/organization/administration/components/permission/details/permission-details.component.html
+++ b/feature-libs/organization/administration/components/permission/details/permission-details.component.html
@@ -16,14 +16,13 @@
     actions
     i18nRoot="orgPurchaseLimit"
     [disabled]="false"
-  ></cx-org-toggle-status>
+  />
 
   <cx-org-disable-info
     info
     i18nRoot="orgPurchaseLimit"
     [displayInfoConfig]="{ disabledEnable: false }"
-  >
-  </cx-org-disable-info>
+  />
 
   <section main class="details" cxOrgItemExists>
     <div class="property">

--- a/feature-libs/organization/administration/components/permission/form/permission-form.component.html
+++ b/feature-libs/organization/administration/components/permission/form/permission-form.component.html
@@ -22,7 +22,7 @@
         id="codeError"
         [translationParams]="{ label: 'orgPurchaseLimit.code' | cxTranslate }"
         [control]="form.get('code')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label
@@ -49,15 +49,14 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{
           label: 'orgPurchaseLimit.orderApprovalPermissionType' | cxTranslate,
         }"
         [control]="form.get('orderApprovalPermissionType.code')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label *ngIf="form.get('periodRange')">
@@ -76,15 +75,14 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{
           label: 'orgPurchaseLimit.periodRange' | cxTranslate,
         }"
         [control]="form.get('periodRange')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label
@@ -108,15 +106,14 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{
           label: 'orgPurchaseLimit.currency' | cxTranslate,
         }"
         [control]="form.get('currency.isocode')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label *ngIf="form.get('threshold')">
@@ -142,7 +139,7 @@
           label: 'orgPurchaseLimit.threshold' | cxTranslate,
         }"
         [control]="form.get('threshold')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label [formGroup]="$any(form.get('orgUnit'))">
@@ -164,15 +161,14 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{
           label: 'orgPurchaseLimit.orgUnit' | cxTranslate,
         }"
         [control]="form.get('orgUnit.uid')"
-      ></cx-form-errors>
+      />
     </label>
   </ng-container>
 </cx-org-form>

--- a/feature-libs/organization/administration/components/shared/card/card.component.html
+++ b/feature-libs/organization/administration/components/shared/card/card.component.html
@@ -23,7 +23,7 @@
             [attr.aria-label]="'organization.information' | cxTranslate"
             [attr.title]="'organization.information' | cxTranslate"
           >
-            <cx-icon [type]="iconTypes.INFO"> </cx-icon>
+            <cx-icon [type]="iconTypes.INFO" />
           </button>
         </h3>
         <h4>
@@ -34,7 +34,7 @@
         </h4>
       </div>
       <div class="actions">
-        <ng-content select="[actions]"></ng-content>
+        <ng-content select="[actions]" />
       </div>
     </div>
     <button
@@ -48,19 +48,19 @@
         type="CLOSE"
         title="{{ 'common.close' | cxTranslate }}"
         (click)="closeView($event)"
-      ></cx-icon>
+      />
       <ng-template #prevLabel>{{ previousLabel | cxTranslate }}</ng-template>
     </button>
   </div>
 
   <div class="main">
-    <cx-org-message aria-live="assertive"></cx-org-message>
-    <ng-content select="[info]"></ng-content>
-    <ng-content select="[main]"></ng-content>
+    <cx-org-message aria-live="assertive" />
+    <ng-content select="[info]" />
+    <ng-content select="[main]" />
   </div>
 </cx-view>
 
-<router-outlet></router-outlet>
+<router-outlet />
 
 <ng-template #detailHint>
   <p>

--- a/feature-libs/organization/administration/components/shared/card/card.testing.module.ts
+++ b/feature-libs/organization/administration/components/shared/card/card.testing.module.ts
@@ -8,7 +8,7 @@ import { Component, Input, NgModule } from '@angular/core';
 
 @Component({
   selector: 'cx-org-card',
-  template: '<ng-content></ng-content>',
+  template: '<ng-content />',
 })
 export class MockCardComponent {
   @Input() i18nRoot;

--- a/feature-libs/organization/administration/components/shared/detail/disable-info/disable-info.component.html
+++ b/feature-libs/organization/administration/components/shared/detail/disable-info/disable-info.component.html
@@ -8,7 +8,7 @@
       displayCustomInfo
     "
   >
-    <cx-icon [type]="iconTypes.INFO"></cx-icon>
+    <cx-icon [type]="iconTypes.INFO" />
     <ul>
       <li *ngIf="displayDisabledEnable(item)">
         {{ i18nRoot + '.info.disabledEnable' | cxTranslate }}
@@ -22,7 +22,7 @@
       <li *ngIf="displayDisabledDisable(item)">
         {{ i18nRoot + '.info.disabledDisable' | cxTranslate }}
       </li>
-      <ng-content></ng-content>
+      <ng-content />
     </ul>
   </section>
 </ng-container>

--- a/feature-libs/organization/administration/components/shared/form/form.component.html
+++ b/feature-libs/organization/administration/components/shared/form/form.component.html
@@ -30,7 +30,7 @@
     </button>
 
     <section main class="details">
-      <ng-content select="[main]" ngProjectAs="[main]"></ng-content>
+      <ng-content select="[main]" ngProjectAs="[main]" />
     </section>
   </cx-org-card>
 </form>

--- a/feature-libs/organization/administration/components/shared/form/form.testing.module.ts
+++ b/feature-libs/organization/administration/components/shared/form/form.testing.module.ts
@@ -10,7 +10,7 @@ import { FormService } from './form.service';
 
 @Component({
   selector: 'cx-org-form',
-  template: '<ng-content></ng-content>',
+  template: '<ng-content />',
 })
 class MockFormComponent {
   @Input() i18nRoot;

--- a/feature-libs/organization/administration/components/shared/list/list.component.html
+++ b/feature-libs/organization/administration/components/shared/list/list.component.html
@@ -39,7 +39,7 @@
                     : { title: viewType + '.groupName' | cxTranslate }
               "
             >
-              <cx-icon [type]="iconTypes.INFO"> </cx-icon>
+              <cx-icon [type]="iconTypes.INFO" />
             </button>
           </h2>
         </div>
@@ -69,7 +69,7 @@
                   [attr.aria-label]="'organization.search.label' | cxTranslate"
                   [title]="'organization.search.label' | cxTranslate"
                 >
-                  <cx-icon [type]="iconTypes.SEARCH"></cx-icon>
+                  <cx-icon [type]="iconTypes.SEARCH" />
                 </button>
                 <button
                   *ngIf="searchQuery"
@@ -79,7 +79,7 @@
                   [attr.aria-label]="'organization.search.clear' | cxTranslate"
                   [title]="'organization.search.clear' | cxTranslate"
                 >
-                  <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+                  <cx-icon [type]="iconTypes.CLOSE" />
                 </button>
               </div>
             </label>
@@ -117,7 +117,7 @@
             </ng-select>
           </label>
 
-          <ng-content select="[actions]"></ng-content>
+          <ng-content select="[actions]" />
 
           <ng-container
             *ngIf="
@@ -159,8 +159,7 @@
           [data]="cachedValues"
           [i18nRoot]="domainType"
           role="tree"
-        >
-        </cx-table>
+        />
 
         <!-- List content when not loading -->
         <cx-table
@@ -171,8 +170,7 @@
           [currentItem]="{ property: key, value: currentKey$ | async }"
           (launch)="launchItem($event)"
           role="tree"
-        >
-        </cx-table>
+        />
 
         <!-- Empty list when not loading and no data -->
         <ng-container
@@ -186,8 +184,7 @@
               [data]="[]"
               [i18nRoot]="domainType"
               role="tree"
-            >
-            </cx-table>
+            />
             <p class="cx-no-results">
               {{ 'organization.search.noResultsFound' | cxTranslate }}
             </p>
@@ -204,12 +201,12 @@
         <cx-pagination
           [pagination]="data.pagination"
           (viewPageEvent)="browse($any(data.pagination), $event)"
-        ></cx-pagination>
+        />
       </div>
     </cx-view>
 
     <!-- nested split views are rendered inside child routes -->
-    <router-outlet></router-outlet>
+    <router-outlet />
   </ng-container>
 </cx-split-view>
 

--- a/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.component.html
+++ b/feature-libs/organization/administration/components/shared/message/confirmation/confirmation-message.component.html
@@ -3,7 +3,7 @@
     {{ messageTitle | cxTranslate }}
   </p>
   <div class="message">
-    <cx-icon *ngIf="messageIcon" [type]="messageIcon"></cx-icon>
+    <cx-icon *ngIf="messageIcon" [type]="messageIcon" />
     <p>
       {{ message | cxTranslate }}
     </p>

--- a/feature-libs/organization/administration/components/shared/message/message.component.html
+++ b/feature-libs/organization/administration/components/shared/message/message.component.html
@@ -1,1 +1,1 @@
-<ng-container #vcr></ng-container>
+<ng-container #vcr />

--- a/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
+++ b/feature-libs/organization/administration/components/shared/message/notification/notification-message.component.html
@@ -7,7 +7,7 @@
   "
   (esc)="close()"
 >
-  <cx-icon *ngIf="messageIcon" [type]="messageIcon"></cx-icon>
+  <cx-icon *ngIf="messageIcon" [type]="messageIcon" />
   <p>{{ message | cxTranslate }}</p>
   <button
     class="close"
@@ -16,6 +16,6 @@
     attr.aria-label="{{ 'common.close' | cxTranslate }}"
     attr.title="{{ 'common.close' | cxTranslate }}"
   >
-    <cx-icon [type]="closeIcon"></cx-icon>
+    <cx-icon [type]="closeIcon" />
   </button>
 </div>

--- a/feature-libs/organization/administration/components/shared/sub-list/sub-list.component.html
+++ b/feature-libs/organization/administration/components/shared/sub-list/sub-list.component.html
@@ -4,9 +4,9 @@
   [showHint]="showHint"
   [cxFocus]="{ autofocus: true }"
 >
-  <ng-content select="[actions]" ngProjectAs="[actions]"></ng-content>
-  <ng-content select="[main]" ngProjectAs="[main]"></ng-content>
-  <ng-content select="[info]" ngProjectAs="[info]"></ng-content>
+  <ng-content select="[actions]" ngProjectAs="[actions]" />
+  <ng-content select="[main]" ngProjectAs="[main]" />
+  <ng-content select="[info]" ngProjectAs="[info]" />
 
   <ng-container main *ngIf="dataStructure$ | async as structure">
     <ng-container *ngIf="listData$ | async as data">
@@ -17,8 +17,7 @@
           [data]="data.values"
           [i18nRoot]="domainType"
           [currentItem]="{ property: key, value: subKey$ | async }"
-        >
-        </cx-table>
+        />
       </section>
 
       <div
@@ -32,7 +31,7 @@
         <cx-pagination
           [pagination]="data.pagination"
           (viewPageEvent)="browse(data.pagination, $event)"
-        ></cx-pagination>
+        />
       </div>
     </ng-container>
   </ng-container>

--- a/feature-libs/organization/administration/components/shared/table/cell.component.html
+++ b/feature-libs/organization/administration/components/shared/table/cell.component.html
@@ -3,7 +3,7 @@
   [routerLink]="{ cxRoute: route, params: routeModel } | cxUrl"
   [tabIndex]="tabIndex"
 >
-  <ng-container *ngTemplateOutlet="text"></ng-container>
+  <ng-container *ngTemplateOutlet="text" />
 </a>
 
 <ng-template #text>

--- a/feature-libs/organization/administration/components/shared/table/date-range/date-range-cell.component.html
+++ b/feature-libs/organization/administration/components/shared/table/date-range/date-range-cell.component.html
@@ -3,7 +3,7 @@
   [routerLink]="{ cxRoute: route, params: routeModel } | cxUrl"
   [tabindex]="tabIndex"
 >
-  <ng-container *ngTemplateOutlet="text"></ng-container>
+  <ng-container *ngTemplateOutlet="text" />
 </a>
 
 <ng-template #text>

--- a/feature-libs/organization/administration/components/shared/table/limit/limit-cell.component.html
+++ b/feature-libs/organization/administration/components/shared/table/limit/limit-cell.component.html
@@ -3,7 +3,7 @@
   [routerLink]="{ cxRoute: route, params: routeModel } | cxUrl"
   [tabindex]="tabIndex"
 >
-  <ng-container *ngTemplateOutlet="threshold"></ng-container>
+  <ng-container *ngTemplateOutlet="threshold" />
 </a>
 
 <ng-template #threshold>

--- a/feature-libs/organization/administration/components/shared/table/roles/roles-cell.component.html
+++ b/feature-libs/organization/administration/components/shared/table/roles/roles-cell.component.html
@@ -3,7 +3,7 @@
   [routerLink]="{ cxRoute: route, params: routeModel } | cxUrl"
   [tabindex]="tabIndex"
 >
-  <ng-container *ngTemplateOutlet="text"></ng-container>
+  <ng-container *ngTemplateOutlet="text" />
 </a>
 
 <ng-template #text>

--- a/feature-libs/organization/administration/components/shared/table/status/status-cell.component.html
+++ b/feature-libs/organization/administration/components/shared/table/status/status-cell.component.html
@@ -3,7 +3,7 @@
   [routerLink]="{ cxRoute: route, params: routeModel } | cxUrl"
   [tabindex]="tabIndex"
 >
-  <ng-container *ngTemplateOutlet="text"></ng-container>
+  <ng-container *ngTemplateOutlet="text" />
 </a>
 
 <ng-template #text>

--- a/feature-libs/organization/administration/components/unit/details/unit-details.component.html
+++ b/feature-libs/organization/administration/components/unit/details/unit-details.component.html
@@ -23,14 +23,13 @@
     key="uid"
     *ngIf="isUpdatingUnitAllowed"
     i18nRoot="orgUnit"
-  ></cx-org-toggle-status>
+  />
 
   <cx-org-disable-info
     info
     i18nRoot="orgUnit"
     [displayInfoConfig]="{ disabledDisable: true }"
-  >
-  </cx-org-disable-info>
+  />
 
   <section main class="details" cxOrgItemExists>
     <div class="property">

--- a/feature-libs/organization/administration/components/unit/form/unit-form.component.html
+++ b/feature-libs/organization/administration/components/unit/form/unit-form.component.html
@@ -25,7 +25,7 @@
           label: 'orgUnit.name' | cxTranslate,
         }"
         [control]="form.get('name')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -51,7 +51,7 @@
           label: 'orgUnit.uid' | cxTranslate,
         }"
         [control]="form.get('uid')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label formGroupName="approvalProcess" class="full-width">
@@ -75,8 +75,7 @@
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
         [cxNgSelectA11y]="{}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         id="codeError"
@@ -84,7 +83,7 @@
           label: 'orgUnit.approvalProcess' | cxTranslate,
         }"
         [control]="form.get('approvalProcess.code')"
-      ></cx-form-errors>
+      />
     </label>
     <ng-container *ngIf="form.get('parentOrgUnit'); else parentOrgUnitNotes">
       <label formGroupName="parentOrgUnit">
@@ -110,8 +109,7 @@
             form.get('uid')?.touched && form.get('uid')?.invalid
           "
           [attr.aria-errormessage]="'codeError'"
-        >
-        </ng-select>
+        />
 
         <cx-form-errors
           id="parentUnitUidError"
@@ -119,7 +117,7 @@
             label: 'orgUnit.form.parentOrgUnit' | cxTranslate,
           }"
           [control]="form.get('parentOrgUnit.uid')"
-        ></cx-form-errors>
+        />
       </label>
     </ng-container>
     <ng-template #parentOrgUnitNotes>

--- a/feature-libs/organization/administration/components/unit/links/addresses/details/unit-address-details.component.html
+++ b/feature-libs/organization/administration/components/unit/links/addresses/details/unit-address-details.component.html
@@ -14,7 +14,7 @@
       key="id"
       [additionalParam]="unit.uid"
       i18nRoot="orgUnitAddress"
-    ></cx-org-delete-item>
+    />
 
     <section main class="details">
       <div class="property">

--- a/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.component.html
+++ b/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.component.html
@@ -26,13 +26,12 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{ label: 'orgUnitAddress.country' | cxTranslate }"
         [control]="form.get('country.isocode')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -51,8 +50,7 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
     </label>
 
     <label>
@@ -78,7 +76,7 @@
           label: 'orgUnitAddress.firstName' | cxTranslate,
         }"
         [control]="form.get('firstName')"
-      ></cx-form-errors>
+      />
     </label>
     <label>
       <span class="label-content required"
@@ -101,7 +99,7 @@
         id="lastNameError"
         [translationParams]="{ label: 'orgUnitAddress.lastName' | cxTranslate }"
         [control]="form.get('lastName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label class="full-width">
@@ -125,7 +123,7 @@
         id="line1Error"
         [translationParams]="{ label: 'orgUnitAddress.address1' | cxTranslate }"
         [control]="form.get('line1')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label class="full-width">
@@ -213,7 +211,7 @@
         id="townError"
         [translationParams]="{ label: 'orgUnitAddress.city' | cxTranslate }"
         [control]="form.get('town')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -237,7 +235,7 @@
         id="postalCodeError"
         [translationParams]="{ label: 'orgUnitAddress.zipCode' | cxTranslate }"
         [control]="form.get('postalCode')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label></label>
@@ -266,13 +264,12 @@
           ariaLabelDropdown="{{
             'common.ngSelectDropdownOptionsList' | cxTranslate
           }}"
-        >
-        </ng-select>
+        />
 
         <cx-form-errors
           [translationParams]="{ label: 'orgUnitAddress.state' | cxTranslate }"
           [control]="form.get('region.isocode')"
-        ></cx-form-errors>
+        />
       </label>
     </ng-container>
   </ng-container>

--- a/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.component.html
+++ b/feature-libs/organization/administration/components/unit/links/addresses/form/unit-address-form.component.html
@@ -147,7 +147,7 @@
             label: 'orgUnitAddress.address2' | cxTranslate,
           }"
           [control]="form.get('line2')"
-        ></cx-form-errors>
+        />
       </ng-container>
       <input
         *cxFeature="'!enableFormFieldMaxLength'"
@@ -179,7 +179,7 @@
             label: 'orgUnitAddress.phoneNumber' | cxTranslate,
           }"
           [control]="form.get('phone')"
-        ></cx-form-errors>
+        />
       </ng-container>
       <input
         *cxFeature="'!enableFormFieldMaxLength'"

--- a/feature-libs/organization/administration/components/unit/links/addresses/list/link-cell.component.ts
+++ b/feature-libs/organization/administration/components/unit/links/addresses/list/link-cell.component.ts
@@ -25,7 +25,7 @@ import { CellComponent } from '../../../../shared/table/cell.component';
         [routerLink]="{ cxRoute: route, params: getRouterModel(uid) } | cxUrl"
         [tabIndex]="tabIndex"
       >
-        <ng-container *ngTemplateOutlet="text"></ng-container>
+        <ng-container *ngTemplateOutlet="text" />
       </a>
     </ng-container>
 

--- a/feature-libs/organization/administration/components/unit/links/children/create/unit-child-create.component.html
+++ b/feature-libs/organization/administration/components/unit/links/children/create/unit-child-create.component.html
@@ -1,4 +1,1 @@
-<cx-org-unit-form
-  [createChildUnit]="true"
-  i18nRoot="orgUnit.children"
-></cx-org-unit-form>
+<cx-org-unit-form [createChildUnit]="true" i18nRoot="orgUnit.children" />

--- a/feature-libs/organization/administration/components/unit/links/children/unit-children.component.html
+++ b/feature-libs/organization/administration/components/unit/links/children/unit-children.component.html
@@ -15,6 +15,5 @@
       disabledEnable: false,
       disabledEdit: false,
     }"
-  >
-  </cx-org-disable-info>
+  />
 </cx-org-sub-list>

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/create/unit-cost-center-create.component.html
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/create/unit-cost-center-create.component.html
@@ -1,1 +1,1 @@
-<cx-org-cost-center-form [unitKey]="unitKey$ | async"></cx-org-cost-center-form>
+<cx-org-cost-center-form [unitKey]="unitKey$ | async" />

--- a/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.component.html
+++ b/feature-libs/organization/administration/components/unit/links/cost-centers/unit-cost-centers.component.html
@@ -15,6 +15,5 @@
       disabledEnable: false,
       disabledEdit: false,
     }"
-  >
-  </cx-org-disable-info>
+  />
 </cx-org-sub-list>

--- a/feature-libs/organization/administration/components/unit/links/users/create/unit-user-create.component.html
+++ b/feature-libs/organization/administration/components/unit/links/users/create/unit-user-create.component.html
@@ -1,4 +1,1 @@
-<cx-org-user-form
-  [unitKey]="unitKey$ | async"
-  i18nRoot="orgUnit.users"
-></cx-org-user-form>
+<cx-org-user-form [unitKey]="unitKey$ | async" i18nRoot="orgUnit.users" />

--- a/feature-libs/organization/administration/components/unit/links/users/list/unit-user-list.component.html
+++ b/feature-libs/organization/administration/components/unit/links/users/list/unit-user-list.component.html
@@ -16,6 +16,5 @@
       disabledEnable: false,
       disabledEdit: false,
     }"
-  >
-  </cx-org-disable-info>
+  />
 </cx-org-sub-list>

--- a/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.html
+++ b/feature-libs/organization/administration/components/unit/list/toggle-link/toggle-link-cell.component.html
@@ -36,7 +36,7 @@
     (click)="toggleItem($event)"
     tabindex="-1"
   >
-    <cx-icon [type]="expanded ? 'CARET_DOWN' : 'CARET_RIGHT'"></cx-icon>
+    <cx-icon [type]="expanded ? 'CARET_DOWN' : 'CARET_RIGHT'" />
   </button>
   <span class="text" title="{{ combinedName }}">{{ combinedName }}</span>
 </a>

--- a/feature-libs/organization/administration/components/unit/list/unit-list.component.spec.ts
+++ b/feature-libs/organization/administration/components/unit/list/unit-list.component.spec.ts
@@ -20,7 +20,7 @@ import { UrlTestingModule } from 'core-libs/core/src/routing/configurable-routes
 import { UnitTreeService } from '../services/unit-tree.service';
 
 @Component({
-  template: '<ng-content select="[actions]"></ng-content>',
+  template: '<ng-content select="[actions]"/>',
   selector: 'cx-org-list',
   imports: [I18nTestingModule, UrlTestingModule],
 })

--- a/feature-libs/organization/administration/components/user-group/details/user-group-details.component.html
+++ b/feature-libs/organization/administration/components/user-group/details/user-group-details.component.html
@@ -12,11 +12,7 @@
     {{ 'organization.edit' | cxTranslate }}
   </a>
 
-  <cx-org-delete-item
-    actions
-    key="uid"
-    i18nRoot="orgUserGroup"
-  ></cx-org-delete-item>
+  <cx-org-delete-item actions key="uid" i18nRoot="orgUserGroup" />
 
   <section main class="details" cxOrgItemExists>
     <div class="property">

--- a/feature-libs/organization/administration/components/user-group/form/user-group-form.component.html
+++ b/feature-libs/organization/administration/components/user-group/form/user-group-form.component.html
@@ -23,7 +23,7 @@
         id="nameError"
         [translationParams]="{ label: 'orgUserGroup.name' | cxTranslate }"
         [control]="form.get('name')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -47,7 +47,7 @@
         id="uidError"
         [translationParams]="{ label: 'orgUserGroup.uid' | cxTranslate }"
         [control]="form.get('uid')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label [formGroup]="$any(form.get('orgUnit'))">
@@ -69,13 +69,12 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{ label: 'orgUserGroup.orgUnit' | cxTranslate }"
         [control]="form.get('orgUnit.uid')"
-      ></cx-form-errors>
+      />
     </label>
   </ng-container>
 </cx-org-form>

--- a/feature-libs/organization/administration/components/user/change-password-form/user-change-password-form.component.html
+++ b/feature-libs/organization/administration/components/user/change-password-form/user-change-password-form.component.html
@@ -45,7 +45,7 @@
             label: 'orgUser.password.newPassword' | cxTranslate,
           }"
           [control]="form.get('password')"
-        ></cx-form-errors>
+        />
       </label>
       <label>
         <span class="label-content"
@@ -74,7 +74,7 @@
             label: 'orgUser.password.confirmPassword' | cxTranslate,
           }"
           [control]="form.get('confirmPassword')"
-        ></cx-form-errors>
+        />
       </label>
     </section>
   </cx-org-card>

--- a/feature-libs/organization/administration/components/user/details/user-details.component.html
+++ b/feature-libs/organization/administration/components/user/details/user-details.component.html
@@ -18,9 +18,9 @@
     *ngIf="isUpdatingUserAllowed"
     key="customerId"
     i18nRoot="orgUser"
-  ></cx-org-toggle-status>
+  />
 
-  <cx-org-disable-info info i18nRoot="orgUser"> </cx-org-disable-info>
+  <cx-org-disable-info info i18nRoot="orgUser" />
 
   <section main class="details" cxOrgItemExists>
     <div class="property">

--- a/feature-libs/organization/administration/components/user/form/user-form.component.html
+++ b/feature-libs/organization/administration/components/user/form/user-form.component.html
@@ -17,13 +17,12 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{ label: 'orgUser.title' | cxTranslate }"
         [control]="form.get('titleCode')"
-      ></cx-form-errors>
+      />
     </label>
     <label>
       <span class="label-content required">
@@ -46,7 +45,7 @@
         id="firstNameError"
         [translationParams]="{ label: 'orgUser.firstName' | cxTranslate }"
         [control]="form.get('firstName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -70,7 +69,7 @@
         id="lastNameError"
         [translationParams]="{ label: 'orgUser.lastName' | cxTranslate }"
         [control]="form.get('lastName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -94,7 +93,7 @@
         id="emailError"
         [translationParams]="{ label: 'orgUser.email' | cxTranslate }"
         [control]="form.get('email')"
-      ></cx-form-errors>
+      />
     </label>
 
     <fieldset required="true" class="full-width" formArrayName="roles">
@@ -163,13 +162,12 @@
         ariaLabelDropdown="{{
           'common.ngSelectDropdownOptionsList' | cxTranslate
         }}"
-      >
-      </ng-select>
+      />
 
       <cx-form-errors
         [translationParams]="{ label: 'orgUser.orgUnit' | cxTranslate }"
         [control]="form.get('orgUnit.uid')"
-      ></cx-form-errors>
+      />
     </label>
 
     <div *ngIf="isAssignedToApprovers" class="full-width">

--- a/feature-libs/organization/order-approval/components/details/order-approval-detail-form/order-approval-detail-form.component.html
+++ b/feature-libs/organization/order-approval/components/details/order-approval-detail-form/order-approval-detail-form.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="orderApproval$ | async as orderApproval">
   <div *ngIf="loading$ | async; else approvalFormTemplate">
     <div class="cx-spinner">
-      <cx-spinner></cx-spinner>
+      <cx-spinner />
     </div>
   </div>
 
@@ -52,7 +52,7 @@
                   '.label' | cxTranslate,
             }"
             [control]="approvalForm.get('comment')"
-          ></cx-form-errors>
+          />
         </label>
         <div class="form-group row">
           <div class="col-lg-6 col-md-12">

--- a/feature-libs/organization/order-approval/components/list/order-approval-list.component.html
+++ b/feature-libs/organization/order-approval/components/list/order-approval-list.component.html
@@ -21,7 +21,7 @@
             [selectedOption]="orderApprovals.pagination.sort"
             [ariaLabel]="'orderHistory.sortOrders' | cxTranslate"
             ariaControls="order-approval-table"
-          ></cx-sorting>
+          />
         </label>
       </div>
       <div class="cx-order-approval-pagination">
@@ -29,7 +29,7 @@
           [pagination]="orderApprovals.pagination"
           (viewPageEvent)="pageChange($event)"
           paginationID="pagination-top"
-        ></cx-pagination>
+        />
       </div>
     </div>
     <!-- TABLE -->
@@ -183,7 +183,7 @@
             [selectedOption]="orderApprovals.pagination.sort"
             [ariaLabel]="'orderHistory.sortOrders' | cxTranslate"
             ariaControls="order-approval-table"
-          ></cx-sorting>
+          />
         </label>
       </div>
       <div class="cx-order-approval-pagination">
@@ -191,7 +191,7 @@
           [pagination]="orderApprovals.pagination"
           (viewPageEvent)="pageChange($event)"
           paginationID="pagination-bottom"
-        ></cx-pagination>
+        />
       </div>
     </div>
   </ng-container>

--- a/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/unit-level-order-overview.component.html
+++ b/feature-libs/organization/unit-order/components/unit-level-order-detail/unit-level-order-overview/unit-level-order-overview.component.html
@@ -1,42 +1,40 @@
 <div class="cx-order-summary" *ngIf="order$ | async as order">
   <div class="container">
     <div class="cx-summary-card">
-      <cx-card
-        [content]="getOrderCodeCardContent(order.code) | async"
-      ></cx-card>
+      <cx-card [content]="getOrderCodeCardContent(order.code) | async" />
 
       <cx-card
         [content]="
           getOrderCurrentDateCardContent(order.created | cxDate) | async
         "
-      ></cx-card>
+      />
 
       <cx-card
         [content]="getOrderStatusCardContent(order.statusDisplay) | async"
-      ></cx-card>
+      />
 
       <cx-card
         class="cx-display-inline"
         [content]="getBuyerNameCardContent(order.orgCustomer) | async"
-      ></cx-card>
+      />
     </div>
     <div class="cx-summary-card">
       <cx-card
         [content]="getUnitNameCardContent(order.orgUnit?.name) | async"
-      ></cx-card>
+      />
 
       <cx-card
         [content]="getPurchaseOrderNumber(order.purchaseOrderNumber) | async"
-      ></cx-card>
+      />
 
       <cx-card
         [content]="getMethodOfPaymentCardContent(order.paymentInfo) | async"
-      ></cx-card>
+      />
 
       <ng-container *ngIf="order.costCenter">
         <cx-card
           [content]="getCostCenterCardContent(order.costCenter) | async"
-        ></cx-card>
+        />
       </ng-container>
     </div>
 
@@ -44,13 +42,13 @@
       <ng-container *ngIf="order.deliveryAddress">
         <cx-card
           [content]="getAddressCardContent(order.deliveryAddress) | async"
-        ></cx-card>
+        />
       </ng-container>
 
       <ng-container *ngIf="order.deliveryMode">
         <cx-card
           [content]="getDeliveryModeCardContent(order.deliveryMode) | async"
-        ></cx-card>
+        />
       </ng-container>
     </div>
 
@@ -58,14 +56,14 @@
       <div class="cx-summary-card">
         <cx-card
           [content]="getPaymentInfoCardContent(order.paymentInfo) | async"
-        ></cx-card>
+        />
 
         <cx-card
           [content]="
             getBillingAddressCardContent(order.paymentInfo?.billingAddress)
               | async
           "
-        ></cx-card>
+        />
       </div>
     </ng-container>
   </div>

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/filter/unit-level-order-history-filter.component.html
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/filter/unit-level-order-history-filter.component.html
@@ -12,7 +12,7 @@
       [attr.aria-label]="'common.close' | cxTranslate"
       (click)="closeFilterNav()"
     >
-      <cx-icon aria-hidden="true" [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon aria-hidden="true" [type]="iconTypes.CLOSE" />
     </button>
   </div>
 
@@ -28,7 +28,7 @@
       "
       [attr.title]="'unitLevelOrderHistory.filterByBuyerLabel' | cxTranslate"
     >
-      <cx-icon aria-hidden="true" [type]="iconTypes.CARET_RIGHT"></cx-icon>
+      <cx-icon aria-hidden="true" [type]="iconTypes.CARET_RIGHT" />
     </button>
   </div>
 
@@ -44,7 +44,7 @@
       "
       [attr.title]="'unitLevelOrderHistory.filterByUnitLabel' | cxTranslate"
     >
-      <cx-icon aria-hidden="true" [type]="iconTypes.CARET_RIGHT"></cx-icon>
+      <cx-icon aria-hidden="true" [type]="iconTypes.CARET_RIGHT" />
     </button>
   </div>
 </div>
@@ -60,7 +60,7 @@
       <div class="cx-filter-list">
         <div class="cx-filter-back-button" (click)="backFilterSubNav()">
           <button type="button" [attr.title]="'common.back' | cxTranslate">
-            <cx-icon aria-hidden="true" [type]="iconTypes.CARET_LEFT"></cx-icon>
+            <cx-icon aria-hidden="true" [type]="iconTypes.CARET_LEFT" />
           </button>
           <span>{{ 'unitLevelOrderHistory.filterByBuyer' | cxTranslate }}</span>
         </div>
@@ -71,7 +71,7 @@
           [attr.aria-label]="'common.close' | cxTranslate"
           (click)="closeFilterNav()"
         >
-          <cx-icon aria-hidden="true" [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon aria-hidden="true" [type]="iconTypes.CLOSE" />
         </button>
       </div>
 
@@ -98,7 +98,7 @@
           (keydown.enter)="clearBuyerMobile()"
           class="reset cx-unit-level-order-history-filter-reset-button"
         >
-          <cx-icon [type]="iconTypes.RESET"></cx-icon>
+          <cx-icon [type]="iconTypes.RESET" />
         </button>
 
         <div role="presentation" class="search-icon">
@@ -108,7 +108,7 @@
               'unitLevelOrderHistory.searchByNameBuyer' | cxTranslate
             "
             [type]="iconTypes.SEARCH"
-          ></cx-icon>
+          />
         </div>
       </label>
 
@@ -134,7 +134,7 @@
       <div class="cx-filter-list">
         <div class="cx-filter-back-button" (click)="backFilterSubNav()">
           <button type="button" [attr.title]="'common.back' | cxTranslate">
-            <cx-icon aria-hidden="true" [type]="iconTypes.CARET_LEFT"></cx-icon>
+            <cx-icon aria-hidden="true" [type]="iconTypes.CARET_LEFT" />
           </button>
           <span>{{ 'unitLevelOrderHistory.filterByUnit' | cxTranslate }}</span>
         </div>
@@ -145,7 +145,7 @@
           [attr.aria-label]="'common.close' | cxTranslate"
           (click)="closeFilterNav()"
         >
-          <cx-icon aria-hidden="true" [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon aria-hidden="true" [type]="iconTypes.CLOSE" />
         </button>
       </div>
 
@@ -171,7 +171,7 @@
           (keydown.enter)="clearUnitMobile()"
           class="reset cx-unit-level-order-history-filter-reset-button"
         >
-          <cx-icon [type]="iconTypes.RESET"></cx-icon>
+          <cx-icon [type]="iconTypes.RESET" />
         </button>
 
         <div role="presentation" class="search-icon">
@@ -181,7 +181,7 @@
               'unitLevelOrderHistory.searchByNameUnit' | cxTranslate
             "
             [type]="iconTypes.SEARCH"
-          ></cx-icon>
+          />
         </div>
       </label>
 
@@ -236,7 +236,7 @@
               (keydown.enter)="clearBuyer()"
               class="reset cx-unit-level-order-history-filter-reset-button"
             >
-              <cx-icon [type]="iconTypes.RESET"></cx-icon>
+              <cx-icon [type]="iconTypes.RESET" />
             </button>
 
             <div role="presentation" class="search-icon">
@@ -246,7 +246,7 @@
                   'unitLevelOrderHistory.searchByNameBuyer' | cxTranslate
                 "
                 [type]="iconTypes.SEARCH"
-              ></cx-icon>
+              />
             </div>
           </label>
         </div>
@@ -288,7 +288,7 @@
               (keydown.enter)="clearUnit()"
               class="reset cx-unit-level-order-history-filter-reset-button"
             >
-              <cx-icon [type]="iconTypes.RESET"></cx-icon>
+              <cx-icon [type]="iconTypes.RESET" />
             </button>
 
             <div role="presentation" class="search-icon">
@@ -298,7 +298,7 @@
                 "
                 class="search-icon-filter"
                 [type]="iconTypes.SEARCH"
-              ></cx-icon>
+              />
             </div>
           </label>
         </div>
@@ -332,7 +332,7 @@
     class="btn btn-action btn-block dialog-trigger"
     (click)="launchMobileFilters()"
   >
-    <cx-icon [type]="iconTypes.FILTER"></cx-icon>
+    <cx-icon [type]="iconTypes.FILTER" />
     {{ 'unitLevelOrderHistory.filterBy' | cxTranslate }}
   </button>
 

--- a/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.html
+++ b/feature-libs/organization/unit-order/components/unit-level-order-history/unit-level-order-history.component.html
@@ -9,7 +9,7 @@
 
       <cx-unit-level-order-history-filter
         (filterListEvent)="filterChange($event)"
-      ></cx-unit-level-order-history-filter>
+      />
 
       <!-- BODY -->
       <div class="cx-unit-level-order-history-body">
@@ -30,10 +30,10 @@
                 placeholder="{{ 'unitLevelOrderHistory.sortBy' | cxTranslate }}"
                 [ariaLabel]="'unitLevelOrderHistory.sortOrders' | cxTranslate"
                 ariaControls="order-history-table"
-              ></cx-sorting>
+              />
             </label>
             <div class="cx-unit-level-order-history-total-result">
-              <cx-total [pagination]="orderHistory?.pagination"></cx-total>
+              <cx-total [pagination]="orderHistory?.pagination" />
             </div>
             <div
               *ngIf="orderHistory?.pagination?.totalPages ?? 0 > 1"
@@ -43,7 +43,7 @@
                 [pagination]="orderHistory?.pagination"
                 (viewPageEvent)="pageChange($event)"
                 paginationID="pagination-top"
-              ></cx-pagination>
+              />
             </div>
           </div>
           <!-- TABLE -->
@@ -197,10 +197,10 @@
                 placeholder="{{ 'unitLevelOrderHistory.sortBy' | cxTranslate }}"
                 [ariaLabel]="'unitLevelOrderHistory.sortOrders' | cxTranslate"
                 ariaControls="order-history-table"
-              ></cx-sorting>
+              />
             </label>
             <div class="cx-unit-level-order-history-total-result">
-              <cx-total [pagination]="orderHistory?.pagination"></cx-total>
+              <cx-total [pagination]="orderHistory?.pagination" />
             </div>
             <div
               *ngIf="orderHistory?.pagination?.totalPages ?? 0 > 1"
@@ -210,7 +210,7 @@
                 [pagination]="orderHistory?.pagination"
                 (viewPageEvent)="pageChange($event)"
                 paginationID="pagination-bottom"
-              ></cx-pagination>
+              />
             </div>
           </div>
         </ng-container>

--- a/feature-libs/organization/user-registration/components/form/user-registration-form.component.html
+++ b/feature-libs/organization/user-registration/components/form/user-registration-form.component.html
@@ -23,8 +23,7 @@
           ariaLabel:
             'userRegistrationForm.fields.titleCode.label' | cxTranslate,
         }"
-      >
-      </ng-select>
+      />
     </label>
 
     <label>
@@ -54,7 +53,7 @@
           label: 'userRegistrationForm.fields.firstName.label' | cxTranslate,
         }"
         [control]="registerForm.get('firstName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -84,7 +83,7 @@
           label: 'userRegistrationForm.fields.lastName.label' | cxTranslate,
         }"
         [control]="registerForm.get('lastName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -113,7 +112,7 @@
           label: 'userRegistrationForm.fields.companyName.label' | cxTranslate,
         }"
         [control]="registerForm.get('companyName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -143,7 +142,7 @@
           label: 'userRegistrationForm.fields.email.label' | cxTranslate,
         }"
         [control]="registerForm.get('email')"
-      ></cx-form-errors>
+      />
     </label>
 
     <ng-container
@@ -173,15 +172,14 @@
             ariaLabel:
               'userRegistrationForm.fields.country.label' | cxTranslate,
           }"
-        >
-        </ng-select>
+        />
 
         <cx-form-errors
           [translationParams]="{
             label: 'userRegistrationForm.fields.country.label' | cxTranslate,
           }"
           [control]="registerForm.get('country.isocode')"
-        ></cx-form-errors>
+        />
       </label>
     </ng-container>
 
@@ -209,7 +207,7 @@
           label: 'userRegistrationForm.fields.addressLine.label' | cxTranslate,
         }"
         [control]="registerForm.get('line1')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -230,10 +228,7 @@
         "
         [attr.aria-errormessage]="'line2Error'"
       />
-      <cx-form-errors
-        id="line2Error"
-        [control]="registerForm.get('line2')"
-      ></cx-form-errors>
+      <cx-form-errors id="line2Error" [control]="registerForm.get('line2')" />
     </label>
 
     <label>
@@ -252,10 +247,7 @@
         "
         [attr.aria-errormessage]="'townError'"
       />
-      <cx-form-errors
-        id="townError"
-        [control]="registerForm.get('town')"
-      ></cx-form-errors>
+      <cx-form-errors id="townError" [control]="registerForm.get('town')" />
     </label>
 
     <label>
@@ -282,7 +274,7 @@
           label: 'userRegistrationForm.fields.postalCode.label' | cxTranslate,
         }"
         [control]="registerForm.get('postalCode')"
-      ></cx-form-errors>
+      />
     </label>
 
     <ng-container *ngIf="regions$ | async as regions" formGroupName="region">
@@ -308,15 +300,14 @@
           [cxNgSelectA11y]="{
             ariaLabel: 'userRegistrationForm.fields.state.label' | cxTranslate,
           }"
-        >
-        </ng-select>
+        />
 
         <cx-form-errors
           [translationParams]="{
             label: 'userRegistrationForm.fields.state.label' | cxTranslate,
           }"
           [control]="registerForm.get('region.isocode')"
-        ></cx-form-errors>
+        />
       </label>
     </ng-container>
 
@@ -344,7 +335,7 @@
           label: 'userRegistrationForm.fields.phoneNumber.label' | cxTranslate,
         }"
         [control]="registerForm.get('phoneNumber')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -371,7 +362,7 @@
           label: 'userRegistrationForm.fields.message.label' | cxTranslate,
         }"
         [control]="registerForm.get('message')"
-      ></cx-form-errors>
+      />
     </label>
 
     <button type="submit" class="btn btn-block btn-primary">
@@ -386,5 +377,5 @@
 </section>
 
 <ng-template #loading>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/feature-libs/organization/user-registration/components/registration-otp-form/user-registration-otp-form.component.html
+++ b/feature-libs/organization/user-registration/components/registration-otp-form/user-registration-otp-form.component.html
@@ -24,8 +24,7 @@
             'userRegistrationForm.fields.titleCodeOnOTPForm.label'
             | cxTranslate,
         }"
-      >
-      </ng-select>
+      />
     </label>
 
     <label>
@@ -49,7 +48,7 @@
           label: 'userRegistrationForm.fields.firstName.label' | cxTranslate,
         }"
         [control]="registerForm.get('firstName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -73,7 +72,7 @@
           label: 'userRegistrationForm.fields.lastName.label' | cxTranslate,
         }"
         [control]="registerForm.get('lastName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -96,7 +95,7 @@
           label: 'userRegistrationForm.fields.companyName.label' | cxTranslate,
         }"
         [control]="registerForm.get('companyName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -120,7 +119,7 @@
           label: 'userRegistrationForm.fields.email.label' | cxTranslate,
         }"
         [control]="registerForm.get('email')"
-      ></cx-form-errors>
+      />
     </label>
 
     <ng-container
@@ -152,8 +151,7 @@
               'userRegistrationForm.fields.countryOnOTPForm.label'
               | cxTranslate,
           }"
-        >
-        </ng-select>
+        />
 
         <cx-form-errors
           [translationParams]="{
@@ -162,7 +160,7 @@
               | cxTranslate,
           }"
           [control]="registerForm.get('country.isocode')"
-        ></cx-form-errors>
+        />
       </label>
     </ng-container>
 
@@ -187,7 +185,7 @@
             | cxTranslate,
         }"
         [control]="registerForm.get('line1')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -204,7 +202,7 @@
         }}"
         formControlName="line2"
       />
-      <cx-form-errors [control]="registerForm.get('line2')"></cx-form-errors>
+      <cx-form-errors [control]="registerForm.get('line2')" />
     </label>
 
     <label>
@@ -219,7 +217,7 @@
         }}"
         formControlName="town"
       />
-      <cx-form-errors [control]="registerForm.get('town')"></cx-form-errors>
+      <cx-form-errors [control]="registerForm.get('town')" />
     </label>
 
     <label>
@@ -243,7 +241,7 @@
             | cxTranslate,
         }"
         [control]="registerForm.get('postalCode')"
-      ></cx-form-errors>
+      />
     </label>
 
     <ng-container *ngIf="regions$ | async as regions" formGroupName="region">
@@ -271,8 +269,7 @@
             ariaLabel:
               'userRegistrationForm.fields.stateOnOTPForm.label' | cxTranslate,
           }"
-        >
-        </ng-select>
+        />
 
         <cx-form-errors
           [translationParams]="{
@@ -280,7 +277,7 @@
               'userRegistrationForm.fields.stateOnOTPForm.label' | cxTranslate,
           }"
           [control]="registerForm.get('region.isocode')"
-        ></cx-form-errors>
+        />
       </label>
     </ng-container>
 
@@ -305,7 +302,7 @@
             | cxTranslate,
         }"
         [control]="registerForm.get('phoneNumber')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -328,7 +325,7 @@
             'userRegistrationForm.fields.messageOnOTPForm.label' | cxTranslate,
         }"
         [control]="registerForm.get('message')"
-      ></cx-form-errors>
+      />
     </label>
 
     <button type="submit" class="btn btn-block btn-primary">
@@ -343,5 +340,5 @@
 </section>
 
 <ng-template #loading>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/feature-libs/organization/user-registration/components/verification-token-form/verification-token-form.component.html
+++ b/feature-libs/organization/user-registration/components/verification-token-form/verification-token-form.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"></cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
   <label>
@@ -15,7 +15,7 @@
       "
       aria-describedby="tokenInputHint"
     />
-    <cx-form-errors [control]="form.get('tokenCode')"></cx-form-errors>
+    <cx-form-errors [control]="form.get('tokenCode')" />
     <div class="rate-limit-error-display" *ngIf="upToRateLimit">
       {{
         'register.rateLimitForRegistrationMessage'

--- a/feature-libs/pdf-invoices/components/invoices-list/invoices-list.component.html
+++ b/feature-libs/pdf-invoices/components/invoices-list/invoices-list.component.html
@@ -28,7 +28,7 @@
               placeholder="{{ 'pdfInvoices.sortBy' | cxTranslate }}"
               [ariaLabel]="'pdfInvoices.sortInvoices' | cxTranslate"
               ariaControls="cx-invoices-list-table"
-            ></cx-sorting>
+            />
           </label>
           <div
             class="cx-invoices-list-pagination"
@@ -42,7 +42,7 @@
               [pagination]="pagination"
               (viewPageEvent)="pageChange($event)"
               paginationID="pagination-top"
-            ></cx-pagination>
+            />
           </div>
         </div>
 
@@ -75,7 +75,7 @@
                   title="{{
                     'pdfInvoices.invoicesTable.attachment' | cxTranslate
                   }}"
-                ></cx-icon>
+                />
               </th>
             </tr>
           </thead>
@@ -156,8 +156,7 @@
                       title="{{
                         'pdfInvoices.invoicesTable.download' | cxTranslate
                       }}"
-                    >
-                    </cx-icon>
+                    />
                     <span
                       class="cx-invoices-list-attachment-text"
                       [innerText]="
@@ -186,7 +185,7 @@
               [pagination]="pagination"
               (viewPageEvent)="pageChange($event)"
               paginationID="pagination-bottom"
-            ></cx-pagination>
+            />
           </div>
         </div>
       </div>

--- a/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.html
+++ b/feature-libs/pickup-in-store/components/container/cart-pickup-options-container/cart-pickup-options-container.component.html
@@ -11,5 +11,5 @@
     [selectedOption]="pickupOption$ | async"
     (pickupOptionChange)="onPickupOptionChange($event)"
     (pickupLocationChange)="openDialog($event)"
-  ></cx-pickup-options>
+  />
 </ng-container>

--- a/feature-libs/pickup-in-store/components/container/my-preferred-store/my-preferred-store.component.html
+++ b/feature-libs/pickup-in-store/components/container/my-preferred-store/my-preferred-store.component.html
@@ -30,9 +30,7 @@
       >
         <div label_container_bottom>
           <div class="info-location">
-            <cx-store-address
-              [storeDetails]="preferredStore$ | async"
-            ></cx-store-address>
+            <cx-store-address [storeDetails]="preferredStore$ | async" />
           </div>
           <div *ngIf="!isStoreFinder">
             <button
@@ -47,15 +45,14 @@
                   [type]="
                     openHoursOpen ? ICON_TYPE.CARET_UP : ICON_TYPE.CARET_DOWN
                   "
-                ></cx-icon
-              ></span>
+              /></span>
             </button>
           </div>
           <div class="store-hours" *ngIf="!isStoreFinder">
             <cx-store-schedule
               *ngIf="openHoursOpen"
               [storeDetails]="preferredStore$ | async"
-            ></cx-store-schedule>
+            />
           </div>
         </div>
       </cx-card>

--- a/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.html
+++ b/feature-libs/pickup-in-store/components/container/pdp-pickup-options-container/pdp-pickup-options-container.component.html
@@ -4,5 +4,5 @@
     [displayPickupLocation]="displayPickupLocation$ | async"
     (pickupOptionChange)="onPickupOptionChange($event)"
     (pickupLocationChange)="openDialog($event)"
-  ></cx-pickup-options>
+  />
 </ng-container>

--- a/feature-libs/pickup-in-store/components/container/pickup-info-container/pickup-info-container.component.html
+++ b/feature-libs/pickup-in-store/components/container/pickup-info-container/pickup-info-container.component.html
@@ -1,4 +1,4 @@
 <cx-pickup-info
   *ngFor="let storeDetailsData of storesDetailsData"
   [storeDetails]="storeDetailsData"
-></cx-pickup-info>
+/>

--- a/feature-libs/pickup-in-store/components/container/pickup-items-details/pickup-items-details.component.html
+++ b/feature-libs/pickup-in-store/components/container/pickup-items-details/pickup-items-details.component.html
@@ -21,19 +21,19 @@
             </p>
             <cx-store-address
               [storeDetails]="deliveryPointOfService?.storeDetails"
-            ></cx-store-address>
+            />
           </div>
           <div class="cx-pickup-items-details-store-schedule">
             <cx-store-schedule
               [storeDetails]="deliveryPointOfService?.storeDetails"
-            ></cx-store-schedule>
+            />
           </div>
           <div *ngIf="showEdit" class="cx-pickup-items-details-edit-icon">
             <a
               [attr.title]="'common.edit' | cxTranslate"
               [routerLink]="{ cxRoute: 'cart' } | cxUrl"
-              ><cx-icon [type]="ICON_TYPE.PENCIL"></cx-icon
-            ></a>
+              ><cx-icon [type]="ICON_TYPE.PENCIL"
+            /></a>
           </div>
         </div>
       </div>
@@ -65,7 +65,7 @@
               <cx-media
                 [container]="item.product?.images?.PRIMARY"
                 format="cartIcon"
-              ></cx-media>
+              />
             </a>
           </div>
           <!-- Item Information -->

--- a/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.html
+++ b/feature-libs/pickup-in-store/components/container/pickup-option-dialog/pickup-option-dialog.component.html
@@ -21,7 +21,7 @@
         type="button"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="ICON_TYPE.CLOSE"></cx-icon>
+          <cx-icon [type]="ICON_TYPE.CLOSE" />
         </span>
       </button>
     </div>
@@ -33,14 +33,14 @@
         (findStores)="onFindStores($event)"
         (showSpinner)="showSpinner($event)"
         (eventHideOutOfStock)="onHideOutOfStock()"
-      ></cx-store-search>
+      />
       <cx-store-list
         [productCode]="productCode"
         (storeSelected)="close(LOCATION_SELECTED)"
-      ></cx-store-list>
+      />
       <div *ngIf="loading">
         <div class="cx-spinner">
-          <cx-spinner></cx-spinner>
+          <cx-spinner />
         </div>
       </div>
     </section>

--- a/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.html
+++ b/feature-libs/pickup-in-store/components/container/set-preferred-store/set-preferred-store.component.html
@@ -14,7 +14,7 @@
           : 'icon-not-selected'
       "
     >
-      <cx-icon aria-hidden="true" [type]="ICON_TYPE.HEART"></cx-icon>
+      <cx-icon aria-hidden="true" [type]="ICON_TYPE.HEART" />
     </div>
     <button
       data-text="setPreferredStore.myStore"

--- a/feature-libs/pickup-in-store/components/container/store-list/store-list.component.html
+++ b/feature-libs/pickup-in-store/components/container/store-list/store-list.component.html
@@ -20,11 +20,11 @@
       *ngFor="let store of stores"
       [storeDetails]="store"
       (storeSelected)="onSelectStore($event)"
-    ></cx-store>
+    />
   </div>
 </div>
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/pickup-in-store/components/presentational/pickup-info/pickup-info.component.html
+++ b/feature-libs/pickup-in-store/components/presentational/pickup-info/pickup-info.component.html
@@ -5,9 +5,9 @@
   </div>
   <div class="info-location">
     <div>{{ 'pickupInfo.pickupFrom' | cxTranslate }}</div>
-    <cx-store-address [storeDetails]="storeDetails"></cx-store-address>
+    <cx-store-address [storeDetails]="storeDetails" />
   </div>
   <div class="store-hours">
-    <cx-store-schedule [storeDetails]="storeDetails"></cx-store-schedule>
+    <cx-store-schedule [storeDetails]="storeDetails" />
   </div>
 </div>

--- a/feature-libs/pickup-in-store/components/presentational/store/store.component.html
+++ b/feature-libs/pickup-in-store/components/presentational/store/store.component.html
@@ -1,7 +1,7 @@
 <div class="cx-store">
   <div class="cx-store-address">
     <div class="cx-store-full-address">
-      <cx-store-address [storeDetails]="storeDetails"></cx-store-address>
+      <cx-store-address [storeDetails]="storeDetails" />
 
       <div>
         <div>
@@ -22,18 +22,19 @@
                 [type]="
                   openHoursOpen ? ICON_TYPE.CARET_UP : ICON_TYPE.CARET_DOWN
                 "
-              ></cx-icon
-            ></span>
+            /></span>
           </button>
         </div>
-        <cx-store-schedule *ngIf="openHoursOpen" [storeDetails]="storeDetails">
-        </cx-store-schedule>
+        <cx-store-schedule
+          *ngIf="openHoursOpen"
+          [storeDetails]="storeDetails"
+        />
         <cx-set-preferred-store
           [pointOfServiceName]="{
             name: storeDetails?.name,
             displayName: storeDetails?.displayName,
           }"
-        ></cx-set-preferred-store>
+        />
       </div>
     </div>
   </div>
@@ -45,7 +46,7 @@
         aria-hidden="true"
         *ngIf="isInStock"
         [type]="ICON_TYPE.CHECK"
-      ></cx-icon>
+      />
       <span
         class="cx-stock-level"
         [ngClass]="{

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-bundle-info/configurator-cart-entry-bundle-info.component.html
@@ -56,7 +56,6 @@
         [readOnly]="(readonly$ | async) ?? false"
         [msgBanner]="false"
         [disabled]="quantityControl.disabled"
-      ></cx-configure-cart-entry
-    ></ng-container>
+    /></ng-container>
   </ng-container>
 </ng-container>

--- a/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.html
+++ b/feature-libs/product-configurator/common/components/configurator-cart-entry-info/configurator-cart-entry-info.component.html
@@ -40,7 +40,6 @@
         [readOnly]="(readonly$ | async) ?? false"
         [msgBanner]="false"
         [disabled]="quantityControl.disabled"
-      ></cx-configure-cart-entry
-    ></ng-container>
+    /></ng-container>
   </ng-container>
 </ng-container>

--- a/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.html
+++ b/feature-libs/product-configurator/common/components/configurator-issues-notification/configurator-issues-notification.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="orderEntry$ | async as orderEntry">
   <ng-container *ngIf="hasIssues(orderEntry) && !(readonly$ | async)">
-    <cx-icon [type]="iconTypes.ERROR"></cx-icon>
+    <cx-icon [type]="iconTypes.ERROR" />
     <div id="{{ getErrorMessageId(orderEntry) }}">
       {{
         'configurator.notificationBanner.numberOfIssues'
@@ -16,7 +16,7 @@
           [readOnly]="(readonly$ | async) ?? false"
           [msgBanner]="true"
           [disabled]="quantityControl.disabled"
-        ></cx-configure-cart-entry>
+        />
       </ng-container>
     </div>
   </ng-container>

--- a/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.html
+++ b/feature-libs/product-configurator/common/components/configure-cart-entry/configure-cart-entry.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="abstractOrderKey$ | async as abstractOrderKey">
   <ng-container *ngIf="cartEntry">
     <label *ngIf="isDisabled()" class="disabled-link">
-      <ng-container *ngIf="isDisabled(); then configureText"> </ng-container>
+      <ng-container *ngIf="isDisabled(); then configureText" />
     </label>
 
     <a
@@ -21,7 +21,7 @@
       cxAutoFocus
       attr.aria-describedby="{{ getResolveIssuesA11yDescription() }}"
     >
-      <ng-container *ngIf="!isDisabled(); then configureText"> </ng-container>
+      <ng-container *ngIf="!isDisabled(); then configureText" />
     </a>
   </ng-container>
 

--- a/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/add-to-cart-button/configurator-add-to-cart-button.component.html
@@ -8,7 +8,7 @@
               <label>{{
                 'configurator.addToCart.quantity' | cxTranslate
               }}</label>
-              <cx-item-counter [control]="quantityControl"></cx-item-counter>
+              <cx-item-counter [control]="quantityControl" />
             </div>
             <button
               class="cx-btn btn btn-block btn-primary cx-add-to-cart-btn"
@@ -32,7 +32,7 @@
                 ) | cxTranslate
               }}"
             >
-              <cx-icon [type]="iconType.CART_PLUS"></cx-icon>
+              <cx-icon [type]="iconType.CART_PLUS" />
             </button>
           </div>
         </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/footer/configurator-attribute-footer.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/footer/configurator-attribute-footer.component.html
@@ -11,7 +11,7 @@
   aria-atomic="true"
   role="alert"
 >
-  <cx-icon [type]="iconType.ERROR"></cx-icon>
+  <cx-icon [type]="iconType.ERROR" />
   <ng-container *ngIf="isUserInput(attribute)">
     {{ 'configurator.attribute.defaultRequiredMessage' | cxTranslate }}
   </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/header/configurator-attribute-header.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="!attribute.visible" class="cx-hidden-msg">
-  <cx-icon [type]="iconTypes.WARNING" aria-hidden="true"></cx-icon>
+  <cx-icon [type]="iconTypes.WARNING" aria-hidden="true" />
   {{ 'configurator.attribute.notVisibleAttributeMsg' | cxTranslate }}
 </div>
 <div class="cx-header-label-container">
@@ -22,7 +22,7 @@
   <cx-configurator-show-options
     *ngIf="attribute.domainOnDemand"
     [attributeComponentContext]="attributeComponentContext"
-  ></cx-configurator-show-options>
+  />
 </div>
 
 <cx-configurator-show-more
@@ -31,7 +31,7 @@
   [textSize]="getAttributeDescriptionLength()"
   [productName]="getLabel(expMode, attribute.label, attribute.name)"
   [tabIndex]="0"
-></cx-configurator-show-more>
+/>
 <div
   *ngIf="attribute.hasConflicts"
   class="cx-conflict-msg"
@@ -49,7 +49,7 @@
     *ngIf="isAttributeGroup()"
     [type]="iconTypes.WARNING"
     aria-hidden="true"
-  ></cx-icon>
+  />
   <ng-container *ngIf="isAttributeGroup(); else conflictGroup">
     <ng-container
       *ngIf="
@@ -79,7 +79,7 @@
   id="{{ createAttributeUiKey('attribute-msg', attribute.name) }}"
   [attr.aria-label]="getRequiredMessageKey() | cxTranslate"
 >
-  <cx-icon [type]="iconTypes.ERROR"></cx-icon>
+  <cx-icon [type]="iconTypes.ERROR" />
   {{ getRequiredMessageKey() | cxTranslate }}
 </div>
 <img

--- a/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/product-card/configurator-attribute-product-card.component.html
@@ -18,7 +18,7 @@
           [container]="product.images?.PRIMARY"
           format="product"
           aria-hidden="true"
-        ></cx-media>
+        />
       </div>
 
       <div class="cx-product-card-info">
@@ -37,7 +37,7 @@
           [textSize]="45"
           [productName]="product.code"
           [tabIndex]="0"
-        ></cx-configurator-show-more>
+        />
       </div>
     </div>
 
@@ -51,12 +51,10 @@
             *ngIf="showQuantity"
             (changeQuantity)="onChangeQuantity($event)"
             [quantityOptions]="extractQuantityParameters()"
-          ></cx-configurator-attribute-quantity>
+          />
         </div>
         <div class="cx-product-card-price">
-          <cx-configurator-price
-            [formula]="extractPriceFormulaParameters()"
-          ></cx-configurator-price>
+          <cx-configurator-price [formula]="extractPriceFormulaParameters()" />
         </div>
       </div>
       <div class="cx-product-card-action">
@@ -239,7 +237,7 @@
           )
         }}"
       >
-        <cx-icon class="deselection-error-symbol" type="ERROR"></cx-icon>
+        <cx-icon class="deselection-error-symbol" type="ERROR" />
         {{ 'configurator.attribute.deselectionNotPossible' | cxTranslate }}
       </div>
     </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/quantity/configurator-attribute-quantity.component.html
@@ -4,5 +4,5 @@
     [allowZero]="quantityOptions.allowZero ?? false"
     [control]="quantity"
     [min]="quantityOptions.allowZero ? 0 : 1"
-  ></cx-item-counter>
+  />
 </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox-list/configurator-attribute-checkbox-list.component.html
@@ -13,10 +13,8 @@
         [quantityOptions]="
           extractQuantityParameters(attribute.quantity, !attribute.required)
         "
-      ></cx-configurator-attribute-quantity>
-      <cx-configurator-price
-        [formula]="extractPriceFormulaParameters()"
-      ></cx-configurator-price>
+      />
+      <cx-configurator-price [formula]="extractPriceFormulaParameters()" />
     </div>
     <ng-container *ngFor="let value of attribute.values; let i = index">
       <div class="form-check">
@@ -64,7 +62,7 @@
               getLabel(expMode, value.valueDisplay, value.valueCode)
             "
             [tabIndex]="0"
-          ></cx-configurator-show-more>
+          />
         </div>
         <div class="cx-value-price">
           <cx-configurator-price
@@ -73,7 +71,7 @@
                 enrichValueWithPrice(value, changedPrices)
               )
             "
-          ></cx-configurator-price>
+          />
         </div>
       </div>
       <cx-configurator-attribute-quantity
@@ -82,7 +80,7 @@
         [quantityOptions]="
           extractQuantityParameters(value.quantity, allowZeroValueQuantity)
         "
-      ></cx-configurator-attribute-quantity>
+      />
     </ng-container>
   </div>
 </fieldset>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/checkbox/configurator-attribute-checkbox.component.html
@@ -71,7 +71,7 @@
               )
             "
             [tabIndex]="0"
-          ></cx-configurator-show-more>
+          />
         </div>
         <div class="cx-value-price">
           <cx-configurator-price
@@ -80,7 +80,7 @@
                 enrichValueWithPrice(attributeValue, changedPrices)
               )
             "
-          ></cx-configurator-price>
+          />
         </div>
       </div>
     </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/drop-down/configurator-attribute-drop-down.component.html
@@ -64,7 +64,7 @@
           )
         "
         [tabIndex]="0"
-      ></cx-configurator-show-more>
+      />
     </div>
     <div *ngIf="!withQuantity && getSelectedValue()" class="cx-value-price">
       <cx-configurator-price
@@ -73,18 +73,18 @@
             enrichValueWithPrice(getSelectedValue(), changedPrices)
           )
         "
-      ></cx-configurator-price>
+      />
     </div>
   </div>
   <div *ngIf="withQuantity" class="cx-attribute-level-quantity-price">
     <cx-configurator-attribute-quantity
       (changeQuantity)="onChangeQuantity($event, attributeDropDownForm)"
       [quantityOptions]="extractQuantityParameters(attributeDropDownForm)"
-    ></cx-configurator-attribute-quantity>
+    />
     <cx-configurator-price
       *ngIf="getSelectedValuePrice()"
       [formula]="extractPriceFormulaParameters()"
-    ></cx-configurator-price>
+    />
   </div>
 </ng-container>
 
@@ -92,11 +92,10 @@
   *ngIf="isAdditionalValueNumeric"
   class="cx-configurator-attribute-additional-value"
   [attr.aria-label]="'configurator.a11y.additionalValue' | cxTranslate"
-></cx-configurator-attribute-numeric-input-field>
+/>
 
 <cx-configurator-attribute-input-field
   *ngIf="isAdditionalValueAlphaNumeric"
   class="cx-configurator-attribute-additional-value"
   [attr.aria-label]="'configurator.a11y.additionalValue' | cxTranslate"
->
-</cx-configurator-attribute-input-field>
+/>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-bundle/configurator-attribute-multi-selection-bundle.component.html
@@ -9,11 +9,9 @@
     <cx-configurator-attribute-quantity
       (changeQuantity)="onChangeAttributeQuantity($event)"
       [quantityOptions]="extractQuantityParameters(attribute.quantity)"
-    ></cx-configurator-attribute-quantity>
+    />
 
-    <cx-configurator-price
-      [formula]="extractPriceFormulaParameters()"
-    ></cx-configurator-price>
+    <cx-configurator-price [formula]="extractPriceFormulaParameters()" />
   </div>
 
   <ng-container *ngFor="let value of attribute?.values; let i = index">
@@ -28,8 +26,7 @@
       [productCardOptions]="
         extractProductCardParameters(preventAction$ | async, value, i)
       "
-    >
-    </cx-configurator-attribute-product-card>
+    />
     <cx-configurator-attribute-product-card
       *cxFeature="'!productConfiguratorConsolidatedButtonDisabling'"
       id="{{
@@ -46,7 +43,6 @@
           loading$ | async
         )
       "
-    >
-    </cx-configurator-attribute-product-card>
+    />
   </ng-container>
 </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/multi-selection-image/configurator-attribute-multi-selection-image.component.html
@@ -92,7 +92,7 @@
                       }
               "
             >
-              <cx-icon [type]="iconTypes.INFO"></cx-icon>
+              <cx-icon [type]="iconTypes.INFO" />
             </button>
             <cx-configurator-price
               [formula]="
@@ -100,7 +100,7 @@
                   enrichValueWithPrice(value, changedPrices)
                 )
               "
-            ></cx-configurator-price>
+            />
           </label>
         </div>
       </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/numeric-input-field/configurator-attribute-numeric-input-field.component.html
@@ -34,7 +34,7 @@
   aria-atomic="true"
   role="alert"
 >
-  <cx-icon [type]="iconType.ERROR"></cx-icon>
+  <cx-icon [type]="iconType.ERROR" />
   {{
     'configurator.attribute.wrongNumericFormatMessage'
       | cxTranslate: { pattern: numericFormatPattern }
@@ -48,6 +48,6 @@
   aria-atomic="true"
   role="alert"
 >
-  <cx-icon [type]="iconType.ERROR"></cx-icon>
+  <cx-icon [type]="iconType.ERROR" />
   {{ 'configurator.attribute.wrongIntervalFormat' | cxTranslate }}
 </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/radio-button/configurator-attribute-radio-button.component.html
@@ -5,11 +5,11 @@
       <cx-configurator-attribute-quantity
         (changeQuantity)="onChangeQuantity($event)"
         [quantityOptions]="extractQuantityParameters()"
-      ></cx-configurator-attribute-quantity>
+      />
       <cx-configurator-price
         *ngIf="getSelectedValuePrice()"
         [formula]="extractPriceFormulaParameters()"
-      ></cx-configurator-price>
+      />
     </div>
     <ng-container *ngIf="changedPrices$ | async as changedPrices">
       <div class="form-check" *ngFor="let value of attribute.values">
@@ -68,7 +68,7 @@
               getLabel(expMode, value.valueDisplay, value.valueCode)
             "
             [tabIndex]="0"
-          ></cx-configurator-show-more>
+          />
         </div>
 
         <div class="cx-value-price">
@@ -78,7 +78,7 @@
                 enrichValueWithPrice(value, changedPrices)
               )
             "
-          ></cx-configurator-price>
+          />
         </div>
       </div>
     </ng-container>
@@ -86,12 +86,11 @@
     <cx-configurator-attribute-numeric-input-field
       *ngIf="isAdditionalValueNumeric"
       class="cx-configurator-attribute-additional-value"
-    ></cx-configurator-attribute-numeric-input-field>
+    />
 
     <cx-configurator-attribute-input-field
       *ngIf="isAdditionalValueAlphaNumeric"
       class="cx-configurator-attribute-additional-value"
-    >
-    </cx-configurator-attribute-input-field>
+    />
   </div>
 </fieldset>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/read-only/configurator-attribute-read-only.component.html
@@ -45,7 +45,7 @@
                 getLabel(expMode, value.valueDisplay, value.valueCode)
               "
               [tabIndex]="0"
-            ></cx-configurator-show-more>
+            />
           </div>
           <div class="cx-value-price">
             <cx-configurator-price
@@ -54,7 +54,7 @@
                   enrichValueWithPrice(value, changedPrices)
                 )
               "
-            ></cx-configurator-price>
+            />
           </div>
         </div>
       </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle-dropdown/configurator-attribute-single-selection-bundle-dropdown.component.html
@@ -59,15 +59,12 @@
   }}"
   (handleDeselect)="onSelect(RETRACT_VALUE_CODE)"
   [productCardOptions]="extractProductCardParameters()"
->
-</cx-configurator-attribute-product-card>
+/>
 
 <div *ngIf="withQuantity" class="cx-attribute-level-quantity-price">
   <cx-configurator-attribute-quantity
     (changeQuantity)="onChangeQuantity($event, attributeDropDownForm)"
     [quantityOptions]="extractQuantityParameters(attributeDropDownForm)"
-  ></cx-configurator-attribute-quantity>
-  <cx-configurator-price
-    [formula]="extractPriceFormulaParameters()"
-  ></cx-configurator-price>
+  />
+  <cx-configurator-price [formula]="extractPriceFormulaParameters()" />
 </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-bundle/configurator-attribute-single-selection-bundle.component.html
@@ -6,11 +6,9 @@
     <cx-configurator-attribute-quantity
       (changeQuantity)="onChangeQuantity($event)"
       [quantityOptions]="extractQuantityParameters()"
-    ></cx-configurator-attribute-quantity>
+    />
 
-    <cx-configurator-price
-      [formula]="extractPriceFormulaParameters()"
-    ></cx-configurator-price>
+    <cx-configurator-price [formula]="extractPriceFormulaParameters()" />
   </div>
 
   <cx-configurator-attribute-product-card
@@ -19,6 +17,5 @@
     (handleSelect)="onSelect($event)"
     *ngFor="let value of attribute?.values; let i = index"
     [productCardOptions]="extractProductCardParameters(value, i)"
-  >
-  </cx-configurator-attribute-product-card>
+  />
 </div>

--- a/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.html
+++ b/feature-libs/product-configurator/rulebased/components/attribute/types/single-selection-image/configurator-attribute-single-selection-image.component.html
@@ -113,7 +113,7 @@
                       }
               "
             >
-              <cx-icon [type]="iconTypes.INFO"></cx-icon>
+              <cx-icon [type]="iconTypes.INFO" />
             </button>
             <cx-configurator-price
               [formula]="
@@ -121,7 +121,7 @@
                   enrichValueWithPrice(value, changedPrices)
                 )
               "
-            ></cx-configurator-price>
+            />
           </label>
         </div>
       </div>

--- a/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/configurator-conflict-and-error-messages.component.html
+++ b/feature-libs/product-configurator/rulebased/components/configurator-conflict-and-error-messages/configurator-conflict-and-error-messages.component.html
@@ -6,7 +6,7 @@
       class="alert-message alert-message-invalid-warning"
     >
       <span class="alert-icon">
-        <cx-icon type="WARNING"></cx-icon>
+        <cx-icon type="WARNING" />
       </span>
       <span
         class="cx-warning-text"
@@ -23,11 +23,11 @@
         {{ 'configurator.header.reviewWarnings' | cxTranslate }}
 
         <ng-container *ngIf="!showWarnings">
-          <cx-icon type="CARET_DOWN"></cx-icon>
+          <cx-icon type="CARET_DOWN" />
         </ng-container>
 
         <ng-container *ngIf="showWarnings">
-          <cx-icon type="CARET_UP"></cx-icon>
+          <cx-icon type="CARET_UP" />
         </ng-container>
       </button>
       <div
@@ -54,7 +54,7 @@
       class="alert-message alert-message-error"
     >
       <span class="alert-icon">
-        <cx-icon type="ERROR"></cx-icon>
+        <cx-icon type="ERROR" />
       </span>
       <span
         class="cx-error-text"
@@ -70,11 +70,11 @@
       >
         {{ 'configurator.header.reviewErrors' | cxTranslate }}
         <ng-container *ngIf="!showErrors">
-          <cx-icon type="CARET_DOWN"></cx-icon>
+          <cx-icon type="CARET_DOWN" />
         </ng-container>
 
         <ng-container *ngIf="showErrors">
-          <cx-icon type="CARET_UP"></cx-icon>
+          <cx-icon type="CARET_UP" />
         </ng-container>
       </button>
       <div

--- a/feature-libs/product-configurator/rulebased/components/conflict-description/configurator-conflict-description.component.html
+++ b/feature-libs/product-configurator/rulebased/components/conflict-description/configurator-conflict-description.component.html
@@ -1,4 +1,4 @@
 <ng-container *ngIf="displayConflictDescription(currentGroup)">
-  <cx-icon [type]="iconTypes.WARNING" aria-hidden="true"></cx-icon>
+  <cx-icon [type]="iconTypes.WARNING" aria-hidden="true" />
   {{ currentGroup.name }}
 </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.component.html
+++ b/feature-libs/product-configurator/rulebased/components/conflict-solver-dialog/configurator-conflict-solver-dialog.component.html
@@ -30,7 +30,7 @@
         (click)="dismissModal('Close conflict solver dialog')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -38,7 +38,7 @@
     <!-- Modal Body -->
     <div class="cx-dialog-body modal-body">
       <div class="cx-msg-warning">
-        <cx-icon [type]="iconTypes.ERROR"></cx-icon>
+        <cx-icon [type]="iconTypes.ERROR" />
         {{ 'configurator.header.conflictWarning' | cxTranslate }}
       </div>
       <ng-container *ngIf="routerData$ | async as routerData">
@@ -47,8 +47,7 @@
             [group]="conflictGroup"
             [owner]="routerData.owner"
             [isNavigationToGroupEnabled]="false"
-          >
-          </cx-configurator-group> </ng-container
+          /> </ng-container
       ></ng-container>
     </div>
   </div>

--- a/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.html
+++ b/feature-libs/product-configurator/rulebased/components/form/configurator-form.component.html
@@ -6,8 +6,7 @@
         [owner]="configuration.owner"
         [isNavigationToGroupEnabled]="isNavigationToGroupEnabled(configuration)"
         [isPricingAsync]="configuration.isPricingAsync"
-      >
-      </cx-configurator-group>
+      />
     </ng-container>
   </ng-container>
 </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.component.html
+++ b/feature-libs/product-configurator/rulebased/components/group-menu/configurator-group-menu.component.html
@@ -40,7 +40,7 @@
                   )
                 "
               >
-                <cx-icon [type]="iconTypes.CARET_LEFT"></cx-icon>
+                <cx-icon [type]="iconTypes.CARET_LEFT" />
                 {{ 'configurator.button.back' | cxTranslate }}
               </button>
             </ng-container>
@@ -100,7 +100,7 @@
                       title="{{
                         'configurator.icon.groupConflict' | cxTranslate
                       }}"
-                    ></cx-icon>
+                    />
                   </div>
                   <div class="groupStatusIndicator">
                     <cx-icon
@@ -113,7 +113,7 @@
                       title="{{
                         'configurator.icon.groupIncomplete' | cxTranslate
                       }}"
-                    ></cx-icon>
+                    />
                     <cx-icon
                       class="COMPLETE"
                       [type]="iconTypes.SUCCESS"
@@ -124,7 +124,7 @@
                       title="{{
                         'configurator.icon.groupComplete' | cxTranslate
                       }}"
-                    ></cx-icon>
+                    />
                   </div>
                   <div class="subGroupIndicator">
                     <cx-icon
@@ -135,7 +135,7 @@
                         'configurator.a11y.iconSubGroup' | cxTranslate
                       "
                       title="{{ 'configurator.icon.subgroup' | cxTranslate }}"
-                    ></cx-icon>
+                    />
                   </div>
                 </div>
               </button>

--- a/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.html
+++ b/feature-libs/product-configurator/rulebased/components/group-title/configurator-group-title.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="displayedGroup$ | async as group; else ghostGroup">
   <div role="heading" aria-level="2" class="cx-group-title">
     <ng-container *ngIf="isMobile() | async">
-      <cx-hamburger-menu></cx-hamburger-menu>
+      <cx-hamburger-menu />
     </ng-container>
 
     {{ getGroupTitle(group) }}

--- a/feature-libs/product-configurator/rulebased/components/group/configurator-group.component.html
+++ b/feature-libs/product-configurator/rulebased/components/group/configurator-group.component.html
@@ -1,8 +1,6 @@
 <div id="{{ createGroupId(group.id) }}" role="tabpanel">
   <ng-container *ngIf="displayConflictDescription(group)">
-    <cx-configurator-conflict-description
-      [currentGroup]="group"
-    ></cx-configurator-conflict-description>
+    <cx-configurator-conflict-description [currentGroup]="group" />
   </ng-container>
   <div
     class="cx-group-attribute"
@@ -19,7 +17,7 @@
         [currentGroup]="group"
         [attribute]="attribute"
         [suggestionNumber]="indexOfAttribute"
-      ></cx-configurator-conflict-suggestion>
+      />
     </ng-container>
 
     <ng-container *ngIf="activeLanguage$ | async as activeLanguage">

--- a/feature-libs/product-configurator/rulebased/components/overview-attribute/configurator-overview-attribute.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-attribute/configurator-overview-attribute.component.html
@@ -33,16 +33,12 @@
     {{ attributeOverview.attribute }}
   </div>
   <div class="cx-attribute-price" aria-hidden="true">
-    <cx-configurator-price
-      [formula]="extractPriceFormulaParameters()"
-    ></cx-configurator-price>
+    <cx-configurator-price [formula]="extractPriceFormulaParameters()" />
   </div>
 </ng-container>
 <ng-template #mobile>
   <div class="cx-attribute-price" aria-hidden="true">
-    <cx-configurator-price
-      [formula]="extractPriceFormulaParameters()"
-    ></cx-configurator-price>
+    <cx-configurator-price [formula]="extractPriceFormulaParameters()" />
   </div>
   <div class="cx-attribute-label" aria-hidden="true">
     {{ attributeOverview.attribute }}

--- a/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/configurator-overview-bundle-attribute.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-bundle-attribute/configurator-overview-bundle-attribute.component.html
@@ -5,7 +5,7 @@
         [container]="getProductPrimaryImage(product)"
         format="product"
         aria-hidden="true"
-      ></cx-media>
+      />
     </div>
     <span class="cx-visually-hidden">
       {{ getAriaLabel() }}
@@ -39,8 +39,6 @@
 
   <div class="cx-attribute-price-container" aria-hidden="true">
     <span class="cx-attribute-label">{{ attributeOverview.attribute }}</span>
-    <cx-configurator-price
-      [formula]="extractPriceFormulaParameters()"
-    ></cx-configurator-price>
+    <cx-configurator-price [formula]="extractPriceFormulaParameters()" />
   </div>
 </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-bar/configurator-overview-filter-bar.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-bar/configurator-overview-filter-bar.component.html
@@ -25,7 +25,7 @@
       ) | cxTranslate
     }}
     <span aria-hidden="true">
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </span>
   </button>
 </ng-container>
@@ -47,7 +47,7 @@
   >
     {{ getGroupFilterDescription(config.overview, groupId) }}
     <span aria-hidden="true">
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </span>
   </button>
 </ng-container>
@@ -63,7 +63,7 @@
   >
     {{ 'configurator.overviewFilter.removeAll' | cxTranslate }}
     <span aria-hidden="true">
-      <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+      <cx-icon [type]="iconTypes.CLOSE" />
     </span>
   </button>
 </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-button/configurator-overview-filter-button.component.html
@@ -34,9 +34,7 @@
       }}
     </button>
   </ng-container>
-  <cx-configurator-overview-filter-bar
-    [config]="configurationWithOv"
-  ></cx-configurator-overview-filter-bar>
+  <cx-configurator-overview-filter-bar [config]="configurationWithOv" />
 </ng-container>
 
 <ng-template #ghostFilterButton>

--- a/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter-dialog/configurator-overview-filter-dialog.component.html
@@ -21,7 +21,7 @@
         (click)="closeFilterModal()"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>
@@ -30,7 +30,7 @@
         <cx-configurator-overview-filter
           [config]="config"
           [showFilterBar]="false"
-        ></cx-configurator-overview-filter>
+        />
       </div>
     </ng-container>
   </div>

--- a/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-filter/configurator-overview-filter.component.html
@@ -1,7 +1,5 @@
 <ng-container *ngIf="showFilterBar">
-  <cx-configurator-overview-filter-bar
-    [config]="config"
-  ></cx-configurator-overview-filter-bar>
+  <cx-configurator-overview-filter-bar [config]="config" />
 </ng-container>
 <ng-container *ngIf="!(isDisplayOnlyVariant() | async)">
   <div class="cx-overview-filter-header">

--- a/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-form/configurator-overview-form.component.html
@@ -9,7 +9,7 @@
           idPrefix: '',
         }
       "
-    ></ng-container>
+    />
   </ng-container>
 </ng-container>
 
@@ -56,22 +56,19 @@
           <ng-container *ngSwitchCase="attributeOverviewType.GENERAL">
             <cx-configurator-overview-attribute
               [attributeOverview]="attributeOverview"
-            >
-            </cx-configurator-overview-attribute>
+            />
           </ng-container>
 
           <ng-container *ngSwitchCase="attributeOverviewType.BUNDLE">
             <cx-configurator-cpq-overview-attribute
               [attributeOverview]="attributeOverview"
-            >
-            </cx-configurator-cpq-overview-attribute>
+            />
           </ng-container>
 
           <ng-container *ngSwitchDefault>
             <cx-configurator-overview-attribute
               [attributeOverview]="attributeOverview"
-            >
-            </cx-configurator-overview-attribute>
+            />
           </ng-container>
         </ng-container>
       </div>
@@ -85,7 +82,7 @@
               idPrefix: getPrefixId(idPrefix, group.id),
             }
           "
-        ></ng-container>
+        />
       </ng-container>
     </div>
   </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/overview-menu/configurator-overview-menu.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-menu/configurator-overview-menu.component.html
@@ -8,7 +8,7 @@
         idPrefix: '',
       }
     "
-  ></ng-container>
+  />
 </ng-container>
 
 <ng-template
@@ -30,7 +30,7 @@
           (click)="navigateToGroup(idPrefix, group.id)"
         >
           <span aria-hidden="true"> {{ group.groupDescription }}</span>
-          <cx-icon [type]="iconTypes.ARROW_LEFT" aria-hidden="true"></cx-icon>
+          <cx-icon [type]="iconTypes.ARROW_LEFT" aria-hidden="true" />
         </button>
         <ng-container *ngIf="group.subGroups?.length > 0">
           <ng-container
@@ -42,7 +42,7 @@
                 idPrefix: getPrefixId(idPrefix, group.id),
               }
             "
-          ></ng-container>
+          />
         </ng-container>
       </li>
     </ng-container>

--- a/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-notification-banner/configurator-overview-notification-banner.component.html
@@ -4,7 +4,7 @@
       class="cx-error-notification-banner"
       *ngIf="numberOfIssues$ | async as numberOfIssues"
     >
-      <cx-icon [type]="iconTypes.ERROR"></cx-icon>
+      <cx-icon [type]="iconTypes.ERROR" />
       <div class="cx-error-msg" id="cx-configurator-overview-error-msg">
         {{
           'configurator.notificationBanner.numberOfIssues'
@@ -37,7 +37,7 @@
       class="cx-conflict-notification-banner"
       *ngIf="numberOfConflicts$ | async as numberOfConflicts"
     >
-      <cx-icon [type]="iconTypes.WARNING"></cx-icon>
+      <cx-icon [type]="iconTypes.WARNING" />
       <div class="cx-conflict-msg" id="cx-configurator-overview-conflict-msg">
         {{
           'configurator.notificationBanner.numberOfConflicts'

--- a/feature-libs/product-configurator/rulebased/components/overview-sidebar/configurator-overview-sidebar.component.html
+++ b/feature-libs/product-configurator/rulebased/components/overview-sidebar/configurator-overview-sidebar.component.html
@@ -33,14 +33,12 @@
   <cx-configurator-overview-filter
     *ngIf="showFilter"
     [config]="configurationWithOv"
-  >
-  </cx-configurator-overview-filter>
+  />
 
   <cx-configurator-overview-menu
     *ngIf="!showFilter"
     [config]="configurationWithOv"
-  >
-  </cx-configurator-overview-menu>
+  />
 </ng-container>
 
 <ng-template #ghostSidebar>

--- a/feature-libs/product-configurator/rulebased/components/product-title/configurator-product-title.component.html
+++ b/feature-libs/product-configurator/rulebased/components/product-title/configurator-product-title.component.html
@@ -23,7 +23,7 @@
               | cxTranslate: { product: product.name }
           "
           [type]="iconTypes.CARET_DOWN"
-        ></cx-icon>
+        />
       </ng-container>
 
       <ng-container *ngIf="showMore">
@@ -36,15 +36,12 @@
               | cxTranslate: { product: product.name }
           "
           [type]="iconTypes.CARET_UP"
-        ></cx-icon>
+        />
       </ng-container>
     </button>
     <div class="cx-details" [class.open]="showMore">
       <div class="cx-details-image" aria-hidden="true">
-        <cx-media
-          [container]="product?.images?.PRIMARY"
-          format="product"
-        ></cx-media>
+        <cx-media [container]="product?.images?.PRIMARY" format="product" />
       </div>
       <div
         class="cx-details-content"

--- a/feature-libs/product-configurator/rulebased/components/restart-dialog/configurator-restart-dialog.component.html
+++ b/feature-libs/product-configurator/rulebased/components/restart-dialog/configurator-restart-dialog.component.html
@@ -22,7 +22,7 @@
             (click)="backToPDP(product)"
           >
             <span aria-hidden="true">
-              <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+              <cx-icon [type]="iconTypes.CLOSE" />
             </span>
           </button>
         </div>

--- a/feature-libs/product-configurator/rulebased/components/update-message/configurator-update-message.component.html
+++ b/feature-libs/product-configurator/rulebased/components/update-message/configurator-update-message.component.html
@@ -1,6 +1,6 @@
 <div aria-live="polite" aria-atomic="false">
   <div class="cx-update-msg" [class.visible]="hasPendingChanges$ | async">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
     <strong>{{ 'configurator.header.updateMessage' | cxTranslate }}</strong>
   </div>
 </div>

--- a/feature-libs/product-configurator/rulebased/components/variant-carousel/configurator-variant-carousel.component.html
+++ b/feature-libs/product-configurator/rulebased/components/variant-carousel/configurator-variant-carousel.component.html
@@ -11,11 +11,10 @@
       [title]="title$ | async"
       [template]="carouselItem"
       itemWidth="285px"
-    >
-    </cx-carousel>
+    />
 
     <ng-template #carouselItem let-item="item">
-      <cx-product-carousel-item [item]="item"></cx-product-carousel-item>
+      <cx-product-carousel-item [item]="item" />
     </ng-template>
   </div>
 </ng-container>

--- a/feature-libs/product-configurator/textfield/components/form/configurator-textfield-form.component.html
+++ b/feature-libs/product-configurator/textfield/components/form/configurator-textfield-form.component.html
@@ -10,12 +10,12 @@
       <cx-configurator-textfield-input-field
         [attribute]="attribute"
         (inputChange)="updateConfiguration($event)"
-      ></cx-configurator-textfield-input-field>
+      />
     </div>
 
     <cx-configurator-textfield-add-to-cart-button
       [configuration]="configuration"
-    ></cx-configurator-textfield-add-to-cart-button>
+    />
   </ng-container>
   <ng-template #readonly>
     <span class="cx-visually-hidden">
@@ -25,9 +25,7 @@
       class="cx-attribute"
       *ngFor="let attribute of configuration.configurationInfos"
     >
-      <cx-configurator-textfield-input-field-readonly
-        [attribute]="attribute"
-      ></cx-configurator-textfield-input-field-readonly>
+      <cx-configurator-textfield-input-field-readonly [attribute]="attribute" />
     </div>
   </ng-template>
 </ng-container>

--- a/feature-libs/product-multi-dimensional/list/root/components/product-item-details/product-multi-dimensional-list-item-details.component.html
+++ b/feature-libs/product-multi-dimensional/list/root/components/product-item-details/product-multi-dimensional-list-item-details.component.html
@@ -2,7 +2,7 @@
   <cx-star-rating
     *ngIf="product.averageRating"
     [rating]="product?.averageRating ?? 0"
-  ></cx-star-rating>
+  />
 
   <div *ngIf="!product.averageRating" class="cx-product-no-review">
     {{ 'productDetails.noReviews' | cxTranslate }}

--- a/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.component.html
+++ b/feature-libs/product/future-stock/components/future-stock-accordion/future-stock-accordion.component.html
@@ -10,7 +10,7 @@
     <cx-icon
       [type]="expanded ? iconType.CARET_UP : iconType.CARET_DOWN"
       aria-hidden="true"
-    ></cx-icon>
+    />
   </button>
 
   <ng-container *cxFeature="'!a11yFutureStockAccordionAriaControls'">

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-dialog/product-image-zoom-dialog.component.html
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-dialog/product-image-zoom-dialog.component.html
@@ -15,14 +15,12 @@
         (click)="close('cross click')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconType.CLOSE"></cx-icon>
+          <cx-icon [type]="iconType.CLOSE" />
         </span>
       </button>
     </div>
     <div class="modal-body cx-dialog-body">
-      <cx-product-image-zoom-view
-        [galleryIndex]="galleryIndex"
-      ></cx-product-image-zoom-view>
+      <cx-product-image-zoom-view [galleryIndex]="galleryIndex" />
     </div>
   </div>
 </div>

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.html
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.html
@@ -4,12 +4,12 @@
     (click)="triggerZoom(true)"
     *cxLcpContext="let lcpContext"
     [fetchPriority]="lcpContext.fetchPriority$ | async"
-  ></cx-media>
+  />
   <cx-product-image-zoom-trigger
     [expandImage]="expandImage.value"
     [galleryIndex]="selectedIndex"
     (dialogClose)="triggerZoom(false)"
-  ></cx-product-image-zoom-trigger>
+  />
 </ng-container>
 
 <ng-container *ngIf="thumbs$ | async as thumbs">
@@ -25,7 +25,7 @@
       [items]="thumbs"
       [template]="thumb"
       [trackByFn]="trackByFn"
-    ></cx-carousel-scrolling>
+    />
   </ng-container>
 </ng-container>
 
@@ -37,6 +37,5 @@
     (focus)="openImage(item.container)"
     [class.is-active]="isActive(item.container) | async"
     format="product"
-  >
-  </cx-media>
+  />
 </ng-template>

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.spec.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-product-images/product-image-zoom-product-images.component.spec.ts
@@ -98,7 +98,7 @@ class MockMediaComponent {
     <ng-container *ngFor="let item$ of items">
       <ng-container
         *ngTemplateOutlet="template; context: { item: item$ | async }"
-      ></ng-container>
+      />
     </ng-container>
   `,
   imports: [NgFor, NgTemplateOutlet, AsyncPipe],

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.html
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.html
@@ -6,7 +6,7 @@
     itemWidth="70px"
     [hideIndicators]="false"
     [template]="thumb"
-  ></cx-carousel>
+  />
 </ng-container>
 
 <ng-template #thumb let-item="item">
@@ -16,6 +16,5 @@
     tabindex="0"
     (focus)="openImage(item.container)"
     [class.is-active]="isActive(item.container) | async"
-  >
-  </cx-media>
+  />
 </ng-template>

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.spec.ts
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-thumbnails/product-image-zoom-thumbnails.component.spec.ts
@@ -31,9 +31,7 @@ const secondImage = {
   selector: 'cx-carousel',
   template: `
     <ng-container *ngFor="let item of items">
-      <ng-container
-        *ngTemplateOutlet="template; context: { item: item }"
-      ></ng-container>
+      <ng-container *ngTemplateOutlet="template; context: { item: item }" />
     </ng-container>
   `,
 })

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-trigger/product-image-zoom-trigger.component.html
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-trigger/product-image-zoom-trigger.component.html
@@ -6,7 +6,7 @@
   (click)="triggerZoom()"
 >
   {{ 'productImageZoomTrigger.expand' | cxTranslate }}
-  <cx-icon [type]="iconType.EXPAND_ARROWS"></cx-icon>
+  <cx-icon [type]="iconType.EXPAND_ARROWS" />
 </button>
 
 <button
@@ -17,6 +17,6 @@
 >
   <span>
     {{ 'productImageZoomTrigger.expand' | cxTranslate }}
-    <cx-icon [type]="iconType.EXPAND_ARROWS"></cx-icon
-  ></span>
+    <cx-icon [type]="iconType.EXPAND_ARROWS"
+  /></span>
 </button>

--- a/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.html
+++ b/feature-libs/product/image-zoom/components/product-image-zoom/product-image-zoom-view/product-image-zoom-view.component.html
@@ -8,7 +8,7 @@
         *ngIf="getPreviousProduct(thumbs) | async as previousProduct"
         (click)="openImage(previousProduct.container)"
       >
-        <cx-icon [type]="iconType.CARET_LEFT"></cx-icon>
+        <cx-icon [type]="iconType.CARET_LEFT" />
       </button>
     </div>
     <!-- TODO: (CXSPA-7492) - Remove feature flag next major release. -->
@@ -19,8 +19,7 @@
         (loaded)="onImageLoad()"
         *ngIf="!isZoomed"
         [container]="main"
-      >
-      </cx-media>
+      />
       <div #zoomContainer class="cx-zoom-container" *ngIf="isZoomed">
         <cx-media
           #zoomedImage
@@ -30,8 +29,7 @@
           (touchmove)="touchMove($event)"
           (touchend)="clearTouch()"
           (loaded)="onImageLoad()"
-        >
-        </cx-media>
+        />
       </div>
     </div>
     <ng-container *cxFeature="'!a11yKeyboardAccessibleZoom'">
@@ -39,9 +37,7 @@
         #defaultImage
         class="cx-default-image-zoom"
         *ngIf="!isZoomed"
-        [container]="main"
-      >
-      </cx-media>
+        [container]="main" />
       <div #zoomContainer class="cx-zoom-container" *ngIf="isZoomed">
         <cx-media
           #zoomedImage
@@ -50,8 +46,7 @@
           (mousemove)="pointerMove($event)"
           (touchmove)="touchMove($event)"
           (touchend)="clearTouch()"
-        >
-        </cx-media></div
+        /></div
     ></ng-container>
     <div class="cx-navigate-image">
       <button
@@ -61,7 +56,7 @@
         *ngIf="getNextProduct(thumbs) | async as nextProduct"
         (click)="openImage(nextProduct.container)"
       >
-        <cx-icon [type]="iconType.CARET_RIGHT"></cx-icon>
+        <cx-icon [type]="iconType.CARET_RIGHT" />
       </button>
     </div>
   </div>
@@ -86,12 +81,12 @@
         [type]="iconType.SEARCH_PLUS"
         *ngIf="!isZoomed"
         class="cx-zoom-indicator"
-      ></cx-icon>
+      />
       <cx-icon
         [type]="iconType.SEARCH_MINUS"
         *ngIf="isZoomed"
         class="cx-zoom-indicator"
-      ></cx-icon>
+      />
     </button>
   </div>
 </ng-container>
@@ -100,4 +95,4 @@
   [thumbs$]="thumbnails$"
   [activeThumb]="activeThumb"
   (productImage)="changeImage($event)"
-></cx-product-image-zoom-thumbnails>
+/>

--- a/feature-libs/product/variants/components/product-variants-container/product-variants-container.component.html
+++ b/feature-libs/product/variants/components/product-variants-container/product-variants-container.component.html
@@ -3,16 +3,16 @@
     <cx-product-variant-style-selector
       *ngIf="variants[variantType.STYLE]"
       [variants]="variants[variantType.STYLE]"
-    ></cx-product-variant-style-selector>
+    />
     <cx-product-variant-size-selector
       *ngIf="variants[variantType.SIZE]"
       [product]="product"
       [variants]="variants[variantType.SIZE]"
-    ></cx-product-variant-size-selector>
+    />
     <cx-product-variant-color-selector
       *ngIf="variants[variantType.COLOR]"
       [product]="product"
       [variants]="variants[variantType.COLOR]"
-    ></cx-product-variant-color-selector>
+    />
   </div>
 </ng-container>

--- a/feature-libs/quote/components/comments/quote-comments.component.html
+++ b/feature-libs/quote/components/comments/quote-comments.component.html
@@ -15,8 +15,7 @@
         <cx-icon
           aria-hidden="false"
           [type]="expandComments ? iconTypes.CARET_UP : iconTypes.CARET_DOWN"
-        >
-        </cx-icon>
+        />
         <span class="cx-text">{{ 'quote.comments.title' | cxTranslate }}</span>
       </div>
       <cx-messaging
@@ -25,7 +24,7 @@
         [messagingConfigs]="messagingConfigs"
         (send)="onSend($event, quoteDetails.code)"
         (itemClicked)="onItemClicked($event)"
-      ></cx-messaging>
+      />
     </ng-container>
   </div>
 </ng-container>

--- a/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.component.html
+++ b/feature-libs/quote/components/confirm-dialog/quote-confirm-dialog.component.html
@@ -27,7 +27,7 @@
         (click)="dismissModal('Cross click')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>

--- a/feature-libs/quote/components/header/buyer-edit/quote-header-buyer-edit.component.html
+++ b/feature-libs/quote/components/header/buyer-edit/quote-header-buyer-edit.component.html
@@ -34,8 +34,7 @@
                     charactersLimit: content.charactersLimit,
                   }
                 "
-              >
-              </ng-container>
+              />
             </div>
           </div>
           <div class="cx-card-paragraph">
@@ -62,8 +61,7 @@
                     charactersLimit: content.charactersLimit,
                   }
                 "
-              >
-              </ng-container>
+              />
             </div>
           </div>
           <div class="cx-card-paragraph" *ngIf="enablePurchaseOrderNumber">

--- a/feature-libs/quote/components/header/overview/quote-header-overview.component.html
+++ b/feature-libs/quote/components/header/overview/quote-header-overview.component.html
@@ -27,7 +27,7 @@
             "
             [truncateParagraphText]="true"
             [charactersLimit]="getCharactersLimitForCardTile()"
-          ></cx-card>
+          />
           <button
             [attr.aria-label]="'quote.header.overview.a11y.edit' | cxTranslate"
             [attr.title]="'quote.header.overview.a11y.edit' | cxTranslate"
@@ -35,7 +35,7 @@
             class="link cx-action-link cx-edit-btn"
             (click)="toggleEditMode()"
           >
-            <cx-icon [type]="iconTypes.PENCIL"></cx-icon>
+            <cx-icon [type]="iconTypes.PENCIL" />
           </button>
         </ng-container>
         <cx-quote-header-buyer-edit
@@ -49,7 +49,7 @@
           "
           (saveCard)="save(quoteDetails, $event)"
           (cancelCard)="cancel()"
-        ></cx-quote-header-buyer-edit>
+        />
       </div>
       <div class="cx-summary-card">
         <cx-card
@@ -59,7 +59,7 @@
               quoteDetails.expirationTime | cxDate
             ) | async
           "
-        ></cx-card>
+        />
       </div>
       <div class="cx-summary-card">
         <cx-card
@@ -69,7 +69,7 @@
               quoteDetails.updatedTime | cxDate
             ) | async
           "
-        ></cx-card>
+        />
       </div>
     </div>
   </div>

--- a/feature-libs/quote/components/items/quote-items.component.html
+++ b/feature-libs/quote/components/items/quote-items.component.html
@@ -15,8 +15,7 @@
         <cx-icon
           aria-hidden="false"
           [type]="state.showCart ? iconTypes.CARET_UP : iconTypes.CARET_DOWN"
-        >
-        </cx-icon>
+        />
         <span class="cx-text">{{ 'quote.commons.cart' | cxTranslate }}</span>
       </div>
       <ng-container *ngIf="state.showCart">
@@ -30,8 +29,7 @@
             items: quoteItemsData.entries ?? [],
             readonly: quoteItemsData.readOnly,
           }"
-        >
-        </ng-template>
+        />
       </ng-container>
     </div>
   </ng-container>

--- a/feature-libs/quote/components/list/quote-list.component.html
+++ b/feature-libs/quote/components/list/quote-list.component.html
@@ -24,7 +24,7 @@
               placeholder="{{ 'quote.list.sortBy' | cxTranslate }}"
               [ariaLabel]="'quote.list.sortQuotes' | cxTranslate"
               ariaControls="quote-list"
-            ></cx-sorting>
+            />
           </label>
           <ng-container
             *ngIf="isPaginationEnabled(quotesState.data.pagination)"
@@ -33,7 +33,7 @@
               [pagination]="quotesState.data.pagination"
               (viewPageEvent)="changePage($event)"
               paginationID="pagination-top"
-            ></cx-pagination>
+            />
           </ng-container>
         </div>
         <table id="quote-list" role="table" aria-describedby="quote-list-desc">
@@ -117,8 +117,7 @@
                   [type]="iconTypes.CARET_RIGHT"
                   aria-hidden="true"
                   [attr.aria-label]="'quote.list.clickableRow' | cxTranslate"
-                >
-                </cx-icon>
+                />
               </td>
             </tr>
           </tbody>
@@ -129,7 +128,7 @@
               [pagination]="quotesState.data.pagination"
               (viewPageEvent)="changePage($event)"
               paginationID="pagination-bottom"
-            ></cx-pagination>
+            />
           </div>
         </ng-container>
       </ng-container>

--- a/feature-libs/quote/components/summary/quote-summary.component.html
+++ b/feature-libs/quote/components/summary/quote-summary.component.html
@@ -7,9 +7,9 @@
     tabindex="-1"
     [attr.aria-label]="'quote.summary.regionTitle' | cxTranslate"
   >
-    <cx-quote-summary-prices></cx-quote-summary-prices>
-    <cx-quote-summary-seller-edit></cx-quote-summary-seller-edit>
-    <cx-quote-summary-actions></cx-quote-summary-actions>
+    <cx-quote-summary-prices />
+    <cx-quote-summary-seller-edit />
+    <cx-quote-summary-actions />
   </div>
 </ng-container>
 

--- a/feature-libs/quote/components/summary/seller-edit/quote-summary-seller-edit.component.html
+++ b/feature-libs/quote/components/summary/seller-edit/quote-summary-seller-edit.component.html
@@ -34,7 +34,7 @@
           aria-atomic="true"
           role="alert"
         >
-          <cx-icon [type]="iconType.ERROR"></cx-icon>
+          <cx-icon [type]="iconType.ERROR" />
           {{ 'quote.summary.sellerEdit.discountValidationText' | cxTranslate }}
         </div>
       </label>
@@ -51,7 +51,7 @@
           [control]="$any(form.get('validityDate'))"
           [required]="true"
           (update)="onSetDate(quoteDetails.code)"
-        ></cx-date-picker>
+        />
       </label>
     </form>
   </div>

--- a/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.html
+++ b/feature-libs/requested-delivery-date/root/components/delivery-mode-date-picker/delivery-mode-date-picker.component.html
@@ -5,7 +5,7 @@
         getRequestedDeliveryDateCardContent(requestedRetrievalAt | cxDate)
           | async
       "
-    ></cx-card>
+    />
   </ng-container>
   <ng-template #datePickerEnabled>
     <div class="form-check">
@@ -20,8 +20,7 @@
               [min]="earliestRetrievalAt"
               [required]="true"
               (update)="setRequestedDeliveryDate()"
-            >
-            </cx-date-picker>
+            />
           </div>
         </label>
       </form>

--- a/feature-libs/requested-delivery-date/root/components/order-overview-delivery-date/order-overview-delivery-date.component.html
+++ b/feature-libs/requested-delivery-date/root/components/order-overview-delivery-date/order-overview-delivery-date.component.html
@@ -4,5 +4,5 @@
       getRequestedDeliveryDateCardContent(order?.requestedRetrievalAt | cxDate)
         | async
     "
-  ></cx-card>
+  />
 </ng-container>

--- a/feature-libs/storefinder/components/schedule-component/schedule.component.html
+++ b/feature-libs/storefinder/components/schedule-component/schedule.component.html
@@ -1,4 +1,4 @@
-<ng-content></ng-content>
+<ng-content />
 <div class="container cx-store-hours" *ngIf="location.openingHours">
   <div *ngFor="let day of weekDays" class="row">
     <div class="cx-days col-4">{{ day.weekDay }}</div>

--- a/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.html
+++ b/feature-libs/storefinder/components/store-finder-grid/store-finder-grid.component.html
@@ -21,14 +21,12 @@
         class="col-sm-6 col-md-4 col-lg-3 item"
         *ngFor="let location of locations?.stores"
       >
-        <cx-store-finder-list-item
-          [location]="location"
-        ></cx-store-finder-list-item>
+        <cx-store-finder-list-item [location]="location" />
       </div>
     </div>
   </div>
 </ng-container>
 
 <ng-template #loading>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/feature-libs/storefinder/components/store-finder-header/store-finder-header.component.html
+++ b/feature-libs/storefinder/components/store-finder-header/store-finder-header.component.html
@@ -2,5 +2,5 @@
   <cx-store-finder-search
     role="search"
     [attr.aria-label]="'storeFinder.storeFinder' | cxTranslate"
-  ></cx-store-finder-search>
+  />
 </ng-container>

--- a/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.html
+++ b/feature-libs/storefinder/components/store-finder-list-item/store-finder-list-item.component.html
@@ -44,7 +44,7 @@
         displayName: location.displayName,
         name: location.name,
       }"
-    ></ng-template>
+    />
 
     <a
       href="{{ getDirections(location) }}"

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.html
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-list/store-finder-list.component.html
@@ -4,7 +4,7 @@
       <div class="col-md-12">
         <cx-store-finder-pagination-details
           [pagination]="locations.pagination"
-        ></cx-store-finder-pagination-details>
+        />
       </div>
       <div class="text-left cx-back-wrapper">
         <div class="cx-visually-hidden">
@@ -16,7 +16,7 @@
           *ngIf="isDetailsModeVisible"
           (click)="hideStoreDetails()"
         >
-          <cx-icon [type]="iconTypes.CARET_LEFT"></cx-icon>
+          <cx-icon [type]="iconTypes.CARET_LEFT" />
           {{ 'storeFinder.back' | cxTranslate }}
         </button>
       </div>
@@ -27,7 +27,7 @@
           <cx-store-finder-store-description
             [location]="storeDetails"
             [disableMap]="true"
-          ></cx-store-finder-store-description>
+          />
         </div>
         <ol class="cx-list" *ngIf="!isDetailsModeVisible">
           <li
@@ -50,7 +50,7 @@
                   locations.pagination.pageSize +
                 1
               "
-            ></cx-store-finder-list-item>
+            />
           </li>
         </ol>
       </div>
@@ -59,7 +59,7 @@
           #storeMap
           [locations]="locations.stores"
           (selectedStoreItem)="selectStoreItemList($event)"
-        ></cx-store-finder-map>
+        />
       </div>
     </div>
 
@@ -99,7 +99,7 @@
                   <cx-store-finder-store-description
                     [location]="storeDetails"
                     [disableMap]="true"
-                  ></cx-store-finder-store-description>
+                  />
                 </div>
                 <ol class="cx-list" *ngIf="!isDetailsModeVisible">
                   <li
@@ -124,7 +124,7 @@
                           locations.pagination.pageSize +
                         1
                       "
-                    ></cx-store-finder-list-item>
+                    />
                   </li>
                 </ol>
               </div>
@@ -143,7 +143,7 @@
                     selectedStore ? [selectedStore] : locations.stores
                   "
                   (selectedStoreItem)="selectStoreItemList($event)"
-                ></cx-store-finder-map>
+                />
               </div>
             </div>
           </ng-template>

--- a/feature-libs/storefinder/components/store-finder-search-result/store-finder-search-result.component.html
+++ b/feature-libs/storefinder/components/store-finder-search-result/store-finder-search-result.component.html
@@ -10,14 +10,14 @@
         aria-hidden="true"
         [pagination]="locations.pagination"
         (viewPageEvent)="viewPage($event)"
-      ></cx-pagination>
+      />
     </div>
   </div>
   <cx-store-finder-list
     *ngIf="locations?.stores.length"
     [locations]="locations"
     [useMylocation]="useMyLocation"
-  ></cx-store-finder-list>
+  />
   <div class="container" *ngIf="!locations?.stores.length">
     <div class="row">
       <span class="cx-no-stores" role="alert">
@@ -28,6 +28,6 @@
 </div>
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/storefinder/components/store-finder-search/store-finder-search.component.html
+++ b/feature-libs/storefinder/components/store-finder-search/store-finder-search.component.html
@@ -24,10 +24,10 @@
           [ngClass]="{
             'disabled-action': !(queryInput.value && queryInput.value.length),
           }"
-        ></cx-icon>
+        />
       </div>
     </div>
-    <ng-template [ngTemplateOutlet]="searchActionButtons"></ng-template>
+    <ng-template [ngTemplateOutlet]="searchActionButtons" />
   </div>
 
   <div class="row align-items-end" *cxFeature="'a11yStoreFinderLabel'">
@@ -64,12 +64,12 @@
                   queryInput.value && queryInput.value.length
                 ),
               }"
-            ></cx-icon>
+            />
           </div>
         </label>
       </div>
     </div>
-    <ng-template [ngTemplateOutlet]="searchActionButtons"></ng-template>
+    <ng-template [ngTemplateOutlet]="searchActionButtons" />
   </div>
 </div>
 

--- a/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.html
+++ b/feature-libs/storefinder/components/store-finder-store-description/store-finder-store-description.component.html
@@ -57,7 +57,7 @@
       </div>
     </div>
     <div class="cx-storeMap" *ngIf="!disableMap">
-      <cx-store-finder-map [locations]="[location]"></cx-store-finder-map>
+      <cx-store-finder-map [locations]="[location]" />
     </div>
   </div>
 </ng-container>

--- a/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.html
+++ b/feature-libs/storefinder/components/store-finder-store/store-finder-store.component.html
@@ -11,7 +11,7 @@
     </div>
     <div class="cx-store-actions">
       <button class="btn btn-block btn-secondary" (click)="goBack()">
-        <cx-icon [type]="iconTypes.CARET_LEFT"></cx-icon>
+        <cx-icon [type]="iconTypes.CARET_LEFT" />
         {{ 'storeFinder.backToList' | cxTranslate }}
       </button>
     </div>
@@ -20,12 +20,12 @@
         <cx-store-finder-store-description
           [disableMap]="disableMap"
           [location]="location"
-        ></cx-store-finder-store-description>
+        />
       </div>
     </div>
   </div>
 </div>
 
 <ng-template #loading>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.html
+++ b/feature-libs/storefinder/components/store-finder-stores-count/store-finder-stores-count.component.html
@@ -55,5 +55,5 @@
   </div>
 </ng-container>
 <ng-template #loading>
-  <div class="cx-count-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-count-spinner"><cx-spinner /></div>
 </ng-template>

--- a/feature-libs/storefinder/components/store-finder/store-finder.component.html
+++ b/feature-libs/storefinder/components/store-finder/store-finder.component.html
@@ -1,4 +1,4 @@
 <div class="cx-store-finder-wrapper">
-  <cx-store-finder-header></cx-store-finder-header>
-  <router-outlet></router-outlet>
+  <cx-store-finder-header />
+  <router-outlet />
 </div>

--- a/feature-libs/subscription-billing/components/actions-modal/subscription-actions-modal.component.html
+++ b/feature-libs/subscription-billing/components/actions-modal/subscription-actions-modal.component.html
@@ -38,7 +38,7 @@
         (click)="onDialogClose('Cross click')"
       >
         <span
-          ><small><cx-icon [type]="iconTypes.CLOSE"></cx-icon></small
+          ><small><cx-icon [type]="iconTypes.CLOSE" /></small
         ></span>
       </button>
     </div>
@@ -97,7 +97,7 @@
         <!-- Loading spinner only if mode is cancel -->
         <ng-template #loading>
           <div class="d-flex justify-content-center p-4">
-            <cx-spinner></cx-spinner>
+            <cx-spinner />
           </div>
         </ng-template>
       </div>
@@ -130,7 +130,7 @@
         (click)="onDialogClose('close-dialog')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>

--- a/feature-libs/subscription-billing/components/billing-details/subscription-billing-details.component.html
+++ b/feature-libs/subscription-billing/components/billing-details/subscription-billing-details.component.html
@@ -80,5 +80,5 @@
   </div>
 </ng-container>
 <ng-template #loading>
-  <cx-spinner></cx-spinner>
+  <cx-spinner />
 </ng-template>

--- a/feature-libs/subscription-billing/components/details/subscription-details.component.html
+++ b/feature-libs/subscription-billing/components/details/subscription-details.component.html
@@ -157,5 +157,5 @@
   </div>
 </ng-container>
 <ng-template #loading>
-  <cx-spinner></cx-spinner>
+  <cx-spinner />
 </ng-template>

--- a/feature-libs/subscription-billing/components/list/billing/date-range-modal/date-range-modal.component.html
+++ b/feature-libs/subscription-billing/components/list/billing/date-range-modal/date-range-modal.component.html
@@ -19,7 +19,7 @@
         attr.aria-label="{{ 'subscriptionActions.closeModal' | cxTranslate }}"
         (click)="onDialogClose('Modal dismissed')"
       >
-        <span><cx-icon [type]="iconTypes.CLOSE"></cx-icon></span>
+        <span><cx-icon [type]="iconTypes.CLOSE" /></span>
       </button>
     </div>
     <div class="cx-dialog-body modal-body">
@@ -35,7 +35,7 @@
               (update)="onFilterDateChange()"
               [min]="minDate"
               [max]="maxDate"
-            ></cx-date-picker>
+            />
           </div>
           <div class="to-date-filter date-filters">
             <span class="sort-label label-text">
@@ -47,7 +47,7 @@
               (update)="onFilterDateChange()"
               [min]="minDate"
               [max]="maxDate"
-            ></cx-date-picker>
+            />
           </div>
           <div class="reset-filter-wrapper">
             <button

--- a/feature-libs/subscription-billing/components/list/billing/subscription-billing-list.component.html
+++ b/feature-libs/subscription-billing/components/list/billing/subscription-billing-list.component.html
@@ -20,7 +20,7 @@
             [value]="getDateRangeFieldValue()"
           />
           <button class="btn btn-tertiary btn-calendar">
-            <cx-icon class="fa fa-calendar"></cx-icon>
+            <cx-icon class="fa fa-calendar" />
           </button>
         </div>
         <button
@@ -43,7 +43,7 @@
         [selectedOption]="billingList.pagination?.sort"
         placeholder="{{ 'subscriptionBillsList.sortLabel' | cxTranslate }}"
         [ariaLabel]="'subscriptionBillsList.sortOrders'"
-      ></cx-sorting>
+      />
     </div>
   </div>
   <ng-container *ngIf="billingList.results?.length > 0; else noBills">
@@ -142,14 +142,14 @@
         <cx-pagination
           [pagination]="billingList.pagination"
           (viewPageEvent)="onPageChange($event)"
-        ></cx-pagination>
+        />
       </ng-container>
     </div>
   </ng-container>
 </ng-container>
 
 <ng-template #loading>
-  <cx-spinner></cx-spinner>
+  <cx-spinner />
 </ng-template>
 
 <ng-template #noBills>

--- a/feature-libs/subscription-billing/components/list/subscription-list.component.html
+++ b/feature-libs/subscription-billing/components/list/subscription-list.component.html
@@ -17,7 +17,7 @@
           placeholder="{{ 'subscriptionList.sortSubtitle' | cxTranslate }}"
           [ariaLabel]="'subscriptionList.sortOrders' | cxTranslate"
           ariaControls="subscription-list-table"
-        ></cx-sorting>
+        />
       </label>
     </div>
 
@@ -99,7 +99,7 @@
         <cx-pagination
           [pagination]="list.pagination"
           (viewPageEvent)="pageChange($event)"
-        ></cx-pagination>
+        />
       </ng-container>
     </div>
   </ng-container>
@@ -112,5 +112,5 @@
 </ng-template>
 
 <ng-template #loading>
-  <cx-spinner></cx-spinner>
+  <cx-spinner />
 </ng-template>

--- a/feature-libs/subscription-billing/components/product/price/subscription-product-price.component.html
+++ b/feature-libs/subscription-billing/components/product/price/subscription-product-price.component.html
@@ -2,18 +2,16 @@
   <ng-container *ngIf="isCurrentProductSubscription()">
     <div>
       <ng-container *ngIf="recurringCharges().length > 0">
-        <ng-container *ngTemplateOutlet="showRecurringCharges"></ng-container>
+        <ng-container *ngTemplateOutlet="showRecurringCharges" />
       </ng-container>
 
       <ng-container *ngIf="oneTimeCharges().length > 0">
-        <ng-container *ngTemplateOutlet="showOneTimeCharges"></ng-container>
+        <ng-container *ngTemplateOutlet="showOneTimeCharges" />
       </ng-container>
 
-      <ng-container *ngTemplateOutlet="showTerm"></ng-container>
+      <ng-container *ngTemplateOutlet="showTerm" />
 
-      <cx-subscription-product-usage-charge
-        [product]="productDetail"
-      ></cx-subscription-product-usage-charge>
+      <cx-subscription-product-usage-charge [product]="productDetail" />
     </div>
   </ng-container>
 

--- a/feature-libs/subscription-billing/components/product/usage/subscription-product-usage-charge.component.html
+++ b/feature-libs/subscription-billing/components/product/usage/subscription-product-usage-charge.component.html
@@ -4,19 +4,19 @@
   </div>
 
   <ng-container *ngIf="tierUsageCharges().length > 0">
-    <ng-container *ngTemplateOutlet="showTierUsageCharges"></ng-container>
+    <ng-container *ngTemplateOutlet="showTierUsageCharges" />
   </ng-container>
 
   <ng-container *ngIf="volumeUsageCharges().length > 0">
-    <ng-container *ngTemplateOutlet="showVolumeUsageCharges"></ng-container>
+    <ng-container *ngTemplateOutlet="showVolumeUsageCharges" />
   </ng-container>
 
   <ng-container *ngIf="percentageUsageCharges().length > 0">
-    <ng-container *ngTemplateOutlet="showPercentageUsageCharges"></ng-container>
+    <ng-container *ngTemplateOutlet="showPercentageUsageCharges" />
   </ng-container>
 
   <ng-container *ngIf="blockUsageCharges().length > 0">
-    <ng-container *ngTemplateOutlet="showBlockUsageCharges"></ng-container>
+    <ng-container *ngTemplateOutlet="showBlockUsageCharges" />
   </ng-container>
 </div>
 

--- a/feature-libs/subscription-billing/root/components/cart/price-body/subscription-cart-price-body.component.html
+++ b/feature-libs/subscription-billing/root/components/cart/price-body/subscription-cart-price-body.component.html
@@ -7,7 +7,7 @@
           else noSubscriptions
         "
       >
-        <ng-container *ngTemplateOutlet="charges"></ng-container>
+        <ng-container *ngTemplateOutlet="charges" />
       </ng-container>
 
       <ng-template #noSubscriptions>
@@ -21,7 +21,7 @@
 
 <ng-container *ngIf="parent() === 'minicart'">
   <ng-container *ngIf="this.productService.isSubscription(item().product)">
-    <ng-container *ngTemplateOutlet="charges"></ng-container>
+    <ng-container *ngTemplateOutlet="charges" />
   </ng-container>
 </ng-container>
 

--- a/feature-libs/user/account/components/login-form/login-form.component.html
+++ b/feature-libs/user/account/components/login-form/login-form.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"></cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 
 <form
   (ngSubmit)="onSubmit()"
@@ -33,7 +33,7 @@
         label: 'loginForm.emailAddress.label' | cxTranslate,
       }"
       [control]="form.get('userId')"
-    ></cx-form-errors>
+    />
   </label>
 
   <label>
@@ -62,7 +62,7 @@
         label: 'loginForm.password.label' | cxTranslate,
       }"
       [control]="form.get('password')"
-    ></cx-form-errors>
+    />
   </label>
 
   <ng-container *cxFeature="'authorizationCodeFlowByDefault'">

--- a/feature-libs/user/account/components/login-register/login-register-b2b/login-register-b2b.component.html
+++ b/feature-libs/user/account/components/login-register/login-register-b2b/login-register-b2b.component.html
@@ -1,1 +1,1 @@
-<cx-login-register *cxFeature="'a11yB2BRegisterComponent'"></cx-login-register>
+<cx-login-register *cxFeature="'a11yB2BRegisterComponent'" />

--- a/feature-libs/user/account/components/login/login.component.html
+++ b/feature-libs/user/account/components/login/login.component.html
@@ -8,7 +8,7 @@
       cxDomChangeTargetSelector="nav ul li:first-child button"
       id="account-nav"
       position="HeaderLinks"
-    ></cx-page-slot>
+    />
   </ng-container>
 </ng-container>
 

--- a/feature-libs/user/account/components/otp-login-form/otp-login-form.component.html
+++ b/feature-libs/user/account/components/otp-login-form/otp-login-form.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"></cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
   <cx-form-required-legend />
@@ -18,10 +18,7 @@
       "
       [attr.aria-errormessage]="'userIdError'"
     />
-    <cx-form-errors
-      id="userIdError"
-      [control]="form.get('userId')"
-    ></cx-form-errors>
+    <cx-form-errors id="userIdError" [control]="form.get('userId')" />
   </label>
 
   <label>
@@ -42,10 +39,7 @@
       [attr.aria-errormessage]="'passwordError'"
       cxPasswordVisibilitySwitch
     />
-    <cx-form-errors
-      id="passwordError"
-      [control]="form.get('password')"
-    ></cx-form-errors>
+    <cx-form-errors id="passwordError" [control]="form.get('password')" />
   </label>
 
   <a [routerLink]="{ cxRoute: 'forgotPassword' } | cxUrl" class="btn-link">

--- a/feature-libs/user/account/components/verification-token-form/verification-token-dialog.component.html
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-dialog.component.html
@@ -10,7 +10,7 @@
     <div class="cx-dialog-header modal-header">
       <div>
         <span class="info-icon">
-          <cx-icon type="INFO"></cx-icon>
+          <cx-icon type="INFO" />
         </span>
         <h3 id="verification-token-dialog-title" class="title modal-title">
           {{ 'verificationTokenDialog.title' | cxTranslate }}

--- a/feature-libs/user/account/components/verification-token-form/verification-token-form.component.html
+++ b/feature-libs/user/account/components/verification-token-form/verification-token-form.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"></cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 
 <form
   (ngSubmit)="onSubmit()"
@@ -23,7 +23,7 @@
       "
       aria-describedby="tokenInputHint"
     />
-    <cx-form-errors [control]="form.get('tokenCode')"></cx-form-errors>
+    <cx-form-errors [control]="form.get('tokenCode')" />
     <div class="rate-limit-error-display" *ngIf="upToRateLimit">
       {{
         'register.rateLimitForRegistrationMessage'

--- a/feature-libs/user/profile/components/address-book/address-book.component.html
+++ b/feature-libs/user/profile/components/address-book/address-book.component.html
@@ -34,7 +34,7 @@
           (deleteCard)="setEdit(address.id ?? '')"
           [editMode]="address.id === editCard"
           (cancelCard)="cancelCard()"
-        ></cx-card>
+        />
       </div>
     </div>
   </ng-container>
@@ -59,7 +59,7 @@
         (submitAddress)="addAddressSubmit($event)"
         (backToAddress)="addAddressCancel()"
         (cancelCard)="cancelCard()"
-      ></cx-address-form>
+      />
     </section>
   </ng-container>
 
@@ -75,13 +75,13 @@
         [addressData]="currentAddress"
         (submitAddress)="editAddressSubmit($event)"
         (backToAddress)="editAddressCancel()"
-      ></cx-address-form>
+      />
     </section>
   </ng-container>
 </div>
 
 <ng-template #loading>
   <div class="col-md-12 cx-address-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/suggested-addresses-dialog.component.html
+++ b/feature-libs/user/profile/components/address-book/address-form/suggested-addresses-dialog/suggested-addresses-dialog.component.html
@@ -21,7 +21,7 @@
         (click)="closeModal('Cross click')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>

--- a/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.html
+++ b/feature-libs/user/profile/components/close-account/components/close-account-modal/close-account-modal.component.html
@@ -17,14 +17,14 @@
           (click)="dismissModal('Cross click')"
         >
           <span aria-hidden="true">
-            <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+            <cx-icon [type]="iconTypes.CLOSE" />
           </span>
         </button>
       </div>
 
       <div *ngIf="isLoading$ | async; else loaded">
         <div class="cx-spinner">
-          <cx-spinner> </cx-spinner>
+          <cx-spinner />
         </div>
       </div>
 

--- a/feature-libs/user/profile/components/forgot-password/forgot-password.component.html
+++ b/feature-libs/user/profile/components/forgot-password/forgot-password.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 <cx-form-required-legend />
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
   <label>
@@ -26,7 +26,7 @@
         label: 'forgottenPassword.emailAddress.label' | cxTranslate,
       }"
       [control]="form.get('userEmail')"
-    ></cx-form-errors>
+    />
   </label>
 
   <button

--- a/feature-libs/user/profile/components/otp-login-register/otp-login-register.component.html
+++ b/feature-libs/user/profile/components/otp-login-register/otp-login-register.component.html
@@ -24,8 +24,7 @@
                   'common.ngSelectDropdownOptionsList' | cxTranslate
                 }}"
                 [cxNgSelectA11y]="{}"
-              >
-              </ng-select>
+              />
             </label>
           </div>
 
@@ -51,7 +50,7 @@
                   label: 'register.firstName.label' | cxTranslate,
                 }"
                 [control]="registerForm.get('firstName')"
-              ></cx-form-errors>
+              />
             </label>
           </div>
 
@@ -77,7 +76,7 @@
                   label: 'register.lastName.label' | cxTranslate,
                 }"
                 [control]="registerForm.get('lastName')"
-              ></cx-form-errors>
+              />
             </label>
           </div>
 
@@ -103,7 +102,7 @@
                   label: 'register.emailAddress.label' | cxTranslate,
                 }"
                 [control]="registerForm.get('email')"
-              ></cx-form-errors>
+              />
             </label>
           </div>
 
@@ -145,7 +144,7 @@
                   <span class="form-check-label">
                     {{ consents[i].template.description }}
                   </span>
-                  <cx-form-errors [control]="control"></cx-form-errors>
+                  <cx-form-errors [control]="control" />
                 </label>
               </div>
             </div>
@@ -177,14 +176,12 @@
                     label: 'register.termsAndConditions' | cxTranslate,
                   }"
                   [control]="registerForm.get('termsandconditions')"
-                ></cx-form-errors>
+                />
               </label>
             </div>
           </div>
-          <cx-captcha (confirmed)="captchaConfirmed()"></cx-captcha>
-          <cx-form-errors
-            [control]="registerForm.get('captcha')"
-          ></cx-form-errors>
+          <cx-captcha (confirmed)="captchaConfirmed()" />
+          <cx-form-errors [control]="registerForm.get('captcha')" />
           <button type="submit" class="btn btn-block btn-primary">
             {{ 'register.furtherRegistration' | cxTranslate }}
           </button>
@@ -200,5 +197,5 @@
 </section>
 
 <ng-template #loading>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/feature-libs/user/profile/components/register/register.component.html
+++ b/feature-libs/user/profile/components/register/register.component.html
@@ -25,8 +25,7 @@
                   'common.ngSelectDropdownOptionsList' | cxTranslate
                 }}"
                 [cxNgSelectA11y]="{}"
-              >
-              </ng-select>
+              />
             </label>
           </div>
 
@@ -58,7 +57,7 @@
                   label: 'register.firstName.label' | cxTranslate,
                 }"
                 [control]="registerForm.get('firstName')"
-              ></cx-form-errors>
+              />
             </label>
           </div>
 
@@ -90,7 +89,7 @@
                   label: 'register.lastName.label' | cxTranslate,
                 }"
                 [control]="registerForm.get('lastName')"
-              ></cx-form-errors>
+              />
             </label>
           </div>
 
@@ -122,7 +121,7 @@
                   label: 'register.emailAddress.label' | cxTranslate,
                 }"
                 [control]="registerForm.get('email')"
-              ></cx-form-errors>
+              />
             </label>
           </div>
 
@@ -156,7 +155,7 @@
                   label: 'register.password.label' | cxTranslate,
                 }"
                 [control]="registerForm.get('password')"
-              ></cx-form-errors>
+              />
             </label>
           </div>
 
@@ -192,7 +191,7 @@
                   label: 'register.confirmPassword.label' | cxTranslate,
                 }"
                 [control]="registerForm.get('passwordconf')"
-              ></cx-form-errors>
+              />
             </label>
           </div>
 
@@ -242,9 +241,7 @@
                       <cx-form-required-asterisks />
                     </ng-container>
                   </span>
-                  <cx-form-errors
-                    [control]="control.get('isConsentGranted')"
-                  ></cx-form-errors>
+                  <cx-form-errors [control]="control.get('isConsentGranted')" />
                 </label>
               </div>
             </div>
@@ -285,14 +282,12 @@
                     label: 'register.termsAndConditions' | cxTranslate,
                   }"
                   [control]="registerForm.get('termsandconditions')"
-                ></cx-form-errors>
+                />
               </label>
             </div>
           </div>
-          <cx-captcha (confirmed)="captchaConfirmed()"></cx-captcha>
-          <cx-form-errors
-            [control]="registerForm.get('captcha')"
-          ></cx-form-errors>
+          <cx-captcha (confirmed)="captchaConfirmed()" />
+          <cx-form-errors [control]="registerForm.get('captcha')" />
           <button type="submit" class="btn btn-block btn-primary">
             {{ 'register.register' | cxTranslate }}
           </button>
@@ -308,5 +303,5 @@
 </section>
 
 <ng-template #loading>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/feature-libs/user/profile/components/registration-verification-token-form/verify-register-verification-token-form.component.html
+++ b/feature-libs/user/profile/components/registration-verification-token-form/verify-register-verification-token-form.component.html
@@ -12,7 +12,7 @@
         'verificationTokenForm.verificationCode.placeholder' | cxTranslate
       }}"
     />
-    <cx-form-errors [control]="registerForm.get('tokenCode')"></cx-form-errors>
+    <cx-form-errors [control]="registerForm.get('tokenCode')" />
     <div class="rate-limit-error-display" *ngIf="upToRateLimit">
       {{
         'register.rateLimitForRegistrationMessage'
@@ -86,7 +86,7 @@
           label: 'register.password.label' | cxTranslate,
         }"
         [control]="registerForm.get('password')"
-      ></cx-form-errors>
+      />
     </label>
   </div>
 
@@ -112,7 +112,7 @@
           label: 'register.confirmPassword.label' | cxTranslate,
         }"
         [control]="registerForm.get('passwordconf')"
-      ></cx-form-errors>
+      />
     </label>
   </div>
 
@@ -135,5 +135,5 @@
 </form>
 
 <ng-template #loading>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/feature-libs/user/profile/components/reset-password/reset-password.component.html
+++ b/feature-libs/user/profile/components/reset-password/reset-password.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 
 <form
   *ngIf="token$ | async as token"
@@ -31,7 +31,7 @@
         label: 'register.newPassword' | cxTranslate,
       }"
       [control]="form.get('password')"
-    ></cx-form-errors>
+    />
   </label>
 
   <label>
@@ -60,7 +60,7 @@
         label: 'register.passwordMinRequirements' | cxTranslate,
       }"
       [control]="form.get('passwordConfirm')"
-    ></cx-form-errors>
+    />
   </label>
 
   <button class="btn btn-block btn-primary" [disabled]="form.disabled">

--- a/feature-libs/user/profile/components/update-email/my-account-v2-email.component.html
+++ b/feature-libs/user/profile/components/update-email/my-account-v2-email.component.html
@@ -1,8 +1,7 @@
 <cx-spinner
   class="overlay"
   *ngIf="(isUpdating$ | async) || !(user$ | async); $"
->
-</cx-spinner>
+/>
 <div>
   <div class="flex-line">
     <span class="headertext">{{
@@ -29,7 +28,7 @@
     [text]="'myAccountV2Email.reloginIndicator' | cxTranslate"
     [type]="globalMessageType.MSG_TYPE_INFO"
     (closeMessage)="closeDialogConfirmationAlert()"
-  ></cx-message>
+  />
   <div *ngIf="isEditing" class="email-editing-area">
     <form (ngSubmit)="onSubmit()" [formGroup]="form">
       <fieldset>
@@ -73,7 +72,7 @@
               label: 'updateEmailForm.newEmailAddress.label' | cxTranslate,
             }"
             [control]="form.get('email')"
-          ></cx-form-errors>
+          />
         </label>
 
         <label>
@@ -103,7 +102,7 @@
                 'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate,
             }"
             [control]="form.get('confirmEmail')"
-          ></cx-form-errors>
+          />
         </label>
 
         <label>
@@ -136,7 +135,7 @@
               label: 'updateEmailForm.password.label' | cxTranslate,
             }"
             [control]="form.get('password')"
-          ></cx-form-errors>
+          />
         </label>
 
         <div class="btn-group">

--- a/feature-libs/user/profile/components/update-email/update-email.component.html
+++ b/feature-libs/user/profile/components/update-email/update-email.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 <cx-form-required-legend />
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
   <fieldset>
@@ -35,7 +35,7 @@
           label: 'updateEmailForm.newEmailAddress.label' | cxTranslate,
         }"
         [control]="form.get('email')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -65,7 +65,7 @@
           label: 'updateEmailForm.confirmNewEmailAddress.label' | cxTranslate,
         }"
         [control]="form.get('confirmEmail')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -93,7 +93,7 @@
           label: 'updateEmailForm.password.label' | cxTranslate,
         }"
         [control]="form.get('password')"
-      ></cx-form-errors>
+      />
     </label>
 
     <a

--- a/feature-libs/user/profile/components/update-password/my-account-v2-password.component.html
+++ b/feature-libs/user/profile/components/update-password/my-account-v2-password.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
   <fieldset>
@@ -14,8 +14,7 @@
       [text]="'myAccountV2PasswordForm.reloginIndicator' | cxTranslate"
       [type]="globalMessageType.MSG_TYPE_INFO"
       (closeMessage)="closeDialogConfirmationAlert()"
-    >
-    </cx-message>
+    />
 
     <label class="myaccount-label-padding">
       <span class="label-content myaccount-password-label">{{
@@ -47,7 +46,7 @@
           label: 'updatePasswordForm.oldPassword.label' | cxTranslate,
         }"
         [control]="form.get('oldPassword')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label class="myaccount-label-padding">
@@ -80,7 +79,7 @@
           label: 'updatePasswordForm.newPassword.label' | cxTranslate,
         }"
         [control]="form.get('newPassword')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label class="myaccount-label-padding">
@@ -114,7 +113,7 @@
           label: 'updatePasswordForm.confirmPassword.label' | cxTranslate,
         }"
         [control]="form.get('newPasswordConfirm')"
-      ></cx-form-errors>
+      />
     </label>
 
     <div class="password-btn-group">

--- a/feature-libs/user/profile/components/update-password/update-password.component.html
+++ b/feature-libs/user/profile/components/update-password/update-password.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 <cx-form-required-legend />
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
   <fieldset>
@@ -38,7 +38,7 @@
           label: 'updatePasswordForm.oldPassword.label' | cxTranslate,
         }"
         [control]="form.get('oldPassword')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -71,7 +71,7 @@
           label: 'updatePasswordForm.newPassword.label' | cxTranslate,
         }"
         [control]="form.get('newPassword')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -105,7 +105,7 @@
           label: 'updatePasswordForm.confirmPassword.label' | cxTranslate,
         }"
         [control]="form.get('newPasswordConfirm')"
-      ></cx-form-errors>
+      />
     </label>
 
     <button

--- a/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.html
+++ b/feature-libs/user/profile/components/update-profile/my-account-v2-profile.component.html
@@ -1,5 +1,4 @@
-<cx-spinner class="overlay" *ngIf="(isUpdating$ | async) || !(user$ | async)">
-</cx-spinner>
+<cx-spinner class="overlay" *ngIf="(isUpdating$ | async) || !(user$ | async)" />
 <div>
   <div>
     <div class="flex-line">
@@ -87,7 +86,7 @@
               label: 'updateProfileForm.firstName.label' | cxTranslate,
             }"
             [control]="form.get('firstName')"
-          ></cx-form-errors>
+          />
         </label>
 
         <label>
@@ -111,7 +110,7 @@
               label: 'updateProfileForm.lastName.label' | cxTranslate,
             }"
             [control]="form.get('lastName')"
-          ></cx-form-errors>
+          />
         </label>
 
         <label>
@@ -137,7 +136,7 @@
               label: 'updateProfileForm.customerId' | cxTranslate,
             }"
             [control]="form.get('customerId')"
-          ></cx-form-errors>
+          />
         </label>
       </fieldset>
     </form>

--- a/feature-libs/user/profile/components/update-profile/update-profile.component.html
+++ b/feature-libs/user/profile/components/update-profile/update-profile.component.html
@@ -1,4 +1,4 @@
-<cx-spinner class="overlay" *ngIf="isUpdating$ | async"> </cx-spinner>
+<cx-spinner class="overlay" *ngIf="isUpdating$ | async" />
 <cx-form-required-legend />
 <form (ngSubmit)="onSubmit()" [formGroup]="form">
   <fieldset>
@@ -55,7 +55,7 @@
           label: 'updateProfileForm.firstName.label' | cxTranslate,
         }"
         [control]="form.get('firstName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -84,7 +84,7 @@
           label: 'updateProfileForm.lastName.label' | cxTranslate,
         }"
         [control]="form.get('lastName')"
-      ></cx-form-errors>
+      />
     </label>
 
     <label>
@@ -112,7 +112,7 @@
           label: 'updateProfileForm.customerId' | cxTranslate,
         }"
         [control]="form.get('customerId')"
-      ></cx-form-errors>
+      />
     </label>
 
     <button

--- a/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent.component.html
+++ b/integration-libs/cdc/user-account/login-form/reconsent/cdc-reconsent.component.html
@@ -18,7 +18,7 @@
           (click)="dismissDialog('Cross click', reconsentEvent.errorMessage)"
         >
           <span aria-hidden="true">
-            <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+            <cx-icon [type]="iconTypes.CLOSE" />
           </span>
         </button>
       </div>
@@ -44,7 +44,7 @@
             [showMandatory]="
               requiredReconsents.includes(consentTemplate.id ?? '')
             "
-          ></cx-consent-management-form>
+          />
         </div>
       </div>
       <!-- Actions -->
@@ -64,6 +64,6 @@
   </div>
 
   <ng-template #loading>
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </ng-template>
 </div>

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.html
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.html
@@ -11,8 +11,7 @@
     [title]="title$ | async"
     [template]="carouselItem"
     itemWidth="285px"
-  >
-  </cx-carousel>
+  />
 
   <ng-template #carouselItem let-item="item">
     <div
@@ -31,8 +30,7 @@
         *ngIf="item.images?.PRIMARY"
         [container]="item.images.PRIMARY"
         format="product"
-      >
-      </cx-media>
+      />
       <h4>{{ item.name }}</h4>
       <div class="price">
         {{ item.price?.formattedValue }}

--- a/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.spec.ts
+++ b/integration-libs/cds/src/merchandising/cms-components/merchandising-carousel/merchandising-carousel.component.spec.ts
@@ -40,7 +40,7 @@ import createSpy = jasmine.createSpy;
     <ng-container *ngFor="let item$ of items">
       <ng-container
         *ngTemplateOutlet="template; context: { item: item$ | async }"
-      ></ng-container>
+      />
     </ng-container>
   `,
   imports: [NgTemplateOutlet, NgFor, AsyncPipe],

--- a/integration-libs/cds/src/profiletag/cms-components/profile-tag.component.ts
+++ b/integration-libs/cds/src/profiletag/cms-components/profile-tag.component.ts
@@ -12,9 +12,7 @@ import { ProfileTagInjectorService } from '../services/profile-tag.injector.serv
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'cx-profiletag',
-  template: `
-    <ng-container *ngIf="profileTagEnabled$ | async"></ng-container>
-  `,
+  template: ` <ng-container *ngIf="profileTagEnabled$ | async" /> `,
   imports: [NgIf, AsyncPipe],
 })
 export class ProfileTagComponent {

--- a/integration-libs/cds/src/recent-searches/recent-searches.component.html
+++ b/integration-libs/cds/src/recent-searches/recent-searches.component.html
@@ -6,7 +6,7 @@
       </h3>
       <cx-recent-searches-header
         *cxFeature="'searchBoxRecentSearchesRemoval'"
-      ></cx-recent-searches-header>
+      />
       <ul
         tabindex="0"
         [ariaLabel]="'cdsRecentSearches.ariaRecentSearches' | cxTranslate"
@@ -54,7 +54,7 @@
             "
           >
             <span aria-hidden="true">
-              <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+              <cx-icon [type]="iconTypes.CLOSE" />
             </span>
           </button>
         </li>

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/dp-confirmation-dialog.component.html
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-confirmation-dialog/dp-confirmation-dialog.component.html
@@ -20,7 +20,7 @@
         (click)="dismissDialog('Cross click')"
       >
         <span aria-hidden="true">
-          <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+          <cx-icon [type]="iconTypes.CLOSE" />
         </span>
       </button>
     </div>

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-callback/dp-payment-callback.component.html
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-callback/dp-payment-callback.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="this.showBillingAddressForm; else showSpinner">
-  <cx-checkout-billing-address-form></cx-checkout-billing-address-form>
+  <cx-checkout-billing-address-form />
 
   <!-- BUTTON SECTION -->
   <div class="cx-checkout-btns row">
@@ -18,5 +18,5 @@
 
 <ng-template #showSpinner>
   <div class="text-center">{{ 'dpPaymentForm.callback' | cxTranslate }}</div>
-  <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+  <div class="cx-spinner"><cx-spinner /></div>
 </ng-template>

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-form/dp-payment-form.component.html
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-form/dp-payment-form.component.html
@@ -1,2 +1,2 @@
 <div class="text-center">{{ 'dpPaymentForm.redirect' | cxTranslate }}</div>
-<div class="cx-spinner"><cx-spinner></cx-spinner></div>
+<div class="cx-spinner"><cx-spinner /></div>

--- a/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-method.component.html
+++ b/integration-libs/digital-payments/src/checkout/cms-components/dp-payment-method/dp-payment-method.component.html
@@ -36,7 +36,7 @@
                 [fitToContainer]="true"
                 [content]="card.content"
                 (sendCard)="selectPaymentMethod(card.paymentMethod)"
-              ></cx-card>
+              />
             </div>
           </div>
         </div>
@@ -64,18 +64,18 @@
       <cx-dp-payment-form
         (setPaymentDetails)="setPaymentDetails($event)"
         (closeForm)="hideNewPaymentForm()"
-      ></cx-dp-payment-form>
+      />
     </ng-template>
   </ng-container>
 
   <ng-template #loading>
-    <div class="cx-spinner"><cx-spinner></cx-spinner></div>
+    <div class="cx-spinner"><cx-spinner /></div>
   </ng-template>
 
   <ng-template #loadingPaymentDetails>
     <cx-dp-payment-callback
       (paymentDetailsAdded)="paymentDetailsAdded($event)"
       (closeCallback)="hideCallbackScreen()"
-    ></cx-dp-payment-callback>
+    />
   </ng-template>
 </ng-container>

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.component.html
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-filter/visual-picking-product-filter.component.html
@@ -21,7 +21,7 @@
     "
     class="search"
     [hidden]="filter.length > 0"
-  ></cx-icon>
+  />
 
   <cx-icon
     [type]="iconTypes.RESET"
@@ -38,5 +38,5 @@
     [hidden]="filter.length === 0"
     class="reset"
     tabindex="0"
-  ></cx-icon>
+  />
 </div>

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.html
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/compact-add-to-cart/compact-add-to-cart.component.html
@@ -6,6 +6,6 @@
     [attr.title]="'addToCart.addToCart' | cxTranslate"
     [disabled]="quantity <= 0 || quantity > maxQuantity"
   >
-    <cx-icon class="fa fa-cart-plus"></cx-icon>
+    <cx-icon class="fa fa-cart-plus" />
   </button>
 </form>

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.html
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/paged-list/paged-list.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="items?.length > 0 && itemsPerSlide">
   <h3 *ngIf="title">{{ title }}</h3>
 
-  <ng-container *ngTemplateOutlet="headerTemplate"></ng-container>
+  <ng-container *ngTemplateOutlet="headerTemplate" />
 
   <div class="list-panel">
     <div class="slides">
@@ -30,7 +30,7 @@
                     active: i === activeSlideStartIndex,
                   }
                 "
-              ></ng-container>
+              />
             </div>
           </ng-container>
         </div>
@@ -48,7 +48,7 @@
       (click)="setActiveSlideStartIndex(activeSlideStartIndex - itemsPerSlide)"
       [disabled]="activeSlideStartIndex === 0"
     >
-      <cx-icon [type]="previousIcon"></cx-icon>
+      <cx-icon [type]="previousIcon" />
     </button>
 
     <ng-container *ngFor="let _ of items; let i = index">
@@ -58,7 +58,7 @@
         [disabled]="i === activeSlideStartIndex"
         class="slide-indicator"
       >
-        <cx-icon [type]="indicatorIcon"></cx-icon>
+        <cx-icon [type]="indicatorIcon" />
       </button>
     </ng-container>
 
@@ -68,7 +68,7 @@
       (click)="setActiveSlideStartIndex(activeSlideStartIndex + itemsPerSlide)"
       [disabled]="activeSlideStartIndex > items.length - itemsPerSlide - 1"
     >
-      <cx-icon [type]="nextIcon"></cx-icon>
+      <cx-icon [type]="nextIcon" />
     </button>
   </div>
 </ng-container>

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.html
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/product-list/visual-picking-product-list.component.html
@@ -5,8 +5,7 @@
   [template]="itemTemplate"
   [itemsPerSlide]="itemsPerSlide"
   [(activeSlideStartIndex)]="activeSlideStartIndex"
->
-</cx-epd-visualization-paged-list>
+/>
 
 <ng-template #headerTemplate>
   <div class="cx-item-list-header row">
@@ -45,7 +44,7 @@
           <cx-media
             [container]="item.product.images?.PRIMARY"
             format="thumbnail"
-          ></cx-media>
+          />
         </div>
       </div>
 
@@ -100,12 +99,11 @@
             #addToCartComponent
             [showQuantity]="false"
             [product]="item.product"
-          ></cx-epd-visualization-compact-add-to-cart>
+          />
         </div>
       </ng-container>
 
-      <ng-container #noPrice *ngIf="item.product.price === undefined">
-      </ng-container>
+      <ng-container #noPrice *ngIf="item.product.price === undefined" />
 
       <ng-container
         *ngIf="

--- a/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.html
+++ b/integration-libs/epd-visualization/components/visual-picking/visual-picking-tab/visual-picking-tab.component.html
@@ -8,20 +8,18 @@
     [hidden]="hideViewport"
     [outlineColor]="'--cx-color-primary'"
     [outlineWidth]="8"
-  >
-  </cx-epd-visualization-viewer>
+  />
 
   <div
     class="visual-picking-product-list-container"
     [hidden]="hideProductList"
     [class.viewportHidden]="hideViewport"
   >
-    <cx-epd-visualization-product-filter></cx-epd-visualization-product-filter>
+    <cx-epd-visualization-product-filter />
 
     <cx-epd-visualization-product-list
       [(selectedProductCodes)]="selectedProductCodes"
-    >
-    </cx-epd-visualization-product-list>
+    />
   </div>
 </div>
 

--- a/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.component.html
+++ b/integration-libs/epd-visualization/components/visual-viewer/toolbar/visual-viewer-toolbar-button/visual-viewer-toolbar-button.component.html
@@ -6,7 +6,7 @@
   [attr.aria-checked]="checked"
 >
   <div class="buttonVBox">
-    <cx-icon class="{{ iconLibraryClass }} {{ iconClass }}"></cx-icon>
+    <cx-icon class="{{ iconLibraryClass }} {{ iconClass }}" />
     <span class="buttonText">{{ text }}</span>
   </div>
 </button>

--- a/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.html
+++ b/integration-libs/epd-visualization/components/visual-viewer/visual-viewer.component.html
@@ -21,7 +21,7 @@
                 | cxTranslate
             }}"
             (click)="activateHomeView()"
-          ></cx-epd-visualization-viewer-toolbar-button>
+          />
 
           <cx-epd-visualization-viewer-toolbar-button
             class="turntableButton toolbarItem"
@@ -34,7 +34,7 @@
             [hidden]="is2D"
             (click)="navigationMode = NavigationMode.Turntable"
             [checked]="navigationMode === NavigationMode.Turntable"
-          ></cx-epd-visualization-viewer-toolbar-button>
+          />
 
           <cx-epd-visualization-viewer-toolbar-button
             class="panButton toolbarItem"
@@ -46,7 +46,7 @@
             }}"
             (click)="navigationMode = NavigationMode.Pan"
             [checked]="navigationMode === NavigationMode.Pan"
-          ></cx-epd-visualization-viewer-toolbar-button>
+          />
 
           <cx-epd-visualization-viewer-toolbar-button
             class="zoomButton toolbarItem"
@@ -58,7 +58,7 @@
             }}"
             (click)="navigationMode = NavigationMode.Zoom"
             [checked]="navigationMode === NavigationMode.Zoom"
-          ></cx-epd-visualization-viewer-toolbar-button>
+          />
 
           <cx-epd-visualization-viewer-toolbar-button
             class="isolateButton toolbarItem"
@@ -74,7 +74,7 @@
             }}"
             (click)="isolateModeEnabled = !isolateModeEnabled"
             [checked]="isolateModeEnabled"
-          ></cx-epd-visualization-viewer-toolbar-button>
+          />
 
           <cx-epd-visualization-viewer-toolbar-button
             class="playPauseButton toolbarItem"
@@ -89,7 +89,7 @@
             [hidden]="is2D || animationTotalDuration <= 0"
             [disabled]="isolateModeEnabled"
             (click)="animationPlaying ? pauseAnimation() : playAnimation()"
-          ></cx-epd-visualization-viewer-toolbar-button>
+          />
 
           <cx-epd-visualization-viewer-toolbar-button
             class="showAllHotpotsButton toolbarItem"
@@ -104,7 +104,7 @@
             [checked]="showAllHotspotsEnabled"
             [hidden]="!is2D"
             (click)="showAllHotspotsEnabled = !showAllHotspotsEnabled"
-          ></cx-epd-visualization-viewer-toolbar-button>
+          />
         </div>
 
         <div [hidden]="is2D || animationTotalDuration <= 0">
@@ -119,7 +119,7 @@
               animationPlaying ? pauseAnimation() : playAnimation();
               $event.preventDefault()
             "
-          ></cx-epd-visualization-animation-slider>
+          />
         </div>
       </div>
     </div>
@@ -128,6 +128,6 @@
 
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/integration-libs/opf/b2b-checkout/components/opf-b2b-checkout-delivery-address/opf-b2b-checkout-delivery-address.component.html
+++ b/integration-libs/opf/b2b-checkout/components/opf-b2b-checkout-delivery-address/opf-b2b-checkout-delivery-address.component.html
@@ -1,7 +1,7 @@
 <h2 class="cx-checkout-title d-none d-lg-block d-xl-block">
   {{ 'checkoutAddress.shippingAddress' | cxTranslate }}
 </h2>
-<cx-opf-b2b-checkout-cost-center></cx-opf-b2b-checkout-cost-center>
+<cx-opf-b2b-checkout-cost-center />
 <ng-container *ngIf="cards$ | async as cards">
   <ng-container *ngIf="!(isUpdating$ | async); else loading">
     <ng-container
@@ -10,8 +10,7 @@
         then showExistingAddresses;
         else newAddressForm
       "
-    >
-    </ng-container>
+    />
 
     <ng-template #showExistingAddresses>
       <p class="cx-checkout-text">
@@ -44,7 +43,7 @@
               [content]="card.card"
               (sendCard)="selectAddress(card.address)"
               [role]="'group'"
-            ></cx-card>
+            />
           </div>
         </div>
       </div>
@@ -73,7 +72,7 @@
         [showTitleCode]="true"
         (backToAddress)="hideNewAddressForm(false)"
         (submitAddress)="addAddress($event)"
-      ></cx-address-form>
+      />
       <ng-template #initialAddressForm>
         <cx-address-form
           [showTitleCode]="true"
@@ -81,7 +80,7 @@
           cancelBtnLabel="{{ backBtnText | cxTranslate }}"
           (backToAddress)="hideNewAddressForm(true)"
           (submitAddress)="addAddress($event)"
-        ></cx-address-form>
+        />
       </ng-template>
     </ng-template>
   </ng-container>
@@ -89,6 +88,6 @@
 
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/integration-libs/opf/b2b-checkout/components/opf-b2b-checkout-payment-and-review/opf-b2b-checkout-payment-and-review.component.html
+++ b/integration-libs/opf/b2b-checkout/components/opf-b2b-checkout-payment-and-review/opf-b2b-checkout-payment-and-review.component.html
@@ -10,7 +10,7 @@
         route: getCheckoutStepUrl(checkoutStepTypePaymentType),
         ariaLabelKey: 'checkoutReview.editPoNumber',
       }"
-    ></cx-opf-checkout-review-card>
+    />
     <cx-opf-checkout-review-card
       [cardContent$]="
         getPaymentMethodNameCard(
@@ -21,7 +21,7 @@
         route: getCheckoutStepUrl(checkoutStepTypePaymentType),
         ariaLabelKey: 'checkoutReview.editPaymentMethod',
       }"
-    ></cx-opf-checkout-review-card>
+    />
     <cx-opf-checkout-review-card
       *ngIf="deliveryAddress$ | async as deliveryAddress"
       [cardContent$]="getDeliveryAddressCard(deliveryAddress)"
@@ -29,7 +29,7 @@
         route: getCheckoutStepUrl(checkoutStepTypeDeliveryAddress),
         ariaLabelKey: 'checkoutReview.editDeliveryAddressDetails',
       }"
-    ></cx-opf-checkout-review-card>
+    />
 
     <cx-opf-checkout-review-card
       *ngIf="deliveryMode$ | async as deliveryMode"
@@ -38,7 +38,7 @@
         route: getCheckoutStepUrl(checkoutStepTypeDeliveryMode),
         ariaLabelKey: 'checkoutReview.editDeliveryMode',
       }"
-    ></cx-opf-checkout-review-card>
+    />
   </div>
 
   <cx-opf-checkout-terms-and-conditions-alert
@@ -47,7 +47,7 @@
     [isVisible]="termsAndConditionInvalid"
     [isExplicit]="explicitTermsAndConditions.value"
     [ngClass]="['for-mobile']"
-  ></cx-opf-checkout-terms-and-conditions-alert>
+  />
 
   <div
     *ngIf="explicitTermsAndConditions.value"
@@ -84,7 +84,7 @@
     </form>
   </div>
 
-  <cx-opf-checkout-billing-address-form></cx-opf-checkout-billing-address-form>
+  <cx-opf-checkout-billing-address-form />
 
   <cx-opf-checkout-payments
     [onlyPaymentWrapperMode]="true"
@@ -105,11 +105,11 @@
       [isVisible]="termsAndConditionInvalid"
       [isExplicit]="explicitTermsAndConditions.value"
       [ngClass]="['for-desktop']"
-    ></cx-opf-checkout-terms-and-conditions-alert>
+    />
   </cx-opf-checkout-payments>
 
   <cx-opf-checkout-review-cart-details
     [cart]="cart$ | async"
     [entries]="entries$ | async"
-  ></cx-opf-checkout-review-cart-details>
+  />
 </ng-container>

--- a/integration-libs/opf/b2b-checkout/components/opf-b2b-checkout-payment-type/opf-b2b-checkout-payment-type.component.html
+++ b/integration-libs/opf/b2b-checkout/components/opf-b2b-checkout-payment-type/opf-b2b-checkout-payment-type.component.html
@@ -31,7 +31,7 @@
         [showBeforePaymentOptionsOutlet]="false"
         (paymentChange)="handlePaymentChange($event)"
         [forceDefaultPaymentOptionInputSelection]="true"
-      ></cx-opf-checkout-payments>
+      />
 
       <div class="cx-checkout-btns row">
         <div class="col-md-12 col-lg-6">
@@ -50,6 +50,6 @@
 </ng-container>
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/integration-libs/opf/b2b-checkout/components/opf-b2b-checkout-review/opf-b2b-checkout-review.component.html
+++ b/integration-libs/opf/b2b-checkout/components/opf-b2b-checkout-review/opf-b2b-checkout-review.component.html
@@ -10,14 +10,14 @@
         route: getCheckoutStepUrl(checkoutStepTypePaymentType),
         ariaLabelKey: 'checkoutReview.editPoNumber',
       }"
-    ></cx-opf-checkout-review-card>
+    />
     <cx-opf-checkout-review-card
       [cardContent$]="getCostCenterCard(costCenter$ | async)"
       [editConfig]="{
         route: getCheckoutStepUrl(checkoutStepTypeDeliveryAddress),
         ariaLabelKey: 'checkoutReview.editDeliveryAddressDetails',
       }"
-    ></cx-opf-checkout-review-card>
+    />
     <cx-opf-checkout-review-card
       *ngIf="deliveryAddress$ | async as deliveryAddress"
       [cardContent$]="getDeliveryAddressCard(deliveryAddress)"
@@ -25,7 +25,7 @@
         route: getCheckoutStepUrl(checkoutStepTypeDeliveryAddress),
         ariaLabelKey: 'checkoutReview.editDeliveryAddressDetails',
       }"
-    ></cx-opf-checkout-review-card>
+    />
     <cx-opf-checkout-review-card
       *ngIf="deliveryMode$ | async as deliveryMode"
       [cardContent$]="getDeliveryModeCard(deliveryMode)"
@@ -33,7 +33,7 @@
         route: getCheckoutStepUrl(checkoutStepTypeDeliveryMode),
         ariaLabelKey: 'checkoutReview.editDeliveryMode',
       }"
-    ></cx-opf-checkout-review-card>
+    />
   </div>
 
   <cx-opf-checkout-terms-and-conditions-alert
@@ -42,7 +42,7 @@
     [isVisible]="termsAndConditionInvalid"
     [isExplicit]="explicitTermsAndConditions.value"
     [ngClass]="['for-mobile']"
-  ></cx-opf-checkout-terms-and-conditions-alert>
+  />
 
   <div
     *ngIf="explicitTermsAndConditions.value"
@@ -55,7 +55,7 @@
       [isVisible]="termsAndConditionInvalid"
       [isExplicit]="explicitTermsAndConditions.value"
       [isDismissible]="false"
-    ></cx-opf-checkout-terms-and-conditions-alert>
+    />
 
     <form
       class="cx-place-order-form form-check"
@@ -105,17 +105,15 @@
       [isVisible]="termsAndConditionInvalid"
       [isExplicit]="explicitTermsAndConditions.value"
       [ngClass]="['for-desktop']"
-    ></cx-opf-checkout-terms-and-conditions-alert>
+    />
   </cx-opf-checkout-payments>
 
   <cx-opf-checkout-review-cart-details
     [cart]="cart$ | async"
     [entries]="entries$ | async"
-  ></cx-opf-checkout-review-cart-details>
+  />
 
   <ng-template #placeOrderTemplate>
-    <cx-opf-b2b-checkout-place-order
-      [isDisabled]="false"
-    ></cx-opf-b2b-checkout-place-order>
+    <cx-opf-b2b-checkout-place-order [isDisabled]="false" />
   </ng-template>
 </ng-container>

--- a/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-billing-address-form/opf-checkout-billing-address-form.component.html
@@ -30,7 +30,7 @@
         <div class="cx-custom-address-info">
           <cx-card
             [content]="addressData.billingAddress | cxGetAddressCardContent"
-          ></cx-card>
+          />
 
           <button
             *ngIf="!addressData.isSameAsDelivery"
@@ -38,7 +38,7 @@
             [attr.title]="'paymentForm.editBillingAddress' | cxTranslate"
             (click)="editCustomBillingAddress()"
           >
-            <cx-icon [type]="iconTypes.PENCIL"></cx-icon>
+            <cx-icon [type]="iconTypes.PENCIL" />
           </button>
         </div>
       </ng-container>
@@ -59,12 +59,12 @@
           (backToAddress)="onBackToAddress()"
           [setAsDefaultField]="false"
           [countries]="countries$"
-        ></cx-address-form>
+        />
       </ng-container>
     </ng-container>
   </ng-container>
 
   <ng-template #loading>
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </ng-template>
 </section>

--- a/integration-libs/opf/checkout/components/opf-checkout-email-update/opf-checkout-email-update.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-email-update/opf-checkout-email-update.component.html
@@ -6,7 +6,7 @@
     <label>
       <span class="label-content">
         {{ 'checkoutLogin.emailAddress.label' | cxTranslate }}
-        <ng-template [ngTemplateOutlet]="requiredAsterisk"></ng-template>
+        <ng-template [ngTemplateOutlet]="requiredAsterisk" />
       </span>
       <input
         required="true"
@@ -27,7 +27,7 @@
           label: 'checkoutLogin.emailAddress.label' | cxTranslate,
         }"
         [control]="checkoutLoginForm.get('email')"
-      ></cx-form-errors>
+      />
     </label>
   </div>
 
@@ -35,7 +35,7 @@
     <label>
       <span class="label-content">
         {{ 'checkoutLogin.confirmEmail.label' | cxTranslate }}
-        <ng-template [ngTemplateOutlet]="requiredAsterisk"></ng-template>
+        <ng-template [ngTemplateOutlet]="requiredAsterisk" />
       </span>
       <input
         required="true"
@@ -56,7 +56,7 @@
           label: 'checkoutLogin.confirmEmail.label' | cxTranslate,
         }"
         [control]="checkoutLoginForm.get('emailConfirmation')"
-      ></cx-form-errors>
+      />
     </label>
   </div>
 

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-and-review/opf-checkout-payment-and-review.component.html
@@ -9,7 +9,7 @@
     [isExplicit]="explicitTermsAndConditions.value"
     [isDismissible]="false"
     [ngClass]="['for-mobile']"
-  ></cx-opf-checkout-terms-and-conditions-alert>
+  />
 
   <div
     *ngIf="explicitTermsAndConditions.value"
@@ -46,7 +46,7 @@
     </form>
   </div>
 
-  <cx-opf-checkout-billing-address-form></cx-opf-checkout-billing-address-form>
+  <cx-opf-checkout-billing-address-form />
 
   <cx-opf-checkout-payments
     [elementsPerPage]="10"
@@ -59,16 +59,16 @@
       [isVisible]="termsAndConditionInvalid"
       [isExplicit]="explicitTermsAndConditions.value"
       [ngClass]="['for-desktop']"
-    ></cx-opf-checkout-terms-and-conditions-alert>
+    />
     <ng-template
       [cxOutlet]="opfCheckoutOutlets.OPF_CHECKOUT_BEFORE_SAVED_PAYMENT_OPTIONS"
       [cxOutletContext]="{ disabled: paymentOptionsDisabled$ }"
-    ></ng-template>
+    />
   </cx-opf-checkout-payments>
 
   <cx-opf-checkout-review-cart-details
     [cart]="cart$ | async"
     [entries]="entries$ | async"
     [isAddressCardVisible]="true"
-  ></cx-opf-checkout-review-cart-details>
+  />
 </ng-container>

--- a/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-payment-wrapper/opf-checkout-payment-wrapper.component.html
@@ -7,8 +7,7 @@
       !paymentLink?.isLoading ? paymentData : noPaymentData;
       context: { paymentLink: paymentLink }
     "
-  >
-  </ng-container>
+  />
 </div>
 
 <ng-template #paymentData let-paymentLink="paymentLink">
@@ -109,6 +108,6 @@
   </ng-container>
 
   <ng-template #loading>
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </ng-template>
 </ng-template>

--- a/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-payments/opf-checkout-payments.component.html
@@ -8,7 +8,7 @@
   >
     <ng-container *ngIf="!activeConfigurationsState?.loading; else loading">
       <div class="cx-payment-options-list">
-        <ng-content></ng-content>
+        <ng-content />
         <div
           *ngIf="
             !(
@@ -20,8 +20,7 @@
             *ngIf="showBeforePaymentOptionsOutlet"
             [cxOutlet]="opfCheckoutOutlets.OPF_CHECKOUT_BEFORE_PAYMENT_OPTIONS"
             [cxOutletContext]="outletContext$"
-          >
-          </ng-template>
+          />
 
           <div
             *ngFor="let configuration of activeConfigurationsState?.data?.value"
@@ -75,7 +74,7 @@
             >
               <div class="cx-payment-info-box">
                 <span class="alert-icon" aria-hidden="true">
-                  <cx-icon [type]="iconTypes.INFO"></cx-icon>
+                  <cx-icon [type]="iconTypes.INFO" />
                 </span>
                 <p
                   class="cx-payment-info-box-message"
@@ -102,7 +101,7 @@
                     class="cx-payment-info-box"
                   >
                     <span class="alert-icon" aria-hidden="true">
-                      <cx-icon [type]="iconTypes.INFO"></cx-icon>
+                      <cx-icon [type]="iconTypes.INFO" />
                     </span>
                     <p
                       class="cx-payment-info-box-message"
@@ -117,9 +116,7 @@
               </ng-container>
 
               <ng-container *ngIf="customPaymentTemplate">
-                <ng-container
-                  *ngTemplateOutlet="customPaymentTemplate"
-                ></ng-container>
+                <ng-container *ngTemplateOutlet="customPaymentTemplate" />
               </ng-container>
 
               <cx-opf-checkout-payment-wrapper
@@ -130,7 +127,7 @@
                   configuration.id === selectedPaymentId
                 "
                 [selectedPaymentId]="selectedPaymentId"
-              ></cx-opf-checkout-payment-wrapper>
+              />
             </ng-container>
           </div>
 
@@ -138,13 +135,13 @@
             class="cx-payment-options-list-pagination"
             [pagination]="paginationModel"
             (viewPageEvent)="pageChange($event)"
-          ></cx-pagination>
+          />
         </div>
       </div>
     </ng-container>
   </ng-container>
 
   <ng-template #loading>
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </ng-template>
 </section>

--- a/integration-libs/opf/checkout/components/opf-checkout-review-card/opf-checkout-review-card.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-review-card/opf-checkout-review-card.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="cardContent$ | async as content">
-  <cx-card [content]="content"></cx-card>
+  <cx-card [content]="content" />
   <button
     *ngIf="editConfig?.route"
     class="cx-opf-card-review-edit-button"
@@ -9,6 +9,6 @@
         | cxTranslate
     "
   >
-    <cx-icon [type]="iconTypes.PENCIL"></cx-icon>
+    <cx-icon [type]="iconTypes.PENCIL" />
   </button>
 </ng-container>

--- a/integration-libs/opf/checkout/components/opf-checkout-review-cart-details/opf-checkout-review-cart-details.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-review-cart-details/opf-checkout-review-cart-details.component.html
@@ -15,10 +15,9 @@
         cart?.potentialOrderPromotions || []
       )
     "
-  ></cx-promotions>
+  />
 
-  <ng-template [cxOutlet]="cartOutlets.OPF_CHECKOUT_PICKUP_ITEMS">
-  </ng-template>
+  <ng-template [cxOutlet]="cartOutlets.OPF_CHECKOUT_PICKUP_ITEMS" />
 
   <ng-container *ngIf="cart?.deliveryItemsQuantity">
     <div class="cx-items-to-ship-label">
@@ -32,7 +31,7 @@
           route: getCheckoutStepUrl(checkoutStepTypeDeliveryAddress),
           ariaLabelKey: 'checkoutReview.editDeliveryAddressDetails',
         }"
-      ></cx-opf-checkout-review-card>
+      />
 
       <cx-opf-checkout-review-card
         *ngIf="deliveryMode$ | async as deliveryMode"
@@ -41,7 +40,7 @@
           route: getCheckoutStepUrl(checkoutStepTypeDeliveryMode),
           ariaLabelKey: 'checkoutReview.editDeliveryMode',
         }"
-      ></cx-opf-checkout-review-card>
+      />
     </div>
 
     <ng-template
@@ -51,7 +50,6 @@
         readonly: true,
         promotionLocation: promotionLocation,
       }"
-    >
-    </ng-template>
+    />
   </ng-container>
 </div>

--- a/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/opf-checkout-terms-and-conditions-alert.component.html
+++ b/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/opf-checkout-terms-and-conditions-alert.component.html
@@ -2,7 +2,7 @@
   <ng-container *ngIf="paymentDisabled$ | async; else termsConditions">
     <div class="alert alert-danger">
       <span class="alert-icon" aria-hidden="true">
-        <cx-icon [type]="iconTypes.ERROR"></cx-icon>
+        <cx-icon [type]="iconTypes.ERROR" />
       </span>
       <p class="message" tabindex="0" role="alert" aria-live="polite">
         {{ 'opfCheckout.errors.noBillingAddress' | cxTranslate }}
@@ -12,7 +12,7 @@
   <ng-template #termsConditions>
     <div class="alert alert-info">
       <span class="alert-icon" aria-hidden="true">
-        <cx-icon [type]="iconTypes.INFO"></cx-icon>
+        <cx-icon [type]="iconTypes.INFO" />
       </span>
       <p class="message" tabindex="0" role="alert" aria-live="polite">
         {{
@@ -32,7 +32,7 @@
         "
         [attr.title]="'opfCheckout.closeTermsAndConditionsAlert' | cxTranslate"
       >
-        <cx-icon [type]="iconTypes.CLOSE"></cx-icon>
+        <cx-icon [type]="iconTypes.CLOSE" />
       </button>
     </div>
   </ng-template>

--- a/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/opf-checkout-terms-and-conditions-alert.component.spec.ts
+++ b/integration-libs/opf/checkout/components/opf-checkout-terms-and-conditions-alert/opf-checkout-terms-and-conditions-alert.component.spec.ts
@@ -9,7 +9,7 @@ import { OpfCheckoutTermsAndConditionsAlertComponent } from './opf-checkout-term
 
 @Component({
   selector: 'cx-icon',
-  template: '<ng-content></ng-content>',
+  template: '<ng-content />',
 })
 class MockIconComponent {
   @Input() type: string;

--- a/integration-libs/opf/cta/components/opf-cta-quick-buy-buttons/opf-cta-quick-buy-buttons.component.html
+++ b/integration-libs/opf/cta/components/opf-cta-quick-buy-buttons/opf-cta-quick-buy-buttons.component.html
@@ -3,6 +3,6 @@
     <cx-opf-cta-element
       *ngFor="let ctaHtml of ctaHtmls"
       [ctaScriptHtml]="ctaHtml"
-    ></cx-opf-cta-element>
+    />
   </ng-container>
 </ng-container>

--- a/integration-libs/opf/cta/components/opf-cta-scripts/opf-cta-scripts.component.html
+++ b/integration-libs/opf/cta/components/opf-cta-scripts/opf-cta-scripts.component.html
@@ -3,6 +3,6 @@
     <cx-opf-cta-element
       *ngFor="let ctaHtml of ctaHtmls"
       [ctaScriptHtml]="ctaHtml"
-    ></cx-opf-cta-element>
+    />
   </ng-container>
 </ng-container>

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-apply/opf-gift-card-apply.component.html
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-apply/opf-gift-card-apply.component.html
@@ -49,7 +49,7 @@
                 label: 'opfGiftCard.cardNumber' | cxTranslate,
               }"
               [control]="giftCardForm.get('cardNumber')"
-            ></cx-form-errors>
+            />
           </div>
 
           <div class="form-group">
@@ -69,7 +69,7 @@
                 label: 'opfGiftCard.pin' | cxTranslate,
               }"
               [control]="giftCardForm.get('pin')"
-            ></cx-form-errors>
+            />
           </div>
 
           <button
@@ -85,8 +85,8 @@
       <!-- Applied Gift Cards -->
       <cx-opf-gift-card-applied
         [opfGiftCards]="(appliedGiftCards$ | async) || []"
-      ></cx-opf-gift-card-applied>
-      <cx-opf-gift-card-checkout-place-order></cx-opf-gift-card-checkout-place-order>
+      />
+      <cx-opf-gift-card-checkout-place-order />
     </div>
   </ng-container>
 </ng-container>

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-checkout/opf-gift-card-checkout-order-summary/opf-gift-card-checkout-order-summary.component.html
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-checkout/opf-gift-card-checkout-order-summary/opf-gift-card-checkout-order-summary.component.html
@@ -1,5 +1,3 @@
 <ng-container *ngIf="cart$ | async as cart">
-  <cx-opf-gift-card-order-summary
-    [cart]="cart"
-  ></cx-opf-gift-card-order-summary>
+  <cx-opf-gift-card-order-summary [cart]="cart" />
 </ng-container>

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-order-confirmation/opf-gift-card-order-confirmation-totals/opf-gift-card-order-confirmation-totals.component.html
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-order-confirmation/opf-gift-card-order-confirmation-totals/opf-gift-card-order-confirmation-totals.component.html
@@ -4,9 +4,7 @@
 >
   <div class="row justify-content-end">
     <div class="col-sm-12 col-md-6 col-lg-5 col-xl-4">
-      <cx-opf-gift-card-order-summary
-        [cart]="order"
-      ></cx-opf-gift-card-order-summary>
+      <cx-opf-gift-card-order-summary [cart]="order" />
     </div>
   </div>
 </div>

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-order-details/opf-gift-card-order-detail-billing/opf-gift-card-order-detail-billing.component.html
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-order-details/opf-gift-card-order-detail-billing/opf-gift-card-order-detail-billing.component.html
@@ -7,13 +7,13 @@
       <ng-container
         *ngIf="!order.paymentInfo?.cardNumber; else partialGiftCardPayment"
       >
-        <cx-card [content]="getPaymentMethodCardContent() | async"></cx-card>
+        <cx-card [content]="getPaymentMethodCardContent() | async" />
       </ng-container>
 
       <ng-template #partialGiftCardPayment>
         <cx-card
           [content]="{ text: ['opfGiftCard.giftCardPayment' | cxTranslate] }"
-        ></cx-card>
+        />
       </ng-template>
     </div>
   </ng-container>

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-order-details/opf-gift-card-order-detail-totals/opf-gift-card-order-detail-totals.component.html
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-order-details/opf-gift-card-order-detail-totals/opf-gift-card-order-detail-totals.component.html
@@ -1,9 +1,7 @@
 <ng-container *ngIf="order$ | async as order">
   <div class="row justify-content-end">
     <div class="cx-summary col-sm-12 col-md-6 col-lg-5 col-xl-4">
-      <cx-opf-gift-card-order-summary
-        [cart]="order"
-      ></cx-opf-gift-card-order-summary>
+      <cx-opf-gift-card-order-summary [cart]="order" />
     </div>
   </div>
 </ng-container>

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-order-details/opf-gift-card-payment-method-detail/opf-gift-card-payment-method-detail.component.html
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-order-details/opf-gift-card-payment-method-detail/opf-gift-card-payment-method-detail.component.html
@@ -5,7 +5,7 @@
         *ngIf="!isPaymentMethodDetailsInfoPresent; else giftCardPartialPayment"
       >
         <div class="cx-gift-card-full-payment">
-          <cx-card [content]="getPaymentMethodCardContent() | async"></cx-card>
+          <cx-card [content]="getPaymentMethodCardContent() | async" />
         </div>
       </ng-container>
 
@@ -13,7 +13,7 @@
         <div class="cx-gift-card-partial-payment">
           <cx-card
             [content]="{ text: ['opfGiftCard.giftCardPayment' | cxTranslate] }"
-          ></cx-card>
+          />
         </div>
       </ng-template>
     </div>

--- a/integration-libs/opf/gift-card/root/components/opf-gift-card-order-summary/opf-gift-card-order-summary.component.html
+++ b/integration-libs/opf/gift-card/root/components/opf-gift-card-order-summary/opf-gift-card-order-summary.component.html
@@ -84,5 +84,5 @@
   <cx-applied-coupons
     [vouchers]="cart.appliedVouchers || []"
     [isReadOnly]="true"
-  ></cx-applied-coupons>
+  />
 </ng-container>

--- a/integration-libs/opf/payment/root/components/opf-payment-method-details/opf-payment-method-details.component.html
+++ b/integration-libs/opf/payment/root/components/opf-payment-method-details/opf-payment-method-details.component.html
@@ -5,10 +5,9 @@
       getPaymentMethodDetailsCardContent(order.paymentInfo.sapPaymentMethod)
         | async
     "
-  ></cx-card>
+  />
 </ng-container>
 <ng-template
   [cxOutlet]="opfCheckoutOutlets.ORDER_DETAILS_AFTER_PAYMENT_OPTIONS"
   [cxOutletContext]="order"
->
-</ng-template>
+/>

--- a/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.html
+++ b/integration-libs/opf/payment/root/components/opf-payment-verification/opf-payment-verification.component.html
@@ -1,3 +1,3 @@
 <div class="cx-spinner">
-  <cx-spinner></cx-spinner>
+  <cx-spinner />
 </div>

--- a/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/opf-quick-buy-buttons.component.html
+++ b/integration-libs/opf/quick-buy/components/opf-quick-buy-buttons/opf-quick-buy-buttons.component.html
@@ -4,7 +4,7 @@
       isPaymentMethodEnabled(PAYMENT_METHODS.APPLE_PAY, paymentGatewayConfig)
     "
     [activeConfiguration]="paymentGatewayConfig"
-  ></cx-opf-apple-pay>
+  />
 </ng-container>
 
 <div class="cx-opf-quick-buy-buttons-fixed-space">
@@ -14,6 +14,6 @@
         isPaymentMethodEnabled(PAYMENT_METHODS.GOOGLE_PAY, paymentGatewayConfig)
       "
       [activeConfiguration]="paymentGatewayConfig"
-    ></cx-opf-google-pay>
+    />
   </ng-container>
 </div>

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-account-payment-methods/opf-tokenisation-account-payment-methods.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-account-payment-methods/opf-tokenisation-account-payment-methods.component.html
@@ -12,7 +12,7 @@
           'paymentMethods.newPaymentMethodsAreAddedDuringCheckout' | cxTranslate
         }}
       </div>
-      <div *ngIf="loading$ | async; else cards"><cx-spinner></cx-spinner></div>
+      <div *ngIf="loading$ | async; else cards"><cx-spinner /></div>
       <ng-template #cards>
         <div class="cx-existing row">
           <div
@@ -29,7 +29,7 @@
                   class="cx-expired-error-icon"
                   [type]="iconTypes.ERROR"
                   aria-hidden="true"
-                ></cx-icon>
+                />
                 <span class="cx-expired-error-message">
                   {{ 'paymentCard.expiredMessage' | cxTranslate }}
                 </span>
@@ -55,7 +55,7 @@
                   (editCard)="setEdit(paymentMethod)"
                   [editMode]="editCard === paymentMethod.id"
                   (cancelCard)="cancelCard()"
-                ></cx-card>
+                />
               </div>
             </div>
           </div>
@@ -69,4 +69,4 @@
   [showDialog]="showDeleteDialog"
   (confirmDelete)="confirmDeletePaymentMethod()"
   (cancelDelete)="closeDeleteDialog()"
-></cx-opf-tokenisation-delete-payment-dialog>
+/>

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-payment-method/opf-tokenisation-payment-method.component.html
@@ -2,8 +2,7 @@
   <ng-container *ngIf="showSavedCards$ | async">
     <ng-container *ngIf="cards$ | async as cards">
       <ng-container *ngIf="!(isUpdating$ | async); else loading">
-        <ng-container *ngIf="cards?.length; then hasExistingPaymentMethods">
-        </ng-container>
+        <ng-container *ngIf="cards?.length; then hasExistingPaymentMethods" />
       </ng-container>
 
       <ng-template #hasExistingPaymentMethods>
@@ -31,7 +30,7 @@
                     class="cx-expired-error-icon"
                     [type]="iconTypes.ERROR"
                     aria-hidden="true"
-                  ></cx-icon>
+                  />
                   <span class="cx-expired-error-message">
                     {{ 'paymentCard.expiredMessage' | cxTranslate }}
                   </span>
@@ -47,7 +46,7 @@
                   !isCardExpired(card.paymentMethod) &&
                     selectPaymentMethod(card.paymentMethod)
                 "
-              ></cx-card>
+              />
             </div>
           </div>
         </div>
@@ -94,6 +93,6 @@
 
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>

--- a/integration-libs/opf/tokenisation/root/components/opf-tokenisation-saved-cards-toggle/opf-tokenisation-saved-cards-toggle.component.html
+++ b/integration-libs/opf/tokenisation/root/components/opf-tokenisation-saved-cards-toggle/opf-tokenisation-saved-cards-toggle.component.html
@@ -33,10 +33,7 @@
         for="paymentId-saved-cards"
       >
         <div class="cx-payment-type">
-          <cx-icon
-            [type]="iconTypes.CREDIT_CARD"
-            class="cx-payment-icon"
-          ></cx-icon>
+          <cx-icon [type]="iconTypes.CREDIT_CARD" class="cx-payment-icon" />
           <span>{{
             ctx.savedCardsHeading || ('opfCheckout.cards' | cxTranslate)
           }}</span>

--- a/integration-libs/punchout/components/punchout-error/punchout-error.component.html
+++ b/integration-libs/punchout/components/punchout-error/punchout-error.component.html
@@ -1,6 +1,6 @@
 <div class="alert">
   <span class="alert-icon">
-    <cx-icon [type]="iconTypes.ERROR"></cx-icon>
+    <cx-icon [type]="iconTypes.ERROR" />
   </span>
   {{ 'punchout.error' | cxTranslate }}
 </div>

--- a/integration-libs/punchout/components/punchout-inspect-cart/punchout-inspect-cart.component.html
+++ b/integration-libs/punchout/components/punchout-inspect-cart/punchout-inspect-cart.component.html
@@ -9,12 +9,12 @@
             isSaveForLater: false,
             disableItemLink: true,
           }"
-        ></cx-cart-item-list>
+        />
       </div>
       <div class="punchoutEndSection">
-        <cx-order-summary [cart]="cart"></cx-order-summary>
+        <cx-order-summary [cart]="cart" />
 
-        <cx-punchout-buttons [removeCancelButton]="true"></cx-punchout-buttons>
+        <cx-punchout-buttons [removeCancelButton]="true" />
       </div>
     </ng-container>
   </ng-container>

--- a/integration-libs/s4-service/checkout/components/checkout-delivery-mode/service-checkout-delivery-mode.component.html
+++ b/integration-libs/s4-service/checkout/components/checkout-delivery-mode/service-checkout-delivery-mode.component.html
@@ -1,5 +1,5 @@
 <fieldset role="radiogroup">
-  <ng-container *ngTemplateOutlet="displayServiceDelivery"></ng-container>
+  <ng-container *ngTemplateOutlet="displayServiceDelivery" />
   <legend class="cx-checkout-title d-none d-lg-block d-xl-block">
     {{ 'serviceOrderCheckout.productDeliveryOptions' | cxTranslate }}
   </legend>
@@ -52,8 +52,7 @@
         [cxOutletContext]="{
           item: activeCartFacade.getActive() | async,
         }"
-      >
-      </ng-template>
+      />
     </div>
   </ng-container>
 </fieldset>
@@ -69,17 +68,16 @@
       items: activeCartFacade.getDeliveryEntries() | async,
       readonly: true,
     }"
-  >
-  </ng-template>
+  />
 </ng-container>
 
 <ng-template #loading>
   <div class="cx-spinner">
-    <cx-spinner></cx-spinner>
+    <cx-spinner />
   </div>
 </ng-template>
 
-<ng-container cxInnerComponentsHost></ng-container>
+<ng-container cxInnerComponentsHost />
 
 <div class="row cx-checkout-btns">
   <div class="col-md-12 col-lg-6">
@@ -144,7 +142,7 @@
             displayDeliveryMode;
             context: { content: serviceDeliveryConfig }
           "
-        ></ng-container>
+        />
       </div>
     </div>
   </ng-container>

--- a/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.component.html
+++ b/integration-libs/s4-service/checkout/components/checkout-review-submit/service-checkout-review-submit.component.html
@@ -20,7 +20,7 @@
                     styleClass: 'cx-review-summary-card',
                   }
                 "
-              ></ng-container>
+              />
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypePaymentType">
               <ng-container *ngIf="paymentType$ | async as paymentType">
@@ -36,7 +36,7 @@
                       styleClass: 'cx-review-summary-card',
                     }
                   "
-                ></ng-container>
+                />
               </ng-container>
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypePaymentDetails">
@@ -54,7 +54,7 @@
                         'cx-review-summary-card cx-review-card-payment',
                     }
                   "
-                ></ng-container>
+                />
               </ng-container>
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypeDeliveryAddress">
@@ -72,7 +72,7 @@
                         styleClass: 'cx-review-summary-card',
                       }
                     "
-                  ></ng-container>
+                  />
                 </ng-container>
               </ng-container>
             </ng-container>
@@ -97,11 +97,11 @@
                         'cx-review-summary-card cx-review-card-address',
                     }
                   "
-                ></ng-container>
+                />
               </ng-container>
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypeDeliveryMode">
-              <ng-container *ngTemplateOutlet="deliveryMode"></ng-container>
+              <ng-container *ngTemplateOutlet="deliveryMode" />
             </ng-container>
             <ng-container *ngSwitchCase="checkoutStepTypeServiceDetails">
               <ng-container *ngIf="scheduledAt$ | async as scheduledAt">
@@ -118,7 +118,7 @@
                         'cx-review-summary-card cx-review-service-details',
                     }
                   "
-                ></ng-container>
+                />
               </ng-container>
             </ng-container>
           </ng-container>
@@ -134,13 +134,13 @@
     let-styleClass="styleClass"
   >
     <div [ngClass]="styleClass">
-      <cx-card [content]="content | async"></cx-card>
+      <cx-card [content]="content | async" />
       <div class="cx-review-summary-edit-step">
         <a
           [attr.title]="label | cxTranslate"
           [routerLink]="{ cxRoute: editRoute } | cxUrl"
         >
-          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>
+          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL" />
         </a>
       </div>
     </div>
@@ -153,16 +153,14 @@
         <cx-card
           *ngIf="shouldShowDeliveryModeCard(deliveryMode)"
           [content]="getDeliveryModeCard(deliveryMode) | async"
-        >
-        </cx-card>
+        />
         <ng-template
           [cxOutlet]="cartOutlets.DELIVERY_MODE"
           [cxOutletContext]="{
             item: cart$ | async,
             readonly: true,
           }"
-        >
-        </ng-template>
+        />
       </div>
 
       <div class="cx-review-summary-edit-step">
@@ -173,7 +171,7 @@
               | cxUrl
           "
         >
-          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL"></cx-icon>
+          <cx-icon aria-hidden="true" [type]="iconTypes.PENCIL" />
         </a>
       </div>
     </div>
@@ -198,7 +196,7 @@
             cart.potentialOrderPromotions || []
           )
         "
-      ></cx-promotions>
+      />
 
       <ng-template
         [cxOutlet]="cartOutlets.CART_ITEM_LIST"
@@ -207,8 +205,7 @@
           readonly: true,
           promotionLocation: promotionLocation,
         }"
-      >
-      </ng-template>
+      />
     </div>
   </ng-container>
 </div>

--- a/integration-libs/s4-service/checkout/components/checkout-service-details/checkout-service-details.component.html
+++ b/integration-libs/s4-service/checkout/components/checkout-service-details/checkout-service-details.component.html
@@ -36,8 +36,7 @@
           [control]="$any(form.get('scheduleDate'))"
           [min]="(minServiceDate$ | async) ?? undefined"
           label="serviceOrderCheckout.datePickerLabel"
-        >
-        </cx-date-picker>
+        />
       </div>
     </label>
 

--- a/integration-libs/s4-service/order/components/cancel-service-order-headline/cancel-service-order-headline.component.html
+++ b/integration-libs/s4-service/order/components/cancel-service-order-headline/cancel-service-order-headline.component.html
@@ -34,7 +34,6 @@
         items: order.entries,
         readonly: true,
       }"
-    >
-    </ng-template>
+    />
   </ng-container>
 </ng-container>

--- a/integration-libs/s4-service/order/components/order-summary/service-details-card.component.html
+++ b/integration-libs/s4-service/order/components/order-summary/service-details-card.component.html
@@ -1,5 +1,3 @@
 <ng-container *ngIf="showServiceDetails()">
-  <cx-card
-    [content]="getServiceDetailsCard(order.servicedAt) | async"
-  ></cx-card>
+  <cx-card [content]="getServiceDetailsCard(order.servicedAt) | async" />
 </ng-container>

--- a/integration-libs/s4-service/order/components/reschedule-service-order/reschedule-service-order.component.html
+++ b/integration-libs/s4-service/order/components/reschedule-service-order/reschedule-service-order.component.html
@@ -58,8 +58,7 @@
         items: order.entries,
         readonly: true,
       }"
-    >
-    </ng-template>
+    />
   </div>
 
   <div class="cx-reschedule-service-actions">

--- a/projects/storefrontapp/src/app/app.component.ts
+++ b/projects/storefrontapp/src/app/app.component.ts
@@ -13,7 +13,7 @@ import { StorefrontComponent } from '@spartacus/storefront';
  */
 @Component({
   selector: 'app-root',
-  template: `<cx-storefront></cx-storefront>`,
+  template: `<cx-storefront />`,
   imports: [StorefrontComponent],
 })
 export class AppComponent {}

--- a/projects/storefrontapp/src/test-outlets/test-outlet-component/test-outlet-component.component.html
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-component/test-outlet-component.component.html
@@ -1,4 +1,4 @@
-<cx-page-layout></cx-page-layout>
+<cx-page-layout />
 
 <ng-template [cxOutletRef]="testComponent" cxOutletPos="before" let-model>
   <p>Before component, uid: {{ model.component.uid }}</p>

--- a/projects/storefrontapp/src/test-outlets/test-outlet-slot/test-outlet-slot.component.html
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-slot/test-outlet-slot.component.html
@@ -1,4 +1,4 @@
-<cx-page-layout></cx-page-layout>
+<cx-page-layout />
 
 <!-- SLOT 1 -->
 <ng-template [cxOutletRef]="testSlot1" cxOutletPos="before" let-model>

--- a/projects/storefrontapp/src/test-outlets/test-outlet-template/test-outlet-template.component.html
+++ b/projects/storefrontapp/src/test-outlets/test-outlet-template/test-outlet-template.component.html
@@ -1,4 +1,4 @@
-<cx-page-layout></cx-page-layout>
+<cx-page-layout />
 
 <ng-template [cxOutletRef]="testTemplate" cxOutletPos="before" let-model>
   <p>


### PR DESCRIPTION
Apply the Angular self-closing-tag migration across all libraries to
align templates with modern Angular style. Component elements without
projected content now use self-closing tags (e.g. `<cx-foo />`).

Template-only, non-breaking change generated via
`ng generate @angular/core:self-closing-tag`. 385 files, no behavioral
changes.

Refs: [CXSPA-11236](https://jira.tools.sap/browse/CXSPA-11236)