### PR TITLE
fix: improve footer copyright and breadcrumb link contrast in default theme (CXSPA-14190)

### DIFF
--- a/core-libs/styles/scss/components/content/navigation/_breadcrumb.scss
+++ b/core-libs/styles/scss/components/content/navigation/_breadcrumb.scss
@@ -60,7 +60,10 @@ html[dir='rtl'] cx-breadcrumb nav span:not(:last-child):after {
         }
         a {
           text-transform: capitalize;
-          color: var(--cx-color-primary);
+          // Use the darker primary-accent so the link meets 4.5:1 against the
+          // breadcrumb background (--cx-color-background, #f4f4f4 in the default
+          // theme). The base primary (#1f7bc0) only reaches ~4.1:1 there.
+          color: var(--cx-color-primary-accent);
           padding: 0px 5px;
 
           &:focus {

--- a/core-libs/styles/scss/cxbase/blocks/paragraph.scss
+++ b/core-libs/styles/scss/cxbase/blocks/paragraph.scss
@@ -2,7 +2,12 @@
   padding: 32px 0;
   text-align: center;
   @include type();
-  color: var(--cx-color-text);
+  // Enforce the theme text color on the footer copyright notice so any
+  // CMS-provided inline gray (e.g. rgb(170,170,170) / #aaa, ~2.32:1 on white)
+  // cannot override it. `!important` is required to win over the
+  // non-important inline `style="color:..."` set by CMS content. Using the
+  // theme variable keeps it adaptive so high-contrast themes meet 7:1.
+  color: var(--cx-color-text) !important;
   background-color: var(--cx-color-inverse);
   margin-bottom: -1.5rem;
 


### PR DESCRIPTION
## Jira
CXSPA-14190 — ACC-262.3, 262.5: Footer copyright text and breadcrumb link have insufficient contrast in the default (santorini) theme.

## Problem
Two elements failed the WCAG minimum 4.5:1 contrast ratio in the default theme:

| Element | FG | BG | Before | Required |
|---|---|---|---|---|
| Footer copyright (`.cx-notice`) | #aaaaaa | #ffffff | 2.32:1 | >= 4.5:1 (>= 7:1 HC Light) |
| Breadcrumb link (`a`) | #1f7bc0 | #f4f4f4 | 4.1:1 | >= 4.5:1 |

## Fix
- **Footer copyright** (`core-libs/styles/scss/cxbase/blocks/paragraph.scss`): the gray came from CMS-provided inline `style="color:rgb(170,170,170)"`, which overrode the non-`!important` theme color. Enforced `color: var(--cx-color-text) !important` so the theme text color wins. In the default theme `--cx-color-text` is `#14293a` -> **~14.9:1** on white, and because it is a theme variable it adapts to high-contrast themes (HC Light meets >= 7:1).
- **Breadcrumb link** (`core-libs/styles/scss/components/content/navigation/_breadcrumb.scss`): switched from `var(--cx-color-primary)` (#1f7bc0, ~4.1:1) to the darker `var(--cx-color-primary-accent)` (#055f9f in the default theme) -> **~6.08:1** on the #f4f4f4 breadcrumb background. Safe across themes (HC Light #004ccb, HC Dark #6bd3ff both high-contrast).

These are styling-only changes (no template changes), so no feature toggle is required.