### PR TITLE
fix(a11y): improve footer copyright and breadcrumb link contrast (CXSPA-14190)

### DIFF
--- a/core-libs/styles/scss/components/content/navigation/_breadcrumb.scss
+++ b/core-libs/styles/scss/components/content/navigation/_breadcrumb.scss
@@ -60,7 +60,11 @@ html[dir='rtl'] cx-breadcrumb nav span:not(:last-child):after {
         }
         a {
           text-transform: capitalize;
-          color: var(--cx-color-primary);
+          // Use the darker primary-accent so the link meets 4.5:1 against the
+          // breadcrumb background (--cx-color-background, #f4f4f4 in the default
+          // theme). The base primary (#1f7bc0) only reaches ~4.1:1 there,
+          // whereas primary-accent (#055f9f) reaches ~6.07:1.
+          color: var(--cx-color-primary-accent);
           padding: 0px 5px;
 
           &:focus {

--- a/core-libs/styles/scss/cxbase/blocks/paragraph.scss
+++ b/core-libs/styles/scss/cxbase/blocks/paragraph.scss
@@ -2,7 +2,13 @@
   padding: 32px 0;
   text-align: center;
   @include type();
-  color: var(--cx-color-text);
+  // Enforce the theme text color on the footer copyright notice so any
+  // CMS-provided inline gray (e.g. rgb(170,170,170) / #aaa, ~2.32:1 on white)
+  // cannot override it. `!important` is required to win over the non-important
+  // inline `style="color:..."` set by CMS content. Using the theme variable
+  // keeps it adaptive: default theme #14293a gives ~14.9:1 on white, and
+  // high-contrast light (#000000) meets the required 7:1.
+  color: var(--cx-color-text) !important;
   background-color: var(--cx-color-inverse);
   margin-bottom: -1.5rem;
 


### PR DESCRIPTION
## CXSPA-14190 — ACC-262.3, 262.5

Two elements failed the WCAG minimum contrast ratio in the default (santorini) theme. The footer copyright also failed 7:1 in HC Light because its rendered color was a hardcoded CMS gray that did not adapt to high-contrast themes.

### Fixes (pure styles change, no template change)

**Footer copyright notice** (`.cx-notice`, footer landmark)
- Before: FG `rgb(170,170,170)` / `#aaaaaa` on white `#ffffff` = **2.32:1** (CMS inline gray was overriding the theme color).
- After: enforce the theme text color with `color: var(--cx-color-text) !important` so the non-important CMS inline `style="color:..."` can no longer win.
  - Default theme `#14293a` on white = **14.91:1** (≥ 4.5:1).
  - HC Light `--cx-color-text` = `#000000` on the light background ≈ **21:1** (≥ 7:1).

**Breadcrumb "Home" link** (`cx-breadcrumb nav a`, nav landmark)
- Before: `var(--cx-color-primary)` `#1f7bc0` on `#f4f4f4` = **4.1:1**.
- After: `var(--cx-color-primary-accent)` `#055f9f` on `#f4f4f4` = **6.07:1** (≥ 4.5:1). The variable keeps it adaptive across high-contrast themes.

### Files changed
- `core-libs/styles/scss/cxbase/blocks/paragraph.scss`
- `core-libs/styles/scss/components/content/navigation/_breadcrumb.scss`