### PR TITLE
feat: display CPQ containers in configuration overview (CXSPA-14094)

### DIFF
--- a/.cursor
+++ b/.cursor
@@ -1,0 +1,1 @@
+/Users/D031179/dev/git-repo/team-tiger-ci/ai-tooling/cursor-spa

--- a/.cursor
+++ b/.cursor
@@ -1,1 +1,0 @@
-/Users/D031179/dev/git-repo/team-tiger-ci/ai-tooling/cursor-spa

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.spec.ts
@@ -2,6 +2,10 @@ import { Type } from '@angular/core';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { LanguageService, TranslationService } from '@spartacus/core';
 import { Configurator } from '@spartacus/product-configurator/rulebased';
+import {
+  MockFeatureTogglesController,
+  provideMockFeatureToggles,
+} from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { Observable, of } from 'rxjs';
 import { Cpq } from '../cpq.models';
 import { CpqConfiguratorNormalizerUtilsService } from './cpq-configurator-normalizer-utils.service';
@@ -146,6 +150,7 @@ class MockTranslationService {
 
 describe('CpqConfiguratorOverviewNormalizer', () => {
   let serviceUnderTest: CpqConfiguratorOverviewNormalizer;
+  let featureToggles: MockFeatureTogglesController;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -160,12 +165,16 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
           provide: TranslationService,
           useClass: MockTranslationService,
         },
+        provideMockFeatureToggles({
+          productConfiguratorCPQContainer: false,
+        }),
       ],
     });
 
     serviceUnderTest = TestBed.inject(
       CpqConfiguratorOverviewNormalizer as Type<CpqConfiguratorOverviewNormalizer>
     );
+    featureToggles = TestBed.inject(MockFeatureTogglesController);
     attr = structuredClone(attrBase);
   }));
 
@@ -511,6 +520,246 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
     expect(ovAttrs[0].valuePriceTotal?.currencyIso).toBe(CURRENCY);
     expect(ovAttrs[0].valuePriceTotal?.value).toBe(123.45);
     expect(ovAttrs[0].valuePriceTotal?.formattedValue).toBe('$123.45');
+  });
+
+  describe('containers', () => {
+    const containerAttributeCode = 500;
+    const nestedContainerAttributeCode = 600;
+    const rootTabId = 1;
+    const nestedTabId = rootTabId;
+
+    const containerAttribute: Cpq.Attribute = {
+      pA_ID: 50,
+      stdAttrCode: containerAttributeCode,
+      name: 'Lenses',
+      displayAs: Cpq.DisplayAs.CONTAINER,
+      values: [],
+    };
+
+    const nestedInputAttribute: Cpq.Attribute = {
+      pA_ID: 60,
+      stdAttrCode: 601,
+      name: 'Lens Color',
+      displayAs: Cpq.DisplayAs.INPUT,
+      dataType: Cpq.DataType.INPUT_STRING,
+      userInput: 'Black',
+      values: [],
+    };
+
+    const nestedContainerAttribute: Cpq.Attribute = {
+      pA_ID: 61,
+      stdAttrCode: nestedContainerAttributeCode,
+      name: 'Filters',
+      displayAs: Cpq.DisplayAs.CONTAINER,
+      values: [],
+    };
+
+    const deepInputAttribute: Cpq.Attribute = {
+      pA_ID: 70,
+      stdAttrCode: 701,
+      name: 'Filter Color',
+      displayAs: Cpq.DisplayAs.INPUT,
+      dataType: Cpq.DataType.INPUT_STRING,
+      userInput: 'Clear',
+      values: [],
+    };
+
+    function createConfigurationWithContainers(): Cpq.Configuration {
+      return {
+        productSystemId: PRODUCT_CODE,
+        currencyISOCode: CURRENCY,
+        tabs: [
+          {
+            id: rootTabId,
+            displayName: 'Camera',
+            attributes: [structuredClone(containerAttribute)],
+          },
+        ],
+        sapContainers: [
+          {
+            stdAttrCode: containerAttributeCode,
+            rows: [
+              {
+                id: 'unselected',
+                productSystemId: 'UNSELECTED',
+                productName: 'Unselected Lens',
+                selected: false,
+              },
+              {
+                id: 'add',
+                productSystemId: 'ADD',
+                productName: 'Add Lens',
+                selected: true,
+                actions: [Cpq.ContainerRowAction.ADD],
+              },
+              {
+                id: 'fixed',
+                productSystemId: 'FIXED_LENS',
+                productName: '50mm Lens',
+                selected: true,
+              },
+              {
+                id: 'zoom',
+                productSystemId: 'ZOOM_LENS',
+                productName: 'Zoom Lens',
+                selected: true,
+                configuration: {
+                  tabs: [
+                    {
+                      id: nestedTabId,
+                      displayName: 'Lens Details',
+                      attributes: [
+                        structuredClone(nestedInputAttribute),
+                        structuredClone(nestedContainerAttribute),
+                      ],
+                    },
+                  ],
+                  containers: [
+                    {
+                      stdAttrCode: nestedContainerAttributeCode,
+                      rows: [
+                        {
+                          id: 'filter',
+                          productSystemId: 'UV_FILTER',
+                          productName: 'UV Filter',
+                          selected: true,
+                          configuration: {
+                            tabs: [
+                              {
+                                id: 2,
+                                displayName: 'Filter Details',
+                                attributes: [
+                                  structuredClone(deepInputAttribute),
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    it('should preserve legacy behavior when the feature toggle is disabled', () => {
+      const loggerWarn = spyOn(serviceUnderTest['logger'], 'warn');
+
+      const result = serviceUnderTest.convert(
+        createConfigurationWithContainers()
+      );
+
+      expect(result.groups).toEqual([]);
+      expect(loggerWarn).toHaveBeenCalled();
+    });
+
+    it('should convert only selected container rows without nested configurations into bundle attributes', () => {
+      featureToggles.set('productConfiguratorCPQContainer', true);
+
+      const result = serviceUnderTest.convert(
+        createConfigurationWithContainers()
+      );
+      const attributes = result.groups?.[0].attributes;
+
+      expect(attributes?.length).toBe(1);
+      expect(attributes?.[0]).toEqual(
+        jasmine.objectContaining({
+          attribute: 'Lenses',
+          attributeId: containerAttributeCode.toString(),
+          value: '50mm Lens',
+          valueId: 'fixed',
+          productCode: 'FIXED_LENS',
+          type: Configurator.AttributeOverviewType.BUNDLE,
+        })
+      );
+      expect(
+        attributes?.some((attribute) => attribute.value === 'Unselected Lens')
+      ).toBe(false);
+      expect(
+        attributes?.some((attribute) => attribute.value === 'Add Lens')
+      ).toBe(false);
+      expect(
+        attributes?.some((attribute) => attribute.value === 'Zoom Lens')
+      ).toBe(false);
+    });
+
+    it('should flatten a single nested group into its container row group', () => {
+      featureToggles.set('productConfiguratorCPQContainer', true);
+
+      const result = serviceUnderTest.convert(
+        createConfigurationWithContainers()
+      );
+      const rootGroup = result.groups?.[0];
+      const rowGroup = rootGroup?.subGroups?.[0];
+      const nestedRowGroup = rowGroup?.subGroups?.[0];
+      const expectedRowGroupId = `${Configurator.ContainerRowGroupIdPrefix}@${containerAttributeCode}@zoom`;
+      const expectedNestedRowGroupId = `${Configurator.ContainerRowGroupIdPrefix}@${nestedContainerAttributeCode}@filter`;
+
+      expect(rootGroup?.id).toBe(rootTabId.toString());
+      expect(rowGroup?.id).toBe(expectedRowGroupId);
+      expect(rowGroup?.groupDescription).toBe('Zoom Lens');
+      expect(rowGroup?.attributes?.length).toBe(1);
+      expect(rowGroup?.attributes?.[0].value).toBe('Black');
+      expect(nestedRowGroup?.id).toBe(expectedNestedRowGroupId);
+      expect(nestedRowGroup?.groupDescription).toBe('UV Filter');
+      expect(nestedRowGroup?.attributes?.[0].value).toBe('Clear');
+      expect(nestedRowGroup?.subGroups).toEqual([]);
+    });
+
+    it('should preserve nested groups when a configuration contains multiple groups', () => {
+      featureToggles.set('productConfiguratorCPQContainer', true);
+      const source = createConfigurationWithContainers();
+      const nestedConfiguration = source.sapContainers?.[0].rows?.find(
+        (row) => row.id === 'zoom'
+      )?.configuration;
+      if (!nestedConfiguration?.tabs) {
+        fail();
+        return;
+      }
+      nestedConfiguration.tabs.push({
+        id: 3,
+        displayName: 'Additional Lens Details',
+        attributes: [structuredClone(deepInputAttribute)],
+      });
+
+      const result = serviceUnderTest.convert(source);
+      const rowGroup = result.groups?.[0].subGroups?.[0];
+      const expectedRowGroupId = `${Configurator.ContainerRowGroupIdPrefix}@${containerAttributeCode}@zoom`;
+
+      expect(rowGroup?.attributes).toEqual([]);
+      expect(rowGroup?.subGroups?.length).toBe(2);
+      expect(rowGroup?.subGroups?.[0].id).toBe(
+        `${expectedRowGroupId}@${nestedTabId}`
+      );
+      expect(rowGroup?.subGroups?.[0].groupDescription).toBe('Lens Details');
+      expect(rowGroup?.subGroups?.[1].id).toBe(`${expectedRowGroupId}@3`);
+      expect(rowGroup?.subGroups?.[1].groupDescription).toBe(
+        'Additional Lens Details'
+      );
+    });
+
+    it('should not attach a container with a non-matching attribute code', () => {
+      featureToggles.set('productConfiguratorCPQContainer', true);
+      const source = createConfigurationWithContainers();
+      source.sapContainers = [{ stdAttrCode: 999, rows: [] }];
+
+      const result = serviceUnderTest.convert(source);
+
+      expect(result.groups).toEqual([]);
+    });
+
+    it('should not log an unsupported warning for containers when the feature toggle is enabled', () => {
+      featureToggles.set('productConfiguratorCPQContainer', true);
+      const loggerWarn = spyOn(serviceUnderTest['logger'], 'warn');
+
+      serviceUnderTest.convert(createConfigurationWithContainers());
+
+      expect(loggerWarn).not.toHaveBeenCalled();
+    });
   });
 
   describe('extractValue', () => {

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.spec.ts
@@ -657,7 +657,7 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
       expect(loggerWarn).toHaveBeenCalled();
     });
 
-    it('should convert only selected container rows without nested configurations into bundle attributes', () => {
+    it('should convert selected container rows into bundle attributes', () => {
       featureToggles.set('productConfiguratorCPQContainer', true);
 
       const result = serviceUnderTest.convert(
@@ -665,7 +665,7 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
       );
       const attributes = result.groups?.[0].attributes;
 
-      expect(attributes?.length).toBe(1);
+      expect(attributes?.length).toBe(2);
       expect(attributes?.[0]).toEqual(
         jasmine.objectContaining({
           attribute: 'Lenses',
@@ -684,7 +684,7 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
       ).toBe(false);
       expect(
         attributes?.some((attribute) => attribute.value === 'Zoom Lens')
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('should flatten a single nested group into its container row group', () => {
@@ -702,8 +702,9 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
       expect(rootGroup?.id).toBe(rootTabId.toString());
       expect(rowGroup?.id).toBe(expectedRowGroupId);
       expect(rowGroup?.groupDescription).toBe('Zoom Lens');
-      expect(rowGroup?.attributes?.length).toBe(1);
+      expect(rowGroup?.attributes?.length).toBe(2);
       expect(rowGroup?.attributes?.[0].value).toBe('Black');
+      expect(rowGroup?.attributes?.[1].value).toBe('UV Filter');
       expect(nestedRowGroup?.id).toBe(expectedNestedRowGroupId);
       expect(nestedRowGroup?.groupDescription).toBe('UV Filter');
       expect(nestedRowGroup?.attributes?.[0].value).toBe('Clear');

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.spec.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.spec.ts
@@ -2,10 +2,6 @@ import { Type } from '@angular/core';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { LanguageService, TranslationService } from '@spartacus/core';
 import { Configurator } from '@spartacus/product-configurator/rulebased';
-import {
-  MockFeatureTogglesController,
-  provideMockFeatureToggles,
-} from 'core-libs/core/src/features-config/feature-toggles/testing';
 import { Observable, of } from 'rxjs';
 import { Cpq } from '../cpq.models';
 import { CpqConfiguratorNormalizerUtilsService } from './cpq-configurator-normalizer-utils.service';
@@ -150,7 +146,6 @@ class MockTranslationService {
 
 describe('CpqConfiguratorOverviewNormalizer', () => {
   let serviceUnderTest: CpqConfiguratorOverviewNormalizer;
-  let featureToggles: MockFeatureTogglesController;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -165,16 +160,12 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
           provide: TranslationService,
           useClass: MockTranslationService,
         },
-        provideMockFeatureToggles({
-          productConfiguratorCPQContainer: false,
-        }),
       ],
     });
 
     serviceUnderTest = TestBed.inject(
       CpqConfiguratorOverviewNormalizer as Type<CpqConfiguratorOverviewNormalizer>
     );
-    featureToggles = TestBed.inject(MockFeatureTogglesController);
     attr = structuredClone(attrBase);
   }));
 
@@ -646,20 +637,18 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
       };
     }
 
-    it('should preserve legacy behavior when the feature toggle is disabled', () => {
+    it('should ignore container attributes when no container data is present', () => {
       const loggerWarn = spyOn(serviceUnderTest['logger'], 'warn');
+      const source = createConfigurationWithContainers();
+      source.sapContainers = undefined;
 
-      const result = serviceUnderTest.convert(
-        createConfigurationWithContainers()
-      );
+      const result = serviceUnderTest.convert(source);
 
       expect(result.groups).toEqual([]);
-      expect(loggerWarn).toHaveBeenCalled();
+      expect(loggerWarn).not.toHaveBeenCalled();
     });
 
     it('should convert selected container rows into bundle attributes', () => {
-      featureToggles.set('productConfiguratorCPQContainer', true);
-
       const result = serviceUnderTest.convert(
         createConfigurationWithContainers()
       );
@@ -687,9 +676,87 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
       ).toBe(true);
     });
 
-    it('should flatten a single nested group into its container row group', () => {
-      featureToggles.set('productConfiguratorCPQContainer', true);
+    it('should preserve the source order of regular and container attributes', () => {
+      const gardeningContainerAttributeCode = 800;
+      const createDropdownAttribute = (
+        code: number,
+        name: string,
+        value: string
+      ): Cpq.Attribute => ({
+        pA_ID: code,
+        stdAttrCode: code,
+        name,
+        displayAs: Cpq.DisplayAs.DROPDOWN,
+        values: [{ paV_ID: code, valueDisplay: value, selected: true }],
+      });
+      const source: Cpq.Configuration = {
+        productSystemId: PRODUCT_CODE,
+        currencyISOCode: CURRENCY,
+        tabs: [
+          {
+            id: rootTabId,
+            attributes: [
+              createDropdownAttribute(1, 'Building Type', 'Residential'),
+              {
+                ...structuredClone(containerAttribute),
+                name: 'Building Component',
+              },
+              createDropdownAttribute(2, 'Power Supply', '230V'),
+              {
+                ...structuredClone(containerAttribute),
+                stdAttrCode: gardeningContainerAttributeCode,
+                name: 'Gardening Component',
+              },
+              createDropdownAttribute(3, 'Insurance', 'Premium'),
+            ],
+          },
+        ],
+        sapContainers: [
+          {
+            stdAttrCode: containerAttributeCode,
+            rows: [
+              {
+                id: 'wall',
+                productName: 'Wall',
+                selected: true,
+              },
+              {
+                id: 'roof',
+                productName: 'Roof',
+                selected: true,
+              },
+            ],
+          },
+          {
+            stdAttrCode: gardeningContainerAttributeCode,
+            rows: [
+              {
+                id: 'greenhouse',
+                productName: 'Greenhouse',
+                selected: true,
+              },
+            ],
+          },
+        ],
+      };
 
+      const result = serviceUnderTest.convert(source);
+
+      expect(
+        result.groups?.[0].attributes?.map(
+          (attribute) => `${attribute.attribute}:${attribute.value}`
+        )
+      ).toEqual([
+        'Building Type:Residential',
+        'Building Component:Wall',
+        'Building Component:Roof',
+        'Power Supply:230V',
+        'Gardening Component:Greenhouse',
+        'Insurance:Premium',
+      ]);
+    });
+
+    it('should flatten a single nested group into its container row group', () => {
       const result = serviceUnderTest.convert(
         createConfigurationWithContainers()
       );
@@ -712,7 +779,6 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
     });
 
     it('should preserve nested groups when a configuration contains multiple groups', () => {
-      featureToggles.set('productConfiguratorCPQContainer', true);
       const source = createConfigurationWithContainers();
       const nestedConfiguration = source.sapContainers?.[0].rows?.find(
         (row) => row.id === 'zoom'
@@ -744,7 +810,6 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
     });
 
     it('should not attach a container with a non-matching attribute code', () => {
-      featureToggles.set('productConfiguratorCPQContainer', true);
       const source = createConfigurationWithContainers();
       source.sapContainers = [{ stdAttrCode: 999, rows: [] }];
 
@@ -753,8 +818,7 @@ describe('CpqConfiguratorOverviewNormalizer', () => {
       expect(result.groups).toEqual([]);
     });
 
-    it('should not log an unsupported warning for containers when the feature toggle is enabled', () => {
-      featureToggles.set('productConfiguratorCPQContainer', true);
+    it('should not log an unsupported warning for containers', () => {
       const loggerWarn = spyOn(serviceUnderTest['logger'], 'warn');
 
       serviceUnderTest.convert(createConfigurationWithContainers());

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
@@ -5,7 +5,12 @@
  */
 
 import { inject, Injectable } from '@angular/core';
-import { Converter, LoggerService, TranslationService } from '@spartacus/core';
+import {
+  Converter,
+  FeatureToggles,
+  LoggerService,
+  TranslationService,
+} from '@spartacus/core';
 import { Configurator } from '@spartacus/product-configurator/rulebased';
 import { take } from 'rxjs/operators';
 import { Cpq } from '../cpq.models';
@@ -19,6 +24,7 @@ export class CpqConfiguratorOverviewNormalizer
 {
   protected readonly NO_OPTION_SELECTED = 0;
   protected logger: LoggerService = inject(LoggerService);
+  private featureToggles = inject(FeatureToggles);
 
   constructor(
     protected cpqConfiguratorNormalizerUtilsService: CpqConfiguratorNormalizerUtilsService,
@@ -36,8 +42,20 @@ export class CpqConfiguratorOverviewNormalizer
       priceSummary:
         this.cpqConfiguratorNormalizerUtilsService.convertPriceSummary(source),
       groups: source.tabs
-        ?.flatMap((tab) => this.convertTab(tab, source.currencyISOCode))
-        .filter((tab) => tab.attributes && tab.attributes.length > 0),
+        ?.flatMap((tab) =>
+          this.convertTab(
+            tab,
+            source.currencyISOCode,
+            this.featureToggles.productConfiguratorCPQContainer
+              ? source.sapContainers
+              : undefined
+          )
+        )
+        .filter((group) =>
+          this.featureToggles.productConfiguratorCPQContainer
+            ? this.hasOverviewContent(group)
+            : !!group.attributes?.length
+        ),
       totalNumberOfIssues: this.calculateTotalNumberOfIssues(source),
     };
     return resultTarget;
@@ -45,18 +63,28 @@ export class CpqConfiguratorOverviewNormalizer
 
   protected convertTab(
     tab: Cpq.Tab,
-    currency: string
+    currency: string,
+    containers?: Cpq.Container[],
+    parentRowGroupId?: string
   ): Configurator.GroupOverview {
     let ovAttributes: Configurator.AttributeOverview[] = [];
     tab.attributes?.forEach((attr) => {
       ovAttributes = ovAttributes.concat(this.convertAttribute(attr, currency));
     });
     const groupOverview: Configurator.GroupOverview = {
-      id: tab.id.toString(),
+      id: this.createTabGroupId(tab.id, parentRowGroupId),
       groupDescription: tab.displayName,
       attributes: ovAttributes,
     };
-    if (groupOverview.id === '0') {
+    if (this.featureToggles.productConfiguratorCPQContainer) {
+      this.attachContainers(
+        groupOverview,
+        tab.attributes,
+        containers,
+        currency
+      );
+    }
+    if (tab.id === 0) {
       this.translation
         .translate('configurator.group.general')
         .pipe(take(1))
@@ -124,12 +152,116 @@ export class CpqConfiguratorOverviewNormalizer
             ovValues.push(this.extractValue(valueSelected, attr, currency));
           });
         break;
+      case Cpq.DisplayAs.CONTAINER:
+        if (!this.featureToggles.productConfiguratorCPQContainer) {
+          this.logUnsupportedAttribute(attr);
+        }
+        break;
       default:
-        this.logger.warn(
-          `Attribute '${attr.name}' (pA_ID=${(<any>attr).PA_ID}) is not supported and hence hidden from overview.`
-        );
+        this.logUnsupportedAttribute(attr);
     }
     return ovValues;
+  }
+
+  protected createTabGroupId(tabId: number, parentRowGroupId?: string): string {
+    return parentRowGroupId ? `${parentRowGroupId}@${tabId}` : tabId.toString();
+  }
+
+  protected attachContainers(
+    group: Configurator.GroupOverview,
+    attributes: Cpq.Attribute[] | undefined,
+    containers: Cpq.Container[] | undefined,
+    currency: string
+  ): void {
+    if (!attributes?.length || !containers?.length) {
+      return;
+    }
+
+    attributes
+      .filter((attribute) => attribute.displayAs === Cpq.DisplayAs.CONTAINER)
+      .forEach((attribute) => {
+        const container = containers.find(
+          (entry) => entry.stdAttrCode === attribute.stdAttrCode
+        );
+        container?.rows
+          ?.filter((row) => this.isSelectedContainerRow(row))
+          .forEach((row) => {
+            if (row.configuration) {
+              group.subGroups ??= [];
+              group.subGroups.push(
+                this.convertNestedConfiguration(
+                  row.configuration,
+                  row,
+                  attribute.stdAttrCode,
+                  currency
+                )
+              );
+            } else {
+              group.attributes?.push(
+                this.convertContainerRowToAttribute(row, attribute)
+              );
+            }
+          });
+      });
+  }
+
+  protected isSelectedContainerRow(row: Cpq.ContainerRow): boolean {
+    return (
+      row.selected === true &&
+      !row.actions?.includes(Cpq.ContainerRowAction.ADD)
+    );
+  }
+
+  protected convertContainerRowToAttribute(
+    row: Cpq.ContainerRow,
+    attribute: Cpq.Attribute
+  ): Configurator.AttributeOverview {
+    return {
+      attribute:
+        this.cpqConfiguratorNormalizerUtilsService.convertAttributeLabel(
+          attribute
+        ),
+      attributeId: attribute.stdAttrCode.toString(),
+      value: row.productName ?? row.productSystemId ?? row.id,
+      valueId: row.id,
+      productCode: row.productSystemId,
+      type: Configurator.AttributeOverviewType.BUNDLE,
+    };
+  }
+
+  protected convertNestedConfiguration(
+    source: Cpq.NestedProductConfiguration,
+    row: Cpq.ContainerRow,
+    attrCode: number,
+    currency: string
+  ): Configurator.GroupOverview {
+    const rowGroupId = `${Configurator.ContainerRowGroupIdPrefix}@${attrCode}@${row.id}`;
+    const nestedGroups = (source.tabs ?? [])
+      .map((tab) =>
+        this.convertTab(tab, currency, source.containers, rowGroupId)
+      )
+      .filter((group) => this.hasOverviewContent(group));
+    const singleNestedGroup =
+      nestedGroups.length === 1 ? nestedGroups[0] : undefined;
+
+    return {
+      id: rowGroupId,
+      groupDescription: row.productName ?? row.productSystemId,
+      attributes: singleNestedGroup?.attributes ?? [],
+      subGroups: singleNestedGroup
+        ? (singleNestedGroup.subGroups ?? [])
+        : nestedGroups,
+    };
+  }
+
+  protected hasOverviewContent(group: Configurator.GroupOverview): boolean {
+    return !!group.attributes?.length || !!group.subGroups?.length;
+  }
+
+  protected logUnsupportedAttribute(attr: Cpq.Attribute): void {
+    this.logger.warn(
+      `Attribute '${attr.name}' (pA_ID=${(<any>attr).PA_ID}) is not supported and hence hidden from overview.`
+    );
   }
 
   protected extractValue(

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
@@ -152,13 +152,8 @@ export class CpqConfiguratorOverviewNormalizer
             ovValues.push(this.extractValue(valueSelected, attr, currency));
           });
         break;
-      case Cpq.DisplayAs.CONTAINER:
-        if (!this.featureToggles.productConfiguratorCPQContainer) {
-          this.logUnsupportedAttribute(attr);
-        }
-        break;
       default:
-        this.logUnsupportedAttribute(attr);
+        this.logUnsupportedAttributeIfNeeded(attr);
     }
     return ovValues;
   }
@@ -262,6 +257,15 @@ export class CpqConfiguratorOverviewNormalizer
     this.logger.warn(
       `Attribute '${attr.name}' (pA_ID=${(<any>attr).PA_ID}) is not supported and hence hidden from overview.`
     );
+  }
+
+  protected logUnsupportedAttributeIfNeeded(attr: Cpq.Attribute): void {
+    if (
+      attr.displayAs !== Cpq.DisplayAs.CONTAINER ||
+      !this.featureToggles.productConfiguratorCPQContainer
+    ) {
+      this.logUnsupportedAttribute(attr);
+    }
   }
 
   protected extractValue(

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
@@ -181,6 +181,9 @@ export class CpqConfiguratorOverviewNormalizer
         container?.rows
           ?.filter((row) => this.isSelectedContainerRow(row))
           .forEach((row) => {
+            group.attributes?.push(
+              this.convertContainerRowToAttribute(row, attribute)
+            );
             if (row.configuration) {
               group.subGroups ??= [];
               group.subGroups.push(
@@ -190,10 +193,6 @@ export class CpqConfiguratorOverviewNormalizer
                   attribute.stdAttrCode,
                   currency
                 )
-              );
-            } else {
-              group.attributes?.push(
-                this.convertContainerRowToAttribute(row, attribute)
               );
             }
           });

--- a/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
+++ b/feature-libs/product-configurator/rulebased/cpq/common/converters/cpq-configurator-overview-normalizer.ts
@@ -5,12 +5,7 @@
  */
 
 import { inject, Injectable } from '@angular/core';
-import {
-  Converter,
-  FeatureToggles,
-  LoggerService,
-  TranslationService,
-} from '@spartacus/core';
+import { Converter, LoggerService, TranslationService } from '@spartacus/core';
 import { Configurator } from '@spartacus/product-configurator/rulebased';
 import { take } from 'rxjs/operators';
 import { Cpq } from '../cpq.models';
@@ -24,7 +19,6 @@ export class CpqConfiguratorOverviewNormalizer
 {
   protected readonly NO_OPTION_SELECTED = 0;
   protected logger: LoggerService = inject(LoggerService);
-  private featureToggles = inject(FeatureToggles);
 
   constructor(
     protected cpqConfiguratorNormalizerUtilsService: CpqConfiguratorNormalizerUtilsService,
@@ -43,19 +37,9 @@ export class CpqConfiguratorOverviewNormalizer
         this.cpqConfiguratorNormalizerUtilsService.convertPriceSummary(source),
       groups: source.tabs
         ?.flatMap((tab) =>
-          this.convertTab(
-            tab,
-            source.currencyISOCode,
-            this.featureToggles.productConfiguratorCPQContainer
-              ? source.sapContainers
-              : undefined
-          )
+          this.convertTab(tab, source.currencyISOCode, source.sapContainers)
         )
-        .filter((group) =>
-          this.featureToggles.productConfiguratorCPQContainer
-            ? this.hasOverviewContent(group)
-            : !!group.attributes?.length
-        ),
+        .filter((group) => this.hasOverviewContent(group)),
       totalNumberOfIssues: this.calculateTotalNumberOfIssues(source),
     };
     return resultTarget;
@@ -67,23 +51,17 @@ export class CpqConfiguratorOverviewNormalizer
     containers?: Cpq.Container[],
     parentRowGroupId?: string
   ): Configurator.GroupOverview {
-    let ovAttributes: Configurator.AttributeOverview[] = [];
-    tab.attributes?.forEach((attr) => {
-      ovAttributes = ovAttributes.concat(this.convertAttribute(attr, currency));
-    });
     const groupOverview: Configurator.GroupOverview = {
       id: this.createTabGroupId(tab.id, parentRowGroupId),
       groupDescription: tab.displayName,
-      attributes: ovAttributes,
+      attributes: [],
     };
-    if (this.featureToggles.productConfiguratorCPQContainer) {
-      this.attachContainers(
-        groupOverview,
-        tab.attributes,
-        containers,
-        currency
+    tab.attributes?.forEach((attribute) => {
+      groupOverview.attributes?.push(
+        ...this.convertAttribute(attribute, currency)
       );
-    }
+      this.attachContainer(groupOverview, attribute, containers, currency);
+    });
     if (tab.id === 0) {
       this.translation
         .translate('configurator.group.general')
@@ -162,40 +140,39 @@ export class CpqConfiguratorOverviewNormalizer
     return parentRowGroupId ? `${parentRowGroupId}@${tabId}` : tabId.toString();
   }
 
-  protected attachContainers(
+  protected attachContainer(
     group: Configurator.GroupOverview,
-    attributes: Cpq.Attribute[] | undefined,
+    attribute: Cpq.Attribute,
     containers: Cpq.Container[] | undefined,
     currency: string
   ): void {
-    if (!attributes?.length || !containers?.length) {
+    if (
+      attribute.displayAs !== Cpq.DisplayAs.CONTAINER ||
+      !containers?.length
+    ) {
       return;
     }
 
-    attributes
-      .filter((attribute) => attribute.displayAs === Cpq.DisplayAs.CONTAINER)
-      .forEach((attribute) => {
-        const container = containers.find(
-          (entry) => entry.stdAttrCode === attribute.stdAttrCode
+    const container = containers.find(
+      (entry) => entry.stdAttrCode === attribute.stdAttrCode
+    );
+    container?.rows
+      ?.filter((row) => this.isSelectedContainerRow(row))
+      .forEach((row) => {
+        group.attributes?.push(
+          this.convertContainerRowToAttribute(row, attribute)
         );
-        container?.rows
-          ?.filter((row) => this.isSelectedContainerRow(row))
-          .forEach((row) => {
-            group.attributes?.push(
-              this.convertContainerRowToAttribute(row, attribute)
-            );
-            if (row.configuration) {
-              group.subGroups ??= [];
-              group.subGroups.push(
-                this.convertNestedConfiguration(
-                  row.configuration,
-                  row,
-                  attribute.stdAttrCode,
-                  currency
-                )
-              );
-            }
-          });
+        if (row.configuration) {
+          group.subGroups ??= [];
+          group.subGroups.push(
+            this.convertNestedConfiguration(
+              row.configuration,
+              row,
+              attribute.stdAttrCode,
+              currency
+            )
+          );
+        }
       });
   }
 
@@ -259,10 +236,7 @@ export class CpqConfiguratorOverviewNormalizer
   }
 
   protected logUnsupportedAttributeIfNeeded(attr: Cpq.Attribute): void {
-    if (
-      attr.displayAs !== Cpq.DisplayAs.CONTAINER ||
-      !this.featureToggles.productConfiguratorCPQContainer
-    ) {
+    if (attr.displayAs !== Cpq.DisplayAs.CONTAINER) {
       this.logUnsupportedAttribute(attr);
     }
   }


### PR DESCRIPTION
# What changed
Display selected CPQ container rows in the configuration overview.
Flatten a single nested group so its attributes appear directly below the container row name.
Avoid duplicate product entries for rows with nested configurations.
Preserve the existing behavior when productConfiguratorCPQContainer is disabled.

# Testing
Added unit tests covering feature-toggle behavior, selected rows, nested configurations, recursion, group flattening, and unique group IDs.
Full product-configurator test suite passed.
Lint and Prettier checks passed.