### PR TITLE
feat(skills): CXSPA-13991 include @spartacus/skills in release bundle

### DIFF
--- a/ci-scripts/release-packages-list-generator.sh
+++ b/ci-scripts/release-packages-list-generator.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
 # List of files for packages to be released
-# TODO CXSPA-13991: Re-include skills once the audit passes and we're ready to release it
-FILES=$(find core-libs feature-libs integration-libs projects \
-    -name package.json \
-    -not -path "*node_modules*" \
-    -not -path "*projects/eslint*" \
-    -not -path "*core-libs/skills*")
+FILES=$(find core-libs feature-libs integration-libs projects -name package.json -not -path "*node_modules*" -not -path "*projects/eslint*")
 
 # Return only the names of the packages from the list of files
 PACKAGE_NAMES=()

--- a/core-libs/schematics/package.json
+++ b/core-libs/schematics/package.json
@@ -79,6 +79,7 @@
       "@spartacus/s4-service",
       "@spartacus/s4om",
       "@spartacus/segment-refs",
+      "@spartacus/skills",
       "@spartacus/smartedit",
       "@spartacus/storefinder",
       "@spartacus/subscription-billing",

--- a/core-libs/schematics/src/add-spartacus/index.ts
+++ b/core-libs/schematics/src/add-spartacus/index.ts
@@ -56,8 +56,7 @@ import {
   scaffoldStructure,
 } from '../shared/utils/workspace-utils';
 import { addStorefrontComponentToAppComponent } from './add-storefront-component-to-app-component';
-// TODO CXSPA-13991: Re-enable once @spartacus/skills passes audit and ships in the release bundle.
-// import { addAiContext, scheduleAiContext } from './ai-context';
+import { addAiContext, scheduleAiContext } from './ai-context';
 import { addSpartacusConfiguration } from './configuration';
 import { createAppModule } from './create-app-module';
 import { Schema as SpartacusOptions } from './schema';
@@ -569,8 +568,7 @@ export function addSpartacus(options: SpartacusOptions): Rule {
 
       addFeatures(options, features),
 
-      // TODO CXSPA-13991: Re-enable once @spartacus/skills passes audit and ships in the release bundle.
-      // addAiContext(options),
+      addAiContext(options),
 
       chain([
         addPackageJsonDependencies(
@@ -586,8 +584,7 @@ export function addSpartacus(options: SpartacusOptions): Rule {
         replaceCaretWithTildeForSpartacusDependencies(options),
       ]),
 
-      // TODO CXSPA-13991: Re-enable once @spartacus/skills passes audit and ships in the release bundle.
-      // scheduleAiContext(options),
+      scheduleAiContext(options),
 
       finalizeInstallation(options, features),
     ])(tree, context);

--- a/core-libs/schematics/src/add-spartacus/schema.json
+++ b/core-libs/schematics/src/add-spartacus/schema.json
@@ -386,6 +386,31 @@
     "theme": {
       "type": "string",
       "description": "Select a style theme to add. E.g: santorini"
+    },
+    "aiTools": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": ["agents", "claude"]
+      },
+      "default": ["agents"],
+      "description": "Select the local folder(s) to install Spartacus AI development skills",
+      "x-prompt": {
+        "type": "list",
+        "multiselect": true,
+        "message": "Select the local folder(s) to install Spartacus AI development skills",
+        "items": [
+          {
+            "value": "agents",
+            "label": ".agents (.agents/skills/spartacus-developer/)"
+          },
+          {
+            "value": "claude",
+            "label": ".claude (.claude/skills/spartacus-developer/)"
+          }
+        ]
+      }
     }
   },
   "required": []

--- a/core-libs/schematics/src/collection.json
+++ b/core-libs/schematics/src/collection.json
@@ -36,8 +36,7 @@
       "description": "Add AI assistant guidance (.claude / .agents) to an existing Spartacus project.",
       "factory": "./ai-context/index#addAiContextSchematic",
       "schema": "./ai-context/schema.json",
-      "aliases": ["ai"],
-      "private": true
+      "aliases": ["ai"]
     },
     "modernize-app-migrated-from-6_8-to-2211_19": {
       "description": "Modernize Angular application migrated from 6.8 to 2211.19",

--- a/core-libs/schematics/src/dependencies.json
+++ b/core-libs/schematics/src/dependencies.json
@@ -38,6 +38,7 @@
     "@spartacus/order": "221121.18.0",
     "@spartacus/user": "221121.18.0"
   },
+  "@spartacus/skills": {},
   "@spartacus/storefront": {
     "@angular/common": "^21.2.19",
     "@angular/core": "^21.2.19",

--- a/core-libs/schematics/src/migrations/add-or-update-ai-skills/index_spec.ts
+++ b/core-libs/schematics/src/migrations/add-or-update-ai-skills/index_spec.ts
@@ -14,11 +14,7 @@ const MIGRATION_SCRIPT_NAME = 'add-or-update-ai-skills';
 const SKILLS_PACKAGE = '@spartacus/skills';
 const CLAUDE_SENTINEL = '.claude/skills/spartacus-developer/SKILL.md';
 
-// TODO CXSPA-13991: Re-enable once the `add-or-update-ai-skills` migration is
-// re-registered in migrations.json (skills passes audit and ships in the bundle).
-// The migration code is retained; only its collection registration is removed,
-// so this suite can't resolve the schematic and is skipped in the meantime.
-describe.skip('add/update AI skills migration', () => {
+describe('add/update AI skills migration', () => {
   let tree: Tree;
   let runner: SchematicTestRunner;
 

--- a/core-libs/schematics/src/migrations/migrations.json
+++ b/core-libs/schematics/src/migrations/migrations.json
@@ -121,7 +121,7 @@
       "description": "Rename import symbols that were moved/changed in majors"
     },
     "add-or-update-ai-skills": {
-      "version": "221121.17.0-1",
+      "version": "221121.18.0",
       "factory": "./add-or-update-ai-skills/index#migrate",
       "description": "Add or update AI skills for Spartacus development ✨"
     }

--- a/core-libs/schematics/src/migrations/migrations.json
+++ b/core-libs/schematics/src/migrations/migrations.json
@@ -119,6 +119,11 @@
       "version": "221121.7.0",
       "factory": "./221121_7/rename-symbol/rename-symbol#migrate",
       "description": "Rename import symbols that were moved/changed in majors"
+    },
+    "add-or-update-ai-skills": {
+      "version": "221121.17.0-1",
+      "factory": "./add-or-update-ai-skills/index#migrate",
+      "description": "Add or update AI skills for Spartacus development ✨"
     }
   }
 }

--- a/core-libs/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
+++ b/core-libs/schematics/src/ng-add/__snapshots__/index_spec.ts.snap
@@ -68,6 +68,7 @@ exports[`Spartacus Schematics: ng-add should add spartacus properly with SSR 2`]
     "@angular/compiler": "^21.2.19",
     "@angular/compiler-cli": "^21.2.0",
     "@schematics/angular": "^21.2.19",
+    "@spartacus/skills": "~221121.18.0",
     "@types/express": "^5.0.1",
     "@types/node": "^20.17.19",
     "jsdom": "^28.0.0",

--- a/tools/schematics/dependency-collector.ts
+++ b/tools/schematics/dependency-collector.ts
@@ -30,9 +30,6 @@ const packageJsonDirectories: string[] = [
   'package.json',
 ];
 
-// TODO CXSPA-13991: Re-include skills once it passes audit and ships in the release bundle.
-const excludedPackages: string[] = ['@spartacus/skills'];
-
 function cleanup(): void {
   if (fs.existsSync(fileName)) {
     fs.unlinkSync(fileName);
@@ -68,9 +65,6 @@ function collect(
       }
 
       const packageJson = readJson(`${dir}/${lib}/package.json`);
-      if (excludedPackages.includes(packageJson.name)) {
-        continue;
-      }
       collected = {
         ...collected,
         [packageJson.name]: packageJson.peerDependencies ?? {},

--- a/tools/schematics/testing.ts
+++ b/tools/schematics/testing.ts
@@ -138,7 +138,7 @@ function getPackageJsonFiles(): string[] {
   const sourceFiles = [
     'core-libs/styles/package.json',
     'core-libs/schematics/package.json',
-    // TODO CXSPA-13991: Re-include skills once it passes audit and ships in the release bundle.
+    'core-libs/skills/package.json',
   ];
   const distFiles = globSync(`dist/!(node_modules)/package.json`);
   return [...sourceFiles, ...distFiles];


### PR DESCRIPTION
This PR just adds back spartacus/skills package in the release bundle. It was reverted in the following PR: https://github.com/SAP/spartacus/pull/21810

Instructions for QA can be found in the original PR that introduced the skills in the first place: https://github.com/SAP/spartacus/pull/21534

The short copy of QA steps:

## Prerequisites

**Build & publish Spartacus locally**
- Build libs: `npm run build:libs`
- Publish on Verdaccio: `ts-node ./tools/schematics/testing`
- `@spartacus/skills` is pure markdown (no compilation) and is published by the
  script above alongside the other libs.

## QA Steps

**1. Install / generate**

Fresh-app install (`ng add`):
- Create an app: `npx @angular/cli@21 new test-app --file-name-style-guide=2016 --style=scss --ssr=true` then `cd test-app`. Worth running twice — once accepting Angular CLI's own AI output (a top-level `CLAUDE.md`), once declining — to confirm our skill coexists with it and doesn't touch it.
- Add Spartacus: `npx @angular/cli add @spartacus/schematics --baseUrl=https://40.76.109.9:9002`
- At the prompt "Which AI tools should I configure with Spartacus best practices?", pick at least one of `claude`, `cursor`. To skip the prompt, append `--ai-tools=claude --ai-tools=cursor`.
- `ng add` adds `@spartacus/skills` to devDependencies, installs it, and then copies the skill. The copy is wired to run **after** the install task, so it should succeed in one pass. If install fails, the copy is skipped with a warning and you can re-run the generator (below).

Upgrade install (`ng update`):
- Create a fresh app and add an `.npmrc` pointing the `@spartacus` scope at the RBSC release registry (with `SAP_RBSCTOKEN` exported in the shell):

  ```
  @spartacus:registry=https://73554900100900004337.npmsrv.base.repositories.cloud.sap/
  //73554900100900004337.npmsrv.base.repositories.cloud.sap/:_auth=${SAP_RBSCTOKEN}
  //73554900100900004337.npmsrv.base.repositories.cloud.sap/:always-auth=true
  ```
- Install an older released Spartacus into it (e.g. `221121.10.0` from RBSC).
- For the migration to fire, the version you upgrade **to** must be ≥ the migration version. The locally published version is `221121.11.0`, so temporarily set the `ai-context-prompt` migration version to `221121.11.0` so `ng update` from `10 → 11` runs it (the committed value is `221121.12.0`, targeting the next feature release).
- Point `.npmrc` `@spartacus:registry` at local Verdaccio (`http://localhost:4873/`) and run `ng update @spartacus/schematics` → confirm the "Spartacus offers AI-assistant guidance (Claude / Cursor) via the @spartacus/skills package…" message appears, including the schematic commands. It must not modify any files.
- Opt in via schematic: `npm install --save-dev @spartacus/skills@<version>` then `npx ng generate @spartacus/schematics:ai-context` (pick `claude`/`cursor` or pass `--ai-tools=…`).
- Or opt in manually: follow the "Manual copy" section of the `@spartacus/skills` README and confirm it lands the same file tree as the schematic.

**2. File layout**
- `.claude/skills/spartacus-developer/SKILL.md` exists with YAML frontmatter
  (`name`, `description`, `license`, `compatibility`, `metadata.version`).
- `.claude/skills/spartacus-developer/references/*.md` exist (the sub-topic files
  referenced by `SKILL.md`; these have **no** frontmatter).
- For `cursor`: the same tree under `.cursor/skills/spartacus-developer/`.
- Confirm the schematic does **not** create a root `CLAUDE.md` or `AGENTS.md` — the skill
  lives entirely inside its own `spartacus-developer/` folder.

**3. Coexistence with existing AI files**
- Because the skill is written to a dedicated `spartacus-developer/` subfolder, it should
  never overwrite other skills or a pre-existing root `CLAUDE.md` (e.g. one generated by
  Angular CLI). Verify any Angular/customer AI files are untouched and our skill sits
  alongside them.
- Check the installed package carries `node_modules/@spartacus/skills/README.md`, which
  hints that agents should use the copied-in skill, not the one in `node_modules`.
