### PR TITLE
fix: make CVV info icon keyboard accessible (CXSPA-12761)

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -794,6 +794,13 @@ export interface FeatureTogglesInterface {
    * `AddressFormComponent`, `UnitAddressFormService`
    */
   enableFormFieldMaxLength?: boolean;
+  /**
+   * Makes the CVV (Card Verification Value) info icon in the checkout
+   * payment form keyboard accessible by rendering it as a focusable button.
+   *
+   * Affects: `CheckoutPaymentFormComponent`
+   */
+  a11yCvvInfoIconKeyboardAccessible?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -891,4 +898,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   globalMessageCloseButtonPadding: false,
   a11yNavigationChevronContrast: false,
   enableFormFieldMaxLength: false,
+  a11yCvvInfoIconKeyboardAccessible: false,
 };

--- a/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.html
+++ b/feature-libs/checkout/base/components/checkout-payment-method/checkout-payment-form/checkout-payment-form.component.html
@@ -193,6 +193,7 @@
                   {{ 'paymentForm.securityCode' | cxTranslate }}
                   <cx-form-required-asterisks />
                   <cx-icon
+                    *cxFeature="'!a11yCvvInfoIconKeyboardAccessible'"
                     [type]="iconTypes.INFO"
                     class="cx-payment-form-tooltip"
                     placement="right"
@@ -202,6 +203,17 @@
                       'paymentForm.securityCodeTitle' | cxTranslate
                     "
                   />
+                  <button
+                    *cxFeature="'a11yCvvInfoIconKeyboardAccessible'"
+                    type="button"
+                    class="cx-payment-form-tooltip cx-cvv-info-btn"
+                    [attr.aria-label]="
+                      'paymentForm.securityCodeTitle' | cxTranslate
+                    "
+                    title="{{ 'paymentForm.securityCodeTitle' | cxTranslate }}"
+                  >
+                    <cx-icon [type]="iconTypes.INFO" />
+                  </button>
                 </span>
                 <input
                   required="true"

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -390,6 +390,7 @@ if (environment.cpq) {
         a11yItemCounterValueText: true,
         a11yNavigationChevronContrast: true,
         enableFormFieldMaxLength: true,
+        a11yCvvInfoIconKeyboardAccessible: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-12761

The Card Verification Value (CVV) info icon on the payment form was not reachable by keyboard. The icon is now wrapped in a focusable `<button>` element with an accessible aria-label so keyboard and screen-reader users can interact with it. The change is gated behind the `a11yCvvInfoIconKeyboardAccessible` feature toggle.

**QA Steps:**
1. Enable the feature toggle `a11yCvvInfoIconKeyboardAccessible: true`.
2. Open the storefront and add a product to the cart.
3. Proceed to checkout and navigate to the Payment tab.
4. Select "Add New Payment".
5. Using only the keyboard (Tab key), navigate through the payment form fields.
6. Verify the CVV info icon (ⓘ) next to the Security Code field receives focus.
7. Press Enter or Space — verify the info tooltip/popover activates.
8. Verify a screen reader (e.g. JAWS) announces the button and its label when focused.
