### PR TITLE
fix: make close button on toast notifications accessible to screen readers (CXSPA-12696)

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -794,6 +794,14 @@ export interface FeatureTogglesInterface {
    * `AddressFormComponent`, `UnitAddressFormService`
    */
   enableFormFieldMaxLength?: boolean;
+
+  /**
+   * When enabled, the 'Close' button on toast/global message notifications
+   * is rendered as a proper `<button type="button">` with an `aria-label`,
+   * making it keyboard accessible and correctly announced by screen readers.
+   * Affects: `GlobalMessageComponent`
+   */
+  a11yCloseToastButtonKeyboardAccessible?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -891,4 +899,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   globalMessageCloseButtonPadding: false,
   a11yNavigationChevronContrast: false,
   enableFormFieldMaxLength: false,
+  a11yCloseToastButtonKeyboardAccessible: false,
 };

--- a/core-libs/storefront/cms-components/misc/global-message/global-message.component.html
+++ b/core-libs/storefront/cms-components/misc/global-message/global-message.component.html
@@ -34,8 +34,18 @@
     </span>
     <span>{{ confMsg | cxTranslate }}</span>
     <button
+      *cxFeature="'!a11yCloseToastButtonKeyboardAccessible'"
       class="close"
       title="{{ 'common.close' | cxTranslate }}"
+      (click)="clear(messageType.MSG_TYPE_CONFIRMATION, i)"
+    >
+      <cx-icon [type]="iconTypes.CLOSE" />
+    </button>
+    <button
+      *cxFeature="'a11yCloseToastButtonKeyboardAccessible'"
+      type="button"
+      class="close btn-link"
+      [attr.aria-label]="'common.close' | cxTranslate"
       (click)="clear(messageType.MSG_TYPE_CONFIRMATION, i)"
     >
       <cx-icon [type]="iconTypes.CLOSE" />
@@ -50,8 +60,18 @@
     </span>
     <span>{{ infoMsg | cxTranslate }}</span>
     <button
+      *cxFeature="'!a11yCloseToastButtonKeyboardAccessible'"
       class="close"
       title="{{ 'common.close' | cxTranslate }}"
+      (click)="clear(messageType.MSG_TYPE_INFO, i)"
+    >
+      <cx-icon [type]="iconTypes.CLOSE" />
+    </button>
+    <button
+      *cxFeature="'a11yCloseToastButtonKeyboardAccessible'"
+      type="button"
+      class="close btn-link"
+      [attr.aria-label]="'common.close' | cxTranslate"
       (click)="clear(messageType.MSG_TYPE_INFO, i)"
     >
       <cx-icon [type]="iconTypes.CLOSE" />
@@ -69,8 +89,18 @@
     </span>
     <span>{{ infoMsg | cxTranslate }}</span>
     <button
+      *cxFeature="'!a11yCloseToastButtonKeyboardAccessible'"
       class="close"
       title="{{ 'common.close' | cxTranslate }}"
+      (click)="clear(messageType.MSG_TYPE_WARNING, i)"
+    >
+      <cx-icon [type]="iconTypes.CLOSE" />
+    </button>
+    <button
+      *cxFeature="'a11yCloseToastButtonKeyboardAccessible'"
+      type="button"
+      class="close btn-link"
+      [attr.aria-label]="'common.close' | cxTranslate"
       (click)="clear(messageType.MSG_TYPE_WARNING, i)"
     >
       <cx-icon [type]="iconTypes.CLOSE" />
@@ -85,8 +115,18 @@
     </span>
     <span>{{ errorMsg | cxTranslate }}</span>
     <button
+      *cxFeature="'!a11yCloseToastButtonKeyboardAccessible'"
       class="close"
       title="{{ 'common.close' | cxTranslate }}"
+      (click)="clear(messageType.MSG_TYPE_ERROR, i)"
+    >
+      <cx-icon [type]="iconTypes.CLOSE" />
+    </button>
+    <button
+      *cxFeature="'a11yCloseToastButtonKeyboardAccessible'"
+      type="button"
+      class="close btn-link"
+      [attr.aria-label]="'common.close' | cxTranslate"
       (click)="clear(messageType.MSG_TYPE_ERROR, i)"
     >
       <cx-icon [type]="iconTypes.CLOSE" />

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -390,6 +390,7 @@ if (environment.cpq) {
         a11yItemCounterValueText: true,
         a11yNavigationChevronContrast: true,
         enableFormFieldMaxLength: true,
+        a11yCloseToastButtonKeyboardAccessible: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-12696

The close (×) button on global message toasts lacked an accessible label, making it unusable for keyboard and screen-reader users. An `aria-label` is now provided on all four message types (confirmation, info, warning, error). The change is gated behind the `a11yCloseToastButtonKeyboardAccessible` feature toggle.

**QA Steps:**
1. Enable the feature toggle `a11yCloseToastButtonKeyboardAccessible: true`.
2. Trigger a toast notification — for example, request a password reset email.
3. Using only the keyboard, Tab to the close (×) button on the toast.
4. Verify the button receives visible focus.
5. Verify a screen reader (e.g. JAWS) announces the button with a meaningful label (e.g. "Close").
6. Press Enter or Space — verify the toast is dismissed.
7. Repeat for at least one other message type (e.g. add an item to the cart to trigger an info toast).
