### PR TITLE
fix: make RESET button in coupon claim dialog keyboard accessible (CXSPA-12777)

### DIFF
--- a/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
+++ b/core-libs/core/src/features-config/feature-toggles/config/feature-toggles.ts
@@ -794,6 +794,15 @@ export interface FeatureTogglesInterface {
    * `AddressFormComponent`, `UnitAddressFormService`
    */
   enableFormFieldMaxLength?: boolean;
+
+  /**
+   * When enabled, the RESET button in the "Add To Your Coupon List" claim dialog
+   * is rendered as a proper `<button>` element instead of an `<a role="button">`
+   * without an `href`, making it reachable and operable with the keyboard.
+   * Fixes WCAG 2.1.1 (Keyboard) ACC-270.1 (Level A).
+   * Affects: `ClaimDialogComponent`
+   */
+  a11yCouponDialogResetButtonKeyboardAccessible?: boolean;
 }
 
 export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
@@ -891,4 +900,5 @@ export const defaultFeatureToggles: Required<FeatureTogglesInterface> = {
   globalMessageCloseButtonPadding: false,
   a11yNavigationChevronContrast: false,
   enableFormFieldMaxLength: false,
+  a11yCouponDialogResetButtonKeyboardAccessible: false,
 };

--- a/core-libs/storefront/cms-components/myaccount/my-coupons/claim-dialog/claim-dialog.component.html
+++ b/core-libs/storefront/cms-components/myaccount/my-coupons/claim-dialog/claim-dialog.component.html
@@ -57,12 +57,21 @@
         <div class="cx-dialog-row">
           <div class="col-md-6 cx-dialog-row--reset-button">
             <a
+              *cxFeature="'!a11yCouponDialogResetButtonKeyboardAccessible'"
               role="button"
               class="btn btn-block btn-secondary"
               (click)="cancelEdit()"
             >
               {{ 'myCoupons.reset' | cxTranslate }}
             </a>
+            <button
+              *cxFeature="'a11yCouponDialogResetButtonKeyboardAccessible'"
+              type="button"
+              class="btn btn-block btn-secondary"
+              (click)="cancelEdit()"
+            >
+              {{ 'myCoupons.reset' | cxTranslate }}
+            </button>
           </div>
           <div class="col-md-6 cx-dialog-row-submit-button">
             <button

--- a/core-libs/storefront/cms-components/myaccount/my-coupons/claim-dialog/claim-dialog.component.ts
+++ b/core-libs/storefront/cms-components/myaccount/my-coupons/claim-dialog/claim-dialog.component.ts
@@ -21,6 +21,7 @@ import {
 
 import {
   CustomerCouponService,
+  FeatureDirective,
   GlobalMessageService,
   GlobalMessageType,
   RoutingService,
@@ -46,6 +47,7 @@ import { IconComponent } from '../../../misc/icon/icon.component';
     FormRequiredAsterisksComponent,
     FormErrorsComponent,
     TranslatePipe,
+    FeatureDirective,
   ],
 })
 export class ClaimDialogComponent implements OnDestroy, OnInit {

--- a/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
+++ b/projects/storefrontapp/src/app/spartacus/spartacus-features.module.ts
@@ -390,6 +390,7 @@ if (environment.cpq) {
         a11yItemCounterValueText: true,
         a11yNavigationChevronContrast: true,
         enableFormFieldMaxLength: true,
+        a11yCouponDialogResetButtonKeyboardAccessible: true,
       };
       return appFeatureToggles;
     }),


### PR DESCRIPTION
Closes: https://jira.tools.sap/browse/CXSPA-12777

The RESET button in the "Add To Your Coupon List" dialog was rendered as an `<a>` element without an `href`, which is skipped by the browser's tab order. It is now a proper `<button type="button">` that can be reached and activated by keyboard users. The change is gated behind the `a11yCouponDialogResetButtonKeyboardAccessible` feature toggle.

**QA Steps:**
1. Enable the feature toggle `a11yCouponDialogResetButtonKeyboardAccessible: true`.
2. Log in and navigate to My Account → My Coupons (or go directly to `#customerCoupon1` in the URL).
3. Open the "Add To Your Coupon List" dialog.
4. Using only the keyboard, Tab through the dialog controls.
5. Verify the RESET button receives focus (it must appear in the tab order).
6. Press Enter or Space — verify the coupon input field is cleared/reset.
7. Verify a screen reader announces the button correctly.
