### PR TITLE
feat: [Quotes] Order Summary: Use Subtotal Value Before Discounts

### DIFF
--- a/feature-libs/quote/components/config/default-quote-ui.config.ts
+++ b/feature-libs/quote/components/config/default-quote-ui.config.ts
@@ -110,5 +110,6 @@ export const defaultQuoteUIConfig: QuoteUIConfig = {
     },
     confirmActionDialogMapping: defaultDialogMappings,
     maximumDecimalsForPercentageDiscount: 8,
+    showSubtotalBeforeDiscounts: true,
   },
 };

--- a/feature-libs/quote/components/config/quote-ui.config.ts
+++ b/feature-libs/quote/components/config/quote-ui.config.ts
@@ -17,6 +17,7 @@ export interface QuoteUIConfigFragment {
   truncateCardTileContentAfterNumChars?: number;
   confirmActionDialogMapping?: ConfirmActionDialogMappingConfig;
   maximumDecimalsForPercentageDiscount?: number;
+  showSubtotalBeforeDiscounts?: boolean;
   updateDebounceTime?: {
     expiryDate?: number;
   };

--- a/feature-libs/quote/components/summary/prices/quote-summary-prices.component.html
+++ b/feature-libs/quote/components/summary/prices/quote-summary-prices.component.html
@@ -7,7 +7,12 @@
       {{ 'quote.summary.prices.subtotal' | cxTranslate }}
     </div>
     <div class="cx-price-amount">
-      {{ quoteDetails.totalPrice?.formattedValue }}
+      {{
+        showSubtotalBeforeDiscounts &&
+        quoteDetails.sapSubtotalExcludingOrderLevelDiscount?.formattedValue
+          ? quoteDetails.sapSubtotalExcludingOrderLevelDiscount!.formattedValue
+          : quoteDetails.totalPrice.formattedValue
+      }}
     </div>
   </div>
   <div
@@ -48,7 +53,7 @@
       {{ 'quote.summary.prices.total' | cxTranslate }}
     </div>
     <div class="cx-price-amount">
-      {{ quoteDetails.totalPrice?.formattedValue }}
+      {{ quoteDetails.totalPrice.formattedValue }}
     </div>
   </div>
   <div class="cx-price-footer">

--- a/feature-libs/quote/components/summary/prices/quote-summary-prices.component.spec.ts
+++ b/feature-libs/quote/components/summary/prices/quote-summary-prices.component.spec.ts
@@ -3,6 +3,7 @@ import { I18nTestingModule } from '@spartacus/core';
 import { Quote, QuoteFacade } from '@spartacus/quote/root';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { createEmptyQuote } from '../../../core/testing/quote-test-utils';
+import { QuoteUIConfig } from '../../config/quote-ui.config';
 import { CommonQuoteTestUtilsService as TestUtil } from '../../testing/common-quote-test-utils.service';
 import { QuoteSummaryPricesComponent } from './quote-summary-prices.component';
 
@@ -30,6 +31,10 @@ describe('QuoteSummaryPricesComponent', () => {
         {
           provide: QuoteFacade,
           useClass: MockCommerceQuotesFacade,
+        },
+        {
+          provide: QuoteUIConfig,
+          useValue: { quote: { showSubtotalBeforeDiscounts: true } },
         },
       ],
     }).compileComponents();
@@ -136,6 +141,53 @@ describe('QuoteSummaryPricesComponent', () => {
       '.total  $1,000.00',
       1
     );
+  });
+
+  describe('showSubtotalBeforeDiscounts', () => {
+    it('should display sapSubtotalExcludingOrderLevelDiscount when switch is on and field is present', () => {
+      quote.sapSubtotalExcludingOrderLevelDiscount = {
+        value: 1200,
+        formattedValue: '$1,200.00',
+      };
+      fixture.detectChanges();
+      TestUtil.expectElementToContainText(
+        expect,
+        htmlElem,
+        '.cx-price-row',
+        '.subtotal  $1,200.00',
+        0
+      );
+    });
+
+    it('should fall back to totalPrice when switch is on but field is absent', () => {
+      quote.sapSubtotalExcludingOrderLevelDiscount = undefined;
+      fixture.detectChanges();
+      TestUtil.expectElementToContainText(
+        expect,
+        htmlElem,
+        '.cx-price-row',
+        '.subtotal  $1,000.00',
+        0
+      );
+    });
+
+    it('should display totalPrice when switch is off', () => {
+      quote.sapSubtotalExcludingOrderLevelDiscount = {
+        value: 1200,
+        formattedValue: '$1,200.00',
+      };
+      (component as any).quoteUIConfig = {
+        quote: { showSubtotalBeforeDiscounts: false },
+      };
+      fixture.detectChanges();
+      TestUtil.expectElementToContainText(
+        expect,
+        htmlElem,
+        '.cx-price-row',
+        '.subtotal  $1,000.00',
+        0
+      );
+    });
   });
 
   describe('hasNonZeroPriceValue', () => {

--- a/feature-libs/quote/components/summary/prices/quote-summary-prices.component.ts
+++ b/feature-libs/quote/components/summary/prices/quote-summary-prices.component.ts
@@ -8,6 +8,7 @@ import { AsyncPipe, NgIf } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { Price, TranslatePipe } from '@spartacus/core';
 import { QuoteFacade } from '@spartacus/quote/root';
+import { QuoteUIConfig } from '../../config/quote-ui.config';
 
 @Component({
   selector: 'cx-quote-summary-prices',
@@ -16,8 +17,13 @@ import { QuoteFacade } from '@spartacus/quote/root';
 })
 export class QuoteSummaryPricesComponent {
   protected quoteFacade = inject(QuoteFacade);
+  protected quoteUIConfig = inject(QuoteUIConfig);
 
   quoteDetails$ = this.quoteFacade.getQuoteDetails();
+
+  get showSubtotalBeforeDiscounts(): boolean {
+    return this.quoteUIConfig.quote?.showSubtotalBeforeDiscounts ?? true;
+  }
 
   /**
    * Checks whether the price has a non-zero value.

--- a/feature-libs/quote/occ/config/default-occ-quote-config.ts
+++ b/feature-libs/quote/occ/config/default-occ-quote-config.ts
@@ -7,7 +7,7 @@
 import { OccConfig } from '@spartacus/core';
 
 const PRICE_HEADER_FIELDS =
-  ',totalPrice(formattedValue),quoteDiscounts(formattedValue),orderDiscounts(formattedValue),productDiscounts(formattedValue)';
+  ',totalPrice(formattedValue),quoteDiscounts(formattedValue),orderDiscounts(formattedValue),productDiscounts(formattedValue),sapSubtotalExcludingOrderLevelDiscount(formattedValue)';
 
 export const defaultOccQuoteConfig: OccConfig = {
   backend: {

--- a/feature-libs/quote/root/model/quote.model.ts
+++ b/feature-libs/quote/root/model/quote.model.ts
@@ -26,6 +26,7 @@ export interface OccQuote {
   sapQuoteDiscountsType?: QuoteDiscountType;
   sapAttachments?: QuoteAttachment[];
   state: QuoteState;
+  sapSubtotalExcludingOrderLevelDiscount?: Price;
   subTotalWithDiscounts?: Price;
   threshold?: number;
   totalItems?: number;


### PR DESCRIPTION
## Summary

Improves the quote order summary by displaying the subtotal before discounts, so the math is clear: subtotal → discounts → total.

Previously, the Subtotal row used `totalPrice` (after all discounts), resulting in Subtotal and Total showing the same value. Now it uses the new `sapSubtotalExcludingOrderLevelDiscount` field introduced by the backend (CXEC-35276).

Changes:
- Add `sapSubtotalExcludingOrderLevelDiscount` to `OccQuote` model
- Include `sapSubtotalExcludingOrderLevelDiscount(formattedValue)` in OCC price header fields
- Add `showSubtotalBeforeDiscounts` property switch to `QuoteUIConfigFragment` (default: `true`) — allows integrators to revert to previous behavior
- Update `QuoteSummaryPricesComponent` to use the new field, with graceful fallback to `totalPrice` when the field is unavailable

## Screenshots

<img width="2196" height="1534" alt="image" src="https://github.com/user-attachments/assets/e8492dd3-d61a-4431-a454-2f4a6f7184c1" />

## Related

- JIRA: [CXSPA-5263](https://jira.tools.sap/browse/CXSPA-5263)
- Backend prerequisite: [CXEC-35276](https://jira.tools.sap/browse/CXEC-35276)

## Test

- Unit tests added for `showSubtotalBeforeDiscounts` switch (on + field present, on + field absent fallback, off)
- Manually verified against S2 environment: Subtotal, discounts, and Total now display correct distinct values